### PR TITLE
fix(wsl-rocdxg): propagate CMAKE_INSTALL_LIBDIR to rocdxg build

### DIFF
--- a/core/wsl-rocdxg/wsl_build_rocdxg.sh.in
+++ b/core/wsl-rocdxg/wsl_build_rocdxg.sh.in
@@ -30,6 +30,7 @@ mkdir -p "$build_root" "$install_root" "$stage_root"
 cmake -B "$build_root" -S "$rocdxg_source_dir" -G Ninja \
   -DCMAKE_BUILD_TYPE="@CMAKE_BUILD_TYPE@" \
   -DCMAKE_INSTALL_PREFIX="$install_root" \
+  -DCMAKE_INSTALL_LIBDIR="@CMAKE_INSTALL_LIBDIR@" \
   -DWIN_SDK="$win_sdk"
 cmake --build "$build_root" --target rocdxg -- -k 0
 cmake --install "$build_root"


### PR DESCRIPTION
## Motivation
The WSL rocdxg build (core/wsl-rocdxg/wsl_build_rocdxg.sh.in) invokes CMake externally via a shell script, bypassing the TheRock-generated toolchain that propagates CMAKE_INSTALL_LIBDIR=lib to all other subprojects. Without this variable, libhsakmt's GNUInstallDirs defaults to lib64 on RHEL-style systems, causing librocdxg.so to install to lib64/ instead of lib/.

Fix: add -DCMAKE_INSTALL_LIBDIR="@CMAKE_INSTALL_LIBDIR@" to the cmake configure invocation in the shell script template. The @CMAKE_INSTALL_LIBDIR@ substitution is handled by configure_file(@ONLY) at TheRock configure time, so the WSL build automatically follows any future change to the top-level setting (CMakeLists.txt:336).

JIRA ID : https://amd-hub.atlassian.net/browse/ROCM-28578

## Technical Details

**Root cause:** core/wsl-rocdxg/wsl_build_rocdxg.sh.in drives an external cmake invocation that never receives the TheRock toolchain (see cmake/therock_subproject.cmake:1673 for how the toolchain propagates CMAKE_INSTALL_LIBDIR to all normal subprojects). libhsakmt/CMakeLists.txt includes GNUInstallDirs (line 56) and installs to ${CMAKE_INSTALL_LIBDIR}, which defaults to lib64 on RHEL-style distros.

**Fix:** One-line addition of -DCMAKE_INSTALL_LIBDIR="@CMAKE_INSTALL_LIBDIR@" using the existing configure_file substitution mechanism already used for CMAKE_BUILD_TYPE in the same template.
**Scope:** WSL/rocdxg builds only. No impact on other subprojects or non-WSL builds.

## Test Plan

Verify the ci build to confirm wsl packages are installed in /lib folder instead of /lib-64

## Test Results
```
dpkg -c amdrocm-wsl7.15_7.15.0~dev20260728-30396762191_amd64.deb
drwxr-xr-x root/root         0 2026-07-28 16:49 ./
drwxr-xr-x root/root         0 2026-07-28 16:49 ./opt/
drwxr-xr-x root/root         0 2026-07-28 16:49 ./opt/rocm/
drwxr-xr-x root/root         0 2026-07-28 16:49 ./opt/rocm/core-7.15/
drwxr-xr-x root/root         0 2026-07-28 16:49 ./opt/rocm/core-7.15/lib/
-rw-r--r-- root/root   4960656 2026-07-28 16:49 ./opt/rocm/core-7.15/lib/librocdxg.so.1.1.0
drwxr-xr-x root/root         0 2026-07-28 15:55 ./opt/rocm/core-7.15/share/
drwxr-xr-x root/root         0 2026-07-28 16:49 ./opt/rocm/core-7.15/share/doc/
drwxr-xr-x root/root         0 2026-07-28 16:49 ./opt/rocm/core-7.15/share/doc/amdrocm-wsl7.15/
-rw-r--r-- root/root       180 2026-07-28 16:49 ./opt/rocm/core-7.15/share/doc/amdrocm-wsl7.15/changelog.Debian.gz
drwxr-xr-x root/root         0 2026-07-28 15:55 ./opt/rocm/core-7.15/share/doc/rocdxg/
-rw-r--r-- root/root      2584 2026-07-28 15:47 ./opt/rocm/core-7.15/share/doc/rocdxg/LICENSE.md
lrwxrwxrwx root/root         0 2026-07-28 16:49 ./opt/rocm/core-7.15/**lib**/librocdxg.so -> librocdxg.so.1
lrwxrwxrwx root/root         0 2026-07-28 16:49 ./opt/rocm/core-7.15/**lib**/librocdxg.so.1 -> librocdxg.so.1.1.0

```