### PR TITLE
chore(compiler): bump amd-llvm to SMP 23.13 (offload-arch Windows DLL fix)

### DIFF
--- a/tests/test_rocm_sanity.py
+++ b/tests/test_rocm_sanity.py
@@ -86,11 +86,6 @@ class TestROCmSanity:
     @pytest.mark.skipif(
         is_asan(), reason="hipcc test fails with ASAN build, see TheRock#3313"
     )
-    # TODO(#4755): Re-enable test for windows once offload-arch.exe is fixed
-    @pytest.mark.skipif(
-        is_windows(),
-        reason="Windows offload-arch.exe is not retrieving correct data, ignoring test",
-    )
     def test_hip_printf(self):
         platform_executable_suffix = ".exe" if is_windows() else ""
 


### PR DESCRIPTION
## Summary

Bumps `compiler/amd-llvm` from `c47eb211` to `2a67d831`, bringing the
`offload-arch` Windows DLL search-path fix from upstream LLVM onto the
current pin, and reverts #5346 to re-enable the Windows `offload-arch`
sanity check now that the fix is in place.

### 1. amd-llvm SMP bump

Cherry-picked on top of the current pin:

| PR | Title |
|----|-------|
| llvm/llvm-project#209898 | `[offload-arch] Fix amdgpu HIP DLL search path on Windows` |

This upstream fix (merged to `amd-staging` as `0769e6d0`, same commit as
upstream) corrects `primeLibraryLoad()` to pass a native backslash path
to `LoadLibraryExW`, which requires backslashes for fully-qualified
paths. It applied cleanly with no conflicts and carries a
`(cherry picked from ...)` provenance line. The prerequisite
`primeLibraryLoad()` (llvm/llvm-project#194063) is already in the pin's
base, so the pick is self-contained.

Numbering: follows SMP 23.12 (the current pin `c47eb211`), so this is
**SMP 23.13**.

### 2. Revert #5346 (re-enable Windows offload-arch test)

Reverts the `is_windows()` skip on `test_hip_printf` added in #5346. With
the fix landing in the same PR, re-enabling the check gives signal that
`offload-arch` works on all Windows test runners.

ISSUE ID: #6571
