### PR TITLE
feat(packaging): add aggregate DEB/RPM metadata scripts

### DIFF
--- a/build_tools/packaging/linux/README-aggregate-repo.txt
+++ b/build_tools/packaging/linux/README-aggregate-repo.txt
@@ -1,0 +1,194 @@
+AMD ROCm Aggregate Repository — Setup Guide
+===========================================
+
+Overview
+--------
+Two aggregation scripts merge package metadata from multiple sources into a
+single repository endpoint. Package files (.deb / .rpm) are never copied or
+moved — only the metadata index files are generated. CloudFront routes each
+prefixed package path to the correct origin bucket at install time.
+
+Scripts
+-------
+  aggregate_deb_metadata.py  — Merge DEB package metadata (Ubuntu/Debian)
+  aggregate_rpm_metadata.py  — Merge RPM package metadata (RHEL/AlmaLinux)
+
+
+How It Works
+------------
+Each source's Packages.gz / primary.xml is fetched, package file paths are
+rewritten with an owner prefix, all entries are merged, and a fresh
+Release / repomd.xml is generated.
+
+When a client installs a package, it resolves the prefixed path against the
+aggregate baseurl. CloudFront routes each prefix to the correct origin:
+
+  DEB:
+    pool/core/<pkg>.deb  ->  core release bucket
+    pool/rvs/<pkg>.deb   ->  RVS bucket
+
+  RPM:
+    core/<pkg>.rpm       ->  core release bucket
+    rvs/<pkg>.rpm        ->  RVS bucket
+
+
+Step 1: Generate Aggregate Metadata
+-------------------------------------
+No additional dependencies required for local generation.
+
+Sources are passed as --source arguments (repeatable, no limit on count).
+
+  DEB format: name,base_url,style,pool_prefix
+    style is "dists" (standard APT layout) or "flat" (Packages.gz at root)
+
+  RPM format: name,base_url,href_prefix
+
+DEB — merge ROCm nightly + RVS:
+
+  python aggregate_deb_metadata.py \
+    --source "core,https://repo.amd.com/rocm/packages-multi-arch/ubuntu2404,dists,pool/core" \
+    --source "rvs,https://d22tya8uodfbu6.cloudfront.net/nightly/rvs/deb,flat,pool/rvs" \
+    --output-dir /tmp/deb-metadata \
+    --suite stable \
+    --component main \
+    --architecture amd64
+
+  Output files:
+    /tmp/deb-metadata/dists/stable/Release
+    /tmp/deb-metadata/dists/stable/main/binary-amd64/Packages
+    /tmp/deb-metadata/dists/stable/main/binary-amd64/Packages.gz
+
+RPM — merge ROCm nightly + RVS:
+
+  python aggregate_rpm_metadata.py \
+    --source "core,https://repo.amd.com/rocm/packages-multi-arch/rhel10/x86_64,core" \
+    --source "rvs,https://d22tya8uodfbu6.cloudfront.net/nightly/rvs/rpm,rvs" \
+    --output-dir /tmp/rpm-metadata
+
+  Output files:
+    /tmp/rpm-metadata/repodata/repomd.xml
+    /tmp/rpm-metadata/repodata/primary.xml.gz
+
+Adding a third source is just another --source flag:
+
+  python aggregate_deb_metadata.py \
+    --source "core,...,dists,pool/core" \
+    --source "rvs,...,flat,pool/rvs" \
+    --source "extras,https://example.com/rocm-extras/deb,flat,pool/extras" \
+    --output-dir /tmp/deb-metadata
+
+
+Step 2 (Optional): Upload Metadata to S3
+-----------------------------------------
+Requires boto3 and AWS credentials with s3:PutObject on the output bucket.
+
+  pip install boto3
+  aws configure
+
+Upload the generated metadata by adding --output-bucket:
+
+  python aggregate_deb_metadata.py \
+    --source "core,https://repo.amd.com/rocm/packages-multi-arch/ubuntu2404,dists,pool/core" \
+    --source "rvs,https://d22tya8uodfbu6.cloudfront.net/nightly/rvs/deb,flat,pool/rvs" \
+    --output-bucket therock-deb-rpm-test \
+    --output-prefix metadata/deb \
+    --suite stable \
+    --component main \
+    --architecture amd64
+
+  Uploads to S3:
+    therock-deb-rpm-test/metadata/deb/dists/stable/Release
+    therock-deb-rpm-test/metadata/deb/dists/stable/main/binary-amd64/Packages
+    therock-deb-rpm-test/metadata/deb/dists/stable/main/binary-amd64/Packages.gz
+
+  python aggregate_rpm_metadata.py \
+    --source "core,https://repo.amd.com/rocm/packages-multi-arch/rhel10/x86_64,core" \
+    --source "rvs,https://d22tya8uodfbu6.cloudfront.net/nightly/rvs/rpm,rvs" \
+    --output-bucket therock-deb-rpm-test \
+    --output-prefix metadata/rpm
+
+  Uploads to S3:
+    therock-deb-rpm-test/metadata/rpm/repodata/repomd.xml
+    therock-deb-rpm-test/metadata/rpm/repodata/primary.xml.gz
+
+Both --output-dir and --output-bucket can be specified together to write
+locally and upload in a single run.
+
+
+Step 3: Set Up CloudFront
+--------------------------
+Add cache behaviors to the repo.amd.com CloudFront distribution. List them
+most-specific first (CloudFront matches top-down).
+
+DEB (ubuntu2404):
+
+  Path pattern                                  Origin / S3 prefix
+  --------------------------------------------  ----------------------------------------
+  /rocm/metadata/ubuntu2404/dists/*            therock-deb-rpm-test: metadata/deb/dists/
+  /rocm/metadata/ubuntu2404/pool/core/*        therock-release-packages: v4/.../deb/
+  /rocm/metadata/ubuntu2404/pool/rvs/*         amd-sharks-rvs: v3/.../deb/
+
+RPM (rhel10):
+
+  Path pattern                                  Origin / S3 prefix
+  --------------------------------------------  ----------------------------------------
+  /rocm/metadata/rhel10/x86_64/repodata/*      therock-deb-rpm-test: metadata/rpm/repodata/
+  /rocm/metadata/rhel10/x86_64/core/*          therock-release-packages: v4/.../rpm/
+  /rocm/metadata/rhel10/x86_64/rvs/*           amd-sharks-rvs: v3/.../rpm/
+
+For each behavior:
+  - Cache policy: CachingDisabled for metadata paths (dists/*, repodata/*)
+                  CachingOptimized for package paths (pool/*, core/*, rvs/*)
+  - Origin request policy: AllViewer
+  - Viewer protocol: HTTPS only
+
+After adding the behaviors, regenerate and upload metadata (Step 1 + Step 2).
+The generated Filename:/href values already use the relative prefixes that
+CloudFront routes correctly — no script changes needed.
+
+
+Step 4: User Setup
+-------------------
+
+Ubuntu/Debian:
+
+  echo "deb [trusted=yes] https://repo.amd.com/rocm/metadata/ubuntu2404 stable main" \
+    | sudo tee /etc/apt/sources.list.d/amdrocm-aggregate.list
+  sudo apt update
+  sudo apt install amdrocm7-rvs
+
+RHEL/AlmaLinux:
+
+  sudo tee /etc/yum.repos.d/amdrocm-aggregate.repo <<EOF
+  [amdrocm-aggregate]
+  name=AMD ROCm Aggregate
+  baseurl=https://repo.amd.com/rocm/metadata/rhel10/x86_64
+  enabled=1
+  gpgcheck=0
+  repo_gpgcheck=0
+  priority=50
+  EOF
+  sudo dnf clean all
+  sudo dnf install amdrocm7.13 amdrocm7-rvs
+
+
+GPG Signing (optional)
+-----------------------
+To allow clients to verify repo metadata integrity, sign with a GPG key.
+Can also be set via environment variable: export AGGREGATE_SIGN_KEY=<KEY_ID>
+
+DEB — produces Release.gpg (detached) + InRelease (clearsigned):
+
+  python aggregate_deb_metadata.py ... --sign-key <KEY_ID>
+
+  Client setup (no [trusted=yes] needed):
+  echo "deb [signed-by=/etc/apt/keyrings/amdrocm.gpg] https://repo.amd.com/rocm/metadata/ubuntu2404 stable main" \
+    | sudo tee /etc/apt/sources.list.d/amdrocm-aggregate.list
+
+RPM — produces repomd.xml.asc (detached):
+
+  python aggregate_rpm_metadata.py ... --sign-key <KEY_ID>
+
+  Client .repo file additions:
+    repo_gpgcheck=1
+    gpgkey=https://repo.amd.com/rocm/rocm.gpg.key

--- a/build_tools/packaging/linux/aggregate_deb_metadata.py
+++ b/build_tools/packaging/linux/aggregate_deb_metadata.py
@@ -82,16 +82,16 @@ def parse_source(value: str) -> dict:
         raise argparse.ArgumentTypeError(
             f"--source must be 'name,base_url,style,pool_prefix', got: {value!r}"
         )
-    name, base_url, style, pool_prefix = parts
+    name, base_url, style, pool_prefix = [p.strip() for p in parts]
     if style not in ("dists", "flat"):
         raise argparse.ArgumentTypeError(
             f"style must be 'dists' or 'flat', got: {style!r}"
         )
     return {
-        "name": name.strip(),
-        "base_url": base_url.strip(),
-        "style": style.strip(),
-        "pool_prefix": pool_prefix.strip(),
+        "name": name,
+        "base_url": base_url,
+        "style": style,
+        "pool_prefix": pool_prefix,
     }
 
 

--- a/build_tools/packaging/linux/aggregate_deb_metadata.py
+++ b/build_tools/packaging/linux/aggregate_deb_metadata.py
@@ -9,6 +9,14 @@ owner-prefix so APT resolves package files through the correct CloudFront path,
 merges all stanzas, regenerates Release/InRelease, and writes output locally
 and/or uploads to S3.
 
+Limitations:
+  - Packages index compression: tries .xz, .bz2, .gz, and uncompressed in
+    APT preference order. Fails fast if none are available for a source.
+  - A single --architecture value is supported per run. To serve multiple
+    architectures, run the script once per architecture. Note that each run
+    overwrites dists/<suite>/Release, so multi-arch runs must use separate
+    --output-prefix values or the Release file must be manually merged.
+
 Usage:
     python aggregate_deb_metadata.py \\
         --source "core,https://repo.amd.com/rocm/packages-multi-arch/ubuntu2404,dists,pool/core" \\
@@ -44,12 +52,15 @@ At least one of --output-dir or --output-bucket must be provided.
 """
 
 import argparse
+import bz2
 import gzip
 import hashlib
+import lzma
 import os
 import subprocess
 import sys
 import tempfile
+import urllib.error
 import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
@@ -97,20 +108,45 @@ def fetch_bytes(url: str) -> bytes:
         return resp.read()
 
 
-def fetch_packages_gz(
+def fetch_packages(
     base_url: str, style: str, suite: str, component: str, arch: str
 ) -> bytes:
     """Download and return decompressed Packages content.
 
-    style="dists" → standard: <base>/dists/<suite>/<component>/binary-<arch>/Packages.gz
-    style="flat"  → flat repo: <base>/Packages.gz  (deb [...] <url> /)
+    Tries compression formats in APT preference order: .xz, .bz2, .gz,
+    then uncompressed. Raises RuntimeError if none are available.
+
+    style="dists" → standard: <base>/dists/<suite>/<component>/binary-<arch>/Packages*
+    style="flat"  → flat repo: <base>/Packages*  (deb [...] <url> /)
     """
     if style == "flat":
-        url = f"{base_url.rstrip('/')}/Packages.gz"
+        base_path = f"{base_url.rstrip('/')}/Packages"
     else:
-        url = f"{base_url.rstrip('/')}/dists/{suite}/{component}/binary-{arch}/Packages.gz"
-    compressed = fetch_bytes(url)
-    return gzip.decompress(compressed)
+        base_path = (
+            f"{base_url.rstrip('/')}/dists/{suite}/{component}/binary-{arch}/Packages"
+        )
+
+    candidates = [
+        (f"{base_path}.xz", lzma.decompress),
+        (f"{base_path}.bz2", bz2.decompress),
+        (f"{base_path}.gz", gzip.decompress),
+        (base_path, lambda b: b),  # uncompressed
+    ]
+
+    for url, decompress in candidates:
+        try:
+            compressed = fetch_bytes(url)
+            return decompress(compressed)
+        except urllib.error.HTTPError as e:
+            if e.code == 404:
+                print(f"  Not found: {url} — trying next format")
+                continue
+            raise
+
+    raise RuntimeError(
+        f"No Packages index found for [{base_url}] — "
+        f"tried .xz, .bz2, .gz, and uncompressed."
+    )
 
 
 def parse_stanzas(packages_text: str) -> list[dict[str, str]]:
@@ -380,7 +416,7 @@ def main():
         print(f"         style={style}  pool_prefix={pool_prefix}")
 
         try:
-            raw = fetch_packages_gz(base_url, style, suite, component, arch)
+            raw = fetch_packages(base_url, style, suite, component, arch)
         except Exception as e:
             sys.exit(
                 f"ERROR: Failed to fetch Packages.gz from [{name}] {base_url}: {e}"

--- a/build_tools/packaging/linux/aggregate_deb_metadata.py
+++ b/build_tools/packaging/linux/aggregate_deb_metadata.py
@@ -1,0 +1,488 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Aggregate DEB package metadata from multiple APT sources into a single repo.
+
+Fetches Packages.gz from each source, rewrites the Filename: field with an
+owner-prefix so APT resolves package files through the correct CloudFront path,
+merges all stanzas, regenerates Release/InRelease, and writes output locally
+and/or uploads to S3.
+
+Usage:
+    python aggregate_deb_metadata.py \\
+        --source "core,https://repo.amd.com/rocm/packages-multi-arch/ubuntu2404,dists,pool/core" \\
+        --source "rvs,https://d22tya8uodfbu6.cloudfront.net/nightly/rvs/deb,flat,pool/rvs" \\
+        [--output-dir /tmp/deb-metadata] \\
+        [--output-bucket therock-deb-rpm-test] \\
+        [--output-prefix metadata/deb] \\
+        [--suite stable] \\
+        [--component main] \\
+        [--architecture amd64] \\
+        [--sign-key KEY_ID]
+
+Each --source value is a comma-separated tuple:
+    name,base_url,style,pool_prefix
+
+  name        - short label used in pool path prefix and collision messages
+  base_url    - public base URL of the APT repo
+  style       - "dists" (standard dists/suite/component/binary-arch layout)
+                "flat"  (Packages.gz at repo root, i.e. deb [...] <url> /)
+  pool_prefix - prefix written into the Filename: field in merged Packages
+                (e.g. "pool/core" → "pool/core/<pkg>.deb")
+                CloudFront routes requests for pool/<prefix>/* to the real origin.
+
+At least one --source is required.
+At least one of --output-dir or --output-bucket must be provided.
+
+--sign-key KEY_ID
+    Signs the Release file with GPG, producing Release.gpg (detached signature)
+    and InRelease (clearsigned). APT clients configured with signed-by= will
+    verify these. Without this flag, packages must be configured with
+    [trusted=yes] on the client side. Can also be set via AGGREGATE_SIGN_KEY
+    environment variable.
+"""
+
+import argparse
+import gzip
+import hashlib
+import os
+import subprocess
+import sys
+import tempfile
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# Source parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_source(value: str) -> dict:
+    """Parse a --source argument into a source dict.
+
+    Format: name,base_url,style,pool_prefix
+    """
+    parts = value.split(",", 3)
+    if len(parts) != 4:
+        raise argparse.ArgumentTypeError(
+            f"--source must be 'name,base_url,style,pool_prefix', got: {value!r}"
+        )
+    name, base_url, style, pool_prefix = parts
+    if style not in ("dists", "flat"):
+        raise argparse.ArgumentTypeError(
+            f"style must be 'dists' or 'flat', got: {style!r}"
+        )
+    return {
+        "name": name.strip(),
+        "base_url": base_url.strip(),
+        "style": style.strip(),
+        "pool_prefix": pool_prefix.strip(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def fetch_bytes(url: str) -> bytes:
+    """Fetch URL, return raw bytes. Raises on HTTP error."""
+    print(f"  Fetching {url}")
+    req = urllib.request.Request(url, headers={"User-Agent": "amdrocm-aggregate/1.0"})
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        return resp.read()
+
+
+def fetch_packages_gz(
+    base_url: str, style: str, suite: str, component: str, arch: str
+) -> bytes:
+    """Download and return decompressed Packages content.
+
+    style="dists" → standard: <base>/dists/<suite>/<component>/binary-<arch>/Packages.gz
+    style="flat"  → flat repo: <base>/Packages.gz  (deb [...] <url> /)
+    """
+    if style == "flat":
+        url = f"{base_url.rstrip('/')}/Packages.gz"
+    else:
+        url = f"{base_url.rstrip('/')}/dists/{suite}/{component}/binary-{arch}/Packages.gz"
+    compressed = fetch_bytes(url)
+    return gzip.decompress(compressed)
+
+
+def parse_stanzas(packages_text: str) -> list[dict[str, str]]:
+    """Parse an APT Packages file into a list of field dicts."""
+    stanzas = []
+    for block in packages_text.strip().split("\n\n"):
+        block = block.strip()
+        if not block:
+            continue
+        fields: dict[str, str] = {}
+        current_key = None
+        for line in block.splitlines():
+            if line.startswith(" ") or line.startswith("\t"):
+                if current_key:
+                    fields[current_key] += "\n" + line
+            elif ": " in line:
+                key, _, val = line.partition(": ")
+                fields[key] = val
+                current_key = key
+            elif line.endswith(":"):
+                key = line[:-1]
+                fields[key] = ""
+                current_key = key
+        if fields:
+            stanzas.append(fields)
+    return stanzas
+
+
+def rewrite_filename(
+    stanza: dict[str, str],
+    base_url: str,
+    pool_prefix: str,
+) -> dict[str, str]:
+    """Rewrite Filename: field to pool_prefix/<basename>.
+
+    APT resolves this relative path against the aggregate baseurl.
+    CloudFront routes pool/<prefix>/* requests to the correct origin bucket.
+    """
+    result = dict(stanza)
+    original = result.get("Filename", "")
+    basename = original.rsplit("/", 1)[-1] if "/" in original else original
+    result["Filename"] = f"{pool_prefix}/{basename}"
+    return result
+
+
+def stanza_to_text(fields: dict[str, str]) -> str:
+    """Serialize a stanza back to RFC 2822 format."""
+    return "\n".join(f"{key}: {val}" for key, val in fields.items())
+
+
+def sha256_of(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def md5_of(data: bytes) -> str:
+    return hashlib.md5(data).hexdigest()
+
+
+def sha1_of(data: bytes) -> str:
+    return hashlib.sha1(data).hexdigest()
+
+
+def generate_release(
+    suite: str,
+    component: str,
+    arch: str,
+    packages_bytes: bytes,
+    packages_gz_bytes: bytes,
+) -> str:
+    """Generate an APT Release file with MD5Sum/SHA1/SHA256 sections."""
+    # APT requires RFC 2822 date with +0000 offset, not the word "UTC"
+    now = datetime.now(timezone.utc).strftime("%a, %d %b %Y %H:%M:%S +0000")
+
+    pkg_path = f"{component}/binary-{arch}/Packages"
+    pkg_gz_path = f"{component}/binary-{arch}/Packages.gz"
+
+    def md5_entry(path, data):
+        return f" {md5_of(data):<32s} {len(data):>16d} {path}"
+
+    def sha1_entry(path, data):
+        return f" {sha1_of(data):<40s} {len(data):>16d} {path}"
+
+    def sha256_entry(path, data):
+        return f" {sha256_of(data):<64s} {len(data):>16d} {path}"
+
+    files = [(pkg_path, packages_bytes), (pkg_gz_path, packages_gz_bytes)]
+    md5_block = "\n".join(md5_entry(p, d) for p, d in files)
+    sha1_block = "\n".join(sha1_entry(p, d) for p, d in files)
+    sha256_block = "\n".join(sha256_entry(p, d) for p, d in files)
+
+    lines = [
+        "Origin: AMD ROCm Aggregate",
+        "Label: AMD ROCm",
+        f"Suite: {suite}",
+        f"Codename: {suite}",
+        f"Components: {component}",
+        f"Architectures: {arch}",
+        f"Date: {now}",
+        "MD5Sum:",
+        md5_block,
+        "SHA1:",
+        sha1_block,
+        "SHA256:",
+        sha256_block,
+        "",  # trailing newline
+    ]
+    return "\n".join(lines)
+
+
+def gpg_sign(release_path: Path, key_id: Optional[str]) -> tuple[Path, Path]:
+    """Produce Release.gpg (detached) and InRelease (clearsigned).
+
+    With --sign-key, APT clients configured with signed-by= can verify the
+    repo metadata. Without signing, clients must use [trusted=yes].
+    Returns (release_gpg_path, inrelease_path).
+    """
+    key_args = ["--local-user", key_id] if key_id else []
+    release_gpg = release_path.parent / "Release.gpg"
+    inrelease = release_path.parent / "InRelease"
+
+    subprocess.run(
+        ["gpg", "--batch", "--yes", "--armor", "--detach-sign"]
+        + key_args
+        + ["--output", str(release_gpg), str(release_path)],
+        check=True,
+    )
+    subprocess.run(
+        ["gpg", "--batch", "--yes", "--armor", "--clearsign"]
+        + key_args
+        + ["--output", str(inrelease), str(release_path)],
+        check=True,
+    )
+    return release_gpg, inrelease
+
+
+def write_local(local_path: Path, dest_dir: Path, rel_key: str) -> None:
+    """Copy a generated file to dest_dir preserving relative path."""
+    dest = dest_dir / rel_key
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(local_path.read_bytes())
+    print(f"  Written  → {dest}")
+
+
+def upload_to_s3(local_path: Path, bucket: str, s3_key: str) -> None:
+    """Upload a single file to S3."""
+    import boto3
+
+    s3 = boto3.client("s3")
+    content_type = "application/octet-stream"
+    if local_path.suffix == ".gz":
+        content_type = "application/x-gzip"
+    elif local_path.name in ("Release", "InRelease", "Packages", "Release.gpg"):
+        content_type = "text/plain"
+
+    extra = {"ContentType": content_type}
+    if local_path.name in ("Release", "InRelease", "Packages.gz", "Release.gpg"):
+        extra["CacheControl"] = "max-age=300"
+    else:
+        extra["CacheControl"] = "max-age=31536000"
+
+    s3.upload_file(str(local_path), bucket, s3_key, ExtraArgs=extra)
+    print(f"  Uploaded → s3://{bucket}/{s3_key}")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Aggregate DEB metadata from multiple APT sources",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--source",
+        dest="sources",
+        action="append",
+        metavar="name,base_url,style,pool_prefix",
+        required=True,
+        help=(
+            "APT source to include (repeatable, no limit on count). "
+            "Format: name,base_url,style,pool_prefix — "
+            "style is 'dists' or 'flat', "
+            "pool_prefix is written into Filename: (e.g. 'pool/core')."
+        ),
+    )
+    parser.add_argument("--suite", default="stable", help="APT suite (default: stable)")
+    parser.add_argument(
+        "--component", default="main", help="APT component (default: main)"
+    )
+    parser.add_argument(
+        "--architecture", default="amd64", help="Package architecture (default: amd64)"
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Local directory to write generated metadata files",
+    )
+    parser.add_argument(
+        "--output-bucket",
+        default=None,
+        help="S3 bucket to upload generated metadata (requires boto3)",
+    )
+    parser.add_argument(
+        "--output-prefix",
+        default="metadata/deb",
+        help="S3 key prefix (default: metadata/deb)",
+    )
+    parser.add_argument(
+        "--sign-key",
+        default=None,
+        help=(
+            "GPG key ID for signing Release. Produces Release.gpg and InRelease "
+            "so APT clients can verify metadata integrity. "
+            "Can also be set via AGGREGATE_SIGN_KEY env var."
+        ),
+    )
+    args = parser.parse_args()
+
+    # Validate sources
+    try:
+        sources = [parse_source(s) for s in args.sources]
+    except argparse.ArgumentTypeError as e:
+        parser.error(str(e))
+
+    if len(sources) == 0:
+        parser.error("At least one --source is required.")
+
+    if args.output_dir is None and args.output_bucket is None:
+        parser.error(
+            "At least one of --output-dir or --output-bucket must be provided."
+        )
+
+    suite = args.suite
+    component = args.component
+    arch = args.architecture
+    prefix = args.output_prefix.rstrip("/")
+
+    print("=" * 70)
+    print("AMD ROCm DEB Aggregate Metadata Job")
+    if args.output_dir:
+        print(f"  Output dir:    {args.output_dir}")
+    if args.output_bucket:
+        print(f"  Output bucket: s3://{args.output_bucket}/{prefix}/")
+    print(f"  Suite: {suite}  Component: {component}  Arch: {arch}")
+    if len(sources) == 1:
+        print(f"  Sources: {sources[0]['name']} (single source — no merge needed)")
+    else:
+        print(f"  Sources: {', '.join(s['name'] for s in sources)}")
+    print("=" * 70)
+
+    # ------------------------------------------------------------------
+    # Step 1: Fetch + parse + rewrite each source
+    # ------------------------------------------------------------------
+    all_stanzas: list[dict[str, str]] = []
+    declared: dict[str, str] = {}
+
+    for source in sources:
+        name = source["name"]
+        base_url = source["base_url"]
+        style = source["style"]
+        pool_prefix = source["pool_prefix"]
+
+        print(f"\n[{name}] Fetching Packages.gz from {base_url}")
+        print(f"         style={style}  pool_prefix={pool_prefix}")
+
+        try:
+            raw = fetch_packages_gz(base_url, style, suite, component, arch)
+        except Exception as e:
+            sys.exit(
+                f"ERROR: Failed to fetch Packages.gz from [{name}] {base_url}: {e}"
+            )
+
+        stanzas = parse_stanzas(raw.decode("utf-8"))
+        print(f"[{name}] Found {len(stanzas)} packages")
+
+        for stanza in stanzas:
+            pkg_name = stanza.get("Package", "")
+            pkg_ver = stanza.get("Version", "")
+            pkg_arch = stanza.get("Architecture", "")
+            nevra_key = f"{pkg_name}_{pkg_ver}_{pkg_arch}"
+            if nevra_key in declared and declared[nevra_key] != name:
+                sys.exit(
+                    f"ERROR: Package collision for '{nevra_key}': "
+                    f"present in both '{declared[nevra_key]}' and '{name}'. "
+                    f"Each NEVRA must come from exactly one source."
+                )
+            declared[nevra_key] = name
+            all_stanzas.append(rewrite_filename(stanza, base_url, pool_prefix))
+
+    print(f"\nTotal packages after merge: {len(all_stanzas)}")
+
+    # ------------------------------------------------------------------
+    # Step 2: Serialize merged Packages
+    # ------------------------------------------------------------------
+    packages_text = "\n\n".join(stanza_to_text(s) for s in all_stanzas) + "\n"
+    packages_bytes = packages_text.encode("utf-8")
+    packages_gz_bytes = gzip.compress(packages_bytes, compresslevel=9)
+    print(
+        f"Packages: {len(packages_bytes):,} bytes uncompressed, "
+        f"{len(packages_gz_bytes):,} bytes compressed"
+    )
+
+    # ------------------------------------------------------------------
+    # Step 3: Generate Release file
+    # ------------------------------------------------------------------
+    release_text = generate_release(
+        suite, component, arch, packages_bytes, packages_gz_bytes
+    )
+    release_bytes = release_text.encode("utf-8")
+    print(f"Release SHA256: {sha256_of(release_bytes)}")
+
+    # ------------------------------------------------------------------
+    # Step 4: Write to temp dir, optionally GPG sign, then output
+    # ------------------------------------------------------------------
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        dist_dir = tmppath / "dists" / suite
+        binary_dir = dist_dir / component / f"binary-{arch}"
+        binary_dir.mkdir(parents=True)
+
+        packages_file = binary_dir / "Packages"
+        packages_gz_file = binary_dir / "Packages.gz"
+        release_file = dist_dir / "Release"
+
+        packages_file.write_bytes(packages_bytes)
+        packages_gz_file.write_bytes(packages_gz_bytes)
+        release_file.write_bytes(release_bytes)
+
+        pkg_rel = f"dists/{suite}/{component}/binary-{arch}/Packages"
+        pkg_gz_rel = f"dists/{suite}/{component}/binary-{arch}/Packages.gz"
+        release_rel = f"dists/{suite}/Release"
+
+        files: list[tuple[Path, str]] = [
+            (packages_file, pkg_rel),
+            (packages_gz_file, pkg_gz_rel),
+            (release_file, release_rel),
+        ]
+
+        # GPG signing
+        key_id = args.sign_key or os.environ.get("AGGREGATE_SIGN_KEY")
+        if key_id:
+            print(f"\nSigning Release with key: {key_id}")
+            release_gpg, inrelease = gpg_sign(release_file, key_id)
+            files += [
+                (release_gpg, f"dists/{suite}/Release.gpg"),
+                (inrelease, f"dists/{suite}/InRelease"),
+            ]
+        else:
+            print("\nNo signing key — skipping GPG signing")
+            print("  (Set --sign-key or AGGREGATE_SIGN_KEY env var to enable)")
+            print("  (Clients must use [trusted=yes] in sources.list)")
+
+        # Local output
+        if args.output_dir:
+            print(f"\nWriting {len(files)} files to {args.output_dir}/")
+            for local_path, rel_key in files:
+                write_local(local_path, args.output_dir, rel_key)
+
+        # S3 upload
+        if args.output_bucket:
+            print(
+                f"\nUploading {len(files)} files to "
+                f"s3://{args.output_bucket}/{prefix}/"
+            )
+            for local_path, rel_key in files:
+                upload_to_s3(local_path, args.output_bucket, f"{prefix}/{rel_key}")
+
+    print("\n✓ Aggregate DEB metadata job complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/build_tools/packaging/linux/aggregate_rpm_metadata.py
+++ b/build_tools/packaging/linux/aggregate_rpm_metadata.py
@@ -125,7 +125,12 @@ def rewrite_location_href(pkg: ET.Element, href_prefix: str) -> None:
     ns = {"c": NS_COMMON}
     location = pkg.find("c:location", ns)
     if location is None:
-        return
+        pkg_name_el = pkg.find("c:name", ns)
+        pkg_name = pkg_name_el.text if pkg_name_el is not None else "<unknown>"
+        raise RuntimeError(
+            f"Package '{pkg_name}' has no <location> element in primary.xml — "
+            f"source repo may be malformed."
+        )
     original_href = location.get("href", "")
     basename = (
         original_href.rsplit("/", 1)[-1] if "/" in original_href else original_href

--- a/build_tools/packaging/linux/aggregate_rpm_metadata.py
+++ b/build_tools/packaging/linux/aggregate_rpm_metadata.py
@@ -1,0 +1,428 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Aggregate RPM repodata from multiple sources into a single repository.
+
+Fetches primary.xml.gz (via repomd.xml) from each source, rewrites
+<location href> with an owner-prefix, merges all <package> entries,
+regenerates repomd.xml with fresh checksums, and writes output locally
+and/or uploads to S3.
+
+Usage:
+    python aggregate_rpm_metadata.py \\
+        --source "core,https://repo.amd.com/rocm/packages-multi-arch/rhel10/x86_64,core" \\
+        --source "rvs,https://d22tya8uodfbu6.cloudfront.net/nightly/rvs/rpm,rvs" \\
+        [--output-dir /tmp/rpm-metadata] \\
+        [--output-bucket therock-deb-rpm-test] \\
+        [--output-prefix metadata/rpm] \\
+        [--sign-key KEY_ID]
+
+Each --source value is a comma-separated tuple:
+    name,base_url,href_prefix
+
+  name        - short label used for collision messages
+  base_url    - public baseurl of the RPM repo (same as dnf baseurl=)
+  href_prefix - prefix written into <location href> in merged primary.xml
+                (e.g. "core" → "core/<pkg>.rpm")
+                CloudFront routes requests for <prefix>/* to the real origin.
+
+At least one --source is required.
+At least one of --output-dir or --output-bucket must be provided.
+
+--sign-key KEY_ID
+    Signs repomd.xml with GPG, producing repomd.xml.asc. DNF verifies this
+    when repo_gpgcheck=1 is set in the .repo file. Without this flag, use
+    repo_gpgcheck=0 on the client side. Can also be set via
+    AGGREGATE_SIGN_KEY environment variable.
+"""
+
+import argparse
+import gzip
+import hashlib
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.request
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Optional
+
+# XML namespaces used in RPM repodata
+NS_COMMON = "http://linux.duke.edu/metadata/common"
+NS_RPM = "http://linux.duke.edu/metadata/rpm"
+NS_REPO = "http://linux.duke.edu/metadata/repo"
+
+
+# ---------------------------------------------------------------------------
+# Source parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_source(value: str) -> dict:
+    """Parse a --source argument into a source dict.
+
+    Format: name,base_url,href_prefix
+    """
+    parts = value.split(",", 2)
+    if len(parts) != 3:
+        raise argparse.ArgumentTypeError(
+            f"--source must be 'name,base_url,href_prefix', got: {value!r}"
+        )
+    name, base_url, href_prefix = parts
+    return {
+        "name": name.strip(),
+        "base_url": base_url.strip(),
+        "href_prefix": href_prefix.strip(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def fetch_bytes(url: str) -> bytes:
+    """Fetch URL, return raw bytes. Raises on HTTP error."""
+    print(f"  Fetching {url}")
+    req = urllib.request.Request(url, headers={"User-Agent": "amdrocm-aggregate/1.0"})
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        return resp.read()
+
+
+def fetch_primary_xml(base_url: str) -> bytes:
+    """Fetch and decompress primary.xml.gz from an RPM repo via repomd.xml."""
+    repomd_url = f"{base_url.rstrip('/')}/repodata/repomd.xml"
+    repomd_data = fetch_bytes(repomd_url)
+    repomd = ET.fromstring(repomd_data)
+
+    ns = {"r": NS_REPO}
+    primary_loc = repomd.find(".//r:data[@type='primary']/r:location", ns)
+    if primary_loc is None:
+        raise RuntimeError(f"No primary data found in repomd.xml from {base_url}")
+
+    primary_href = primary_loc.get("href")
+    primary_url = f"{base_url.rstrip('/')}/{primary_href}"
+    compressed = fetch_bytes(primary_url)
+    return gzip.decompress(compressed)
+
+
+def parse_packages(primary_xml: bytes) -> list[ET.Element]:
+    """Parse primary.xml and return list of <package> elements."""
+    root = ET.fromstring(primary_xml)
+    ns = {"c": NS_COMMON}
+    return root.findall("c:package", ns)
+
+
+def rewrite_location_href(pkg: ET.Element, href_prefix: str) -> None:
+    """Rewrite <location href> to href_prefix/<basename> in-place.
+
+    DNF resolves this relative path against the repo baseurl.
+    CloudFront routes <prefix>/* requests to the correct origin bucket.
+    """
+    ns = {"c": NS_COMMON}
+    location = pkg.find("c:location", ns)
+    if location is None:
+        return
+    original_href = location.get("href", "")
+    basename = (
+        original_href.rsplit("/", 1)[-1] if "/" in original_href else original_href
+    )
+    location.set("href", f"{href_prefix}/{basename}")
+
+
+def sha256_of(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def build_repomd_xml(primary_gz: bytes, primary_xml: bytes, timestamp: int) -> bytes:
+    """Generate repomd.xml with SHA256 checksums for merged primary.xml.gz."""
+    ET.register_namespace("", NS_REPO)
+    ET.register_namespace("rpm", NS_RPM)
+
+    repomd = ET.Element(f"{{{NS_REPO}}}repomd")
+    ET.SubElement(repomd, f"{{{NS_REPO}}}revision").text = str(timestamp)
+
+    data = ET.SubElement(repomd, f"{{{NS_REPO}}}data", type="primary")
+    ET.SubElement(data, f"{{{NS_REPO}}}checksum", type="sha256").text = sha256_of(
+        primary_gz
+    )
+    ET.SubElement(data, f"{{{NS_REPO}}}open-checksum", type="sha256").text = sha256_of(
+        primary_xml
+    )
+    ET.SubElement(data, f"{{{NS_REPO}}}location").set("href", "repodata/primary.xml.gz")
+    ET.SubElement(data, f"{{{NS_REPO}}}timestamp").text = str(timestamp)
+    ET.SubElement(data, f"{{{NS_REPO}}}size").text = str(len(primary_gz))
+    ET.SubElement(data, f"{{{NS_REPO}}}open-size").text = str(len(primary_xml))
+
+    return ET.tostring(repomd, encoding="UTF-8", xml_declaration=True)
+
+
+def gpg_sign_repomd(repomd_path: Path, key_id: Optional[str]) -> Path:
+    """Generate detached ASCII-armored signature for repomd.xml.
+
+    Returns path to repomd.xml.asc. DNF verifies this when repo_gpgcheck=1
+    is set in the .repo file.
+    """
+    key_args = ["--local-user", key_id] if key_id else []
+    asc_path = repomd_path.parent / "repomd.xml.asc"
+    subprocess.run(
+        ["gpg", "--batch", "--yes", "--armor", "--detach-sign"]
+        + key_args
+        + ["--output", str(asc_path), str(repomd_path)],
+        check=True,
+    )
+    return asc_path
+
+
+def write_local(local_path: Path, dest_dir: Path, rel_key: str) -> None:
+    """Copy a generated file to dest_dir preserving relative path."""
+    dest = dest_dir / rel_key
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(local_path.read_bytes())
+    print(f"  Written  → {dest}")
+
+
+def upload_to_s3(local_path: Path, bucket: str, s3_key: str) -> None:
+    """Upload a single file to S3."""
+    import boto3
+
+    s3 = boto3.client("s3")
+    content_type = "application/octet-stream"
+    if local_path.suffix == ".gz":
+        content_type = "application/x-gzip"
+    elif local_path.suffix in (".xml", ".asc"):
+        content_type = "text/xml"
+
+    extra = {"ContentType": content_type}
+    if local_path.name in ("repomd.xml", "repomd.xml.asc", "primary.xml.gz"):
+        extra["CacheControl"] = "max-age=300"
+    else:
+        extra["CacheControl"] = "max-age=31536000"
+
+    s3.upload_file(str(local_path), bucket, s3_key, ExtraArgs=extra)
+    print(f"  Uploaded → s3://{bucket}/{s3_key}")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Aggregate RPM repodata from multiple sources",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--source",
+        dest="sources",
+        action="append",
+        metavar="name,base_url,href_prefix",
+        required=True,
+        help=(
+            "RPM source to include (repeatable, no limit on count). "
+            "Format: name,base_url,href_prefix — "
+            "href_prefix is written into <location href> "
+            "(e.g. 'core' → 'core/<pkg>.rpm')."
+        ),
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Local directory to write generated metadata files",
+    )
+    parser.add_argument(
+        "--output-bucket",
+        default=None,
+        help="S3 bucket to upload generated metadata (requires boto3)",
+    )
+    parser.add_argument(
+        "--output-prefix",
+        default="metadata/rpm",
+        help="S3 key prefix (default: metadata/rpm)",
+    )
+    parser.add_argument(
+        "--sign-key",
+        default=None,
+        help=(
+            "GPG key ID for signing repomd.xml. Produces repomd.xml.asc so DNF "
+            "clients can verify metadata integrity with repo_gpgcheck=1. "
+            "Can also be set via AGGREGATE_SIGN_KEY env var."
+        ),
+    )
+    args = parser.parse_args()
+
+    # Validate sources
+    try:
+        sources = [parse_source(s) for s in args.sources]
+    except argparse.ArgumentTypeError as e:
+        parser.error(str(e))
+
+    if len(sources) == 0:
+        parser.error("At least one --source is required.")
+
+    if args.output_dir is None and args.output_bucket is None:
+        parser.error(
+            "At least one of --output-dir or --output-bucket must be provided."
+        )
+
+    prefix = args.output_prefix.rstrip("/")
+    timestamp = int(time.time())
+
+    print("=" * 70)
+    print("AMD ROCm RPM Aggregate Metadata Job")
+    if args.output_dir:
+        print(f"  Output dir:    {args.output_dir}")
+    if args.output_bucket:
+        print(f"  Output bucket: s3://{args.output_bucket}/{prefix}/")
+    if len(sources) == 1:
+        print(f"  Sources: {sources[0]['name']} (single source — no merge needed)")
+    else:
+        print(f"  Sources: {', '.join(s['name'] for s in sources)}")
+    print("=" * 70)
+
+    # ------------------------------------------------------------------
+    # Step 1: Fetch + parse + rewrite each source
+    # ------------------------------------------------------------------
+    all_packages: list[ET.Element] = []
+    declared: dict[str, str] = {}
+
+    # Register namespaces so output doesn't use ns0/ns1 prefixes
+    ET.register_namespace("", NS_COMMON)
+    ET.register_namespace("rpm", NS_RPM)
+
+    for source in sources:
+        name = source["name"]
+        base_url = source["base_url"]
+        href_prefix = source["href_prefix"]
+
+        print(f"\n[{name}] Fetching repomd.xml + primary.xml.gz from {base_url}")
+        print(f"         href_prefix={href_prefix}")
+
+        try:
+            primary_xml = fetch_primary_xml(base_url)
+        except Exception as e:
+            sys.exit(
+                f"ERROR: Failed to fetch primary.xml.gz from [{name}] {base_url}: {e}"
+            )
+
+        packages = parse_packages(primary_xml)
+        print(f"[{name}] Found {len(packages)} packages")
+
+        ns = {"c": NS_COMMON}
+        for pkg in packages:
+            pkg_name = pkg.find("c:name", ns)
+            pkg_arch = pkg.find("c:arch", ns)
+            pkg_ver = pkg.find("c:version", ns)
+
+            name_str = pkg_name.text if pkg_name is not None else "unknown"
+            arch_str = pkg_arch.text if pkg_arch is not None else "unknown"
+            if pkg_ver is not None:
+                ver_str = (
+                    f"{pkg_ver.get('epoch', '0')}"
+                    f":{pkg_ver.get('ver', '')}"
+                    f"-{pkg_ver.get('rel', '')}"
+                )
+            else:
+                ver_str = "unknown"
+
+            # NEVRA collision detection: same exact package from two sources
+            nevra_key = f"{name_str}-{ver_str}.{arch_str}"
+            if nevra_key in declared and declared[nevra_key] != name:
+                sys.exit(
+                    f"ERROR: Package collision for '{nevra_key}': "
+                    f"present in both '{declared[nevra_key]}' and '{name}'. "
+                    f"Each NEVRA must come from exactly one source."
+                )
+            declared[nevra_key] = name
+
+            rewrite_location_href(pkg, href_prefix)
+            all_packages.append(pkg)
+
+    print(f"\nTotal packages after merge: {len(all_packages)}")
+
+    # ------------------------------------------------------------------
+    # Step 2: Build merged primary.xml
+    # ------------------------------------------------------------------
+    # Register namespaces BEFORE building the tree so ET.tostring() uses
+    # clean prefixes. Do NOT also call .set("xmlns:rpm") on the root element
+    # — that would write the attribute twice and DNF rejects it.
+    ET.register_namespace("", NS_COMMON)
+    ET.register_namespace("rpm", NS_RPM)
+
+    merged_root = ET.Element(
+        f"{{{NS_COMMON}}}metadata",
+        attrib={"packages": str(len(all_packages))},
+    )
+    for pkg in all_packages:
+        merged_root.append(pkg)
+
+    primary_xml_bytes = ET.tostring(merged_root, encoding="UTF-8", xml_declaration=True)
+    primary_gz_bytes = gzip.compress(primary_xml_bytes, compresslevel=9)
+    print(
+        f"primary.xml: {len(primary_xml_bytes):,} bytes uncompressed, "
+        f"{len(primary_gz_bytes):,} bytes compressed"
+    )
+
+    # ------------------------------------------------------------------
+    # Step 3: Generate repomd.xml
+    # ------------------------------------------------------------------
+    repomd_bytes = build_repomd_xml(primary_gz_bytes, primary_xml_bytes, timestamp)
+    print(f"repomd.xml SHA256: {sha256_of(repomd_bytes)}")
+
+    # ------------------------------------------------------------------
+    # Step 4: Write to temp dir, optionally sign, then output
+    # ------------------------------------------------------------------
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        repodata_dir = tmppath / "repodata"
+        repodata_dir.mkdir()
+
+        primary_gz_file = repodata_dir / "primary.xml.gz"
+        primary_xml_file = repodata_dir / "primary.xml"
+        repomd_file = repodata_dir / "repomd.xml"
+
+        primary_gz_file.write_bytes(primary_gz_bytes)
+        primary_xml_file.write_bytes(primary_xml_bytes)
+        repomd_file.write_bytes(repomd_bytes)
+
+        files: list[tuple[Path, str]] = [
+            (primary_gz_file, "repodata/primary.xml.gz"),
+            (repomd_file, "repodata/repomd.xml"),
+        ]
+
+        # GPG signing
+        key_id = args.sign_key or os.environ.get("AGGREGATE_SIGN_KEY")
+        if key_id:
+            print(f"\nSigning repomd.xml with key: {key_id}")
+            asc_path = gpg_sign_repomd(repomd_file, key_id)
+            files.append((asc_path, "repodata/repomd.xml.asc"))
+        else:
+            print("\nNo signing key — skipping GPG signing")
+            print("  (Set --sign-key or AGGREGATE_SIGN_KEY to enable)")
+            print("  (Clients must use repo_gpgcheck=0 in .repo file)")
+
+        # Local output
+        if args.output_dir:
+            print(f"\nWriting {len(files)} files to {args.output_dir}/")
+            for local_path, rel_key in files:
+                write_local(local_path, args.output_dir, rel_key)
+
+        # S3 upload
+        if args.output_bucket:
+            print(
+                f"\nUploading {len(files)} files to "
+                f"s3://{args.output_bucket}/{prefix}/"
+            )
+            for local_path, rel_key in files:
+                upload_to_s3(local_path, args.output_bucket, f"{prefix}/{rel_key}")
+
+    print("\n✓ Aggregate RPM metadata job complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/build_tools/packaging/linux/tests/aggregate_metadata_test.py
+++ b/build_tools/packaging/linux/tests/aggregate_metadata_test.py
@@ -1,0 +1,435 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for aggregate_deb_metadata.py and aggregate_rpm_metadata.py."""
+
+import argparse
+import bz2
+import gzip
+import lzma
+import sys
+import textwrap
+import unittest
+import urllib.error
+import xml.etree.ElementTree as ET
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+# Add parent directory to path so we can import the scripts directly
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import aggregate_deb_metadata as deb
+import aggregate_rpm_metadata as rpm
+
+
+# ---------------------------------------------------------------------------
+# DEB tests
+# ---------------------------------------------------------------------------
+
+
+class TestDebParseSource(unittest.TestCase):
+    def test_valid(self):
+        result = deb.parse_source("core,https://example.com/deb,dists,pool/core")
+        self.assertEqual(result["name"], "core")
+        self.assertEqual(result["base_url"], "https://example.com/deb")
+        self.assertEqual(result["style"], "dists")
+        self.assertEqual(result["pool_prefix"], "pool/core")
+
+    def test_valid_flat(self):
+        result = deb.parse_source("rvs,https://example.com/rvs/deb,flat,pool/rvs")
+        self.assertEqual(result["style"], "flat")
+
+    def test_strips_whitespace(self):
+        result = deb.parse_source(" core , https://example.com , dists , pool/core ")
+        self.assertEqual(result["name"], "core")
+        self.assertEqual(result["base_url"], "https://example.com")
+
+    def test_wrong_field_count(self):
+        with self.assertRaises(argparse.ArgumentTypeError):
+            deb.parse_source("core,https://example.com,dists")
+
+    def test_invalid_style(self):
+        with self.assertRaises(argparse.ArgumentTypeError):
+            deb.parse_source("core,https://example.com,zip,pool/core")
+
+    def test_url_with_commas_in_prefix(self):
+        # pool_prefix is the 4th field — earlier commas should be consumed by split(,3)
+        result = deb.parse_source("core,https://example.com,dists,pool/core/extra")
+        self.assertEqual(result["pool_prefix"], "pool/core/extra")
+
+
+class TestDebParseStanzas(unittest.TestCase):
+    def _stanzas(self, text):
+        return deb.parse_stanzas(textwrap.dedent(text).strip())
+
+    def test_single_stanza(self):
+        stanzas = self._stanzas(
+            """
+            Package: mypkg
+            Version: 1.0
+            Architecture: amd64
+        """
+        )
+        self.assertEqual(len(stanzas), 1)
+        self.assertEqual(stanzas[0]["Package"], "mypkg")
+        self.assertEqual(stanzas[0]["Version"], "1.0")
+
+    def test_multi_stanza(self):
+        stanzas = self._stanzas(
+            """
+            Package: pkg1
+            Version: 1.0
+
+            Package: pkg2
+            Version: 2.0
+        """
+        )
+        self.assertEqual(len(stanzas), 2)
+        self.assertEqual(stanzas[0]["Package"], "pkg1")
+        self.assertEqual(stanzas[1]["Package"], "pkg2")
+
+    def test_continuation_line(self):
+        stanzas = self._stanzas(
+            """
+            Package: mypkg
+            Description: Short desc
+             Long continuation line
+        """
+        )
+        self.assertIn("Long continuation line", stanzas[0]["Description"])
+
+    def test_empty_blocks_ignored(self):
+        stanzas = self._stanzas(
+            """
+            Package: pkg1
+            Version: 1.0
+
+
+            Package: pkg2
+            Version: 2.0
+        """
+        )
+        self.assertEqual(len(stanzas), 2)
+
+    def test_empty_input(self):
+        self.assertEqual(deb.parse_stanzas(""), [])
+
+
+class TestDebRewriteFilename(unittest.TestCase):
+    def test_dists_style_path(self):
+        stanza = {
+            "Package": "mypkg",
+            "Filename": "pool/main/m/mypkg/mypkg_1.0_amd64.deb",
+        }
+        result = deb.rewrite_filename(stanza, "https://example.com", "pool/core")
+        self.assertEqual(result["Filename"], "pool/core/mypkg_1.0_amd64.deb")
+
+    def test_flat_style_basename_only(self):
+        stanza = {"Package": "mypkg", "Filename": "mypkg_1.0_amd64.deb"}
+        result = deb.rewrite_filename(stanza, "https://example.com", "pool/rvs")
+        self.assertEqual(result["Filename"], "pool/rvs/mypkg_1.0_amd64.deb")
+
+    def test_original_stanza_not_mutated(self):
+        stanza = {"Package": "mypkg", "Filename": "pool/main/mypkg_1.0_amd64.deb"}
+        deb.rewrite_filename(stanza, "https://example.com", "pool/core")
+        self.assertEqual(stanza["Filename"], "pool/main/mypkg_1.0_amd64.deb")
+
+    def test_missing_filename_field(self):
+        stanza = {"Package": "mypkg"}
+        result = deb.rewrite_filename(stanza, "https://example.com", "pool/core")
+        self.assertEqual(result["Filename"], "pool/core/")
+
+
+class TestDebFetchPackages(unittest.TestCase):
+    def _make_http_error(self, code):
+        return urllib.error.HTTPError(
+            url="http://x", code=code, msg="", hdrs={}, fp=None
+        )
+
+    def test_xz_preferred(self):
+        xz_data = lzma.compress(b"Package: pkg\nVersion: 1.0\n")
+        with patch.object(deb, "fetch_bytes", return_value=xz_data) as mock_fetch:
+            result = deb.fetch_packages(
+                "https://example.com", "dists", "stable", "main", "amd64"
+            )
+        self.assertEqual(result, b"Package: pkg\nVersion: 1.0\n")
+        # Should have fetched the .xz URL first
+        self.assertIn(".xz", mock_fetch.call_args[0][0])
+
+    def test_falls_back_to_gz_when_xz_and_bz2_404(self):
+        gz_data = gzip.compress(b"Package: pkg\nVersion: 2.0\n")
+
+        def side_effect(url):
+            if url.endswith(".xz") or url.endswith(".bz2"):
+                raise self._make_http_error(404)
+            return gz_data
+
+        with patch.object(deb, "fetch_bytes", side_effect=side_effect):
+            result = deb.fetch_packages(
+                "https://example.com", "dists", "stable", "main", "amd64"
+            )
+        self.assertEqual(result, b"Package: pkg\nVersion: 2.0\n")
+
+    def test_falls_back_through_all_to_uncompressed(self):
+        raw = b"Package: pkg\nVersion: 3.0\n"
+
+        def side_effect(url):
+            if url.endswith((".xz", ".bz2", ".gz")):
+                raise self._make_http_error(404)
+            return raw
+
+        with patch.object(deb, "fetch_bytes", side_effect=side_effect):
+            result = deb.fetch_packages(
+                "https://example.com", "flat", "stable", "main", "amd64"
+            )
+        self.assertEqual(result, raw)
+
+    def test_raises_when_all_404(self):
+        with patch.object(deb, "fetch_bytes", side_effect=self._make_http_error(404)):
+            with self.assertRaises(RuntimeError):
+                deb.fetch_packages(
+                    "https://example.com", "dists", "stable", "main", "amd64"
+                )
+
+    def test_non_404_error_reraises(self):
+        with patch.object(deb, "fetch_bytes", side_effect=self._make_http_error(500)):
+            with self.assertRaises(urllib.error.HTTPError) as ctx:
+                deb.fetch_packages(
+                    "https://example.com", "dists", "stable", "main", "amd64"
+                )
+            self.assertEqual(ctx.exception.code, 500)
+
+    def test_flat_style_url_construction(self):
+        with patch.object(deb, "fetch_bytes", side_effect=self._make_http_error(404)):
+            with self.assertRaises(RuntimeError):
+                deb.fetch_packages(
+                    "https://example.com/rvs", "flat", "stable", "main", "amd64"
+                )
+
+
+class TestDebGenerateRelease(unittest.TestCase):
+    def _release(self, **kwargs):
+        defaults = dict(
+            suite="stable",
+            component="main",
+            arch="amd64",
+            packages_bytes=b"Package: p\n",
+            packages_gz_bytes=gzip.compress(b"Package: p\n"),
+        )
+        defaults.update(kwargs)
+        return deb.generate_release(**defaults)
+
+    def test_required_fields_present(self):
+        text = self._release()
+        self.assertIn("Suite: stable", text)
+        self.assertIn("Codename: stable", text)
+        self.assertIn("Components: main", text)
+        self.assertIn("Architectures: amd64", text)
+        self.assertIn("MD5Sum:", text)
+        self.assertIn("SHA1:", text)
+        self.assertIn("SHA256:", text)
+
+    def test_date_format_has_plus0000(self):
+        text = self._release()
+        # APT requires +0000 not UTC
+        self.assertIn("+0000", text)
+        self.assertNotIn("UTC", text)
+
+    def test_package_paths_listed(self):
+        text = self._release()
+        self.assertIn("main/binary-amd64/Packages", text)
+        self.assertIn("main/binary-amd64/Packages.gz", text)
+
+
+class TestDebNevraCollision(unittest.TestCase):
+    """Test NEVRA collision detection in the merge loop."""
+
+    def _make_stanza(self, name, version, arch):
+        return {
+            "Package": name,
+            "Version": version,
+            "Architecture": arch,
+            "Filename": f"{name}.deb",
+        }
+
+    def test_same_nevra_different_sources_raises(self):
+        declared = {"pkg1_1.0_amd64": "core"}
+        stanza = self._make_stanza("pkg1", "1.0", "amd64")
+        nevra_key = f"{stanza['Package']}_{stanza['Version']}_{stanza['Architecture']}"
+        self.assertIn(nevra_key, declared)
+        self.assertNotEqual(declared[nevra_key], "rvs")
+
+    def test_same_nevra_same_source_allowed(self):
+        declared = {"pkg1_1.0_amd64": "core"}
+        self.assertEqual(declared.get("pkg1_1.0_amd64"), "core")
+
+    def test_different_versions_no_collision(self):
+        declared = {"pkg1_1.0_amd64": "core"}
+        key = "pkg1_2.0_amd64"
+        self.assertNotIn(key, declared)
+
+
+class TestDebStanzaRoundTrip(unittest.TestCase):
+    def test_roundtrip(self):
+        original = "Package: mypkg\nVersion: 1.0\nArchitecture: amd64"
+        stanzas = deb.parse_stanzas(original)
+        self.assertEqual(len(stanzas), 1)
+        text = deb.stanza_to_text(stanzas[0])
+        self.assertIn("Package: mypkg", text)
+        self.assertIn("Version: 1.0", text)
+
+
+# ---------------------------------------------------------------------------
+# RPM tests
+# ---------------------------------------------------------------------------
+
+NS_COMMON = "http://linux.duke.edu/metadata/common"
+NS_REPO = "http://linux.duke.edu/metadata/repo"
+
+
+class TestRpmParseSource(unittest.TestCase):
+    def test_valid(self):
+        result = rpm.parse_source("core,https://example.com/rpm/x86_64,core")
+        self.assertEqual(result["name"], "core")
+        self.assertEqual(result["base_url"], "https://example.com/rpm/x86_64")
+        self.assertEqual(result["href_prefix"], "core")
+
+    def test_strips_whitespace(self):
+        result = rpm.parse_source(" rvs , https://example.com/rvs , rvs ")
+        self.assertEqual(result["name"], "rvs")
+
+    def test_wrong_field_count_too_few(self):
+        with self.assertRaises(argparse.ArgumentTypeError):
+            rpm.parse_source("core,https://example.com")
+
+    def test_wrong_field_count_too_many(self):
+        # Only 3 fields expected; split(,2) handles extra commas in base_url
+        result = rpm.parse_source("core,https://example.com/a,b,extra,core")
+        # href_prefix gets everything after 2nd comma
+        self.assertEqual(result["href_prefix"], "b,extra,core")
+
+
+class TestRpmRewriteLocationHref(unittest.TestCase):
+    def _make_pkg(self, href):
+        pkg = ET.Element(f"{{{NS_COMMON}}}package", type="rpm")
+        ET.SubElement(pkg, f"{{{NS_COMMON}}}name").text = "mypkg"
+        loc = ET.SubElement(pkg, f"{{{NS_COMMON}}}location")
+        loc.set("href", href)
+        return pkg
+
+    def test_rewrites_simple_basename(self):
+        pkg = self._make_pkg("mypkg-1.0.x86_64.rpm")
+        rpm.rewrite_location_href(pkg, "core")
+        ns = {"c": NS_COMMON}
+        loc = pkg.find("c:location", ns)
+        self.assertEqual(loc.get("href"), "core/mypkg-1.0.x86_64.rpm")
+
+    def test_rewrites_path_with_subdirectory(self):
+        pkg = self._make_pkg("Packages/mypkg-1.0.x86_64.rpm")
+        rpm.rewrite_location_href(pkg, "rvs")
+        ns = {"c": NS_COMMON}
+        loc = pkg.find("c:location", ns)
+        self.assertEqual(loc.get("href"), "rvs/mypkg-1.0.x86_64.rpm")
+
+    def test_missing_location_raises(self):
+        pkg = ET.Element(f"{{{NS_COMMON}}}package", type="rpm")
+        ET.SubElement(pkg, f"{{{NS_COMMON}}}name").text = "mypkg"
+        with self.assertRaises(RuntimeError) as ctx:
+            rpm.rewrite_location_href(pkg, "core")
+        self.assertIn("mypkg", str(ctx.exception))
+        self.assertIn("location", str(ctx.exception).lower())
+
+
+class TestRpmFetchPrimaryXml(unittest.TestCase):
+    def _make_repomd(self, primary_href):
+        repomd = ET.Element(f"{{{NS_REPO}}}repomd")
+        data = ET.SubElement(repomd, f"{{{NS_REPO}}}data", type="primary")
+        loc = ET.SubElement(data, f"{{{NS_REPO}}}location")
+        loc.set("href", primary_href)
+        return ET.tostring(repomd, encoding="UTF-8", xml_declaration=True)
+
+    def test_fetches_and_decompresses(self):
+        primary_content = b"<metadata/>"
+        primary_gz = gzip.compress(primary_content)
+        repomd_bytes = self._make_repomd("repodata/primary.xml.gz")
+
+        def side_effect(url):
+            if "repomd.xml" in url:
+                return repomd_bytes
+            return primary_gz
+
+        with patch.object(rpm, "fetch_bytes", side_effect=side_effect):
+            result = rpm.fetch_primary_xml("https://example.com/rpm")
+        self.assertEqual(result, primary_content)
+
+    def test_raises_when_no_primary_in_repomd(self):
+        repomd = ET.Element(f"{{{NS_REPO}}}repomd")
+        repomd_bytes = ET.tostring(repomd)
+
+        with patch.object(rpm, "fetch_bytes", return_value=repomd_bytes):
+            with self.assertRaises(RuntimeError) as ctx:
+                rpm.fetch_primary_xml("https://example.com/rpm")
+        self.assertIn("primary", str(ctx.exception).lower())
+
+
+class TestRpmNevraCollision(unittest.TestCase):
+    def _make_pkg(self, name, epoch, ver, rel, arch):
+        pkg = ET.Element(f"{{{NS_COMMON}}}package", type="rpm")
+        ET.SubElement(pkg, f"{{{NS_COMMON}}}name").text = name
+        ET.SubElement(pkg, f"{{{NS_COMMON}}}arch").text = arch
+        ver_el = ET.SubElement(pkg, f"{{{NS_COMMON}}}version")
+        ver_el.set("epoch", epoch)
+        ver_el.set("ver", ver)
+        ver_el.set("rel", rel)
+        loc = ET.SubElement(pkg, f"{{{NS_COMMON}}}location")
+        loc.set("href", f"{name}-{ver}.{arch}.rpm")
+        return pkg
+
+    def _nevra_key(self, pkg):
+        ns = {"c": NS_COMMON}
+        name = pkg.find("c:name", ns).text
+        arch = pkg.find("c:arch", ns).text
+        ver_el = pkg.find("c:version", ns)
+        ver_str = f"{ver_el.get('epoch')}:{ver_el.get('ver')}-{ver_el.get('rel')}"
+        return f"{name}-{ver_str}.{arch}"
+
+    def test_same_nevra_different_sources_detected(self):
+        pkg = self._make_pkg("mypkg", "0", "1.0", "1.el8", "x86_64")
+        declared = {self._nevra_key(pkg): "core"}
+        key = self._nevra_key(pkg)
+        self.assertIn(key, declared)
+        self.assertNotEqual(declared[key], "rvs")
+
+    def test_different_versions_no_collision(self):
+        pkg1 = self._make_pkg("mypkg", "0", "1.0", "1.el8", "x86_64")
+        pkg2 = self._make_pkg("mypkg", "0", "2.0", "1.el8", "x86_64")
+        declared = {self._nevra_key(pkg1): "core"}
+        self.assertNotIn(self._nevra_key(pkg2), declared)
+
+
+class TestRpmBuildRepomdXml(unittest.TestCase):
+    def test_output_is_valid_xml(self):
+        primary_xml = b"<metadata/>"
+        primary_gz = gzip.compress(primary_xml)
+        result = rpm.build_repomd_xml(primary_gz, primary_xml, timestamp=1000000)
+        root = ET.fromstring(result)
+        self.assertIsNotNone(root)
+
+    def test_contains_primary_data(self):
+        primary_xml = b"<metadata/>"
+        primary_gz = gzip.compress(primary_xml)
+        result = rpm.build_repomd_xml(primary_gz, primary_xml, timestamp=1000000)
+        self.assertIn(b"primary", result)
+        self.assertIn(b"primary.xml.gz", result)
+
+    def test_checksums_present(self):
+        primary_xml = b"<metadata/>"
+        primary_gz = gzip.compress(primary_xml)
+        result = rpm.build_repomd_xml(primary_gz, primary_xml, timestamp=1000000)
+        self.assertIn(b"sha256", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add two Python scripts and a setup guide for aggregating DEB and RPM package metadata from multiple sources (e.g. ROCm core + RVS) into a single APT/DNF repository endpoint, backed by S3 and CloudFront.

JIRA ID : https://amd-hub.atlassian.net/browse/ROCM-25115

## Motivation
ROCm users currently need to configure separate repo entries for core ROCm packages and supplementary packages like RVS. This creates friction at install time. These scripts merge the metadata from multiple sources into a single repository index so users can install from a single baseurl, while the actual package files stay in their original buckets — only metadata is aggregated.

## Technical Details

**`aggregate_deb_metadata.py`**
- Fetches `Packages.gz` from multiple APT sources (dists-style or flat-style)
- Rewrites `Filename:` with owner-prefixed pool paths (`pool/core/`, `pool/rvs/`) so
  CloudFront can route each prefix to the correct origin bucket
- Merges all stanzas with NEVRA-based collision detection (errors on duplicate
  package+version+arch from different sources)
- Generates `Release` file with MD5/SHA1/SHA256 checksums (RFC 2822 date format
  required by APT)
- Optional GPG signing via `--sign-key` producing `Release.gpg` + `InRelease`

**`aggregate_rpm_metadata.py`**
- Fetches `primary.xml.gz` via `repomd.xml` from multiple RPM sources
- Rewrites `<location href>` with owner-prefixed paths (`core/`, `rvs/`)
- Merges all `<package>` entries with NEVRA-based collision detection
- Regenerates `repomd.xml` with fresh SHA256 checksums
- Optional GPG signing producing `repomd.xml.asc`

**Common design:**
- Sources passed as repeatable `--source` CLI arguments — no hardcoded limit, no
  hardcoded sources in the script
- `--output-dir` writes locally (no dependencies beyond stdlib); `--output-bucket`
  uploads to S3 (requires `boto3`); both can be used together
- 0 sources → error; 1 source → works (no-op merge, useful for format conversion)
- `filelists.xml` intentionally omitted — ROCm packages use name-based and
  soname-based dependencies only, not file-path dependencies

**`README-aggregate-repo.txt`** documents:
- Step-by-step usage with ROCm nightly + RVS as example sources
- Optional S3 upload with prerequisites
- CloudFront behavior configuration for production (path pattern → origin mapping
  for DEB and RPM)
- End-user repo setup commands for Ubuntu and RHEL
- Optional GPG signing client setup
