### PR TITLE
fix(jax): stamp JAX wheels with the real source commit hash

### DIFF
--- a/.github/workflows/multi_arch_build_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_build_linux_jax_wheels.yml
@@ -148,6 +148,7 @@ jobs:
           ref: ${{ inputs.jax_ref }}
 
       - name: Checkout JAX
+        id: checkout_jax
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: jax-source
@@ -219,7 +220,7 @@ jobs:
                 --bazel_options=--repo_env=ROCM_PATH=$(rocm-sdk path --root) \
                 --bazel_options=--repo_env=ML_WHEEL_TYPE=release \
                 --bazel_options=--repo_env=ML_WHEEL_VERSION_SUFFIX="${ML_WHEEL_VERSION_SUFFIX}" \
-                --bazel_options=--//jaxlib/tools:jaxlib_git_hash=$(git rev-parse HEAD) \
+                --bazel_options=--//jaxlib/tools:jaxlib_git_hash="${{ steps.checkout_jax.outputs.commit }}" \
                 --verbose \
                 --detailed_timestamped_log \
                 --output_path=$(pwd)/dist

--- a/.github/workflows/multi_arch_build_linux_jax_wheels_ci.yml
+++ b/.github/workflows/multi_arch_build_linux_jax_wheels_ci.yml
@@ -137,6 +137,7 @@ jobs:
           ref: ${{ inputs.jax_ref }}
 
       - name: Checkout JAX
+        id: checkout_jax
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: jax-source
@@ -208,7 +209,7 @@ jobs:
                 --bazel_options=--repo_env=ROCM_PATH=$(rocm-sdk path --root) \
                 --bazel_options=--repo_env=ML_WHEEL_TYPE=release \
                 --bazel_options=--repo_env=ML_WHEEL_VERSION_SUFFIX="${ML_WHEEL_VERSION_SUFFIX}" \
-                --bazel_options=--//jaxlib/tools:jaxlib_git_hash=$(git rev-parse HEAD) \
+                --bazel_options=--//jaxlib/tools:jaxlib_git_hash="${{ steps.checkout_jax.outputs.commit }}" \
                 --verbose \
                 --detailed_timestamped_log \
                 --output_path=$(pwd)/dist


### PR DESCRIPTION
## Motivation

`jaxlib_git_hash` was resolved by a `git` call that ran *inside* the manylinux
container, where git rejects the runner-owned checkout as dubiously owned. The
command substitution failed silently, so every JAX plugin wheel from these two
workflows was published without a git hash while the job stayed green.

Issue: https://github.com/ROCm/TheRock/issues/6978

## Technical Details

`actions/checkout` already resolves the commit it materialised and exposes it as
`steps.<id>.outputs.commit` (internally `git log -1 --format=%H` in the checkout
directory). Taking the value from there removes the git call from the workflow
entirely, so the change is an `id:` on the checkout step plus one modified line.
* The runner substitutes `${{ ... }}` while rendering the `run:` block, so no
  shell ever sees a variable and nothing has to cross the container boundary.
  This is exactly why the old line failed: `$(...)` *is* shell syntax, so the
  single quotes deferred it to the container, where git rejects the runner-owned
  checkout. `${{ }}` is not shell syntax and the quotes do not apply to it.
* Nothing needs `--env` or `safe.directory`. The container makes no git call for
  this at all: `build/build.py` never shells out to git, and neither `.bazelrc`
  nor `build/rocm/rocm.bazelrc` sets `--stamp` or a `workspace_status_command`.
  `//jaxlib/tools:jaxlib_git_hash` is a plain `string_flag` passed through to
  `build_wheel.py` as a string.
* The resolved sha appears in the step's echoed script, so no extra `echo` is
  needed for observability.
Both the release and CI workflows carried the identical line and are changed
identically.


## Test Plan

Dispatched `multi_arch_build_linux_jax_wheels.yml` on this branch for a single
matrix cell (`build_mode=manylinux`, `python_version=3.14`,
`jax_ref=rocm-jaxlib-v0.10.2`, `rocm_version=7.15.0a20260728`,
`release_type=dev`) with the GPU test job enabled, then inspected the published
wheel.

## Test Result

Run [30513543402](https://github.com/ROCm/TheRock/actions/runs/30513543402), success in 1h17m14s. All 21 steps green; the native v0.9.1 step was skipped as expected.
* The expression is substituted before any shell runs, and Bazel receives it
  intact:
  `--bazel_options=--//jaxlib/tools:jaxlib_git_hash="0dad77d6b293b87573a9e8760b0ddf677a32ea43"`
  `'build' options: ... --//jaxlib/tools:jaxlib_git_hash=0dad77d6b293b87573a9e8760b0ddf677a32ea43`
* That sha is `refs/heads/rocm-jaxlib-v0.10.2` in ROCm/jax (`git ls-remote`) and
  matches what the `Checkout JAX` step reported.
* `dubious ownership`, `git rev-parse` and `GIT_CONFIG` each appear 0 times in
  the log: the container no longer invokes git, so dropping the `safe.directory`
  environment variables is confirmed harmless.
* Published `jax_rocm7_plugin` wheel: `_git_hash: str = '0dad77d6...'`, where the
  20260728 nightly had `None`. `_release_version` unchanged at
  `'0.10.2+rocm7.15.0a20260728'`.
* The GPU test job installed the wheels from this run and passed on
  gfx94X-dcgpu: 982, 480, 19 and 2 passed, 0 failed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
