### PR TITLE
fix(jax): track the ROCm major version in JAX package names

### DIFF
--- a/.github/workflows/test_linux_jax_wheels.yml
+++ b/.github/workflows/test_linux_jax_wheels.yml
@@ -224,6 +224,18 @@ jobs:
 
       - name: Determine JAX package versions
         run: |
+          # The plugin/pjrt wheels embed the ROCm major version in their package
+          # name (jax_rocm7_*, jax_rocm10_*), tracking the ROCm release they were
+          # built against.
+          rocm_major="${{ inputs.rocm_version }}"
+          rocm_major="${rocm_major%%.*}"
+          if [ -z "${rocm_major}" ]; then
+            echo "::error::rocm_version is required to determine the JAX plugin package name"
+            exit 1
+          fi
+          echo "JAX_PLUGIN_PACKAGE=jax_rocm${rocm_major}_plugin" >> "$GITHUB_ENV"
+          echo "JAX_PJRT_PACKAGE=jax_rocm${rocm_major}_pjrt" >> "$GITHUB_ENV"
+
           # Use versions passed from the build workflow when available.
           # For manual workflow_dispatch, compute the version suffix using
           # compute_jax_package_version.py (matches rocm-jax ci_build format).
@@ -248,10 +260,12 @@ jobs:
           echo "  JAX_PLUGIN_VERSION=${JAX_PLUGIN_VERSION}"
           echo "  JAX_PJRT_VERSION=${JAX_PJRT_VERSION}"
           echo "  JAX_VERSION=${JAX_VERSION}"
+          echo "  JAX_PLUGIN_PACKAGE=${JAX_PLUGIN_PACKAGE}"
+          echo "  JAX_PJRT_PACKAGE=${JAX_PJRT_PACKAGE}"
           # Install plugin/pjrt from the GPU-family index
           pip install --index-url "${{ env.WHEEL_INDEX_URL }}" \
-            "jax_rocm7_plugin==${JAX_PLUGIN_VERSION}" \
-            "jax_rocm7_pjrt==${JAX_PJRT_VERSION}"
+            "${JAX_PLUGIN_PACKAGE}==${JAX_PLUGIN_VERSION}" \
+            "${JAX_PJRT_PACKAGE}==${JAX_PJRT_VERSION}"
           # For JAX <= 0.9.0, jaxlib is built and installed from GPU index.
           # For JAX >= 0.9.1, jaxlib is not built - install jax and jaxlib from upstream PyPI.
           if [ -n "${JAXLIB_VERSION}" ]; then

--- a/.github/workflows/test_linux_jax_wheels_partial.yml
+++ b/.github/workflows/test_linux_jax_wheels_partial.yml
@@ -196,6 +196,18 @@ jobs:
 
       - name: Determine JAX package versions
         run: |
+          # The plugin/pjrt wheels embed the ROCm major version in their package
+          # name (jax_rocm7_*, jax_rocm10_*), tracking the ROCm release they were
+          # built against.
+          rocm_major="${{ inputs.rocm_version }}"
+          rocm_major="${rocm_major%%.*}"
+          if [ -z "${rocm_major}" ]; then
+            echo "::error::rocm_version is required to determine the JAX plugin package name"
+            exit 1
+          fi
+          echo "JAX_PLUGIN_PACKAGE=jax_rocm${rocm_major}_plugin" >> "$GITHUB_ENV"
+          echo "JAX_PJRT_PACKAGE=jax_rocm${rocm_major}_pjrt" >> "$GITHUB_ENV"
+
           if [ -n "${{ inputs.jax_plugin_version }}" ] && [ -n "${{ inputs.jax_version }}" ]; then
             echo "JAX_VERSION=${{ inputs.jax_version }}" >> "$GITHUB_ENV"
             echo "JAXLIB_VERSION=${{ inputs.jaxlib_version }}" >> "$GITHUB_ENV"
@@ -237,8 +249,8 @@ jobs:
 
           pip install \
             --index-url "${WHEEL_INDEX_URL}" \
