### PR TITLE
feat(ci): Add AMDGPU DKMS package version to driver/GPU sanity check

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -56,12 +56,15 @@ def _get_script_path(script_name: str) -> str:
 # --ulimit memlock=-1:-1 - Prevents memory allocation issues with ROCm inside container
 # --ulimit nofile=1048576:1048576 - Increase open file limit for RCCL
 # --security-opt seccomp=unconfined - enables memory mapping, and is recommended for containers running in HPC environments
+# -v /var/lib/dkms:/var/lib/dkms:ro - Read-only host DKMS state so the driver/GPU
+#   sanity check (print_driver_gpu_info.py) can report the AMDGPU DKMS version
 _BASE_CONTAINER_OPTIONS = [
     "--ipc host",
     "--user 0:0",
     "--ulimit memlock=-1:-1",
     "--ulimit nofile=1048576:1048576",
     "--security-opt seccomp=unconfined",
+    "-v /var/lib/dkms:/var/lib/dkms:ro",
 ]
 
 # GPU-specific container options (only applied when linux_cpu_runner != True)

--- a/build_tools/print_driver_gpu_info.py
+++ b/build_tools/print_driver_gpu_info.py
@@ -9,7 +9,7 @@ On Linux:
   - run "amd-smi static"
   - run "rocminfo"
   - run "uname -r"
-  - run "dkms status -m amdgpu"
+  - read "/var/lib/dkms" for the AMDGPU DKMS package version
 
 On Windows:
   - run "hipInfo.exe"
@@ -91,6 +91,52 @@ def run_command_with_search(
     log(f"{command}: command not found")
 
 
+DKMS_ROOT = Path("/var/lib/dkms")
+
+
+def log_dkms_status(module: str = "amdgpu") -> None:
+    """
+    Report a DKMS module's version(s) by reading /var/lib/dkms/<module>/.
+
+    This avoids invoking "dkms status", which requires root on some systems.
+    The on-disk layout mirrors the "dkms status" output:
+
+        /var/lib/dkms/<module>/<version>/<kernel>/<arch>/module
+
+    A module is reported as "installed" when the "module" directory exists for
+    that version/kernel/arch, otherwise "built".
+    """
+    label = f"{module} DKMS package version"
+    log(f"\n=== {label} ===")
+
+    module_root = DKMS_ROOT / module
+    if not module_root.is_dir():
+        log(f"{module}: no DKMS entry found under {DKMS_ROOT}")
+        return
+
+    found = False
+    for version_dir in sorted(module_root.iterdir()):
+        # Skip the "kernel-*" convenience symlinks; only walk real versions.
+        if version_dir.is_symlink() or not version_dir.is_dir():
+            continue
+        version = version_dir.name
+        for kernel_dir in sorted(version_dir.iterdir()):
+            # "source" is a symlink into /usr/src, not a kernel build.
+            if kernel_dir.name == "source" or not kernel_dir.is_dir():
+                continue
+            kernel = kernel_dir.name
+            for arch_dir in sorted(kernel_dir.iterdir()):
+                if not arch_dir.is_dir():
+                    continue
+                arch = arch_dir.name
+                state = "installed" if (arch_dir / "module").is_dir() else "built"
+                log(f"{module}/{version}, {kernel}, {arch}: {state}")
+                found = True
+
+    if not found:
+        log(f"{module}: no built modules found under {module_root}")
+
+
 def run_sanity(os_name: str) -> None:
     THIS_SCRIPT_DIR = Path(__file__).resolve().parent
     THEROCK_DIR = THIS_SCRIPT_DIR.parent
@@ -126,12 +172,7 @@ def run_sanity(os_name: str) -> None:
             args=["-r"],
             extra_command_search_paths=[bin_dir],
         )
-        run_command_with_search(
-            label="AMDGPU DKMS package version",
-            command="dkms",
-            args=["status", "-m", "amdgpu"],
-            extra_command_search_paths=[bin_dir],
-        )
+        log_dkms_status("amdgpu")
 
     log("\n=== End of sanity check ===")
 

