### PR TITLE
Drop repo launcher

### DIFF
--- a/dockerfiles/build_manylinux_x86_64.Dockerfile
+++ b/dockerfiles/build_manylinux_x86_64.Dockerfile
@@ -21,9 +21,6 @@ ENV PATH="/usr/local/therock-tools/bin:/opt/python/cp312-cp312/bin:${PATH}"
 RUN pip install --upgrade pip setuptools==69.1.1 wheel==0.46.2 && \
 pip install CppHeaderParser==2.7.4 meson==1.7.0 tomli==2.2.1 PyYAML==6.0.2
 
-######## Repo ########
-RUN curl https://storage.googleapis.com/git-repo-downloads/repo > /usr/local/bin/repo && chmod a+x /usr/local/bin/repo
-
 ######## CCache ########
 WORKDIR /install-ccache
 COPY install_ccache.sh ./


### PR DESCRIPTION
## Motivation

`repo` was downloaded with curl and made executable with no checksum verification. As it is no longer used, this patch drops it.

JIRA ID: ROCM-26750

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
