### PR TITLE
Set (top-level) workflow permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,6 +16,9 @@ on:
       - '.github/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/gitleaks_main.yml
+++ b/.github/workflows/gitleaks_main.yml
@@ -14,6 +14,9 @@ on:
   # the Security tab can be refreshed without an unrelated commit.
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   gitleaks:
     uses: ./.github/workflows/gitleaks.yml

--- a/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
@@ -70,12 +70,16 @@ on:
         type: string
         default: ""
 
+permissions:
+  contents: read
+
 jobs:
   build_stage:
     name: ${{ inputs.stage_display_name }}
     runs-on: ${{ inputs.build_runs_on }}
     timeout-minutes: ${{ inputs.timeout_minutes }}
     permissions:
+      contents: read
       id-token: write
     container:
       image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:a382085df3ba2419b58aa9051350883a0d0b732a4bc0a4ef60458f8161bb08c6

--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels_ci.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels_ci.yml
@@ -103,6 +103,9 @@ on:
           - ccache
         default: sccache
 
+permissions:
+  contents: read
+
 run-name: Build portable Linux PyTorch Wheels CI (${{ inputs.artifact_group }}, py${{ inputs.python_version }}, ${{ inputs.pytorch_git_ref }})
 
 jobs:

--- a/.github/workflows/multi_arch_build_windows_artifacts.yml
+++ b/.github/workflows/multi_arch_build_windows_artifacts.yml
@@ -67,12 +67,16 @@ on:
         type: string
         default: ""
 
+permissions:
+  contents: read
+
 jobs:
   build_stage:
     name: ${{ inputs.stage_display_name }}
     runs-on: ${{ inputs.build_runs_on }}
     timeout-minutes: ${{ inputs.timeout_minutes }}
     permissions:
+      contents: read
       id-token: write
     defaults:
       run:

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels_ci.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels_ci.yml
@@ -102,6 +102,9 @@ on:
           - ccache
         default: sccache
 
+permissions:
+  contents: read
+
 run-name: Build Windows PyTorch Wheels CI (${{ inputs.artifact_group }}, py${{ inputs.python_version }}, ${{ inputs.pytorch_git_ref }})
 
 jobs:

--- a/.github/workflows/multi_arch_build_wsl_rocdxg_artifacts.yml
+++ b/.github/workflows/multi_arch_build_wsl_rocdxg_artifacts.yml
@@ -48,6 +48,9 @@ on:
         type: string
         default: ""
 
+permissions:
+  contents: read
+
 jobs:
   build_stage:
     name: ${{ inputs.stage_display_name }}

--- a/.github/workflows/publish_dockerfile.yml
+++ b/.github/workflows/publish_dockerfile.yml
@@ -10,6 +10,9 @@ on:
       DOCKER_IMAGE_NAME:
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   build-and-push-image:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Motivation

The workflows have had job-level permissions set but no top-level workflow permissions. Restricting those to `contents: read` where applicable.

JIRA ID: ROCM-26883

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
