### PR TITLE
feat(enable-sanity-step-name): add step metadata to Driver GPU sanity check

### DIFF
--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -174,7 +174,7 @@ jobs:
 
           # Auto-reboot server on any failure (*) if uptime > 2 hours (7200s)
           # Helps recover from driver issues, GPU hangs, or system corruption
-          SELF_HEALING_ACTIONS: ${{ env.PROLENSE_REBOOT_ENABLED == 'true' && '*:reboot[threshold=7200,max_attempts=1]' || '' }}
+          SELF_HEALING_ACTIONS: ${{ env.PROLENSE_REBOOT_ENABLED == 'true' && '*:reboot[threshold=7200,max_attempts=0]' || '' }}
         run: |
           python ./build_tools/print_driver_gpu_info.py
 

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -146,7 +146,7 @@ jobs:
         env:
           STEP_NAME: "Driver GPU sanity check" # name that shows up in prolense dashboards
           STEP_TIMEOUT_MINUTES: "5" # should match timeout-minutes specified above at this step
-          NO_OUTPUT_TIMEOUT: "3" # prolense timesout the step at 3 mins if no-output; the 2 min buffer to timeout-minutes (5 min) allows prolense to report status before GitHub Actions terminates the step
+          NO_OUTPUT_TIMEOUT: "3" # prolense times out the step at 3 mins if no-output (matching previous timeout-minutes); the 2 min buffer to timeout-minutes (5 min) allows prolense to report status before GitHub Actions terminates the step
           SELF_HEALING_ACTIONS: "*:reboot[threshold=7200]" # reboot if error occurs in this step and server uptime is > threshold value
         run: |
           python ./build_tools/print_driver_gpu_info.py

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -89,6 +89,15 @@ jobs:
       BENCHMARK_DB_URL: ${{ secrets.BENCHMARK_DB_URL }}
       BENCHMARK_DB_FALLBACK_URL: ${{ secrets.BENCHMARK_DB_FALLBACK_URL }}
     steps:
+      # Copy PROLENSE_REBOOT_ENABLED from runner environment to workflow env context
+      # GitHub Actions workflow expressions (${{ env.* }}) can only access variables set in
+      # workflow env: blocks. Runner environment variables (from prolense config) are only
+      # available in shell scripts, not workflow expressions. This step bridges the gap.
+      - name: Set PROLENSE_REBOOT_ENABLED in workflow env
+        shell: bash
+        run: |
+          echo "PROLENSE_REBOOT_ENABLED=${PROLENSE_REBOOT_ENABLED:-false}" >> $GITHUB_ENV
+
       - name: "Fetch 'build_tools' from repository"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -90,9 +90,15 @@ jobs:
       BENCHMARK_DB_FALLBACK_URL: ${{ secrets.BENCHMARK_DB_FALLBACK_URL }}
     steps:
       # Copy PROLENSE_REBOOT_ENABLED from runner environment to workflow env context
-      # GitHub Actions workflow expressions (${{ env.* }}) can only access variables set in
-      # workflow env: blocks. Runner environment variables (from prolense config) are only
-      # available in shell scripts, not workflow expressions. This step bridges the gap.
+      #
+      # PHASED ROLLOUT: This enables testing automatic reboot on SELECT SERVERS before fleet-wide deployment
+      # - Runners WITH this env var in config.yaml → prolense features enabled (3-min timeout, auto-reboot)
+      # - Runners WITHOUT it → backward compatible (3-min timeout, no reboot)
+      # - Easy rollback: just update runner config and restart (no workflow changes)
+      #
+      # TECHNICAL: GitHub Actions workflow expressions (${{ env.* }}) can only access variables
+      # from workflow env: blocks. Runner environment variables (from prolense config.yaml) are
+      # only available in shell scripts. This step bridges the gap by copying from shell to workflow env.
       - name: Set PROLENSE_REBOOT_ENABLED in workflow env
         shell: bash
         run: |
@@ -151,12 +157,23 @@ jobs:
 
       - name: Driver / GPU sanity check
         id: driver-gpu-sanity-check
+        # PHASED ROLLOUT: Timeout is 3 min (default) or 5 min (when reboot enabled, allows buffer for telemetry flush)
         timeout-minutes: ${{ env.PROLENSE_REBOOT_ENABLED == 'true' && 5 || 3 }}
         env:
+          # Always set: enables step identification in Grafana dashboards
           STEP_NAME: "Driver GPU sanity check"
           STEP_TIMEOUT_MINUTES: ${{ env.PROLENSE_REBOOT_ENABLED == 'true' && '5' || '3' }}
-          # Prolense-specific metadata is only set when PROLENSE_REBOOT_ENABLED is 'true' on the runner
+
+          # PHASED ROLLOUT: Prolense-specific features only enabled on select servers with PROLENSE_REBOOT_ENABLED=true
+          # - Empty string ('') disables the feature (rule checks for truthy/numeric value)
+          # - Enables gradual testing before fleet-wide deployment
+          # - Easy rollback: just update runner config (no workflow changes)
+
+          # Kill step if no output for 3 minutes (prevents hung processes from blocking runners)
           NO_OUTPUT_TIMEOUT: ${{ env.PROLENSE_REBOOT_ENABLED == 'true' && '3' || '' }}
+
+          # Auto-reboot server on any failure (*) if uptime > 2 hours (7200s)
+          # Helps recover from driver issues, GPU hangs, or system corruption
           SELF_HEALING_ACTIONS: ${{ env.PROLENSE_REBOOT_ENABLED == 'true' && '*:reboot[threshold=7200]' || '' }}
         run: |
           python ./build_tools/print_driver_gpu_info.py

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -141,7 +141,11 @@ jobs:
           python ./build_tools/health_status.py
 
       - name: Driver / GPU sanity check
