### PR TITLE
Harden docker helper downloads against supply-chain tampering

### DIFF
--- a/dockerfiles/install_awscli.sh
+++ b/dockerfiles/install_awscli.sh
@@ -7,14 +7,31 @@
 
 set -euo pipefail
 
+AWSCLI_VERSION="${1:-2.36.7}"
 ARCH="$(uname -m)"
+case "${AWSCLI_VERSION}:${ARCH}" in
+    2.36.7:x86_64)
+        AWSCLI_SHA256="d641283d37f1a2168457a9f26a20d4e29167652e9ab1719b37114ef1ebe859f4"
+        ;;
+    2.36.7:aarch64)
+        AWSCLI_SHA256="85826b67912b44bb45d1e46c6e66f383c14405ee0b2f4686f73bdf949c93bd61"
+        ;;
+    *)
+        echo "Unsupported AWS CLI version/architecture: ${AWSCLI_VERSION}/${ARCH}" >&2
+        exit 1
+        ;;
+esac
+
+AWSCLI_ARCHIVE="awscli-exe-linux-${ARCH}-${AWSCLI_VERSION}.zip"
 
 # https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
 curl --silent --fail --show-error --location \
-    "https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}.zip" \
-    --output "awscliv2.zip"
+    "https://awscli.amazonaws.com/${AWSCLI_ARCHIVE}" \
+    --output "${AWSCLI_ARCHIVE}"
 
-unzip -qq awscliv2.zip
+printf '%s  %s\n' "${AWSCLI_SHA256}" "${AWSCLI_ARCHIVE}" | sha256sum --check --strict
+
+unzip -qq "${AWSCLI_ARCHIVE}"
 
 if [ "$EUID" -ne 0 ]; then
   sudo ./aws/install --update

--- a/dockerfiles/install_ccache.sh
+++ b/dockerfiles/install_ccache.sh
@@ -10,10 +10,22 @@ set -euo pipefail
 CCACHE_VERSION="$1"
 
 ARCH="$(uname -m)"
+case "${CCACHE_VERSION}:${ARCH}" in
+    4.11.2:x86_64)
+        CCACHE_SHA256="c97655c75e1e7137d9bc9a9c854220fcbe14f1d7224c64a18c43c70195567ccb"
+        ;;
+    *)
+        echo "Unsupported ccache version/architecture: ${CCACHE_VERSION}/${ARCH}" >&2
+        exit 1
+        ;;
+esac
 
+CCACHE_ARCHIVE="ccache-${CCACHE_VERSION}-linux-${ARCH}.tar.xz"
 curl --silent --fail --show-error --location \
-    "https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}-linux-${ARCH}.tar.xz" \
-    --output ccache.tar.xz
+    "https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/${CCACHE_ARCHIVE}" \
+    --output "${CCACHE_ARCHIVE}"
 
-tar xf ccache.tar.xz
+printf '%s  %s\n' "${CCACHE_SHA256}" "${CCACHE_ARCHIVE}" | sha256sum --check --strict
+
+tar xf "${CCACHE_ARCHIVE}"
 cp ccache-${CCACHE_VERSION}-linux-${ARCH}/ccache /usr/local/bin

--- a/dockerfiles/install_cmake.sh
+++ b/dockerfiles/install_cmake.sh
@@ -11,12 +11,27 @@ CMAKE_VERSION="$1"
 
 ARCH="$(uname -m)"
 INSTALL_PREFIX="/usr/local/therock-tools"
+case "${CMAKE_VERSION}:${ARCH}" in
+    3.27.9:x86_64)
+        CMAKE_SHA256="341c415b98abeebc0a31903dc65d4ad2eba1e897fea7ed723a8d6066cc7a21ae"
+        ;;
+    3.27.9:aarch64)
+        CMAKE_SHA256="f6628eee0dc3ca849e662bdfe9b7ca52324ad41e2acd87462e0d782fba5cc5d9"
+        ;;
+    *)
+        echo "Unsupported CMake version/architecture: ${CMAKE_VERSION}/${ARCH}" >&2
+        exit 1
+        ;;
+esac
 
 mkdir -p "${INSTALL_PREFIX}"
 