--- a/build_tools/print_driver_gpu_info.py
+++ b/build_tools/print_driver_gpu_info.py
@@ -109,6 +109,14 @@ def log_dkms_status(module: str = "amdgpu") -> None:
     label = f"{module} DKMS package version"
     log(f"\n=== {label} ===")
 
+    # Diagnostic: report what is actually visible under /var/lib/dkms. Inside a
+    # container this is empty/missing unless the host path is bind-mounted in.
+    if DKMS_ROOT.is_dir():
+        entries = sorted(p.name for p in DKMS_ROOT.iterdir())
+        log(f"{DKMS_ROOT} contents: {entries if entries else '(empty)'}")
+    else:
+        log(f"{DKMS_ROOT}: directory does not exist (not mounted into container?)")
+
     module_root = DKMS_ROOT / module
     if not module_root.is_dir():
         log(f"{module}: no DKMS entry found under {DKMS_ROOT}")

--- a/build_tools/print_driver_gpu_info.py
+++ b/build_tools/print_driver_gpu_info.py
@@ -8,6 +8,8 @@ Sanity check script for CI runners.
 On Linux:
   - run "amd-smi static"
   - run "rocminfo"
+  - run "uname -r"
+  - run "dkms status -m amdgpu"
 
 On Windows:
   - run "hipInfo.exe"
@@ -122,6 +124,12 @@ def run_sanity(os_name: str) -> None:
             label="Kernel version",
             command="uname",
             args=["-r"],
+            extra_command_search_paths=[bin_dir],
+        )
+        run_command_with_search(
+            label="AMDGPU DKMS package version",
+            command="dkms",
+            args=["status", "-m", "amdgpu"],
             extra_command_search_paths=[bin_dir],
         )
 

--- a/build_tools/print_driver_gpu_info.py
+++ b/build_tools/print_driver_gpu_info.py
@@ -116,8 +116,13 @@ def log_dkms_status(module: str = "amdgpu") -> None:
 
     found = False
     for version_dir in sorted(module_root.iterdir()):
-        # Skip the "kernel-*" convenience symlinks; only walk real versions.
-        if version_dir.is_symlink() or not version_dir.is_dir():
+        # Skip the "kernel-*" convenience symlinks and the "original_module"
+        # backup directory; only walk real version directories.
+        if (
+            version_dir.is_symlink()
+            or version_dir.name == "original_module"
+            or not version_dir.is_dir()
+        ):
             continue
         version = version_dir.name
         for kernel_dir in sorted(version_dir.iterdir()):


### PR DESCRIPTION
## Summary

Adds the installed AMDGPU DKMS package version to the Linux CI runner sanity check in `build_tools/print_driver_gpu_info.py`, alongside the existing `amd-smi static`, `rocminfo`, and kernel version (`uname -r`) output. This makes runner driver state easier to diagnose from CI logs.

Rather than shelling out to `dkms status` (which requires root on some systems and would break running the script as a non-root user), a new `log_dkms_status()` helper reads `/var/lib/dkms/<module>/` directly. It walks the on-disk `<version>/<kernel>/<arch>` layout and reports each entry as `installed`/`built`, producing output equivalent to `dkms status` without elevated privileges. The `kernel-*` symlinks and the `original_module` backup directory are skipped.

Note: the script assumes Python 3.10+ (it already uses the `str | Path` PEP 604 annotation).

## Test plan

Verified as a non-root user on runners with different distros:

- [x] `dayatsin-test-01` (Python 3.12): lists both installed kernels for `amdgpu/6.18.10-2299007.24.04`
- [x] `f05-1` (Python 3.12): lists both installed kernels for `amdgpu/6.19.0-2372803.24.04`
- [x] `original_module` backup directory is correctly skipped (verified against b06-2's `/var/lib/dkms/amdgpu` layout)
- [x] Output matches prior `dkms status` and requires no `sudo`
- [x] Graceful handling when the module has no DKMS entry (prints "no DKMS entry found under /var/lib/dkms")

Made with [Cursor](https://cursor.com)
