### PR TITLE
fix(ci): derive sanitizer runtime dir from clang, not hardcoded lib/linux

### DIFF
--- a/cmake/therock_subproject_dep_provider.cmake
+++ b/cmake/therock_subproject_dep_provider.cmake
@@ -142,14 +142,36 @@ if(THEROCK_INCLUDE_CLANG_RESOURCE_DIR_RPATH)
     # This will yield an absolute path like: /some/long/path/lib/llvm/lib/clang/20
     # The version number on the end is all we want as we will form the correct
     # prefix relative path from that.
-    # The actual libraries live under lib/linux in that directory. We shamelessly
-    # just hardcode "linux" since that is the only system we do RPATH munging for.
     cmake_path(GET _abs_resource_dir FILENAME _clang_version)
     set(_prefix_resource_dir "lib/llvm/lib/clang/${_clang_version}")
-    list(APPEND THEROCK_PRIVATE_INSTALL_RPATH_DIRS "${_prefix_resource_dir}/lib/linux")
+    # Which sub-directory of the resource dir holds the runtimes depends on how
+    # the toolchain was configured: LLVM_ENABLE_PER_TARGET_RUNTIME_DIR (which
+    # TheRock enables for its own amd-llvm) installs them to lib/<target-triple>
+    # and leaves no lib/linux at all, so ask clang rather than assuming. A
+    # toolchain can also report a per-target dir that only holds non-sanitizer
+    # runtimes (i.e. flang_rt) while compiler-rt still lives in lib/linux, so
+    # only trust the reported dir if it actually has shared sanitizer runtimes.
+    execute_process(
+      COMMAND "${CMAKE_CXX_COMPILER}" --print-runtime-dir
+      OUTPUT_VARIABLE _abs_runtime_dir
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      RESULT_VARIABLE _runtime_dir_status
+    )
+    set(_runtime_libs)
+    if(_runtime_dir_status EQUAL 0 AND _abs_runtime_dir)
+      file(GLOB _runtime_libs "${_abs_runtime_dir}/libclang_rt.*.so")
+    endif()
+    if(NOT _runtime_libs)
+      set(_abs_runtime_dir "${_abs_resource_dir}/lib/linux")
+      message(STATUS "No shared sanitizer runtimes found via ${CMAKE_CXX_COMPILER} --print-runtime-dir: falling back to ${_abs_runtime_dir}")
+    endif()
+    # The install RPATH is prefix relative, so mirror the same sub-directory.
+    cmake_path(RELATIVE_PATH _abs_runtime_dir BASE_DIRECTORY "${_abs_resource_dir}"
+      OUTPUT_VARIABLE _rel_runtime_dir)
+    list(APPEND THEROCK_PRIVATE_INSTALL_RPATH_DIRS "${_prefix_resource_dir}/${_rel_runtime_dir}")
     # Build tree needs absolute paths to the resource dir.
-    list(APPEND THEROCK_PRIVATE_BUILD_RPATH_DIRS "${_abs_resource_dir}/lib/linux")
-    message(STATUS "Added clang resource dir to RPATH: ${_prefix_resource_dir} (since sanitizer enabled)")
+    list(APPEND THEROCK_PRIVATE_BUILD_RPATH_DIRS "${_abs_runtime_dir}")
+    message(STATUS "Added clang resource dir to RPATH: ${_prefix_resource_dir}/${_rel_runtime_dir} (since sanitizer enabled)")
   endblock()
 endif()
 
@@ -171,12 +193,57 @@ block(PROPAGATE THEROCK_SANITIZER_LAUNCHER)
     else()
       message(FATAL_ERROR "Unknown processor ${CMAKE_SYSTEM_PROCESSOR}")
     endif()