-        timeout-minutes: 3
+        timeout-minutes: 5
+        env:
+          STEP_NAME: Driver GPU sanity check # name that shows up in prolens dashboards
+          STEP_TIMEOUT_MINUTES: "5" # should match timeout-minutes specified above at this step
+          NO_OUTPUT_TIMEOUT: "3" # prolense will timeout the step at this timeout mins but timeout-minutes is 5 mins so prolense has time to emit status as overall step timeout is enforced by timeout-minutes value
         run: |
           python ./build_tools/print_driver_gpu_info.py
 

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -142,12 +142,13 @@ jobs:
 
       - name: Driver / GPU sanity check
         id: driver-gpu-sanity-check
-        timeout-minutes: 5
+        timeout-minutes: ${{ env.PROLENSE_REBOOT_ENABLED == 'true' && 5 || 3 }}
         env:
-          STEP_NAME: "Driver GPU sanity check" # name that shows up in prolense dashboards
-          STEP_TIMEOUT_MINUTES: "5" # should match timeout-minutes specified above at this step
-          NO_OUTPUT_TIMEOUT: "3" # prolense times out the step at 3 mins if no-output (matching previous timeout-minutes); the 2 min buffer to timeout-minutes (5 min) allows prolense to report status before GitHub Actions terminates the step
-          SELF_HEALING_ACTIONS: "*:reboot[threshold=7200]" # reboot if error occurs in this step and server uptime is > threshold value
+          STEP_NAME: "Driver GPU sanity check"
+          STEP_TIMEOUT_MINUTES: ${{ env.PROLENSE_REBOOT_ENABLED == 'true' && '5' || '3' }}
+          # Prolense-specific metadata is only set when PROLENSE_REBOOT_ENABLED is 'true' on the runner
+          NO_OUTPUT_TIMEOUT: ${{ env.PROLENSE_REBOOT_ENABLED == 'true' && '3' || '' }}
+          SELF_HEALING_ACTIONS: ${{ env.PROLENSE_REBOOT_ENABLED == 'true' && '*:reboot[threshold=7200]' || '' }}
         run: |
           python ./build_tools/print_driver_gpu_info.py
 

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -174,7 +174,7 @@ jobs:
 
           # Auto-reboot server on any failure (*) if uptime > 2 hours (7200s)
           # Helps recover from driver issues, GPU hangs, or system corruption
-          SELF_HEALING_ACTIONS: ${{ env.PROLENSE_REBOOT_ENABLED == 'true' && '*:reboot[threshold=7200]' || '' }}
+          SELF_HEALING_ACTIONS: ${{ env.PROLENSE_REBOOT_ENABLED == 'true' && '*:reboot[threshold=7200,max_attempts=1]' || '' }}
         run: |
           python ./build_tools/print_driver_gpu_info.py
 

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -141,11 +141,13 @@ jobs:
           python ./build_tools/health_status.py
 
       - name: Driver / GPU sanity check
+        id: driver-gpu-sanity-check
         timeout-minutes: 5
         env:
-          STEP_NAME: Driver GPU sanity check # name that shows up in prolens dashboards
+          STEP_NAME: "Driver GPU sanity check" # name that shows up in prolense dashboards
           STEP_TIMEOUT_MINUTES: "5" # should match timeout-minutes specified above at this step
-          NO_OUTPUT_TIMEOUT: "3" # prolense will timeout the step at this timeout mins but timeout-minutes is 5 mins so prolense has time to emit status as overall step timeout is enforced by timeout-minutes value
+          NO_OUTPUT_TIMEOUT: "3" # prolense timesout the step at 3 mins if no-output; the 2 min buffer to timeout-minutes (5 min) allows prolense to report status before GitHub Actions terminates the step
+          SELF_HEALING_ACTIONS: "*:reboot[threshold=7200]" # reboot if error occurs in this step and server uptime is > threshold value
         run: |
           python ./build_tools/print_driver_gpu_info.py
 


### PR DESCRIPTION
## Summary

Add environment variable metadata to the Driver / GPU sanity check step in `test_component.yml` to enable proper step identification and timeout handling in Grafana dashboards and prolense monitoring. Metadata is conditionally enabled via `PROLENSE_REBOOT_ENABLED` env var to allow selective testing on specific servers.

## Changes

- Add `STEP_NAME` environment variable with Grafana-friendly name (always set)
- Add `STEP_TIMEOUT_MINUTES` to match the step's timeout (3 mins default, 5 mins when prolense enabled)
- Add `NO_OUTPUT_TIMEOUT` for prolense timeout handling (only when `PROLENSE_REBOOT_ENABLED=true`)
- Add `SELF_HEALING_ACTIONS` for automatic reboot on errors (only when `PROLENSE_REBOOT_ENABLED=true`)
- Step timeout conditionally set: 3 minutes default, 5 minutes when prolense reboot enabled

## Motivation

This change aligns the Driver GPU sanity check step with the existing pattern used in the Test step, ensuring consistent monitoring and observability across workflow steps. The conditional metadata enables:

- Gradual rollout by testing on select servers first before full deployment
- Proper step identification in Grafana dashboards
- Correct timeout handling by prolense monitoring with buffer for status reporting
- Automatic server reboot on failures (when enabled) if uptime > 2 hours
- Consistent observability patterns across all workflow steps

## Testing

- Workflow syntax validated
- Environment variable pattern matches existing Test step implementation
- Conditional logic ensures backwards compatibility (3 min timeout) when env var not set