### PR TITLE
Set top-level permissions

### DIFF
--- a/.github/workflows/notify_quartz.yml
+++ b/.github/workflows/notify_quartz.yml
@@ -66,6 +66,9 @@ on:
         type: string
         default: "main"
 
+permissions:
+  contents: read
+
 jobs:
   notify:
     name: Quartz - ${{ inputs.run_phase }} ${{ inputs.reporting_workflow }}


### PR DESCRIPTION
## Motivation

Adds top-level permissions to restrict to `contents: read` by default.

JIRA ID: ROCM-26883

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