-    execute_process(
-      COMMAND ${CMAKE_CXX_COMPILER} "--print-file-name=libclang_rt.${_suffix}-${_arch_suffix}.so"
-      OUTPUT_VARIABLE _rt_path
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-      COMMAND_ERROR_IS_FATAL ANY
-    )
+    # With LLVM_ENABLE_PER_TARGET_RUNTIME_DIR the runtime is named
+    # libclang_rt.<sanitizer>.so with no arch suffix, so probe both names. Since
+    # clang echoes the query back verbatim when it cannot find the file, only an
+    # absolute path that exists counts as resolved: a bare soname would make the
+    # LD_PRELOAD silently fail and run the tool with no sanitizer at all.
+    set(_rt_names "libclang_rt.${_suffix}.so" "libclang_rt.${_suffix}-${_arch_suffix}.so")
+    set(_rt_path)
+    set(_rt_probe_log)
+    foreach(_rt_name ${_rt_names})
+      execute_process(
+        COMMAND ${CMAKE_CXX_COMPILER} "--print-file-name=${_rt_name}"
+        OUTPUT_VARIABLE _rt_candidate
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        COMMAND_ERROR_IS_FATAL ANY
+      )
+      string(APPEND _rt_probe_log "\n      --print-file-name=${_rt_name} -> ${_rt_candidate}")
+      if(IS_ABSOLUTE "${_rt_candidate}" AND EXISTS "${_rt_candidate}")
+        set(_rt_path "${_rt_candidate}")
+        break()
+      endif()
+    endforeach()
+    if(NOT _rt_path)
+      # Only pay for the extra diagnostic queries on the failure path.
+      execute_process(
+        COMMAND "${CMAKE_CXX_COMPILER}" --print-resource-dir
+        OUTPUT_VARIABLE _rt_resource_dir
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+      )
+      execute_process(
+        COMMAND "${CMAKE_CXX_COMPILER}" --print-runtime-dir
+        OUTPUT_VARIABLE _rt_runtime_dir
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+      )
+      message(FATAL_ERROR
+        "Could not resolve the shared ${THEROCK_SANITIZER} runtime library required to "
+        "run build time tools under the sanitizer.\n"
+        "    Sanitizer   : ${THEROCK_SANITIZER}\n"
+        "    Compiler    : ${CMAKE_CXX_COMPILER}\n"
+        "    Resource dir: ${_rt_resource_dir}\n"
+        "    Runtime dir : ${_rt_runtime_dir}\n"
+        "    Probed sonames (clang echoes the query back verbatim when it cannot find "
+        "the file, so a bare soname below means NOT FOUND):${_rt_probe_log}\n"
+        "Provide a shared sanitizer runtime for this toolchain (compiler-rt built with "
+        "COMPILER_RT_BUILD_SANITIZERS=ON) or disable the sanitizer for this build. "
+        "Refusing to continue: an unresolvable LD_PRELOAD is ignored by the loader, so "
+        "carrying on here would silently run build time tools with no sanitizer at all "
+        "rather than failing."
+      )
+    endif()
     set(THEROCK_SANITIZER_LAUNCHER
       "${CMAKE_COMMAND}" -E env "LD_PRELOAD=${_rt_path}" --
     )


### PR DESCRIPTION
## Motivation

Fixes https://github.com/ROCm/TheRock/issues/6801

ASAN builds fail at **build time** with a loader error as soon as an instrumented build-time host tool is executed:

```text
.../GPUArchitectureGenerator: error while loading shared libraries: libclang_rt.asan.so: cannot open shared object file: No such file or directory
ninja: build stopped: subcommand failed.
```

The same failure reproduces in the downstream `rocm-libraries` hipBLASLt ASAN job (`Build (hipBLASLt | gfx942 | HOST_ASAN)`) for `tensilelite/rocisa`'s `tablegen_inst_gen`, so this is not specific to one sub-project — it hits any sanitized sub-project that runs a host code generator during its build.

## Technical Details

Since #5758, TheRock configures its own `amd-llvm` with `LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=ON` unconditionally for non-Windows (`compiler/CMakeLists.txt`). That installs the compiler-rt runtimes to `<resource_dir>/lib/<target-triple>/` with **no** architecture suffix and creates **no** `lib/linux` directory at all. On the toolchain built by this repo today:

