### PR TITLE
feat(test): add TEST_SUBPROJECTS to amdsmi and register rccl/rdc/rocrtst

### DIFF
--- a/comm-libs/CMakeLists.txt
+++ b/comm-libs/CMakeLists.txt
@@ -58,6 +58,7 @@ if(THEROCK_ENABLE_RCCL)
       rocprofiler-register
       ${_rccl_optional_runtime_deps}
       ${optional_profiler_deps}
+    TEST_SUBPROJECTS
   )
   therock_cmake_subproject_glob_c_sources(rccl
     SUBDIRS

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -81,7 +81,16 @@ if(THEROCK_ENABLE_CORE_AMDSMI)
         lib
       INTERFACE_INSTALL_RPATH_DIRS
         lib
+      TEST_SUBPROJECTS
+        hipblas
+        hipblaslt
+        rccl
+        rdc
+        rocblas
+        rocprofiler-systems
+        rocrtst
     )
+
     therock_cmake_subproject_provide_package(amdsmi amd_smi lib/cmake)
     therock_cmake_subproject_activate(amdsmi)
 
@@ -636,6 +645,7 @@ if(THEROCK_BUILD_TESTING AND THEROCK_ENABLE_CORE_RUNTIME_TESTS AND _therock_enab
       "lib/rocm_sysdeps/lib"
     INTERFACE_INSTALL_RPATH_DIRS
       "lib/rocm_sysdeps/lib"
+    TEST_SUBPROJECTS
   )
   therock_cmake_subproject_glob_c_sources(rocrtst SUBDIRS .)
   therock_cmake_subproject_activate(rocrtst)

--- a/dctools/CMakeLists.txt
+++ b/dctools/CMakeLists.txt
@@ -59,6 +59,8 @@ if(THEROCK_ENABLE_RDC)
 
     INTERFACE_INSTALL_RPATH_DIRS
       lib
+
+    TEST_SUBPROJECTS
   )
   therock_cmake_subproject_glob_c_sources(rdc
     SUBDIRS .


### PR DESCRIPTION
Wire hipblas, hipblaslt, rccl, rdc, rocblas, rocprofiler-systems, and rocrtst as test subprojects triggered by amdsmi changes. Also add bare TEST_SUBPROJECTS declarations to rccl, rdc, and rocrtst so the test dependency tool recognizes them as valid subproject names.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

<!-- Most pull requests should be associated with at least one GitHub issue -->

<!-- GitHub issue: https://github.com/ROCm/TheRock/issues/1234 -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
