### PR TITLE
Add CODEOWNERS specifically for python packages and key CI files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,17 @@
 # This file accumulated unrelated code, tighten reviews until cleaned up.
 /build_tools/github_actions/github_actions_api.py       @ScottTodd
 
+# Python packages. Changes to these paths must align with
+# https://github.com/ROCm/TheRock/blob/main/docs/packaging/python_packaging.md
+/build_tools/packaging/python           @ScottTodd @marbre
+/build_tools/build_python_packages.py   @ScottTodd @marbre
+/external-builds/pytorch                @ScottTodd
+
+# A few central CI system components that must align with
+# https://github.com/ROCm/TheRock/blob/main/docs/development/ci_overview.md
+/.github/workflows/setup_multi_arch.yml                   @ScottTodd
+/build_tools/github_actions/configure_multi_arch_ci.py    @ScottTodd
+
 # Debug tools configs and ROCgdb cmake wrapper.
 /debug-tools            @ROCm/TheRock-infra-write @ROCm/ROCm-DevTools-Debugger
 /debug-tools/rocgdb     @ROCm/TheRock-infra-write @ROCm/ROCm-DevTools-Debugger


### PR DESCRIPTION
## Motivation

Multiple PRs have been merged to these paths recently that needed closer review (went against packaging design, were missing meaningful tests, did not follow the style guide, etc.). For example:
* https://github.com/ROCm/TheRock/pull/6452
* https://github.com/ROCm/TheRock/pull/6850

Until we get enough policies documented (https://github.com/ROCm/TheRock/issues/6711) and automated enforcement (https://github.com/ROCm/TheRock/issues/5998) in place, I'd like to review all changes to these paths. I don't want to stay in CODEOWNERS for so many files given code review loads, but the cost of fixing these after review/merge is too high right now.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