+INSTALLER="cmake-installer.sh"
 curl --silent --fail --show-error --location \
     "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${ARCH}.sh" \
-    --output cmake-installer.sh
+    --output "${INSTALLER}"
 
-chmod +x cmake-installer.sh
-./cmake-installer.sh --skip-license --prefix="${INSTALL_PREFIX}"
+printf '%s  %s\n' "${CMAKE_SHA256}" "${INSTALLER}" | sha256sum --check --strict
+
+chmod +x "${INSTALLER}"
+"./${INSTALLER}" --skip-license --prefix="${INSTALL_PREFIX}"

--- a/dockerfiles/install_googletest.sh
+++ b/dockerfiles/install_googletest.sh
@@ -8,12 +8,24 @@
 set -euo pipefail
 
 GOOGLE_TEST_VERSION="$1"
+case "${GOOGLE_TEST_VERSION}" in
+    1.16.0)
+        GOOGLE_TEST_SHA256="78c676fc63881529bf97bf9d45948d905a66833fbfa5318ea2cd7478cb98f399"
+        ;;
+    *)
+        echo "Unsupported googletest version: ${GOOGLE_TEST_VERSION}" >&2
+        exit 1
+        ;;
+esac
 
+GOOGLE_TEST_ARCHIVE="googletest-${GOOGLE_TEST_VERSION}.tar.gz"
 curl --silent --fail --show-error --location \
-    "https://github.com/google/googletest/releases/download/v${GOOGLE_TEST_VERSION}/googletest-${GOOGLE_TEST_VERSION}.tar.gz" \
-    --output gtest.tar.xz
+    "https://github.com/google/googletest/releases/download/v${GOOGLE_TEST_VERSION}/${GOOGLE_TEST_ARCHIVE}" \
+    --output "${GOOGLE_TEST_ARCHIVE}"
 
-tar xf gtest.tar.xz
+printf '%s  %s\n' "${GOOGLE_TEST_SHA256}" "${GOOGLE_TEST_ARCHIVE}" | sha256sum --check --strict
+
+tar xzf "${GOOGLE_TEST_ARCHIVE}"
 cd "googletest-${GOOGLE_TEST_VERSION}" && mkdir build && cd build
 
 cmake -GNinja .. -DCMAKE_POSITION_INDEPENDENT_CODE=ON

--- a/dockerfiles/install_ninja.sh
+++ b/dockerfiles/install_ninja.sh
@@ -10,10 +10,22 @@ set -euo pipefail
 NINJA_VERSION="$1"
 
 ARCH="$(uname -m)"
+case "${NINJA_VERSION}:${ARCH}" in
+    1.12.1:x86_64)
+        NINJA_SHA256="6f98805688d19672bd699fbbfa2c2cf0fc054ac3df1f0e6a47664d963d530255"
+        ;;
+    *)
+        echo "Unsupported Ninja version/architecture: ${NINJA_VERSION}/${ARCH}" >&2
+        exit 1
+        ;;
+esac
 
+NINJA_ARCHIVE="ninja-${NINJA_VERSION}-linux.zip"
 curl --silent --fail --show-error --location \
     "https://github.com/ninja-build/ninja/releases/download/v${NINJA_VERSION}/ninja-linux.zip" \
-    --output ninja.zip
+    --output "${NINJA_ARCHIVE}"
 
-unzip ninja.zip
+printf '%s  %s\n' "${NINJA_SHA256}" "${NINJA_ARCHIVE}" | sha256sum --check --strict
+
+unzip "${NINJA_ARCHIVE}"
 cp ninja /usr/local/bin

--- a/dockerfiles/install_patchelf.sh
+++ b/dockerfiles/install_patchelf.sh
@@ -11,6 +11,16 @@ PATCHELF_GIT_REF="${1:?usage: $0 <NixOS/patchelf git ref>}"
 INSTALL_PREFIX="${INSTALL_PREFIX:-/usr/local}"
 SOURCE_URL="https://github.com/NixOS/patchelf/archive/${PATCHELF_GIT_REF}.tar.gz"
 SHORT_GIT_REF="${PATCHELF_GIT_REF:0:12}"
