### PR TITLE
docs: fix inaccuracies in hipcc_deprecation.md

### DIFF
--- a/docs/development/hipcc_deprecation.md
+++ b/docs/development/hipcc_deprecation.md
@@ -3,8 +3,9 @@
 `hipcc` is a compiler wrapper that historically injected HIP-specific flags
 (include paths, device library paths, GPU target flags, etc.) before invoking
 `clang++`. TheRock is deprecating `hipcc` in favor of calling `amdclang++`
-directly, which is a symlink to the same underlying clang binary with the HIP
-toolchain configured by CMake.
+directly. `amdclang++` is a user-facing binary (`amdllvm`) that provides the
+same HIP-capable compiler as `clang++` but under the AMD-branded name, with the
+HIP toolchain configured by CMake.
 
 This document explains why the change is being made, what the equivalents are,
 and how to migrate your project.
@@ -29,10 +30,7 @@ and how to migrate your project.
 ## What changed in TheRock
 
 - The `amd-hip` compiler toolchain now explicitly sets `CMAKE_HIP_COMPILER` to
-  `amdclang++` (our built clang) in the generated `_toolchain.cmake` file.
-- `--rtlib=compiler-rt --unwindlib=libgcc` linker flags are now injected via
-  `CMAKE_EXE_LINKER_FLAGS_INIT` and `CMAKE_SHARED_LINKER_FLAGS_INIT`, replacing
-  the equivalent flags hipcc provided.
+  `clang++` (our built clang, user-facing as `amdclang++`) in the generated `_toolchain.cmake` file.
 - `hipcc` is no longer listed as a `COMPILER_TOOLCHAIN` or `RUNTIME_DEPS` entry
   for subprojects that use the `amd-hip` toolchain.
 - The test script `test_libhipcxx_hipcc.py` has been renamed to
@@ -51,9 +49,8 @@ CMake variables that replace it when using `amdclang++` directly.
 | ---------------------------------------------------- | --------------------------------------------------------------------------- |
 | Injects `-I<hip>/include`                            | `--hip-path=<path>` (set in `CMAKE_CXX_FLAGS_INIT`)                         |
 | Injects `--hip-device-lib-path=<path>`               | `--hip-device-lib-path=<path>` (set in `CMAKE_CXX_FLAGS_INIT`)              |
