### PR TITLE
Use filters to make python tar file extractions safer

### DIFF
--- a/build_tools/install_rocm_from_artifacts.py
+++ b/build_tools/install_rocm_from_artifacts.py
@@ -273,7 +273,7 @@ def _untar_files(output_dir: Path, destination: Path):
     """
     log(f"Extracting {destination.name} to {str(output_dir)}")
     with tarfile.open(destination) as extracted_tar_file:
-        extracted_tar_file.extractall(output_dir)
+        extracted_tar_file.extractall(output_dir, filter="tar")
     destination.unlink()
 
 

--- a/docs/development/ccache_troubleshooting.md
+++ b/docs/development/ccache_troubleshooting.md
@@ -152,7 +152,7 @@ dctx = zstandard.ZstdDecompressor()
 with open("ccache_logs.tar.zst", "rb") as f:
     reader = dctx.stream_reader(f)
     with tarfile.open(fileobj=reader, mode="r|") as tf:
-        tf.extractall("output_dir")
+        tf.extractall("output_dir", filter="tar")
 ```
 
 ### Using the analysis scripts


### PR DESCRIPTION
Restrict tar extraction to recommended behavior following PEP 706: https://peps.python.org/pep-0706/#filters

Using "tar" as filter for build_tools/install_rocm_from_artifacts.py, because the extracted release tarball contains .so linker symlinks that filter="data" can reject as unsafe; "tar" preserves them while still blocking ../ and absolute-path traversal, consistent with the sibling extractors artifact_manager.py and fetch_artifacts.py

Doc change is just to have at least the minimum of extraction safety, matching the script analyze_ccache_logs.py.

JIRA ID: ROCM-26879
