### PR TITLE
feat(ci): restrict ASAN sandbox runner to nightly builds only

### DIFF
--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -1021,11 +1021,12 @@ def _expand_build_config_for_platform(
                     f"disabling tests"
                 )
         elif build_variant == "host-asan":
-            # Run host-asan tests only on push (postsubmit)
-            if not ci_inputs.is_push:
+            # Run host-asan tests only on nightly (schedule or workflow_dispatch)
+            # due to limited ASAN runner capacity and stability concerns.
+            if not (ci_inputs.is_schedule or ci_inputs.is_workflow_dispatch):
                 test_runs_on = ""
                 print(
-                    f"  {family_name}: host-asan tests only run on postsubmit, "
+                    f"  {family_name}: host-asan tests only run on nightly, "
                     f"disabling tests"
                 )
             elif "test-runs-on-sandbox" in platform_info:


### PR DESCRIPTION
Change host-asan tests to only run on schedule/workflow_dispatch triggers (nightly) instead of push (postsubmit). This aligns with the existing full ASAN behavior and addresses limited ASAN runner capacity and stability concerns.

ISSUE ID: https://github.com/ROCm/TheRock/issues/6627