### PR TITLE
enable pytorch test_memory tests

### DIFF
--- a/external-builds/pytorch/skip_tests/generic.py
+++ b/external-builds/pytorch/skip_tests/generic.py
@@ -20,9 +20,6 @@ skip_tests = {
             # Skipped across all PyTorch versions; the hipblas.h include error
             # persists in the ROCm SDK environment.
             "test_mempool_empty_cache_inactive",
-            # TestCudaAllocator - FileNotFoundError: flamegraph.pl missing in CI
-            "test_memory_snapshot",
-            "test_memory_plots",
             # HIP_VISIBLE_DEVICES and CUDA_VISIBLE_DEVICES not working
             # to restrict visibility of devices
             # AssertionError: String comparison failed: '8, 1' != '8, 8'

--- a/external-builds/pytorch/skip_tests/pytorch_2.11.py
+++ b/external-builds/pytorch/skip_tests/pytorch_2.11.py
@@ -4,18 +4,6 @@
 skip_tests = {
     "common": {
         "cuda": [
-            # AssertionError: False is not true
-            "test_memory_plots",
-            # AssertionError: Booleans mismatch: False is not True
-            "test_memory_plots_free_segment_stack",
-            # FileNotFoundError: [Errno 2] No such file or directory: '/github/home/.cache//flamegraph.pl'
-            "test_memory_snapshot",
-            # AssertionError: String comparison failed: 'test_memory_snapshot' != 'foo'
-            "test_memory_snapshot_script",
-            # AssertionError: False is not true
-            "test_memory_snapshot_with_cpp",
-            # AssertionError: Scalars are not equal!
-            "test_mempool_ctx_multithread",
             # RuntimeError: Error building extension 'dummy_allocator'
             "test_mempool_empty_cache_inactive",
             # RuntimeError: Error building extension 'dummy_allocator_v1'

--- a/external-builds/pytorch/skip_tests/pytorch_2.12.py
+++ b/external-builds/pytorch/skip_tests/pytorch_2.12.py
@@ -6,8 +6,6 @@ skip_tests = {
         "cuda": [
             # RuntimeError: Error building extension 'dummy_allocator_v1'
             "test_mempool_limited_memory_with_allocator",
-            # AssertionError: Scalars are not equal!
-            "test_mempool_ctx_multithread",
             # torch.AcceleratorError: HIP error: operation not permitted when
             # stream is capturing
             "test_cuda_graph_tensor_item_not_allowed",

--- a/external-builds/pytorch/skip_tests/pytorch_2.13.py
+++ b/external-builds/pytorch/skip_tests/pytorch_2.13.py
@@ -13,9 +13,6 @@ skip_tests = {
             # TestCuda - conflicts with how our test script and runners are
             # configured.
             "test_hip_device_count",
-            # TestCudaAllocator - passes on single run, crashes if run in a
-            # group. TypeError: 'CustomDecompTable' object is not a mapping
-            "test_memory_compile_regions",
             # TestMemPool - RuntimeError: Error building extension
             # 'dummy_allocator'. The hipblas.h include error persists in the
             # ROCm SDK environment:


### PR DESCRIPTION
## Motivation

Enable Pytorch test_memory tests in release/2.11, 2.12, 2.13

## Technical Details

Several commits were cherry-picked from upstream to release/2.11, 2.12 and 2.13
List of fixed tests:
- test_cuda.py::TestCudaAllocator::test_memory_compile_regions
- test_cuda.py::TestCudaAllocator::test_memory_plots
- test_cuda.py::TestCudaAllocator::test_memory_plots_free_segment_stack
- test_cuda.py::TestCudaAllocator::test_memory_snapshot
- test_cuda.py::TestCudaAllocator::test_memory_snapshot_script
- test_cuda.py::TestCudaAllocator::test_memory_snapshot_with_cpp
- test_cuda.py::TestMemPool::test_mempool_ctx_multithread

## Test Plan

```bash
PYTORCH_TEST_WITH_ROCM=1 PYTORCH_TESTING_DEVICE_ONLY_FOR="cuda" pytest test/test_cuda.py -p no:randomly -x -q -v
```

## Test Result

TheRock CI looks green with my branch:
- release/2.11 https://github.com/ROCm/TheRock/actions/runs/30452392825
- release/2.12 https://github.com/ROCm/TheRock/actions/runs/30406393261
- release/2.13 https://github.com/ROCm/TheRock/actions/runs/30452419099 (failed but enabled tests passed)
