### PR TITLE
Set top-level permissions in hip_tagging_automation.yml

### DIFF
--- a/.github/workflows/hip_tagging_automation.yml
+++ b/.github/workflows/hip_tagging_automation.yml
@@ -10,6 +10,9 @@ on:
     paths:
         - rocm-systems
 
+permissions:
+  contents: read
+
 jobs:
   tag-rocm-systems:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Motivation

Adds top-level permissions to restrict to `contents: read` by default.

JIRA ID: ROCM-26883

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
