### PR TITLE
Set top-level permissions in bump_submodules.yml

### DIFF
--- a/.github/workflows/bump_submodules.yml
+++ b/.github/workflows/bump_submodules.yml
@@ -25,6 +25,10 @@ on:
       - rocm-systems
       - rocm-libraries
       - debug-tools/rocgdb/source
+
+permissions:
+  contents: read
+
 jobs:
   bump-submodules:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Motivation

Adds top-level permissions to restrict to `contents: read` by default.

JIRA ID: ROCM-26883

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