-            "jax_rocm7_plugin==${JAX_PLUGIN_VERSION}" \
-            "jax_rocm7_pjrt==${JAX_PJRT_VERSION}"
+            "${JAX_PLUGIN_PACKAGE}==${JAX_PLUGIN_VERSION}" \
+            "${JAX_PJRT_PACKAGE}==${JAX_PJRT_VERSION}"
 
           if [ -n "${JAXLIB_VERSION}" ]; then
             pip install \

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -419,7 +419,12 @@ Install JAX with ROCm support using the unified multi-arch index.
 > as a dependency. You must install ROCm first by following
 > [Installing multi-arch ROCm Python packages](#installing-multi-arch-rocm-python-packages).
 >
-> Always pin `jax`, `jax_rocm7_plugin`, and `jax_rocm7_pjrt` to the same version.
+> Always pin `jax`, `jax_rocm<major>_plugin`, and `jax_rocm<major>_pjrt` to the
+> same version.
+>
+> The plugin and PJRT package names embed the ROCm major version they were built
+> against, so the name to install depends on the ROCm release: `jax_rocm7_*` for
+> ROCm 7.x and `jax_rocm10_*` for ROCm 10.x.
 
 ```bash
 # Set the version (currently supported: 0.9.1, 0.10.0, and 0.10.2)
@@ -430,9 +435,12 @@ pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
     "rocm[libraries,device-gfx942]"
 
 # 2. Install JAX ROCm wheels
+# Use the ROCm major version the wheels were built against: 7 for ROCm 7.x, 10
+# for ROCm 10.x.
+ROCM_MAJOR=7
 pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
-    "jax_rocm7_plugin==${JAX_VERSION}" \
-    "jax_rocm7_pjrt==${JAX_VERSION}"
+    "jax_rocm${ROCM_MAJOR}_plugin==${JAX_VERSION}" \
+    "jax_rocm${ROCM_MAJOR}_pjrt==${JAX_VERSION}"
 
 # 3. Install matching jax from PyPI
 pip install "jax==${JAX_VERSION}"

--- a/build_tools/packaging/download_python_packages.py
+++ b/build_tools/packaging/download_python_packages.py
@@ -135,12 +135,15 @@ except ImportError:
 MAX_S3_KEYS_CHECK = 100
 BYTES_TO_MB = 1024 * 1024  # Conversion factor from bytes to MB
 
+# The JAX plugin/pjrt wheels embed the ROCm major version in their package name
+# (jax_rocm7_plugin for ROCm 7, jax_rocm10_plugin for ROCm 10), so they are
+# matched by pattern instead of listed once per ROCm release.
+JAX_ROCM_PACKAGE_PATTERN = re.compile(r"^jax_rocm\d+_(plugin|pjrt)$")
+
 # Package categories
 # Note: replace - in package names with _ to match the filename patterns in S3
 PACKAGES_TO_PROMOTE = {
     "apex",
-    "jax_rocm7_pjrt",
-    "jax_rocm7_plugin",
     "jaxlib",
     "rocm",
     "rocm_profiler",
@@ -157,8 +160,6 @@ PACKAGES_TO_PROMOTE_MULTI_ARCH = {
     "amd_torch_device",
     "amd_torchvision_device",
     "apex",
-    "jax_rocm7_pjrt",
-    "jax_rocm7_plugin",
     "rocm",
     "rocm_profiler",
     "rocm_sdk_core",
@@ -266,6 +267,9 @@ def is_allowed_multi_arch_package(
     base = re.split(r"-\d", filename, maxsplit=1)[0]
     base = base.lower().replace("-", "_")
 
+    if JAX_ROCM_PACKAGE_PATTERN.match(base):
+        return True
+
     for pkg in PACKAGES_TO_PROMOTE_MULTI_ARCH:
 
         # Device packages contain gfx targets
@@ -303,8 +307,12 @@ def categorize_package(filename: str) -> str:
     """
     pkg_name = filename.split("-", 1)[0]
 
-    # Check for rocm-sdk-libraries-* pattern
-    if pkg_name.startswith("rocm_sdk_libraries") or pkg_name in PACKAGES_TO_PROMOTE:
+    # Check for rocm-sdk-libraries-* and jax-rocm<major>-* patterns
+    if (
+        pkg_name.startswith("rocm_sdk_libraries")
+        or JAX_ROCM_PACKAGE_PATTERN.match(pkg_name)
+        or pkg_name in PACKAGES_TO_PROMOTE
+    ):
         return "promote"
 
     if pkg_name in DEPENDENCY_PACKAGES:

--- a/build_tools/packaging/promote_packages.py
+++ b/build_tools/packaging/promote_packages.py
@@ -722,6 +722,11 @@ GFX_AWARE_WHEEL_PREFIXES = (
     "torchvision-",
 )
 
+# The JAX plugin/pjrt wheels embed the ROCm major version in their package name
+# (jax_rocm7_plugin for ROCm 7, jax_rocm10_plugin for ROCm 10), so they are
+# matched by pattern instead of listed once per ROCm release.
+JAX_ROCM_PACKAGE_PATTERN = re.compile(r"^jax_rocm\d+_(plugin|pjrt)$")
+
 
 def wheel_apply_gfx_keep_list(
     new_dir_path: pathlib.Path, keep_archs: list[str]
@@ -828,10 +833,7 @@ def wheel_change_extra_files(
     # rocm-* package to the build's rocm version. Rewrite those, then return.
     if "device_gfx" in new_dir_path.name:
         return
-    if (
-        "jax_rocm7_plugin" in package_name_no_version
-        or "jax_rocm7_pjrt" in package_name_no_version
-    ):
+    if JAX_ROCM_PACKAGE_PATTERN.match(package_name_no_version):
         return
 
     # rocm packages needing extra handling

--- a/build_tools/packaging/tests/download_python_packages_test.py
+++ b/build_tools/packaging/tests/download_python_packages_test.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for package recognition in download_python_packages.py.
+
+The JAX plugin/pjrt wheels embed the ROCm major version in their package name,
+so these tests cover both the ROCm 7 and ROCm 10 spellings to make sure a ROCm
+version bump does not silently drop the wheels from promotion.
+"""
+
+import os
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
+
+from download_python_packages import (
+    categorize_package,
+    is_allowed_multi_arch_package,
+)
+
+JAX_ROCM7_WHEELS = [
+    "jax_rocm7_plugin-0.9.2+rocm7.15.0-cp312-cp312-manylinux_2_28_x86_64.whl",
+    "jax_rocm7_pjrt-0.9.2+rocm7.15.0-py3-none-manylinux_2_28_x86_64.whl",
+]
+
+JAX_ROCM10_WHEELS = [
+    "jax_rocm10_plugin-0.10.0+rocm10.0.0-cp313-cp313-manylinux_2_27_x86_64.whl",
+    "jax_rocm10_pjrt-0.10.0+rocm10.0.0-py3-none-manylinux_2_27_x86_64.whl",
+]
+
+
+class CategorizePackageTest(unittest.TestCase):
+    def test_jax_rocm7_wheels_are_promoted(self):
+        for filename in JAX_ROCM7_WHEELS:
+            with self.subTest(filename=filename):
+                self.assertEqual(categorize_package(filename), "promote")
+
+    def test_jax_rocm10_wheels_are_promoted(self):
+        for filename in JAX_ROCM10_WHEELS:
+            with self.subTest(filename=filename):
+                self.assertEqual(categorize_package(filename), "promote")
+
+    def test_jaxlib_is_still_promoted(self):
+        self.assertEqual(
+            categorize_package("jaxlib-0.9.2-cp312-cp312-manylinux_2_28_x86_64.whl"),
+            "promote",
+        )
+
+    def test_unrelated_jax_rocm_name_is_unknown(self):
+        # Only the plugin/pjrt wheels carry the ROCm major in their name; a
+        # majorless or unexpected variant should not be promoted silently.
+        self.assertEqual(
+            categorize_package("jax_rocm_plugin-0.10.0-py3-none-any.whl"),
+            "unknown",
+        )
+
+
+class IsAllowedMultiArchPackageTest(unittest.TestCase):
+    def test_jax_rocm7_wheels_are_allowed(self):
+        for filename in JAX_ROCM7_WHEELS:
+            with self.subTest(filename=filename):
+                self.assertTrue(is_allowed_multi_arch_package(filename))
+
+    def test_jax_rocm10_wheels_are_allowed(self):
+        for filename in JAX_ROCM10_WHEELS:
+            with self.subTest(filename=filename):
+                self.assertTrue(is_allowed_multi_arch_package(filename))
+
+    def test_unknown_package_is_not_allowed(self):
+        self.assertFalse(
+            is_allowed_multi_arch_package("some_other_pkg-1.0-py3-none-any.whl")
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/build_tools/third_party/s3_management/manage.py
+++ b/build_tools/third_party/s3_management/manage.py
@@ -200,10 +200,10 @@ PACKAGE_ALLOW_LIST = {x.lower() for x in [
     "setuptools_scm",
     "wheel",
     # ---- JAX ----
+    # Note: jax_rocm<major>_plugin / jax_rocm<major>_pjrt embed the ROCm major
+    # version in the package name and are allowed by prefix below.
     "jax",
     "jaxlib",
-    "jax_rocm7_plugin",
-    "jax_rocm7_pjrt",
 ]}
 
 S3IndexType = TypeVar('S3IndexType', bound='S3Index')
@@ -288,6 +288,7 @@ class S3Index:
                 or pkg.startswith("rocm_sdk_libraries_")
                 or pkg.startswith("amd_torch_device")
                 or pkg.startswith("amd_torchvision_device")
+                or pkg.startswith("jax_rocm")
             ):
                 packages[package_name] += 1
             else:

--- a/external-builds/jax/README.md
+++ b/external-builds/jax/README.md
@@ -22,11 +22,25 @@ For upstream JAX development references, see:
 
 ### Project and feature support status
 
-| Project / feature | Linux support | Windows support  |
-| ----------------- | ------------- | ---------------- |
-| jaxlib            | ✅ Supported  | ❌ Not supported |
-| jax_rocm7_pjrt    | ✅ Supported  | ❌ Not supported |
-| jax_rocm7_plugin  | ✅ Supported  | ❌ Not supported |
+| Project / feature        | Linux support | Windows support  |
+| ------------------------ | ------------- | ---------------- |
+| jaxlib                   | ✅ Supported  | ❌ Not supported |
+| `jax_rocm<major>_pjrt`   | ✅ Supported  | ❌ Not supported |
+| `jax_rocm<major>_plugin` | ✅ Supported  | ❌ Not supported |
+
+> [!IMPORTANT]
+> The plugin and PJRT package names embed the major version of the ROCm release
+> they were built against, so the name changes across ROCm releases:
+>
+> | ROCm release | Package names                          |
+> | ------------ | -------------------------------------- |
+> | 7.x          | `jax_rocm7_plugin`, `jax_rocm7_pjrt`   |
+> | 10.x         | `jax_rocm10_plugin`, `jax_rocm10_pjrt` |
+>
+> Wheels published from earlier ROCm releases keep their original name, so look
+> for `jax_rocm7_*` when installing a historical ROCm 7.x release.
+>
+> This document writes `jax_rocm<major>_*` where either spelling applies.
 
 ### Supported JAX versions
 
@@ -51,13 +65,13 @@ See also:
 This repository builds the following ROCm-enabled JAX artifacts:
 
 - **jaxlib** (ROCm) - built for JAX ≤ 0.9.0 only
-- **jax_rocm7_pjrt** (PJRT runtime for ROCm)
-- **jax_rocm7_plugin** (JAX runtime plugin for ROCm)
+- **`jax_rocm<major>_pjrt`** (PJRT runtime for ROCm)
+- **`jax_rocm<major>_plugin`** (JAX runtime plugin for ROCm)
 
 > [!NOTE]
 > Starting with JAX 0.9.1, jaxlib is **not built** - it is used from upstream
-> PyPI (`pip install jaxlib==0.9.1`). Only **jax_rocm7_pjrt** and
-> **jax_rocm7_plugin** are built.
+> PyPI (`pip install jaxlib==0.9.1`). Only **`jax_rocm<major>_pjrt`** and
+> **`jax_rocm<major>_plugin`** are built.
 
 ### How building with TheRock differs from upstream
 
@@ -151,8 +165,9 @@ TheRock currently supports two build paths depending on the JAX release branch:
    - `.github/workflows/multi_arch_build_linux_jax_wheels.yml`
 
    The workflow installs ROCm Python packages from the configured TheRock
-   multi-arch package index before building `jax_rocm7_plugin` and
-   `jax_rocm7_pjrt`.
+   multi-arch package index before building `jax_rocm<major>_plugin` and
+   `jax_rocm<major>_pjrt`, where `<major>` is the ROCm major version being built
+   against.
 
 1. Locate built wheels:
 
@@ -224,10 +239,12 @@ release branch you are using.
 1. Install JAX wheels from the package index:
 
    ```bash
+   # Replace <rocm_major> with the ROCm major version of the index you install
+   # from, e.g. 7 for a ROCm 7.x release or 10 for a ROCm 10.x release.
    pip install \
    --index-url <package_index_url> \
-   jax_rocm7_plugin \
-   jax_rocm7_pjrt
+   jax_rocm<rocm_major>_plugin \
+   jax_rocm<rocm_major>_pjrt
 
    # Install jax from PyPI to match the version
    pip install jax==<JAX_VERSION>


### PR DESCRIPTION
Issue: #6958
## Motivation
The JAX plugin/pjrt wheels embed the ROCm major version in their package name (`jax_rocm7_plugin` for ROCm 7, `jax_rocm10_plugin` for ROCm 10). Now that `version.json` is at 10.0.0, the builds emit `jax_rocm10_*`, but everything
downstream of the build still hardcodes the ROCm 7 spelling: the test job can't resolve the package, and the promotion/index allowlists silently drop the wheels.

#6956 fixes detection at build time. This fixes the consumers.

## Changes
- `test_linux_jax_wheels.yml`, `test_linux_jax_wheels_partial.yml`: derive the package name from `rocm_version` instead of installing a literal `jax_rocm7_plugin`. Fails fast if `rocm_version` is empty.
- `download_python_packages.py`, `promote_packages.py`: match the wheels with a `^jax_rocm\d+_(plugin|pjrt)$` pattern instead of listing them once per ROCm release.
- `s3_management/manage.py`: allow the wheels into the package index by prefix, alongside the existing `rocm_sdk_device_` / `amd_torch_device` cases.

## Test Plan
New `build_tools/packaging/tests/download_python_packages_test.py` 7 passed.
Package recognition, before vs after:

| wheel | before | after |
| --- | --- | --- |
| `jax_rocm7_plugin-0.9.2+rocm7.15.0-…` | `promote`, allowed | `promote`, allowed |
| `jax_rocm10_plugin-0.10.0+rocm10.0.0-…` | `unknown`, **not** allowed | `promote`, allowed |

Name derivation, against real version strings:
```console
rocm_version='10.0.0'          -> jax_rocm10_plugin
rocm_version='10.0.0a20260729' -> jax_rocm10_plugin
rocm_version='7.15.0'          -> jax_rocm7_plugin
rocm_version='7.15.0.dev0+abc' -> jax_rocm7_plugin
rocm_version=''                -> error (fail fast)
```

## Test Results

```console
$ python3 -m pytest build_tools/packaging/tests/download_python_packages_test.py -v
platform linux -- Python 3.12.3, pytest-9.1.1, pluggy-1.6.0
rootdir: /home/ggudukba/JAX/th-jaxpkg/build_tools
configfile: pyproject.toml
collected 7 items
CategorizePackageTest::test_jax_rocm10_wheels_are_promoted PASSED         [ 14%]
CategorizePackageTest::test_jax_rocm7_wheels_are_promoted PASSED          [ 28%]
CategorizePackageTest::test_jaxlib_is_still_promoted PASSED               [ 42%]
CategorizePackageTest::test_unrelated_jax_rocm_name_is_unknown PASSED     [ 57%]
IsAllowedMultiArchPackageTest::test_jax_rocm10_wheels_are_allowed PASSED  [ 71%]
IsAllowedMultiArchPackageTest::test_jax_rocm7_wheels_are_allowed PASSED   [ 85%]
IsAllowedMultiArchPackageTest::test_unknown_package_is_not_allowed PASSED [100%]
===================== 7 passed, 8 subtests passed in 0.06s =====================
```
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
