### PR TITLE
ci(jax): respect GPU isolation on JAX test runners

### DIFF
--- a/.github/workflows/test_linux_jax_wheels_partial.yml
+++ b/.github/workflows/test_linux_jax_wheels_partial.yml
@@ -282,8 +282,6 @@ jobs:
           unset HIP_DEVICE_LIB_PATH
           unset JAX_ROCM_PLUGIN_INTERNAL_BITCODE_PATH
           unset JAX_ROCM_PLUGIN_INTERNAL_LLD_PATH
-          unset HIP_VISIBLE_DEVICES
-          unset ROCR_VISIBLE_DEVICES
 
           python -c "import jax; print(jax.local_devices())"
 


### PR DESCRIPTION
## Summary

JAX test jobs were discarding the GPU isolation supplied by the runner, letting a job on a 1-GPU runner use every GPU on the host. This removes the two `unset` calls responsible.

## Problem

`test_linux_jax_wheels_partial.yml` unset `HIP_VISIBLE_DEVICES` and `ROCR_VISIBLE_DEVICES` before running tests. Those are exactly the variables the runner provides through `--env-file /etc/podinfo/gha-gpu-isolation-settings`, and since the container is given `/dev/kfd` and `/dev/dri` outright, that env file is the only isolation mechanism in play.

So a job scheduled on `linux-gfx942-1gpu-ccs-csp-ossci-rocm` enumerates all 8 GPUs and allocates across them.

## Impact

In [run 30032481350](https://github.com/ROCm/TheRock/actions/runs/30032481350) all 15 test jobs saw 8 devices, and three failed with `RESOURCE_EXHAUSTED` on GPUs they were never assigned, all in `multi_device_test.py::MultiDeviceTest::test_lax_full_like_efficient`:

| Job | Allocation | Allocator |
|---|---|---|
| [py3.14 / v0.10.2](https://github.com/ROCm/TheRock/actions/runs/30032481350/job/89307813608) | 12 GiB | `GPU_5_bfc` |
| [py3.11 / v0.10.2](https://github.com/ROCm/TheRock/actions/runs/30032481350/job/89308971448) | 12 GiB | `GPU_7_bfc` |
| [py3.13 / v0.10.1](https://github.com/ROCm/TheRock/actions/runs/30032481350/job/89308509210) | 16 GiB | `XLA_backend_5_bfc` |

A 12 GiB allocation is trivial for a 192 GiB MI300X, so those GPUs were occupied by other tenants. This produces flaky failures that look like JAX or ROCm bugs, and our jobs can equally OOM other workloads on the same host.

## Why this fix

Five workflows mount the isolation env file `test_pytorch_wheels.yml`, `test_pytorch_wheels_full.yml`, `test_rocm_wheels.yml`, `test_linux_jax_wheels.yml`, and this one. Only this one unsets the masks; removing them restores parity.

The remaining unsets (`ROCM_ROOT`, `HIP_DEVICE_LIB_PATH`, `JAX_ROCM_PLUGIN_INTERNAL_*`) are unrelated to GPU visibility, they exist because the image is deliberately `/opt/rocm`-less and are left in place. No test logic, runner selection, or matrix configuration is touched.

## Note on multi-device coverage

With isolation respected, jobs on 1-GPU runners see one GPU, so `run_pytest_rocm.sh` will skip the `multiaccelerator` subset (it gates on `gpu_count > 1`). Those tests need a properly labeled multi-GPU runner, tracked separately in #6853. Measured cost of that subset is 3:13 for 855 tests.

## Tests

**Mechanism confirmed.** To show the masks were the cause rather than a correlation, I re-applied them explicitly after the unsets on a 1-GPU runner ([run 30325982453](https://github.com/ROCm/TheRock/actions/runs/30325982453)):

```
Number of GPUs detected: 1
[RocmDevice(id=0)]
```

`rocminfo` and JAX both reported one device, versus 8 in every unmasked run on the same runner label.

**Verification of this branch.** [Run 30375175749](https://github.com/ROCm/TheRock/actions/runs/30375175749) on `linux-gfx942-1gpu-ccs-csp-ossci-rocm`, covering `multi_device_test.py` (the test that OOM'd above), `core_test.py`, `util_test.py` and `scipy_stats_test.py`.

| Check | Expected | Result |
|---|---|---|
| Devices visible to JAX | `[RocmDevice(id=0)]` | `[RocmDevice(id=0)]` - 1 device |
| Cross-tenant OOM | none | none |
| Overall conclusion | success | success |

Per-file results:
| Test file | Result |
|---|---|
| `multi_device_test.py` | 2 passed, 18 skipped (3.87s) |
| `core_test.py` | 480 passed (40.04s) |
| `util_test.py` | 19 passed, 6 subtests passed (0.87s) |
| `scipy_stats_test.py` | 982 passed (282.69s) |

The `multi_device_test.py` numbers are the expected consequence of restoring isolation. On the same file **before** the fix, [job 89307813608](https://github.com/ROCm/TheRock/actions/runs/30032481350/job/89307813608) ran 19 passed / 1 failed, the failure being the cross-tenant OOM because the job could see 8 GPUs. With one GPU visible, 18 of those 20 tests correctly skip as requiring multiple devices, and `test_lax_full_like_efficient` no longer OOMs.
That skipped coverage is real and is what #6853 exists to restore, on a runner where multiple GPUs are actually allocated to us rather than borrowed from neighbours.


## Submission Checklist
- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.