### PR TITLE
ci: show TheRock build commit in Multi-Arch run summary

### DIFF
--- a/.github/workflows/setup_multi_arch.yml
+++ b/.github/workflows/setup_multi_arch.yml
@@ -180,6 +180,8 @@ jobs:
           STAGE_REUSE_CURRENT_SHA: ${{ steps.checkout.outputs.commit }}
           STAGE_REUSE_MAX_AGE_HOURS: ${{ inputs.stage_reuse_max_age_hours }}
           STAGE_REUSE_COMMIT_HISTORY: ${{ inputs.stage_reuse_commit_history }}
+          THEROCK_COMMIT_SHA: ${{ steps.checkout.outputs.commit }}
+          THEROCK_REPOSITORY: ${{ inputs.repository || github.repository }}
           # Skip path filtering for external repos (git sha won't exist in TheRock)
           SKIP_PATH_FILTERS: ${{ inputs.external_repo != '' && 'true' || '' }}
           CI_CONFIG_PATH: ci-config

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -159,6 +159,10 @@ class CIInputs:
     prebuilt_stages: str = ""
     baseline_run_id: str = ""
 
+    # Resolved checkout identity (set by setup_multi_arch.yml)
+    therock_commit_sha: str = ""
+    therock_repository: str = ""
+
     def log(self) -> None:
         """Log parsed inputs for CI diagnostics."""
         print("CIInputs:")
@@ -257,6 +261,8 @@ class CIInputs:
             windows_test_labels=windows_test_labels,
             prebuilt_stages=os.environ.get("PREBUILT_STAGES", ""),
             baseline_run_id=os.environ.get("BASELINE_RUN_ID", ""),
+            therock_commit_sha=os.environ.get("THEROCK_COMMIT_SHA", ""),
+            therock_repository=os.environ.get("THEROCK_REPOSITORY", ""),
         )
 
 

--- a/build_tools/github_actions/configure_multi_arch_ci_summary.py
+++ b/build_tools/github_actions/configure_multi_arch_ci_summary.py
@@ -44,6 +44,14 @@ def format_summary(
         f"Trigger: `{ci_inputs.event_name}` on `{ci_inputs.commit_ref}`, "
         f"`{ci_inputs.build_variant}` variant."
     )
+    if ci_inputs.therock_commit_sha:
+        repo = ci_inputs.therock_repository or _REPO_SLUG
+        sha = ci_inputs.therock_commit_sha
+        short_sha = sha[:12]
+        lines.append(
+            f"TheRock commit: [`{short_sha}`]"
+            f"(https://github.com/{repo}/commit/{sha})"
+        )
     lines.append("")
 
     # Nothing to build (e.g. workflow_dispatch with no families selected)


### PR DESCRIPTION
## Summary

- Surface the resolved TheRock checkout commit SHA as a clickable GitHub link in the Multi-Arch workflow run summary (the `$GITHUB_STEP_SUMMARY` block titled "Multi-Arch CI Configuration").
- Today, identifying which TheRock commit was actually built requires digging into the setup job's checkout step logs. Worse, every job log shows a `Commit: <sha>` line at the top — but that is the *caller* repo's commit (e.g. `ROCm/rockrel`), not TheRock's, which is misleading for reusable-workflow runs.
- The new line appears right below the existing trigger/branch/variant line and renders as: `TheRock commit: [<short_sha>](https://github.com/<repo>/commit/<full_sha>)`.

## Changes

- `.github/workflows/setup_multi_arch.yml` — pass `THEROCK_COMMIT_SHA` and `THEROCK_REPOSITORY` env vars to the configure step from the checkout step output and repository input.
- `build_tools/github_actions/configure_multi_arch_ci.py` — add `therock_commit_sha` and `therock_repository` fields to `CIInputs`, parsed from the new env vars (defaults to empty, so no breakage).
- `build_tools/github_actions/configure_multi_arch_ci_summary.py` — render a clickable commit link in `format_summary()` when the SHA is available, using the repository slug for correct fork/non-default repo URLs.

## Test plan

- [x] All existing unit tests pass (94/95; the 1 pre-existing failure is an unrelated `boto3` import in an S3 test).
- [x] Summary-specific tests (`TestFormatSummary`, `TestWriteOutputs`) pass — the new fields default to empty strings, so existing `CIInputs()` calls in tests are unaffected.
- [ ] Verify in a real workflow run that the commit link appears in the run summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)