### PR TITLE
ci: show TheRock build commit in Multi-Arch run summary

### DIFF
--- a/.github/workflows/setup_multi_arch.yml
+++ b/.github/workflows/setup_multi_arch.yml
@@ -180,6 +180,8 @@ jobs:
           STAGE_REUSE_CURRENT_SHA: ${{ steps.checkout.outputs.commit }}
           STAGE_REUSE_MAX_AGE_HOURS: ${{ inputs.stage_reuse_max_age_hours }}
           STAGE_REUSE_COMMIT_HISTORY: ${{ inputs.stage_reuse_commit_history }}
+          THEROCK_COMMIT_SHA: ${{ steps.checkout.outputs.commit }}
+          THEROCK_REPOSITORY: ${{ inputs.repository || github.repository }}
           # Skip path filtering for external repos (git sha won't exist in TheRock)
           SKIP_PATH_FILTERS: ${{ inputs.external_repo != '' && 'true' || '' }}
           CI_CONFIG_PATH: ci-config

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -159,6 +159,10 @@ class CIInputs:
     prebuilt_stages: str = ""
     baseline_run_id: str = ""
 
+    # Resolved checkout identity (set by setup_multi_arch.yml)
+    therock_commit_sha: str = ""
+    therock_repository: str = ""
+
     def log(self) -> None:
         """Log parsed inputs for CI diagnostics."""
         print("CIInputs:")
@@ -257,6 +261,8 @@ class CIInputs:
             windows_test_labels=windows_test_labels,
             prebuilt_stages=os.environ.get("PREBUILT_STAGES", ""),
             baseline_run_id=os.environ.get("BASELINE_RUN_ID", ""),
+            therock_commit_sha=os.environ.get("THEROCK_COMMIT_SHA", ""),
+            therock_repository=os.environ.get("THEROCK_REPOSITORY", ""),
         )
 
 

--- a/build_tools/github_actions/configure_multi_arch_ci_summary.py
+++ b/build_tools/github_actions/configure_multi_arch_ci_summary.py
@@ -44,6 +44,14 @@ def format_summary(
         f"Trigger: `{ci_inputs.event_name}` on `{ci_inputs.commit_ref}`, "
         f"`{ci_inputs.build_variant}` variant."
     )
+    if ci_inputs.therock_commit_sha:
+        repo = ci_inputs.therock_repository or _REPO_SLUG
+        sha = ci_inputs.therock_commit_sha
+        short_sha = sha[:12]
+        lines.append(
+            f"TheRock commit: [`{short_sha}`]"
+            f"(https://github.com/{repo}/commit/{sha})"
+        )
     lines.append("")
 
     # Nothing to build (e.g. workflow_dispatch with no families selected)

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -24,7 +24,6 @@ from amdgpu_family_matrix import get_all_families_for_trigger_types
 from configure_multi_arch_ci_summary import format_summary
 from workflow_utils import WORKFLOWS_DIR
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -1448,6 +1447,41 @@ class TestFormatSummary(unittest.TestCase):
         # The summary should also mention that CI was skipped with some
         # explanation for why.
         self.assertIn("skipped", result)
+
+    def test_summary_includes_therock_commit_link(self):
+        """When therock_commit_sha is set, summary contains a clickable commit link."""
+        full_sha = "abc123def456abc123def456abc123def456abcd"
+        short_sha = full_sha[:12]
+        repo = "radhaksri/TheRock"
+        jobs = cm.JobDecisions(
+            build_rocm=cm.BuildRocmDecision(action=cm.JobAction.RUN),
+            test_rocm=cm.TestRocmDecision(action=cm.JobAction.RUN, test_type="full"),
+            build_rocm_python=cm.JobGroupDecision(action=cm.JobAction.RUN),
+            build_pytorch=cm.JobGroupDecision(action=cm.JobAction.RUN),
+            test_pytorch=cm.JobGroupDecision(action=cm.JobAction.RUN),
+            build_jax=cm.JobGroupDecision(action=cm.JobAction.SKIP),
+        )
+        outputs = cm.CIOutputs(is_ci_enabled=True, jobs=jobs)
+        result = format_summary(
+            self._inputs(therock_commit_sha=full_sha, therock_repository=repo),
+            outputs,
+        )
+        self.assertIn(short_sha, result)
+        self.assertIn(f"https://github.com/{repo}/commit/{full_sha}", result)
+
+    def test_summary_omits_commit_link_when_sha_empty(self):
+        """When therock_commit_sha is empty, no commit link line appears."""
+        jobs = cm.JobDecisions(
+            build_rocm=cm.BuildRocmDecision(action=cm.JobAction.RUN),
+            test_rocm=cm.TestRocmDecision(action=cm.JobAction.RUN, test_type="full"),
+            build_rocm_python=cm.JobGroupDecision(action=cm.JobAction.RUN),
+            build_pytorch=cm.JobGroupDecision(action=cm.JobAction.RUN),
+            test_pytorch=cm.JobGroupDecision(action=cm.JobAction.RUN),
+            build_jax=cm.JobGroupDecision(action=cm.JobAction.SKIP),
+        )
+        outputs = cm.CIOutputs(is_ci_enabled=True, jobs=jobs)
+        result = format_summary(self._inputs(), outputs)
+        self.assertNotIn("TheRock commit:", result)
 
 
 class TestWriteOutputs(unittest.TestCase):


### PR DESCRIPTION
Closes #6899

## Summary

- Surface the resolved TheRock checkout commit SHA as a clickable GitHub link in the Multi-Arch workflow run summary (the `$GITHUB_STEP_SUMMARY` block titled "Multi-Arch CI Configuration").
- Today, identifying which TheRock commit was actually built requires digging into the setup job's checkout step logs. Worse, every job log shows a `Commit: <sha>` line at the top — but that is the *caller* repo's commit (e.g. `ROCm/rockrel`), not TheRock's, which is misleading for reusable-workflow runs.
- The new line appears right below the existing trigger/branch/variant line and renders as: `TheRock commit: [<short_sha>](https://github.com/<repo>/commit/<full_sha>)`.

## Changes

- `.github/workflows/setup_multi_arch.yml` — pass `THEROCK_COMMIT_SHA` and `THEROCK_REPOSITORY` env vars to the configure step from the checkout step output and repository input.
- `build_tools/github_actions/configure_multi_arch_ci.py` — add `therock_commit_sha` and `therock_repository` fields to `CIInputs`, parsed from the new env vars (defaults to empty, so no breakage).
- `build_tools/github_actions/configure_multi_arch_ci_summary.py` — render a clickable commit link in `format_summary()` when the SHA is available, using the repository slug for correct fork/non-default repo URLs.
- `build_tools/github_actions/tests/configure_multi_arch_ci_test.py` — add two test cases to `TestFormatSummary` covering the commit link rendering (present when SHA is set, absent when empty).

## Test plan

- [x] All existing unit tests pass (96/97; the 1 pre-existing failure is an unrelated `boto3` import in an S3 test).
- [x] New `test_summary_includes_therock_commit_link` and `test_summary_omits_commit_link_when_sha_empty` tests pass.
- [ ] Verify in a real workflow run that the commit link appears in the run summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)