```console
$ clang++ -print-resource-dir
.../lib/llvm/lib/clang/23
$ ls .../lib/llvm/lib/clang/23/lib
amdgcn-amd-amdhsa
x86_64-unknown-linux-gnu          # <- no "linux"
$ ls .../lib/clang/23/lib/x86_64-unknown-linux-gnu/libclang_rt.asan.so
libclang_rt.asan.so               # <- no "-x86_64" suffix
```

Two places in `cmake/therock_subproject_dep_provider.cmake` still assumed the legacy layout.

### 1. Dead sanitizer RPATH entry (the build failure)

`cmake/therock_sanitizers.cmake` adds `-shared-libsan`, so every C/C++ binary in a sanitized sub-project gets `DT_NEEDED: libclang_rt.asan.so`. clang passes the runtime by absolute path on the link line but adds **no** `-rpath`, so the binary carries no `DT_RPATH`/`DT_RUNPATH` covering it:

```console
$ clang -fsanitize=address -shared-libasan demo.c -o demo && readelf -d demo | grep -E 'clang_rt|RPATH|RUNPATH'
 0x0000000000000001 (NEEDED)             Shared library: [libclang_rt.asan.so]
$ ./demo
./demo: error while loading shared libraries: libclang_rt.asan.so: cannot open shared object file: No such file or directory
```

`THEROCK_INCLUDE_CLANG_RESOURCE_DIR_RPATH` exists to close exactly that gap, but the RPATH directories hardcoded `lib/linux` (with a comment noting it "shamelessly just hardcode[s] 'linux'"). Under per-target runtime dirs that directory does not exist, so `therock_global_post_subproject.cmake` applied a dead `BUILD_RPATH` and the tool could not load.

Both the absolute build RPATH and the prefix-relative install RPATH are now derived from the same `clang --print-runtime-dir` query, with the install path obtained as the runtime dir *relative to the resource dir* rather than by pasting a different hardcoded token.

One extra guard worth calling out: `--print-runtime-dir` reports the per-target directory whenever it exists, even if only non-sanitizer runtimes were installed there. A packaged ROCm toolchain on this machine does exactly that — it reports `lib/x86_64-unknown-linux-gnu`, which holds only `libflang_rt.*`, while compiler-rt still lives in `lib/linux`. Trusting the report blindly would have *regressed* that layout, so the reported directory is only used when it actually contains shared sanitizer runtimes; otherwise it falls back to the previous `lib/linux` behavior with a `message(STATUS)`. This is also why `--print-runtime-dir` was preferred over the `--print-target-triple` sketch in the issue: it needs no branching and is the value clang itself uses.

This RPATH fallback stays non-fatal on purpose: a runtime directory that cannot be located here is a *degraded RPATH*, not necessarily unsanitized execution, and the binary may still resolve its runtime by other means.

### 2. `THEROCK_SANITIZER_LAUNCHER` was silently doing nothing (found incidentally)

The launcher resolved the runtime with `--print-file-name=libclang_rt.asan-x86_64.so`. **clang echoes an unfound query back verbatim**, so on a per-target toolchain the launcher became a bare, unresolvable soname:

```text
-- Sanitizer launcher: .../cmake;-E;env;LD_PRELOAD=libclang_rt.asan-x86_64.so;--
```

A failed `LD_PRELOAD` is reported by `ld.so` and then **ignored**, so nothing fails and the tool just runs unsanitized. Counting ASAN mappings in `/proc/self/maps` shows how complete the degradation is — **0** mappings with the bare soname versus **4** with the resolved absolute path:

```console
$ LD_PRELOAD=libclang_rt.asan-x86_64.so /bin/echo "tool still ran (UNSANITIZED)"
ERROR: ld.so: object 'libclang_rt.asan-x86_64.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
tool still ran (UNSANITIZED)
exit=0 ; asan mappings -> 0
```

The query now tries the suffix-less name as well as the arch-suffixed one and accepts **only** an absolute path that exists, precisely because a bare soname is indistinguishable from "not found" and degrades silently to no sanitization.

