### PR TITLE
feat(build): add THEROCK_COMGR_DLL_NAME to override comgr DLL name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,11 @@ option(THEROCK_BUILD_LLVM_TOOLS "Enables building all LLVM tools (not just minim
 option(THEROCK_BUILD_LLVM_TESTS "Enables building LLVM LIT tests" OFF)
 option(THEROCK_ENABLE_HOTSWAP "Enables the comgr hotswap transpiler/tool and loads it in the runtime via HSA_TOOLS_LIB" ON)
 option(THEROCK_USE_NEW_HOSTCALL_IMPL "Use the new phase/occupancy-based hostcall implementation in device-libs and clr" OFF)
+# Overrides the Comgr shared-library name for both the Comgr build (its output
+# name) and CLR's dynamic load of it. Empty keeps each component's default
+# (amd_comgr). Used on Windows to ship an OpenCL-flavoured comgr
+# (amd_comgr_opencl.dll) that sits side-by-side with the HIP SDK's comgr.
+set(THEROCK_COMGR_DLL_NAME "" CACHE STRING "Override the Comgr DLL name for the comgr build and CLR load (e.g. amd_comgr_opencl.dll); empty = component default")
 
 set(THEROCK_SANITIZER "" CACHE STRING "Enable project wide sanitizer build ('ASAN' for host+device, 'HOST_ASAN' for host-only)")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,10 +126,6 @@ option(THEROCK_BUILD_LLVM_TOOLS "Enables building all LLVM tools (not just minim
 option(THEROCK_BUILD_LLVM_TESTS "Enables building LLVM LIT tests" OFF)
 option(THEROCK_ENABLE_HOTSWAP "Enables the comgr hotswap transpiler/tool and loads it in the runtime via HSA_TOOLS_LIB" ON)
 option(THEROCK_USE_NEW_HOSTCALL_IMPL "Use the new phase/occupancy-based hostcall implementation in device-libs and clr" OFF)
-# Overrides the Comgr shared-library name for both the Comgr build (its output
-# name) and CLR's dynamic load of it. Empty keeps each component's default
-# (amd_comgr). Used on Windows to ship an OpenCL-flavoured comgr
-# (amd_comgr_opencl.dll) that sits side-by-side with the HIP SDK's comgr.
 set(THEROCK_COMGR_DLL_NAME "" CACHE STRING "Override the Comgr DLL name for the comgr build and CLR load (e.g. amd_comgr_opencl.dll); empty = component default")
 
 set(THEROCK_SANITIZER "" CACHE STRING "Enable project wide sanitizer build ('ASAN' for host+device, 'HOST_ASAN' for host-only)")

--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -185,6 +185,13 @@ if(THEROCK_ENABLE_COMPILER)
     endif()
   endif()
 
+  # Optionally override the comgr DLL/shared-library output name (Windows). Kept
+  # in sync with the CLR load side via the same THEROCK_COMGR_DLL_NAME option.
+  set(_comgr_dll_name_cmake_args)
+  if(THEROCK_COMGR_DLL_NAME)
+    list(APPEND _comgr_dll_name_cmake_args "-DCOMGR_DLL_NAME=${THEROCK_COMGR_DLL_NAME}")
+  endif()
+
   therock_cmake_subproject_declare(amd-comgr
     USE_DIST_AMDGPU_TARGETS
     NO_INSTALL_RPATH  # See manual handling in the pre_hook.
@@ -201,6 +208,7 @@ if(THEROCK_ENABLE_COMPILER)
       "-DLLVM_VERSION_SUFFIX=-rocm${ROCM_MAJOR_VERSION}"
       -DLLVM_ENABLE_SYMBOL_VERSIONING=ON
       ${_comgr_hotswap_cmake_args}
+      ${_comgr_dll_name_cmake_args}
     BUILD_DEPS
       rocm-cmake
       ${_comgr_gtest_deps}

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -275,6 +275,14 @@ if(THEROCK_ENABLE_HIP_RUNTIME)
     )
   endif()
 
+  # Optionally override the comgr DLL name that CLR dynamically loads (Windows).
+  # Kept in sync with the comgr build side via the same THEROCK_COMGR_DLL_NAME
+  # option, so the name CLR loads matches the name comgr is built as.
+  set(_clr_comgr_dll_name_cmake_args)
+  if(THEROCK_COMGR_DLL_NAME)
+    list(APPEND _clr_comgr_dll_name_cmake_args "-DCOMGR_DLL_NAME=${THEROCK_COMGR_DLL_NAME}")
+  endif()
+
 
 
   therock_cmake_subproject_declare(hip-clr
@@ -292,6 +300,7 @@ if(THEROCK_ENABLE_HIP_RUNTIME)
       "-DCLR_BUILD_HIP=ON"
       "-DROCM_KPACK_ENABLED=ON"
       "-DUSE_NEW_HOSTCALL_IMPL=${THEROCK_USE_NEW_HOSTCALL_IMPL}"
+      ${_clr_comgr_dll_name_cmake_args}
       # Legacy: Disable various auto-detection logic that breaks out of jail
       # and can use local machine tools.
       "-DHIPCC_BIN_DIR="


### PR DESCRIPTION
Adds a top-level `THEROCK_COMGR_DLL_NAME` option that forwards `-DCOMGR_DLL_NAME=<value>` to both the `amd-comgr` build (comgr's output name) and `hip-clr` (the name CLR loads), keeping the two in sync. Empty default = today's behavior (`amd_comgr`); effect is Windows-only.

Lets a build ship an OpenCL-flavoured comgr (`amd_comgr_opencl.dll`) side-by-side with the ROCm on Window's comgr, for the Windows `compute` OpenCL driver rework.

ISSUE ID: #6970
