### PR TITLE
feat(ci): add ci:asan label to trigger ASAN CI on PRs

### DIFF
--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -578,7 +578,9 @@ def should_skip_ci(
         and git_context.has_submodule_changes is False
         and "ci:asan" not in ci_inputs.pr_labels
     ):
-        print("  Skipping: ASAN PR without submodule changes (add 'ci:asan' label to force)")
+        print(
+            "  Skipping: ASAN PR without submodule changes (add 'ci:asan' label to force)"
+        )
         return True
 
     if "ci:asan" in ci_inputs.pr_labels and ci_inputs.build_variant == "asan":

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -568,18 +568,21 @@ def should_skip_ci(
         print("  Skipping: 'ci:skip' PR label")
         return True
 
-    # Skip ASAN on PRs unless submodule changes are present.
+    # Skip ASAN on PRs unless submodule changes are present or ci:asan label is set.
     # This avoids running expensive ASAN builds on every PR while still
     # catching ASAN issues when library code (submodules) changes.
-    # TODO: Contributors may open draft PRs with submodule updates which run ASAN builds.
-    #       If overly expensive, remove that option
+    # The ci:asan label allows manual triggering of ASAN CI on any PR.
     if (
         ci_inputs.is_pull_request
         and ci_inputs.build_variant == "asan"
         and git_context.has_submodule_changes is False
+        and "ci:asan" not in ci_inputs.pr_labels
     ):
-        print("  Skipping: ASAN PR without submodule changes")
+        print("  Skipping: ASAN PR without submodule changes (add 'ci:asan' label to force)")
         return True
+
+    if "ci:asan" in ci_inputs.pr_labels and ci_inputs.build_variant == "asan":
+        print("  Running: 'ci:asan' PR label triggers ASAN CI")
 
     # If we have a list of changed files (push/pull_request events), check if
     # CI should run for that set of changed files. For example: if only .md

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -294,6 +294,15 @@ class TestShouldSkipCI(unittest.TestCase):
         )
         self.assertTrue(cm.should_skip_ci(inputs, git))
 
+    def test_asan_pr_with_ci_asan_label_runs(self):
+        """ASAN PR with ci:asan label runs CI even without submodule changes."""
+        inputs = self._inputs(build_variant="asan", pr_labels=["ci:asan"])
+        git = cm.GitContext(
+            changed_files=["CMakeLists.txt", "build_tools/script.py"],
+            submodule_paths=["rocm-libraries", "rocm-systems"],
+        )
+        self.assertFalse(cm.should_skip_ci(inputs, git))
+
     def test_asan_pr_with_submodule_change_runs(self):
         """ASAN PR with submodule changes runs CI."""
         inputs = self._inputs(build_variant="asan", pr_labels=[])


### PR DESCRIPTION
Add support for the ci:asan PR label to manually trigger ASAN CI on any pull request, even without submodule changes. This allows developers to explicitly request ASAN testing when needed.

By default, ASAN CI on PRs only runs when submodule changes are detected to avoid expensive builds on every PR. The ci:asan label bypasses this restriction.

ISSUE ID: #6627

Next steps: this will get propogated to r-l and r-s