If nothing resolves, the configure **fails** with `FATAL_ERROR`. A sanitized build must either be sanitized or fail: the 0-vs-4 measurement above is a build that looks entirely healthy while providing no sanitization at all, and a warning scrolling past in a superbuild log does not prevent that. Because this file is injected into every sub-project's configure, the blast radius was checked explicitly — the block is guarded by `if(LINUX AND THEROCK_SANITIZER)`, so a non-sanitized configure never reaches it (verified below, including against a deliberately broken toolchain), and both real toolchains available here resolve successfully. The error is written to be diagnosable on its own, naming the sanitizer, compiler, resource dir, runtime dir and every soname probed with its raw `--print-file-name` output.

## Test Plan

A full superbuild takes hours, so validation was done on the mechanism rather than end to end. Two real toolchains were used:

- **per-target**: TheRock's own `amd-llvm` built at the CI-pinned commit `44146cd73e5e016e4e89bfdcb1322c83f24071bf` (`LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=ON`).
- **legacy/packaged**: `/opt/rocm-versions/gfx950-7.15.0a20260710` (compiler-rt in `lib/linux`).

1. Probe `--print-runtime-dir` and `--print-file-name` on both toolchains and confirm the reported directory really holds the ASAN runtime.
2. Drive the **real, unmodified** `therock_subproject_dep_provider.cmake` via `cmake -P` with `THEROCK_INCLUDE_CLANG_RESOURCE_DIR_RPATH=ON` and `THEROCK_SANITIZER=HOST_ASAN`, before and after the change, against both toolchains, and assert the derived build RPATH directory contains the runtime.
3. Reproduce the loader failure and the fix directly: link a trivial program with `-fsanitize=address -shared-libasan`, confirm `DT_NEEDED: libclang_rt.asan.so` with zero runpath entries, confirm it fails to run, then confirm it runs once the derived directory is on the runpath.
4. Confirm the failed-`LD_PRELOAD` degradation and that the resolved path actually loads ASAN.
5. Bound the blast radius of the new `FATAL_ERROR`: confirm a non-sanitized configure cannot reach it, confirm both real toolchains resolve and so never hit it, and confirm it does fire (with a legible message) on a toolchain that has no shared sanitizer runtime.

## Test Result

**1. `--print-runtime-dir` on both toolchains** — correct on the per-target toolchain, and demonstrably *not* sufficient on its own for the packaged one:

```console
# per-target
$ clang++ --print-runtime-dir
.../lib/llvm/lib/clang/23/lib/x86_64-unknown-linux-gnu
$ ls .../lib/x86_64-unknown-linux-gnu | grep asan
libclang_rt.asan.so                      # ASAN present

# packaged (hybrid: per-target dir exists but holds only flang_rt)
$ clang++ --print-runtime-dir
/opt/.../lib/llvm/lib/clang/23/lib/x86_64-unknown-linux-gnu
$ ls /opt/.../lib/x86_64-unknown-linux-gnu
libflang_rt.openmp.a  libflang_rt.quadmath.a  libflang_rt.runtime.a
$ ls /opt/.../lib/linux | grep asan-x86_64.so
libclang_rt.asan-x86_64.so               # ASAN actually here
```

**Old vs new query** on the per-target toolchain:

```console
$ clang++ --print-file-name=libclang_rt.asan-x86_64.so
libclang_rt.asan-x86_64.so                                    # echoed back = NOT FOUND
$ clang++ --print-file-name=libclang_rt.asan.so
.../lib/clang/23/lib/x86_64-unknown-linux-gnu/libclang_rt.asan.so   # absolute = found
```

**2. `cmake -P` harness driving the real file** (parses cleanly; `cmake -P` on the file itself also exits 0):