+case "${PATCHELF_GIT_REF}" in
+    d0f70eea5397606c486857e0a105e53ec123904a)
+        PATCHELF_SHA256="0bda9fc5f4e233e655f591eff7c43ab9334f95ac04e39e26d6c1f85458daa3a7"
+        ;;
+    *)
+        echo "Unsupported patchelf git ref: ${PATCHELF_GIT_REF}" >&2
+        exit 1
+        ;;
+esac
+SOURCE_ARCHIVE="patchelf-${PATCHELF_GIT_REF}.tar.gz"
 
 # The PyPA manylinux base image installs a pipx patchelf at /usr/local/bin.
 # Remove that known install before installing our pinned source build so PATH
@@ -24,10 +34,12 @@ rm -rf "${PIPX_PATCHELF_VENV}"
 
 curl --silent --fail --show-error --location \
     "${SOURCE_URL}" \
-    --output patchelf.tar.gz
+    --output "${SOURCE_ARCHIVE}"
+
+printf '%s  %s\n' "${PATCHELF_SHA256}" "${SOURCE_ARCHIVE}" | sha256sum --check --strict
 
 mkdir -p src
-tar -xzf patchelf.tar.gz --strip-components=1 -C src
+tar -xzf "${SOURCE_ARCHIVE}" --strip-components=1 -C src
 
 cd src
 BASE_VERSION="$(cat version)"

--- a/dockerfiles/install_rust.sh
+++ b/dockerfiles/install_rust.sh
@@ -15,21 +15,41 @@
 set -euo pipefail
 
 RUST_VERSION="${1:-stable}"
+RUSTUP_INIT_VERSION="1.29.0"
+ARCH="$(uname -m)"
+case "${ARCH}" in
+    x86_64)
+        RUSTUP_TARGET="x86_64-unknown-linux-gnu"
+        RUSTUP_SHA256="4acc9acc76d5079515b46346a485974457b5a79893cfb01112423c89aeb5aa10"
+        ;;
+    aarch64)
+        RUSTUP_TARGET="aarch64-unknown-linux-gnu"
+        RUSTUP_SHA256="9732d6c5e2a098d3521fca8145d826ae0aaa067ef2385ead08e6feac88fa5792"
+        ;;
+    *)
+        echo "Unsupported rustup-init architecture: ${ARCH}" >&2
+        exit 1
+        ;;
+esac
+RUSTUP_BOOTSTRAP="rustup-init"
 
 export RUSTUP_HOME="/usr/local/rustup"
 export CARGO_HOME="/usr/local/cargo"
 
-echo "Installing Rust toolchain '${RUST_VERSION}' via rustup..."
+echo "Installing Rust toolchain '${RUST_VERSION}' via rustup-init ${RUSTUP_INIT_VERSION}..."
 curl --silent --fail --show-error --location \
-    "https://sh.rustup.rs" \
-    --output rustup-init.sh
+    "https://static.rust-lang.org/rustup/archive/${RUSTUP_INIT_VERSION}/${RUSTUP_TARGET}/rustup-init" \
+    --output "${RUSTUP_BOOTSTRAP}"
 
-sh rustup-init.sh -y \
+printf '%s  %s\n' "${RUSTUP_SHA256}" "${RUSTUP_BOOTSTRAP}" | sha256sum --check --strict
+
+chmod +x "${RUSTUP_BOOTSTRAP}"
+"./${RUSTUP_BOOTSTRAP}" -y \
     --no-modify-path \
     --profile minimal \
     --default-toolchain "${RUST_VERSION}"
 
-rm -f rustup-init.sh
+rm -f "${RUSTUP_BOOTSTRAP}"
 
 # Make the toolchain available system-wide.
 chmod -R a+rwX "${RUSTUP_HOME}" "${CARGO_HOME}"

