### PR TITLE
docs: mark gfx90c as Build Passing on Linux and Windows

### DIFF
--- a/SUPPORTED_GPUS.md
+++ b/SUPPORTED_GPUS.md
@@ -66,7 +66,7 @@ See also the [ROCm Device Support Wishlist GitHub Discussion](https://github.com
 | RDNA1        | gfx1011     | ✅            | ✅            | ✅            |
 | RDNA1        | gfx1010     | ✅            | ✅            | ✅            |
 | GCN5.1       | gfx906      | ✅            |               |               |
-| GCN5.0       | gfx90c      |               |               |               |
+| GCN5.0       | gfx90c      | ✅            |               |               |
 | GCN5.0       | gfx900      | ✅            |               |               |
 
 ## ROCm on Windows
@@ -98,5 +98,5 @@ Check [windows_support.md](https://github.com/ROCm/TheRock/blob/main/docs/develo
 | RDNA1        | gfx1011     | ✅            | ✅            | ✅            |
 | RDNA1        | gfx1010     | ✅            | ✅            | ✅            |
 | GCN5.1       | gfx906      | ✅            |               |               |
-| GCN5.0       | gfx90c      |               |               |               |
+| GCN5.0       | gfx90c      | ✅            |               |               |
 | GCN5.0       | gfx900      | ✅            |               |               |


### PR DESCRIPTION
## Motivation

gfx90c builds (ROCm and torch) are now passing and being published at https://rocm.nightlies.amd.com/whl-multi-arch/
* Progress on https://github.com/ROCm/TheRock/issues/3818

## Technical Details

Update `SUPPORTED_GPUS.md` to indicate the builds are now passing.

## Test Plan

Local build and TheRock nightly CI

## Test Result

Build passes locally and w/ nightly CI https://github.com/ROCm/rockrel/actions/runs/30316789061

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