-| Sets HIP compiler in CMake                           | `CMAKE_HIP_COMPILER` set to `amdclang++` in toolchain                       |
-| Adds `--rtlib=compiler-rt --unwindlib=libgcc`        | Added to `CMAKE_EXE_LINKER_FLAGS_INIT` and `CMAKE_SHARED_LINKER_FLAGS_INIT` |
-| Auto-detects GPU targets via `rocm_agent_enumerator` | `AMDGPU_TARGETS` / `CMAKE_HIP_ARCHITECTURES` set by TheRock super-project   |
+| Sets HIP compiler in CMake                           | `CMAKE_HIP_COMPILER` set to `clang++` (user-facing as `amdclang++`) in toolchain |
+| Auto-detects GPU targets via `rocm_agent_enumerator` | CMake: `AMDGPU_TARGETS` / `CMAKE_HIP_ARCHITECTURES` set by TheRock super-project. Direct: `--offload-arch=native` (build machine's GPUs) or explicit `--offload-arch=gfxNNNN` |
 | Defines `-D__HIP_PLATFORM_AMD__`                     | Added by `hip-config.cmake` target properties via `find_package(hip)`       |
 
 ## Migrating a CMake project
@@ -137,9 +134,9 @@ hipcc -o my_kernel my_kernel.cpp --offload-arch=gfx1100
 # After
 amdclang++ \
   --hip-path=${ROCM_PATH} \
-  --hip-device-lib-path=${ROCM_PATH}/lib/llvm/amdgcn/bitcode \
+  --hip-device-lib-path=${ROCM_PATH}/lib/llvm/amdgcn/bitcode \  # usually derivable from --hip-path; explicit here for clarity
   -x hip \
-  --offload-arch=gfx1100 \
+  --offload-arch=gfx1100 \  # or --offload-arch=native to target the build machine's GPUs
   -o my_kernel my_kernel.cpp
 ```
 

--- a/docs/development/hipcc_deprecation.md
+++ b/docs/development/hipcc_deprecation.md
@@ -2,7 +2,7 @@
 
 `hipcc` is a compiler wrapper that historically injected HIP-specific flags
 (include paths, device library paths, GPU target flags, etc.) before invoking
-`clang++`. TheRock is deprecating `hipcc` in favor of calling `amdclang++`
+`clang++`. `hipcc` is being deprecated in favor of calling `amdclang++`
 directly. `amdclang++` is a user-facing binary (`amdllvm`) that provides the
 same HIP-capable compiler as `clang++` but under the AMD-branded name, with the
 HIP toolchain configured by CMake.
@@ -12,8 +12,8 @@ and how to migrate your project.
 
 ## Why deprecate hipcc?
 
-- **Redundant indirection.** The `amd-hip` CMake toolchain already injects
-  `--hip-path`, `--hip-device-lib-path`, and all other necessary flags via
+- **Redundant indirection.** CMake toolchains can inject `--hip-path`,
+  `--hip-device-lib-path`, and all other necessary flags via
   `CMAKE_CXX_FLAGS_INIT`. hipcc was doing the same thing via shell script logic,
   creating two overlapping mechanisms for the same job.
 - **CMake-native HIP support.** CMake has had first-class HIP language support
@@ -27,19 +27,6 @@ and how to migrate your project.
   `hipcc`. Callers that used `hipconfig --version`, `--cxxflags`, or `--ldflags`
   should migrate to CMake-native equivalents (see below).
 
-## What changed in TheRock
-
-- The `amd-hip` compiler toolchain now explicitly sets `CMAKE_HIP_COMPILER` to
-  `clang++` (our built clang, user-facing as `amdclang++`) in the generated `_toolchain.cmake` file.
-- `hipcc` is no longer listed as a `COMPILER_TOOLCHAIN` or `RUNTIME_DEPS` entry
-  for subprojects that use the `amd-hip` toolchain.
-- The test script `test_libhipcxx_hipcc.py` has been renamed to
-  `test_libhipcxx_amdclang.py` and updated to use `amdclang++` directly.
-
-> **Note:** The `hipcc` binary is still built as part of TheRock for now as a
-> compatibility shim. This will be removed in a future PR once all downstream
-> consumers have migrated.
-
 ## Flag equivalency table
 
 The following table maps hipcc's implicit behavior to the explicit flags or
@@ -47,10 +34,10 @@ CMake variables that replace it when using `amdclang++` directly.
 
 | hipcc behavior                                       | amdclang++ / CMake equivalent                                                                                                                                                 |
 | ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Injects `-I<hip>/include`                            | `--hip-path=<path>` (set in `CMAKE_CXX_FLAGS_INIT`)                                                                                                                           |
-| Injects `--hip-device-lib-path=<path>`               | `--hip-device-lib-path=<path>` (set in `CMAKE_CXX_FLAGS_INIT`)                                                                                                                |
+| Injects `-I<hip>/include`                            | `--hip-path=<path>`                                                                                                                                                           |
+| Injects `--hip-device-lib-path=<path>`               | `--hip-device-lib-path=<path>` (usually derivable from `--hip-path`)                                                                                                          |
 | Sets HIP compiler in CMake                           | `CMAKE_HIP_COMPILER` set to `clang++` (user-facing as `amdclang++`) in toolchain                                                                                              |
-| Auto-detects GPU targets via `rocm_agent_enumerator` | CMake: `AMDGPU_TARGETS` / `CMAKE_HIP_ARCHITECTURES` set by TheRock super-project. Direct: `--offload-arch=native` (build machine's GPUs) or explicit `--offload-arch=gfxNNNN` |
+| Auto-detects GPU targets via `rocm_agent_enumerator` | `--offload-arch=native` (build machine's GPUs) or explicit `--offload-arch=gfxNNNN`, or `CMAKE_HIP_ARCHITECTURES` in CMake                                                    |
 | Defines `-D__HIP_PLATFORM_AMD__`                     | Added by `hip-config.cmake` target properties via `find_package(hip)`                                                                                                         |
 
 ## Migrating a CMake project
@@ -73,9 +60,6 @@ If your project uses CMake's native HIP language support, set
 ```cmake
 cmake -DCMAKE_HIP_COMPILER=amdclang++ ...
 ```
-
-When building inside TheRock, this is handled automatically by the `amd-hip`
-toolchain — you do not need to set these manually.
 
 ### HIP_HIPCC_EXECUTABLE
 
@@ -140,6 +124,5 @@ amdclang++ \
   -o my_kernel my_kernel.cpp
 ```
 
-When using a TheRock build, the `--hip-path` and `--hip-device-lib-path` values
-are available from the toolchain's `_toolchain.cmake` or from the `hip-config.cmake`
-installed in `<dist>/lib/cmake/hip/`.
+The `--hip-path` and `--hip-device-lib-path` values are available from the
+`hip-config.cmake` installed in `<rocm_install>/lib/cmake/hip/`.

--- a/docs/development/hipcc_deprecation.md
+++ b/docs/development/hipcc_deprecation.md
@@ -45,13 +45,13 @@ and how to migrate your project.
 The following table maps hipcc's implicit behavior to the explicit flags or
 CMake variables that replace it when using `amdclang++` directly.
 
-| hipcc behavior                                       | amdclang++ / CMake equivalent                                               |
-| ---------------------------------------------------- | --------------------------------------------------------------------------- |
-| Injects `-I<hip>/include`                            | `--hip-path=<path>` (set in `CMAKE_CXX_FLAGS_INIT`)                         |
-| Injects `--hip-device-lib-path=<path>`               | `--hip-device-lib-path=<path>` (set in `CMAKE_CXX_FLAGS_INIT`)              |
-| Sets HIP compiler in CMake                           | `CMAKE_HIP_COMPILER` set to `clang++` (user-facing as `amdclang++`) in toolchain |
+| hipcc behavior                                       | amdclang++ / CMake equivalent                                                                                                                                                 |
+| ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Injects `-I<hip>/include`                            | `--hip-path=<path>` (set in `CMAKE_CXX_FLAGS_INIT`)                                                                                                                           |
+| Injects `--hip-device-lib-path=<path>`               | `--hip-device-lib-path=<path>` (set in `CMAKE_CXX_FLAGS_INIT`)                                                                                                                |
+| Sets HIP compiler in CMake                           | `CMAKE_HIP_COMPILER` set to `clang++` (user-facing as `amdclang++`) in toolchain                                                                                              |
 | Auto-detects GPU targets via `rocm_agent_enumerator` | CMake: `AMDGPU_TARGETS` / `CMAKE_HIP_ARCHITECTURES` set by TheRock super-project. Direct: `--offload-arch=native` (build machine's GPUs) or explicit `--offload-arch=gfxNNNN` |
-| Defines `-D__HIP_PLATFORM_AMD__`                     | Added by `hip-config.cmake` target properties via `find_package(hip)`       |
+| Defines `-D__HIP_PLATFORM_AMD__`                     | Added by `hip-config.cmake` target properties via `find_package(hip)`                                                                                                         |
 
 ## Migrating a CMake project
 


### PR DESCRIPTION

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Clean up the HIPPC to amdclang++ migration guide.

<!-- Most pull requests should be associated with at least one GitHub issue -->

<!-- GitHub issue: https://github.com/ROCm/TheRock/issues/1234 -->

JIRA ID: ROCM-8370
JIRA ID: https://amd-hub.atlassian.net/browse/ROCM-8370

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Correct amdclang++ description: it is its own binary (amdllvm), not a symlink to clang++
- Fix CMAKE_HIP_COMPILER claim: toolchain sets it to clang++, not amdclang++
- Remove --rtlib=compiler-rt --unwindlib=libgcc references
- Expand rocm_agent_enumerator row to include --offload-arch=native for direct invocation path
- Add note that --hip-device-lib-path is usually derivable from --hip-path
## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
CI jobs
## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