```text
########## BEFORE / per-target ##########
build   RPATH dir: .../lib/clang/23/lib/linux
install RPATH dir: lib/llvm/lib/clang/23/lib/linux
launcher         : cmake;-E;env;LD_PRELOAD=libclang_rt.asan-x86_64.so;--
asan present in build RPATH dir: NO            <-- the bug (both of them)

########## AFTER / per-target ##########
build   RPATH dir: .../lib/clang/23/lib/x86_64-unknown-linux-gnu
install RPATH dir: lib/llvm/lib/clang/23/lib/x86_64-unknown-linux-gnu
launcher         : cmake;-E;env;LD_PRELOAD=.../lib/x86_64-unknown-linux-gnu/libclang_rt.asan.so;--
asan present in build RPATH dir: YES (libclang_rt.asan.so)

########## BEFORE / packaged ##########
build   RPATH dir: /opt/.../lib/clang/23/lib/linux
install RPATH dir: lib/llvm/lib/clang/23/lib/linux
asan present in build RPATH dir: YES (libclang_rt.asan-x86_64.so)

########## AFTER / packaged ##########   (no regression)
-- No shared sanitizer runtimes found via .../clang++ --print-runtime-dir: falling back to /opt/.../lib/clang/23/lib/linux
build   RPATH dir: /opt/.../lib/clang/23/lib/linux
install RPATH dir: lib/llvm/lib/clang/23/lib/linux
launcher         : cmake;-E;env;LD_PRELOAD=/opt/.../lib/linux/libclang_rt.asan-x86_64.so;--
asan present in build RPATH dir: YES (libclang_rt.asan-x86_64.so)
```

**3. The underlying mechanism, reproduced and fixed** (per-target toolchain):

```console
$ clang -fsanitize=address -shared-libasan -fno-omit-frame-pointer -g demo.c -o demo_norpath
$ readelf -d demo_norpath | grep -E 'NEEDED.*clang_rt|RPATH|RUNPATH'
 0x0000000000000001 (NEEDED)             Shared library: [libclang_rt.asan.so]
(runpath/rpath entry count: 0)

$ ./demo_norpath
./demo_norpath: error while loading shared libraries: libclang_rt.asan.so: cannot open shared object file: No such file or directory
exit=127                                            # == the CI error, verbatim

$ LD_LIBRARY_PATH=$(clang --print-runtime-dir) ./demo_norpath
ran ok

$ clang ... demo.c -o demo_rpath -Wl,-rpath,$(clang --print-runtime-dir)
$ readelf -d demo_rpath | grep -E 'NEEDED.*clang_rt|RUNPATH'
 0x000000000000001d (RUNPATH)            Library runpath: [.../lib/clang/23/lib/x86_64-unknown-linux-gnu]
 0x0000000000000001 (NEEDED)             Shared library: [libclang_rt.asan.so]
$ ./demo_rpath
ran ok                                              # fixed by the derived directory
```

**4. Silent `LD_PRELOAD` degradation** (ASAN mappings counted in `/proc/self/maps`):

```console
$ LD_PRELOAD=libclang_rt.asan-x86_64.so /bin/echo "tool still ran (UNSANITIZED)"
ERROR: ld.so: object 'libclang_rt.asan-x86_64.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
tool still ran (UNSANITIZED)
exit=0 ; asan actually loaded -> 0                  # old launcher: no sanitization

$ LD_PRELOAD=.../lib/x86_64-unknown-linux-gnu/libclang_rt.asan.so /bin/echo "tool ran"
tool ran
exit=0 ; asan actually loaded -> 4                  # new launcher: ASAN really loaded
```

**5. Blast radius of the `FATAL_ERROR`.**

*A non-sanitized configure never reaches it.* The block is guarded by `if(LINUX AND THEROCK_SANITIZER)`, and `THEROCK_SANITIZER` is only set by the stanza `therock_sanitizer_configure()` emits when a sanitizer is actually requested. Running the harness with `THEROCK_SANITIZER` unset — even pointed at a deliberately broken "toolchain" that echoes every query back — configures cleanly and probes nothing:

```text
-- RESULT reached configure end WITHOUT error
-- RESULT build   RPATH dir: ''
-- RESULT launcher         : ''
exit=0
```