--- a/dockerfiles/install_sccache.sh
+++ b/dockerfiles/install_sccache.sh
@@ -20,13 +20,24 @@ SCCACHE_ARCH="x86_64-unknown-linux-musl"
 
 SCCACHE_TARBALL="sccache-v${SCCACHE_VERSION}-${SCCACHE_ARCH}.tar.gz"
 SCCACHE_URL="https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/${SCCACHE_TARBALL}"
+case "${SCCACHE_VERSION}:${SCCACHE_ARCH}" in
+    0.14.0:x86_64-unknown-linux-musl)
+        SCCACHE_SHA256="8424b38cda4ecce616a1557d81328f3d7c96503a171eab79942fad618b42af44"
+        ;;
+    *)
+        echo "Unsupported sccache version/architecture: ${SCCACHE_VERSION}/${SCCACHE_ARCH}" >&2
+        exit 1
+        ;;
+esac
 
 echo "Downloading sccache ${SCCACHE_VERSION} for ${ARCH}..."
 curl --silent --fail --show-error --location \
     "${SCCACHE_URL}" \
-    --output sccache.tar.gz
+    --output "${SCCACHE_TARBALL}"
 
-tar xf sccache.tar.gz
+printf '%s  %s\n' "${SCCACHE_SHA256}" "${SCCACHE_TARBALL}" | sha256sum --check --strict
+
+tar xf "${SCCACHE_TARBALL}"
 cp "sccache-v${SCCACHE_VERSION}-${SCCACHE_ARCH}/sccache" /usr/local/bin/
 chmod +x /usr/local/bin/sccache
 

--- a/dockerfiles/install_shared_pythons.sh
+++ b/dockerfiles/install_shared_pythons.sh
@@ -23,15 +23,29 @@ PYTHON_VERSIONS=(
   "3.13.2"
   "3.14.0"
 )
+declare -Ar PYTHON_SHA256S=(
+  ["3.10.16"]="f2e22ed965a93cfeb642378ed6e6cdbc127682664b24123679f3d013fafe9cd0"
+  ["3.11.11"]="883bddee3c92fcb91cf9c09c5343196953cbb9ced826213545849693970868ed"
+  ["3.12.9"]="45313e4c5f0e8acdec9580161d565cf5fea578e3eabf25df7cc6355bf4afa1ee"
+  ["3.13.2"]="b8d79530e3b7c96a5cb2d40d431ddb512af4a563e863728d8713039aa50203f9"
+  ["3.14.0"]="88d2da4eed42fa9a5f42ff58a8bc8988881bd6c547e297e46682c2687638a851"
+)
 
 mkdir -p "${BUILD_ROOT}"
 
 download_python() {
   local version="$1"
   local url="https://www.python.org/ftp/python/${version}/Python-${version}.tgz"
+  local tarball="${BUILD_ROOT}/Python-${version}.tgz"
+  local expected_sha256="${PYTHON_SHA256S[${version}]:-}"
+  if [[ -z "${expected_sha256}" ]]; then
+    echo "[error] No SHA256 configured for Python ${version}" >&2
+    return 1
+  fi
   echo "[download] Python ${version}"
   curl --silent --fail --show-error --location "${url}" \
-    --output "${BUILD_ROOT}/Python-${version}.tgz"
+    --output "${tarball}"
+  printf '%s  %s\n' "${expected_sha256}" "${tarball}" | sha256sum --check --strict
 }
 
 build_python() {


### PR DESCRIPTION
## Motivation

Add integrity protection for the pinned third-party binaries and source archives fetched by the docker helper install scripts. These downloads were previously trusted based only on HTTPS and then executed or extracted immediately.

JIRA ID: ROCM-26750

Generated with Codex

## Test Plan

New image build via https://github.com/ROCm/TheRock/actions/runs/30248091598.

## Test Result

Building the new image passed, available at https://github.com/ROCm/TheRock/pkgs/container/therock_build_manylinux_x86_64/1069706460?tag=users-marbre-harden-downloads.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.

Generated with Codex