*Both real toolchains resolve, so neither hits the fatal path* (`HOST_ASAN`, real file, `env -u LD_LIBRARY_PATH`), each via a different soname:

```text
# per-target -> resolves via the suffix-less name
-- Sanitizer launcher: /usr/bin/cmake;-E;env;LD_PRELOAD=/tmp/therock-verify/.../lib/clang/23/lib/x86_64-unknown-linux-gnu/libclang_rt.asan.so;--
exit=0

# packaged hybrid -> resolves via the arch-suffixed name in lib/linux
-- Sanitizer launcher: /usr/bin/cmake;-E;env;LD_PRELOAD=/opt/rocm-versions/gfx950-7.15.0a20260710/lib/llvm/lib/clang/23/lib/linux/libclang_rt.asan-x86_64.so;--
exit=0
```

*And it does fire when nothing resolves.* Full rendered error, using a stand-in compiler that echoes every `--print-file-name` query back (clang's real not-found behavior). Note the RPATH block above it degrades with `STATUS` and keeps going — only the launcher resolution is fatal:

```text
-- No shared sanitizer runtimes found via /tmp/asan-validate/fake-clang++ --print-runtime-dir: falling back to /tmp/asan-validate/fake-toolchain/lib/clang/23/lib/linux
-- Added clang resource dir to RPATH: lib/llvm/lib/clang/23/lib/linux (since sanitizer enabled)
CMake Error at cmake/therock_subproject_dep_provider.cmake:231 (message):
  Could not resolve the shared HOST_ASAN runtime library required to run
  build time tools under the sanitizer.

      Sanitizer   : HOST_ASAN
      Compiler    : /tmp/asan-validate/fake-clang++
      Resource dir: /tmp/asan-validate/fake-toolchain/lib/clang/23
      Runtime dir : /tmp/asan-validate/fake-toolchain/lib/clang/23/lib/x86_64-unknown-linux-gnu
      Probed sonames (clang echoes the query back verbatim when it cannot find the file, so a bare soname below means NOT FOUND):
        --print-file-name=libclang_rt.asan.so -> libclang_rt.asan.so
        --print-file-name=libclang_rt.asan-x86_64.so -> libclang_rt.asan-x86_64.so

  Provide a shared sanitizer runtime for this toolchain (compiler-rt built
  with COMPILER_RT_BUILD_SANITIZERS=ON) or disable the sanitizer for this
  build.  Refusing to continue: an unresolvable LD_PRELOAD is ignored by the
  loader, so carrying on here would silently run build time tools with no
  sanitizer at all rather than failing.
exit=1
```

The two diagnostic queries that fill in the resource dir and runtime dir are issued only on this failure path, so the successful path costs no extra sub-processes.

### Not verified

Stated plainly, since it bounds how much this change is proven:

- **No TheRock superbuild was run.** No sub-project was configured or built with these changes; the CMake was exercised via `cmake -P` against the real file, not through `therock_cmake_subproject_activate`. **CI on this PR is what will validate the fix end to end**, which is also why it is opened as a draft.
- The original failing hipBLASLt / rocRoller / rocFFT builds were not re-run.
- The **install** RPATH was not validated in a real install tree; only the derived prefix-relative string was checked. Its `$ORIGIN`-relative form is computed later by `therock_global_post_subproject.cmake`, which is unchanged.
- Only `HOST_ASAN` on `x86_64` Linux was exercised. TSAN and full device `ASAN` share the same code path but were not run.
- `pre-commit` is not installed in this environment. The changed file was checked by hand for what the `.cmake`-relevant hooks enforce (no trailing whitespace, final newline present, no tabs, LF endings, no conflict markers).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.

______________________________________________________________________

> [!NOTE]
> Per TheRock's [AI tool use policy](https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md#ai-tool-use-policy): this change was authored with the assistance of an AI coding agent. The root cause analysis, the code, and all command output quoted above were produced and verified against the two real toolchains described in the Test Plan. I am accountable for the contribution and can answer questions about it in review.