### PR TITLE
parallelize native package builds using ProcessPoolExecutor

### DIFF
--- a/build_tools/_therock_utils/log_utils.py
+++ b/build_tools/_therock_utils/log_utils.py
@@ -1,0 +1,545 @@
+"""Unified logging utilities for TheRock build tools.
+
+Provides a consistent logging API across all Python scripts with:
+- Console output capture to files (Python print + subprocess output)
+- CI-friendly formatting (GitHub Actions groups, annotations)
+- Verbosity control via environment variables or API
+- Thread-safe stream handling
+
+Usage::
+
+    from _therock_utils.log_utils import configure_logging, get_logger, capture_console
+
+    # One-time setup in main()
+    configure_logging(verbose=args.verbose)
+
+    # Get logger for module
+    logger = get_logger(__name__)
+    logger.info("Processing artifacts")
+
+    # Capture all output to file
+    with capture_console("build.log"):
+        logger.info("Building...")
+        subprocess.run(["cmake", ".."])  # Also captured
+"""
+
+import io
+import logging
+import os
+import sys
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator, TextIO
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_FORMAT = "[%(asctime)s][%(levelname)-8s]: %(message)s"
+DEFAULT_DATE_FORMAT = "%y-%m-%d %H:%M:%S"
+CI_FORMAT = "[%(levelname)-8s] %(name)s: %(message)s"
+
+# Environment variables
+ENV_LOG_ENABLED = "THEROCK_LOG_ENABLED"
+ENV_LOG_LEVEL = "THEROCK_LOG_LEVEL"
+ENV_GITHUB_ACTIONS = "GITHUB_ACTIONS"
+
+# Module state
+_configured = False
+_verbosity = 0
+_capture_depth = threading.local()  # Per-thread capture depth counter
+_MAX_CAPTURE_DEPTH = 3
+
+
+def _get_capture_depth() -> int:
+    """Get capture depth for current thread."""
+    return getattr(_capture_depth, "value", 0)
+
+
+def _increment_capture_depth() -> int:
+    """Increment and return capture depth for current thread."""
+    depth = getattr(_capture_depth, "value", 0) + 1
+    _capture_depth.value = depth
+    return depth
+
+
+def _decrement_capture_depth() -> None:
+    """Decrement capture depth for current thread."""
+    _capture_depth.value = max(0, getattr(_capture_depth, "value", 0) - 1)
+
+
+# ---------------------------------------------------------------------------
+# CI Detection
+# ---------------------------------------------------------------------------
+
+
+def is_ci() -> bool:
+    """Check if running in CI (GitHub Actions)."""
+    return os.environ.get(ENV_GITHUB_ACTIONS, "").lower() == "true"
+
+
+def is_logging_enabled() -> bool:
+    """Check if logging is globally enabled."""
+    return os.environ.get(ENV_LOG_ENABLED, "1") != "0"
+
+
+# ---------------------------------------------------------------------------
+# Flushing Handler
+# ---------------------------------------------------------------------------
+
+
+class FlushingStreamHandler(logging.StreamHandler):
+    """StreamHandler that flushes after every emit for CI compatibility."""
+
+    def emit(self, record: logging.LogRecord) -> None:
+        super().emit(record)
+        self.flush()
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+def configure_logging(
+    *,
+    enabled: bool | None = None,
+    level: int | str = logging.INFO,
+    verbose: bool = False,
+    ci_mode: bool | None = None,
+    stream: TextIO | None = None,
+) -> None:
+    """Configure root logger for script execution.
+
+    Call once at the start of main(). Replaces logging.basicConfig().
+
+    Args:
+        enabled: Enable/disable logging. None = check THEROCK_LOG_ENABLED env.
+        level: Base logging level (default INFO).
+        verbose: If True, sets level to DEBUG.
+        ci_mode: CI-specific formatting. None = auto-detect from GITHUB_ACTIONS.
+        stream: Output stream (default sys.stderr).
+    """
+    global _configured
+
+    # Check if globally disabled
+    if enabled is None:
+        enabled = is_logging_enabled()
+
+    if not enabled:
+        logging.disable(logging.CRITICAL)
+        _configured = True
+        return
+
+    # Determine level
+    env_level = os.environ.get(ENV_LOG_LEVEL, "").upper()
+    if env_level:
+        level = getattr(logging, env_level, logging.INFO)
+    elif verbose:
+        level = logging.DEBUG
+
+    # Determine CI mode
+    if ci_mode is None:
+        ci_mode = is_ci()
+
+    # Select format
+    fmt = CI_FORMAT if ci_mode else DEFAULT_FORMAT
+    datefmt = None if ci_mode else DEFAULT_DATE_FORMAT
+
+    # Configure root logger
+    root = logging.getLogger()
+    root.setLevel(level)
+
+    # Remove existing handlers to avoid duplicates
+    for handler in root.handlers[:]:
+        root.removeHandler(handler)
+
+    # Add new handler
+    handler = FlushingStreamHandler(stream or sys.stderr)
+    handler.setFormatter(logging.Formatter(fmt, datefmt))
+    root.addHandler(handler)
+
+    _configured = True
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Get a configured logger instance.
+
+    Args:
+        name: Logger name (typically __name__).
+
+    Returns:
+        Configured Logger instance.
+    """
+    if not _configured:
+        configure_logging()
+    return logging.getLogger(name)
+
+
+# ---------------------------------------------------------------------------
+# Verbosity Control
+# ---------------------------------------------------------------------------
+
+
+def set_verbosity(level: int) -> None:
+    """Set global verbosity level.
+
+    Args:
+        level: -1 = silent (disabled), 0 = normal (INFO), 1+ = verbose (DEBUG)
+    """
+    global _verbosity
+    _verbosity = level
+
+    if level < 0:
+        logging.disable(logging.CRITICAL)
+    else:
+        logging.disable(logging.NOTSET)
+        root = logging.getLogger()
+        if level >= 1:
+            root.setLevel(logging.DEBUG)
+        else:
+            root.setLevel(logging.INFO)
+
+
+def vlog(message: str, *args, level: int = 0, **kwargs) -> None:
+    """Log with verbosity level (py_packaging compatibility).
+
+    Args:
+        message: Log message.
+        level: Minimum verbosity level required to show this message.
+        *args, **kwargs: Passed to logger.debug().
+    """
+    if _verbosity >= level:
+        logger = get_logger("therock")
+        logger.debug(message, *args, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# TeeStream - Thread-safe dual output
+# ---------------------------------------------------------------------------
+
+
+class TeeStream:
+    """Thread-safe stream that writes to two destinations.
+
+    Used by capture_console() to write to both console and file.
+    """
+
+    def __init__(self, stream1: TextIO, stream2: TextIO):
+        self.stream1 = stream1
+        self.stream2 = stream2
+        self._lock = threading.Lock()
+
+    def write(self, data: str) -> int:
+        with self._lock:
+            if isinstance(data, bytes):
+                data = data.decode("utf-8", errors="replace")
+
+            self.stream1.write(data)
+            self.stream2.write(data)
+            self.stream1.flush()
+            self.stream2.flush()
+            return len(data)
+
+    def flush(self) -> None:
+        with self._lock:
+            self.stream1.flush()
+            self.stream2.flush()
+
+    def fileno(self) -> int:
+        """Return file descriptor for subprocess compatibility."""
+        return self.stream1.fileno()
+
+    def isatty(self) -> bool:
+        return self.stream1.isatty()
+
+    @property
+    def encoding(self) -> str:
+        return getattr(self.stream1, "encoding", "utf-8")
+
+    @property
+    def errors(self) -> str:
+        return getattr(self.stream1, "errors", "replace")
+
+
+# ---------------------------------------------------------------------------
+# Console Capture with OS-level file descriptor redirection
+# ---------------------------------------------------------------------------
+
+
+class _TeeWriter(threading.Thread):
+    """Background thread that reads from a pipe and writes to multiple destinations.
+
+    This enables capturing subprocess output that writes directly to file descriptors.
+    """
+
+    def __init__(self, read_fd: int, outputs: list[TextIO], name: str = "TeeWriter"):
+        super().__init__(daemon=True, name=name)
+        self.read_fd = read_fd
+        self.outputs = outputs
+        self._stop_event = threading.Event()
+
+    def run(self) -> None:
+        try:
+            while not self._stop_event.is_set():
+                try:
+                    data = os.read(self.read_fd, 4096)
+                    if not data:
+                        break
+                    text = data.decode("utf-8", errors="replace")
+                    for out in self.outputs:
+                        try:
+                            out.write(text)
+                            out.flush()
+                        except (IOError, ValueError):
+                            pass
+                except OSError:
+                    break
+        finally:
+            try:
+                os.close(self.read_fd)
+            except OSError:
+                pass
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+
+@contextmanager
+def capture_console(
+    log_file: Path | str,
+    *,
+    also_to_console: bool = True,
+    enabled: bool | None = None,
+) -> Iterator[Path]:
+    """Capture all console output to a file.
+
+    Uses OS-level file descriptor redirection to capture:
+    - Python print() statements
+    - Python logging calls
+    - Subprocess stdout/stderr (even direct fd writes)
+    - C library output (printf, etc.)
+
+    Supports nesting up to 3 levels for per-component + combined logs.
+
+    Args:
+        log_file: Path to output file.
+        also_to_console: If True (default), output also appears on console.
+        enabled: Enable/disable capture. None = check THEROCK_LOG_ENABLED env.
+
+    Yields:
+        Path to the log file.
+
+    Example::
+
+        with capture_console("build.log"):
+            print("Building...")  # Goes to console AND build.log
+            subprocess.run(["make"])  # Subprocess output also captured
+    """
+    # Check if enabled
+    if enabled is None:
+        enabled = is_logging_enabled()
+
+    log_path = Path(log_file)
+
+    if not enabled:
+        yield log_path
+        return
+
+    # Check nesting depth (thread-safe via thread-local storage)
+    if _get_capture_depth() >= _MAX_CAPTURE_DEPTH:
+        log = get_logger(__name__)
+        log.warning(
+            f"capture_console: max nesting depth ({_MAX_CAPTURE_DEPTH}) reached, "
+            f"skipping capture to {log_path}"
+        )
+        yield log_path
+        return
+
+    _increment_capture_depth()
+
+    # Ensure parent directory exists
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Save original file descriptors
+    orig_stdout_fd = os.dup(1)
+    orig_stderr_fd = os.dup(2)
+    orig_stdout = sys.stdout
+    orig_stderr = sys.stderr
+
+    # Create pipes for capturing
+    stdout_read_fd, stdout_write_fd = os.pipe()
+    stderr_read_fd, stderr_write_fd = os.pipe()
+
+    tee_threads = []
+    log_fh = None
+
+    try:
+        log_fh = open(log_path, "w", encoding="utf-8")
+
+        # Determine output destinations
+        if also_to_console:
+            stdout_outputs = [os.fdopen(orig_stdout_fd, "w", closefd=False), log_fh]
+            stderr_outputs = [os.fdopen(orig_stderr_fd, "w", closefd=False), log_fh]
+        else:
+            stdout_outputs = [log_fh]
+            stderr_outputs = [log_fh]
+
+        # Start tee threads to read from pipes and write to outputs
+        stdout_tee = _TeeWriter(stdout_read_fd, stdout_outputs, "StdoutTee")
+        stderr_tee = _TeeWriter(stderr_read_fd, stderr_outputs, "StderrTee")
+        tee_threads = [stdout_tee, stderr_tee]
+
+        stdout_tee.start()
+        stderr_tee.start()
+
+        # Redirect file descriptors 1 and 2 to write ends of pipes
+        os.dup2(stdout_write_fd, 1)
+        os.dup2(stderr_write_fd, 2)
+        os.close(stdout_write_fd)
+        os.close(stderr_write_fd)
+
+        # Redirect Python's sys.stdout/stderr to the new fd 1/2
+        sys.stdout = io.TextIOWrapper(
+            io.FileIO(1, "w", closefd=False),
+            encoding="utf-8",
+            errors="replace",
+            line_buffering=True,
+        )
+        sys.stderr = io.TextIOWrapper(
+            io.FileIO(2, "w", closefd=False),
+            encoding="utf-8",
+            errors="replace",
+            line_buffering=True,
+        )
+
+        # Update logging handlers
+        root = logging.getLogger()
+        old_handlers = []
+        for handler in root.handlers:
+            if isinstance(handler, logging.StreamHandler):
+                old_handlers.append((handler, handler.stream))
+                handler.stream = sys.stderr
+
+        try:
+            yield log_path
+        finally:
+            # Flush Python streams
+            sys.stdout.flush()
+            sys.stderr.flush()
+
+            # Restore logging handlers
+            for handler, old_stream in old_handlers:
+                handler.stream = old_stream
+
+    finally:
+        # Restore original file descriptors
+        os.dup2(orig_stdout_fd, 1)
+        os.dup2(orig_stderr_fd, 2)
+        os.close(orig_stdout_fd)
+        os.close(orig_stderr_fd)
+
+        # Restore Python streams
+        sys.stdout = orig_stdout
+        sys.stderr = orig_stderr
+
+        # Wait for tee threads to finish (they'll exit when pipes close)
+        for t in tee_threads:
+            t.stop()
+            t.join(timeout=1.0)
+
+        # Close log file
+        if log_fh:
+            log_fh.close()
+
+        _decrement_capture_depth()
+
+
+# ---------------------------------------------------------------------------
+# GitHub Actions Integration
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def github_group(title: str) -> Iterator[None]:
+    """Create a collapsible group in GitHub Actions logs.
+
+    No-op when not running in CI.
+
+    Args:
+        title: Group title shown in the UI.
+
+    Example::
+
+        with github_group("Building ROCm Components"):
+            for component in components:
+                build(component)
+    """
+    if is_ci():
+        print(f"::group::{title}", flush=True)
+    try:
+        yield
+    finally:
+        if is_ci():
+            print("::endgroup::", flush=True)
+
+
+def github_warning(
+    message: str, *, file: str | None = None, line: int | None = None
+) -> None:
+    """Emit a warning annotation in GitHub Actions.
+
+    Args:
+        message: Warning message.
+        file: Optional file path to annotate.
+        line: Optional line number.
+    """
+    if not is_ci():
+        return
+
+    params = []
+    if file:
+        params.append(f"file={file}")
+    if line:
+        params.append(f"line={line}")
+
+    param_str = " " + ",".join(params) if params else ""
+    print(f"::warning{param_str}::{message}", flush=True)
+
+
+def github_error(
+    message: str, *, file: str | None = None, line: int | None = None
+) -> None:
+    """Emit an error annotation in GitHub Actions.
+
+    Args:
+        message: Error message.
+        file: Optional file path to annotate.
+        line: Optional line number.
+    """
+    if not is_ci():
+        return
+
+    params = []
+    if file:
+        params.append(f"file={file}")
+    if line:
+        params.append(f"line={line}")
+
+    param_str = " " + ",".join(params) if params else ""
+    print(f"::error{param_str}::{message}", flush=True)
+
+
+# ---------------------------------------------------------------------------
+# Logger Disable
+# ---------------------------------------------------------------------------
+
+
+def disable_logger(name: str) -> None:
+    """Disable a specific logger by name.
+
+    Args:
+        name: Logger name to disable (e.g., 'therock.packaging').
+    """
+    logging.getLogger(name).disabled = True

--- a/build_tools/packaging/linux/build_package.py
+++ b/build_tools/packaging/linux/build_package.py
@@ -28,9 +28,12 @@ create RPM and DEB packages and upload to artifactory server
 import argparse
 import json
 import os
+import shutil
 import sys
+import tempfile
 import traceback
 
+from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import replace
 from pathlib import Path
 
@@ -208,7 +211,7 @@ def build_gfxarch_package_variants(pkg_name, config: PackageConfig) -> list:
     if pkg:
         built_packages.extend(pkg)
 
-    cleanup_build_directory(config)
+    cleanup_build_directory(config, pkg_name)
     return built_packages
 
 
@@ -242,7 +245,7 @@ def build_simple_package_variants(pkg_name, config: PackageConfig) -> list:
     if pkg:
         built_packages.extend(pkg)
 
-    cleanup_build_directory(config)
+    cleanup_build_directory(config, pkg_name)
     return built_packages
 
 
@@ -293,7 +296,7 @@ def build_singlearch_package_variants(pkg_name, config: PackageConfig) -> list:
     except Exception as e:
         logger.error(f"Failed to build non-versioned package for {pkg_name}: {e}")
 
-    cleanup_build_directory(config)
+    cleanup_build_directory(config, pkg_name)
     return built_packages
 
 
@@ -426,16 +429,22 @@ def build_nonversioned_package(pkg_name, config: PackageConfig) -> list:
         return []
 
 
-def cleanup_build_directory(config: PackageConfig):
+def cleanup_build_directory(config: PackageConfig, pkg_name: str = ""):
     """Clean up build directory after all package variants are built.
 
     This should only be called after all variants for a package are complete.
-    Defers cleanup to allow parallel builds of variants in the future.
+    In parallel mode, each package has its own subdirectory under the pkg_type dir.
 
     Parameters:
     config: Configuration object containing dest_dir and pkg_type
+    pkg_name: Package name for parallel-safe cleanup (cleans only this package's dir)
     """
-    build_dir = Path(config.dest_dir) / config.pkg_type
+    if pkg_name:
+        # Parallel-safe: only clean this package's build directory
+        build_dir = Path(config.dest_dir) / config.pkg_type / pkg_name
+    else:
+        # Legacy: clean entire pkg_type directory (only safe in sequential mode)
+        build_dir = Path(config.dest_dir) / config.pkg_type
     if build_dir.exists():
         remove_dir(build_dir)
         logger.debug(f"Cleaned up build directory: {build_dir}")
@@ -601,6 +610,29 @@ def create_package_config(args: argparse.Namespace) -> PackageConfig:
     )
 
 
+def build_pkg(args):
+    """Build a single package in isolated process. Used by ProcessPoolExecutor."""
+    pkg_name, config, logs_dir = args
+    pkg_log_file = logs_dir / f"{config.pkg_type}-{pkg_name}.log"
+    temp_dir = tempfile.mkdtemp(prefix=f"pkg_{pkg_name}_")
+    try:
+        pkg_config = replace(config, dest_dir=Path(temp_dir))
+        with capture_console(pkg_log_file):
+            output_list = build_package_variants(pkg_name, pkg_config)
+        # Move packages to final dest
+        result = []
+        for f in output_list:
+            src = Path(temp_dir) / f
+            if src.exists():
+                dst = config.dest_dir / f
+                config.dest_dir.mkdir(parents=True, exist_ok=True)
+                shutil.move(str(src), str(dst))
+                result.append(f)
+        return (pkg_name, result)
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
 def run(args: argparse.Namespace):
     # Create configuration from arguments
     config = create_package_config(args)
@@ -621,22 +653,18 @@ def run(args: argparse.Namespace):
         logger.error("No packages found to build. Package list is empty.")
         sys.exit(1)
 
-    current_pkg_idx = 0
-    try:
-        built_pkglist = []
-        failed_pkglist = []
+    logs_dir = Path(config.dest_dir) / "logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
 
-        for current_pkg_idx, pkg_name in enumerate(pkg_list):
-            logger.info(f"Creating {config.pkg_type} package: {pkg_name}")
+    built_pkglist = []
+    failed_pkglist = []
 
-            # Build all package variants for this package
-            # Capture per-package logs
-            logs_dir = Path(config.dest_dir) / "logs"
-            logs_dir.mkdir(parents=True, exist_ok=True)
-            pkg_log_file = logs_dir / f"{config.pkg_type}-{pkg_name}.log"
-            with capture_console(pkg_log_file):
-                output_list = build_package_variants(pkg_name, config)
-
+    with ProcessPoolExecutor(max_workers=args.parallel) as executor:
+        futures = {
+            executor.submit(build_pkg, (pkg, config, logs_dir)): pkg for pkg in pkg_list
+        }
+        for future in as_completed(futures):
+            pkg_name, output_list = future.result()
             if output_list:
                 built_pkglist.extend(output_list)
                 logger.info(
@@ -647,42 +675,21 @@ def run(args: argparse.Namespace):
                 failed_pkglist.append(pkg_name)
                 logger.error(f"Failed to build any variants for {pkg_name}")
 
-        # Clean the build directories
-        cleanup_packaging_environment(config)
+    # Clean the build directories
+    cleanup_packaging_environment(config)
 
-        if built_pkglist:
-            logger.info(f"Built packages: {built_pkglist}")
+    if built_pkglist:
+        logger.info(f"Built packages: {built_pkglist}")
 
-        pkglist_status = PackageList(
-            total=pkg_list,
-            built=built_pkglist,
-            skipped=skipped_list,
-            failed=failed_pkglist,
-        )
+    pkglist_status = PackageList(
+        total=pkg_list,
+        built=built_pkglist,
+        skipped=skipped_list,
+        failed=failed_pkglist,
+    )
 
-        # Print build summary
-        print_build_summary(config, pkglist_status)
-    except SystemExit as e:
-        # Build aborted somewhere inside create_* functions
-        tb = traceback.extract_tb(sys.exc_info()[2])
-        if tb:
-            filename, line_no, func, text = tb[-1]
-            logger.error(f"Build aborted due to an error at {filename}:{line_no}: {e}")
-        else:
-            logger.error(f"Build aborted due to an error: {e}")
-        # Record failed package and all pending packages
-        failed_pkglist.append(pkg_list[current_pkg_idx])
-        pending_pkgs = pkg_list[current_pkg_idx + 1 :]
-        failed_pkglist.extend(pending_pkgs)
-        pkglist_status = PackageList(
-            total=pkg_list,
-            built=built_pkglist,
-            skipped=skipped_list,
-            failed=failed_pkglist,
-        )
-        print_build_summary(config, pkglist_status)
-        # Stop the program
-        raise
+    # Print build summary
+    print_build_summary(config, pkglist_status)
 
 
 def main(argv: list[str]):
@@ -764,6 +771,14 @@ def main(argv: list[str]):
         "--pkg-names",
         nargs="+",
         help="Specify the packages to be created",
+    )
+
+    p.add_argument(
+        "-j",
+        "--parallel",
+        type=int,
+        default=os.cpu_count() or 1,
+        help="Number of parallel package builds (default: all available cores)",
     )
 
     args = p.parse_args(argv)

--- a/build_tools/packaging/linux/build_package.py
+++ b/build_tools/packaging/linux/build_package.py
@@ -36,21 +36,23 @@ from pathlib import Path
 
 # Setup paths
 SCRIPT_DIR = Path(__file__).resolve().parent
-BUILD_TOOLS_DIR = SCRIPT_DIR.parent.parent
-
-# Add build_tools directory to Python path to import _therock_utils
-# This allows the script to be run from anywhere: TheRock root or packaging/linux directory
-if str(BUILD_TOOLS_DIR) not in sys.path:
-    sys.path.insert(0, str(BUILD_TOOLS_DIR))
 
 from packaging_summary import *
 from packaging_utils import *
 from runpath_to_rpath import *
 
 from _therock_utils.artifacts import ArtifactCatalog
+from _therock_utils.log_utils import (
+    configure_logging,
+    get_logger,
+    capture_console,
+    github_group,
+)
 
 from deb_package import *
 from rpm_package import *
+
+logger = get_logger(__name__)
 
 
 # Default install prefix
@@ -177,7 +179,7 @@ def build_gfxarch_package_variants(pkg_name, config: PackageConfig) -> list:
     # Host package (contains generic artifacts)
     # Skip for metapackages - they have no artifacts, only dependencies
     if not is_meta:
-        print(f"\n=== Building host variant for {pkg_name} ===")
+        logger.info(f"Building host variant for {pkg_name}")
         pkg = build_host_package(pkg_name, config)
         if pkg:
             built_packages.extend(pkg)
@@ -185,20 +187,20 @@ def build_gfxarch_package_variants(pkg_name, config: PackageConfig) -> list:
     # Device packages (one per architecture)
     # For metapackages, these become arch-specific meta packages
     for device_arch in config.gfxarch_list:
-        print(f"\n=== Building device variant for {pkg_name} ({device_arch}) ===")
+        logger.info(f"Building device variant for {pkg_name} ({device_arch})")
         pkg = build_device_package(pkg_name, config, device_arch)
         if pkg:
             built_packages.extend(pkg)
 
     # Meta package (depends on host + all devices for regular packages,
     # or depends on all arch-specific metas for metapackages)
-    print(f"\n=== Building meta variant for {pkg_name} ===")
+    logger.info(f"Building meta variant for {pkg_name}")
     pkg = build_meta_package(pkg_name, config)
     if pkg:
         built_packages.extend(pkg)
 
     # Non-versioned package (user-facing, depends on meta)
-    print(f"\n=== Building non-versioned variant for {pkg_name} ===")
+    logger.info(f"Building non-versioned variant for {pkg_name}")
     # For gfxarch packages in kpack mode, non-versioned has no arch suffix (e.g., amdrocm-fft)
     # It depends on the meta package which pulls in host + all devices
     meta_config = replace(config, gfx_arch=GFX_META)
@@ -227,13 +229,13 @@ def build_simple_package_variants(pkg_name, config: PackageConfig) -> list:
     built_packages = []
 
     # Versioned package
-    print(f"\n=== Building versioned variant for {pkg_name} ===")
+    logger.info(f"Building versioned variant for {pkg_name}")
     pkg = build_versioned_package(pkg_name, config)
     if pkg:
         built_packages.extend(pkg)
 
     # Non-versioned package
-    print(f"\n=== Building non-versioned variant for {pkg_name} ===")
+    logger.info(f"Building non-versioned variant for {pkg_name}")
     # For non-gfxarch packages, non-versioned has no arch suffix (e.g., amdrocm-core)
     simple_config = replace(config, gfx_arch="")
     pkg = build_nonversioned_package(pkg_name, simple_config)
@@ -264,7 +266,7 @@ def build_singlearch_package_variants(pkg_name, config: PackageConfig) -> list:
     built_packages = []
 
     # Versioned package
-    print(f"\n=== Building versioned package for {pkg_name} (single-arch mode) ===")
+    logger.info(f"Building versioned package for {pkg_name} (single-arch mode)")
     try:
         versioned_config = replace(config, versioned_pkg=True)
         if versioned_config.pkg_type == "rpm":
@@ -274,10 +276,10 @@ def build_singlearch_package_variants(pkg_name, config: PackageConfig) -> list:
         if pkg:
             built_packages.extend(pkg)
     except Exception as e:
-        print(f"ERROR: Failed to build versioned package for {pkg_name}: {e}")
+        logger.error(f"Failed to build versioned package for {pkg_name}: {e}")
 
     # Non-versioned package
-    print(f"\n=== Building non-versioned package for {pkg_name} (single-arch mode) ===")
+    logger.info(f"Building non-versioned package for {pkg_name} (single-arch mode)")
     try:
         # In single-arch mode, non-versioned packages keep the arch suffix
         # to indicate they're specific to that architecture (e.g., amdrocm-fft-gfx1100)
@@ -289,7 +291,7 @@ def build_singlearch_package_variants(pkg_name, config: PackageConfig) -> list:
         if pkg:
             built_packages.extend(pkg)
     except Exception as e:
-        print(f"ERROR: Failed to build non-versioned package for {pkg_name}: {e}")
+        logger.error(f"Failed to build non-versioned package for {pkg_name}: {e}")
 
     cleanup_build_directory(config)
     return built_packages
@@ -315,7 +317,7 @@ def build_host_package(pkg_name, config: PackageConfig) -> list:
         else:
             return create_versioned_deb_package(pkg_name, host_config)
     except Exception as e:
-        print(f"ERROR: Failed to build host package for {pkg_name}: {e}")
+        logger.error(f"Failed to build host package for {pkg_name}: {e}")
         return []
 
 
@@ -340,8 +342,8 @@ def build_device_package(pkg_name, config: PackageConfig, device_arch: str) -> l
         else:
             return create_versioned_deb_package(pkg_name, device_config)
     except Exception as e:
-        print(
-            f"ERROR: Failed to build device package for {pkg_name} ({device_arch}): {e}"
+        logger.error(
+            f"Failed to build device package for {pkg_name} ({device_arch}): {e}"
         )
         return []
 
@@ -366,7 +368,7 @@ def build_meta_package(pkg_name, config: PackageConfig) -> list:
         else:
             return create_versioned_deb_package(pkg_name, meta_config)
     except Exception as e:
-        print(f"ERROR: Failed to build meta package for {pkg_name}: {e}")
+        logger.error(f"Failed to build meta package for {pkg_name}: {e}")
         return []
 
 
@@ -390,7 +392,7 @@ def build_versioned_package(pkg_name, config: PackageConfig) -> list:
         else:
             return create_versioned_deb_package(pkg_name, versioned_config)
     except Exception as e:
-        print(f"ERROR: Failed to build versioned package for {pkg_name}: {e}")
+        logger.error(f"Failed to build versioned package for {pkg_name}: {e}")
         return []
 
 
@@ -420,7 +422,7 @@ def build_nonversioned_package(pkg_name, config: PackageConfig) -> list:
         else:
             return create_nonversioned_deb_package(pkg_name, nonversioned_config)
     except Exception as e:
-        print(f"ERROR: Failed to build non-versioned package for {pkg_name}: {e}")
+        logger.error(f"Failed to build non-versioned package for {pkg_name}: {e}")
         return []
 
 
@@ -436,7 +438,7 @@ def cleanup_build_directory(config: PackageConfig):
     build_dir = Path(config.dest_dir) / config.pkg_type
     if build_dir.exists():
         remove_dir(build_dir)
-        print(f"Cleaned up build directory: {build_dir}")
+        logger.debug(f"Cleaned up build directory: {build_dir}")
 
 
 def cleanup_packaging_environment(config: PackageConfig):
@@ -451,7 +453,7 @@ def cleanup_packaging_environment(config: PackageConfig):
 
     Returns: None
     """
-    print_function_name()
+    logger.debug("cleanup_packaging_environment")
     PYCACHE_DIR = Path(SCRIPT_DIR) / "__pycache__"
     remove_dir(PYCACHE_DIR)
 
@@ -473,7 +475,7 @@ def parse_input_package_list(pkg_name, artifact_dir):
 
     Returns: Package list
     """
-    print_function_name()
+    logger.debug("parse_input_package_list")
     pkg_list = []
     skipped_list = []
     # If pkg_name is None, include all packages
@@ -497,7 +499,7 @@ def parse_input_package_list(pkg_name, artifact_dir):
                 pkg_list.append(name)
                 break
 
-    print(f"pkg_list:\n  {pkg_list}")
+    logger.debug(f"pkg_list: {pkg_list}")
     return pkg_list, skipped_list
 
 
@@ -526,12 +528,12 @@ def create_package_config(args: argparse.Namespace) -> PackageConfig:
         # Auto-detect from artifact directory
         normalized_targets = get_all_target_families(args.artifacts_dir)
         if not normalized_targets:
-            print(
+            logger.warning(
                 f"No GFX architectures found in artifact directory: {args.artifacts_dir}. "
                 "Either provide --target explicitly or ensure artifacts are present."
             )
         else:
-            print(f"Auto-detected GFX architectures: {normalized_targets}")
+            logger.info(f"Auto-detected GFX architectures: {normalized_targets}\n")
 
     # Output packaging architecture list to GitHub Actions
     github_output = os.environ.get("GITHUB_OUTPUT")
@@ -545,7 +547,7 @@ def create_package_config(args: argparse.Namespace) -> PackageConfig:
     if not args.enable_kpack:
         args.enable_kpack = load_kpack_from_manifest(artifacts_dir)
         if args.enable_kpack:
-            print(
+            logger.info(
                 "Detected KPACK_SPLIT_ARTIFACTS in manifest — producing host + device packages"
             )
 
@@ -616,7 +618,7 @@ def run(args: argparse.Namespace):
     )
 
     if not pkg_list:
-        print("Error: No packages found to build. Package list is empty.")
+        logger.error("No packages found to build. Package list is empty.")
         sys.exit(1)
 
     current_pkg_idx = 0
@@ -625,26 +627,31 @@ def run(args: argparse.Namespace):
         failed_pkglist = []
 
         for current_pkg_idx, pkg_name in enumerate(pkg_list):
-            print(f"Creating {config.pkg_type} package: {pkg_name}")
+            logger.info(f"Creating {config.pkg_type} package: {pkg_name}")
 
             # Build all package variants for this package
-            output_list = build_package_variants(pkg_name, config)
+            # Capture per-package logs
+            logs_dir = Path(config.dest_dir) / "logs"
+            logs_dir.mkdir(parents=True, exist_ok=True)
+            pkg_log_file = logs_dir / f"{config.pkg_type}-{pkg_name}.log"
+            with capture_console(pkg_log_file):
+                output_list = build_package_variants(pkg_name, config)
 
             if output_list:
                 built_pkglist.extend(output_list)
-                print(
-                    f"\n✓ Successfully built {len(output_list)} variant(s) for {pkg_name}"
+                logger.info(
+                    f"Successfully built {len(output_list)} variant(s) for {pkg_name}"
                 )
             else:
                 # Package failed to build
                 failed_pkglist.append(pkg_name)
-                print(f"\n✗ Failed to build any variants for {pkg_name}")
+                logger.error(f"Failed to build any variants for {pkg_name}")
 
         # Clean the build directories
         cleanup_packaging_environment(config)
 
         if built_pkglist:
-            print(f"\nBuilt packages: {built_pkglist}")
+            logger.info(f"Built packages: {built_pkglist}")
 
         pkglist_status = PackageList(
             total=pkg_list,
@@ -660,9 +667,9 @@ def run(args: argparse.Namespace):
         tb = traceback.extract_tb(sys.exc_info()[2])
         if tb:
             filename, line_no, func, text = tb[-1]
-            print(f"\n❌ Build aborted due to an error at {filename}:{line_no}: {e}\n")
+            logger.error(f"Build aborted due to an error at {filename}:{line_no}: {e}")
         else:
-            print(f"\n❌ Build aborted due to an error: {e}\n")
+            logger.error(f"Build aborted due to an error: {e}")
         # Record failed package and all pending packages
         failed_pkglist.append(pkg_list[current_pkg_idx])
         pending_pkgs = pkg_list[current_pkg_idx + 1 :]
@@ -681,6 +688,12 @@ def run(args: argparse.Namespace):
 def main(argv: list[str]):
 
     p = argparse.ArgumentParser()
+    p.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable verbose output (DEBUG level logging)",
+    )
     p.add_argument(
         "--artifacts-dir",
         type=Path,
@@ -754,6 +767,10 @@ def main(argv: list[str]):
     )
 
     args = p.parse_args(argv)
+
+    # Configure logging based on verbose flag
+    configure_logging(verbose=args.verbose)
+
     run(args)
 
 

--- a/build_tools/packaging/linux/deb_package.py
+++ b/build_tools/packaging/linux/deb_package.py
@@ -17,6 +17,9 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 from pathlib import Path
 
 from packaging_utils import *
+from _therock_utils.log_utils import get_logger
+
+logger = get_logger(__name__)
 
 # Setup paths
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -35,7 +38,7 @@ def create_nonversioned_deb_package(pkg_name, config: PackageConfig):
     Returns:
     output_list: List of packages created
     """
-    print_function_name()
+    logger.debug("create_nonversioned_deb_package")
     # Create immutable config copy with versioned_pkg=False
     build_config = replace(config, versioned_pkg=False)
 
@@ -75,7 +78,7 @@ def create_versioned_deb_package(pkg_name, config: PackageConfig):
     Returns:
     output_list: List of packages created
     """
-    print_function_name()
+    logger.debug("create_versioned_deb_package")
     # Explicitly ensure versioned_pkg=True
     build_config = replace(config, versioned_pkg=True)
 
@@ -104,13 +107,13 @@ def create_versioned_deb_package(pkg_name, config: PackageConfig):
     )
     sourcedir_list.extend(dir_list)
 
-    print(f"sourcedir_list:\n  {sourcedir_list}")
+    logger.debug(f"sourcedir_list: {sourcedir_list}")
     # GFX_META is a versioned meta package (empty content, just dependencies)
     is_gfx_meta = build_config.enable_kpack and build_config.gfx_arch == GFX_META
     if not sourcedir_list and not is_meta and not is_gfx_meta:
         if build_config.enable_kpack:
-            print(
-                f"ERROR: {pkg_name}: Empty sourcedir_list and not a meta package, skipping"
+            logger.error(
+                f"{pkg_name}: Empty sourcedir_list and not a meta package, skipping"
             )
             return []
         else:
@@ -119,7 +122,7 @@ def create_versioned_deb_package(pkg_name, config: PackageConfig):
             )
 
     if not sourcedir_list:
-        print(f"{pkg_name} is a Meta package")
+        logger.debug(f"{pkg_name} is a Meta package")
     else:
         # Copy package contents first
         dest_dir = package_dir / Path(build_config.install_prefix).relative_to("/")
@@ -147,7 +150,7 @@ def generate_changelog_file(pkg_info, deb_dir, config: PackageConfig):
 
     Returns: None
     """
-    print_function_name()
+    logger.debug("generate_changelog_file")
     changelog = Path(deb_dir) / "changelog"
 
     pkg_name = update_package_name(pkg_info.get("Package"), config)
@@ -199,7 +202,7 @@ def generate_install_file(pkg_info, deb_dir, config: PackageConfig, dest_dir=Non
 
     Returns: None
     """
-    print_function_name()
+    logger.debug("generate_install_file")
     # Note: pkg_info is not used currently:
     # May be required in future to populate any context
     install_file = Path(deb_dir) / "install"
@@ -250,7 +253,7 @@ def generate_rules_file(pkg_info, deb_dir, config: PackageConfig):
 
     Returns: None
     """
-    print_function_name()
+    logger.debug("generate_rules_file")
     rules_file = Path(deb_dir) / "rules"
     disable_dh_strip = is_key_defined(pkg_info, "Disable_DEB_STRIP")
     disable_dwz = is_key_defined(pkg_info, "Disable_DWZ")
@@ -298,7 +301,7 @@ def generate_control_file(pkg_info, deb_dir, config: PackageConfig):
 
     Returns: None
     """
-    print_function_name()
+    logger.debug("generate_control_file")
     control_file = Path(deb_dir) / "control"
     pkg_name = pkg_info.get("Package")
     is_meta = is_meta_package(pkg_info)
@@ -414,13 +417,13 @@ def copy_package_contents(source_dir, destination_dir):
 
     Returns: None
     """
-    print_function_name()
+    logger.debug("copy_package_contents")
 
     source_dir = Path(source_dir)
     destination_dir = Path(destination_dir)
 
     if not source_dir.is_dir():
-        print(f"Directory does not exist: {source_dir}")
+        logger.warning(f"Directory does not exist: {source_dir}")
         return
 
     # Ensure destination directory exists
@@ -456,14 +459,14 @@ def package_with_dpkg_build(pkg_dir):
 
     Returns: None
     """
-    print_function_name()
+    logger.debug("package_with_dpkg_build")
     # Build the command
     cmd = ["dpkg-buildpackage", "-uc", "-us", "-b"]
 
     # Execute the command
     try:
         subprocess.run(cmd, check=True, cwd=pkg_dir)
-        print(f"Deb Package built successfully: {os.path.basename(pkg_dir)}")
+        logger.info(f"Deb Package built successfully: {os.path.basename(pkg_dir)}\n")
     except subprocess.CalledProcessError as e:
-        print(f"Error building deb package: {os.path.basename(pkg_dir)}: {e}")
+        logger.error(f"Error building deb package: {os.path.basename(pkg_dir)}: {e}")
         sys.exit(e.returncode)

--- a/build_tools/packaging/linux/packaging_summary.py
+++ b/build_tools/packaging/linux/packaging_summary.py
@@ -4,7 +4,10 @@
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from packaging_utils import *
+from _therock_utils.log_utils import get_logger
 from typing import List
+
+logger = get_logger(__name__)
 
 
 @dataclass
@@ -28,7 +31,7 @@ def write_build_manifest(config: PackageConfig, pkg_list: PackageList):
 
     Returns: None
     """
-    print_function_name()
+    logger.debug("write_build_manifest")
 
     # Write successful packages manifest
     manifest_file = Path(config.dest_dir) / "built_packages.txt"

--- a/build_tools/packaging/linux/packaging_utils.py
+++ b/build_tools/packaging/linux/packaging_utils.py
@@ -12,6 +12,17 @@ import sys
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 
+# Setup paths - must be before log_utils import
+SCRIPT_DIR = Path(__file__).resolve().parent
+BUILD_TOOLS_DIR = SCRIPT_DIR.parent.parent
+
+# Add build_tools directory to Python path to import _therock_utils
+if str(BUILD_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(BUILD_TOOLS_DIR))
+
+from _therock_utils.log_utils import get_logger
+
+logger = get_logger(__name__)
 
 # Constants
 # Used for creating host package in kpack mode (contains generic content)
@@ -85,20 +96,6 @@ class PackageConfig:
     versioned_pkg: bool = True
     enable_kpack: bool = False
     gfxarch_list: tuple = field(default_factory=tuple)
-
-
-SCRIPT_DIR = Path(__file__).resolve().parent
-currentFuncName = lambda n=0: sys._getframe(n + 1).f_code.co_name
-
-
-def print_function_name():
-    """Print the name of the calling function.
-
-    Parameters: None
-
-    Returns: None
-    """
-    print("In function:", currentFuncName(1))
 
 
 def read_package_json_file():
@@ -380,9 +377,9 @@ def remove_dir(dir_name):
 
     if dir_path.exists() and dir_path.is_dir():
         shutil.rmtree(dir_path)
-        print(f"Removed directory: {dir_path}")
+        logger.debug(f"Removed directory: {dir_path}")
     else:
-        print(f"Directory does not exist: {dir_path}")
+        logger.debug(f"Directory does not exist: {dir_path}")
 
 
 def update_package_name(pkg_name, config: PackageConfig):
@@ -398,7 +395,7 @@ def update_package_name(pkg_name, config: PackageConfig):
 
     Returns: Updated package name
     """
-    print_function_name()
+    logger.debug("update_package_name")
 
     pkg_suffix = ""
     if config.versioned_pkg:
@@ -525,7 +522,7 @@ def debian_replace_devel_name(pkg_name):
 
     Returns: Updated package name
     """
-    print_function_name()
+    logger.debug("debian_replace_devel_name")
     # Required for debian developement package
     suffix = "-devel"
     if pkg_name.endswith(suffix):
@@ -721,7 +718,7 @@ def convert_to_versiondependency(
 
     Returns: A string of comma separated versioned packages
     """
-    print_function_name()
+    logger.debug("convert_to_versiondependency")
     # This function is to add Version dependency
     # Make sure the flag is set to True
 
@@ -768,7 +765,7 @@ def append_version_suffix(dep_string, config: PackageConfig):
     Returns: A comma-separated string where matching dependencies include the version suffix,
     while all others remain unchanged.
     """
-    print_function_name()
+    logger.debug("append_version_suffix")
 
     pkg_list, skipped_list = get_package_list(config.artifacts_dir)
     updated_depends = []
@@ -812,11 +809,11 @@ def move_packages_to_destination(updated_pkg_name, config: PackageConfig):
     Returns:
     output_packages : list of package names moved to the destination folder
     """
-    print_function_name()
+    logger.debug("move_packages_to_destination")
     output_packages = []
     # Create destination dir to move the packages created
     os.makedirs(config.dest_dir, exist_ok=True)
-    print(f"Updated package name: {updated_pkg_name}")
+    logger.debug(f"Updated package name: {updated_pkg_name}")
     PKG_DIR = Path(config.dest_dir) / config.pkg_type
 
     if config.pkg_type.lower() == "deb":
@@ -863,7 +860,7 @@ def filter_components_fromartifactory(
 
     Returns: List of directories
     """
-    print_function_name()
+    logger.debug("filter_components_fromartifactory")
 
     pkg_info = get_package_info(pkg_name)
     sourcedir_list = []
@@ -888,7 +885,7 @@ def filter_components_fromartifactory(
 
     artifactory = pkg_info.get("Artifactory")
     if artifactory is None:
-        print(
+        logger.debug(
             f'The "Artifactory" key is missing for {pkg_name}. Is this a meta package?'
         )
         return sourcedir_list
@@ -900,7 +897,9 @@ def filter_components_fromartifactory(
         # If "Artifact_Gfxarch" key is specified use it for artifact directory suffix
         # Else use the package "Gfxarch" for finding the suffix
         if "Artifact_Gfxarch" in artifact:
-            print(f"{pkg_name} : Artifact_Gfxarch key exists for artifacts {artifact}")
+            logger.debug(
+                f"{pkg_name} : Artifact_Gfxarch key exists for artifacts {artifact}"
+            )
             is_gfxarch = str(artifact["Artifact_Gfxarch"]).lower() == "true"
 
             # In kpack mode, skip non-gfxarch artifacts when building gfx-specific packages
@@ -912,7 +911,7 @@ def filter_components_fromartifactory(
                 and gfx_arch not in (GFX_HOST, GFX_META)
                 and not is_gfxarch
             ):
-                print(
+                logger.debug(
                     f"{pkg_name} : Skipping artifact '{artifact_prefix}' for {gfx_arch} package "
                     f"(Artifact_Gfxarch=False, should only be in generic package)"
                 )
@@ -933,7 +932,7 @@ def filter_components_fromartifactory(
                 )
                 filename = source_dir / "artifact_manifest.txt"
                 if not filename.exists():
-                    print(f"{pkg_name} : Missing {filename}")
+                    logger.debug(f"{pkg_name} : Missing {filename}")
                     continue
                 try:
                     with filename.open("r", encoding="utf-8") as file:
@@ -945,11 +944,11 @@ def filter_components_fromartifactory(
                             )
 
                             if match_found and line.strip():
-                                print("Matching line:", line.strip())
+                                logger.debug(f"Matching line: {line.strip()}")
                                 source_path = source_dir / line.strip()
                                 sourcedir_list.append(source_path)
                 except OSError as e:
-                    print(f"Could not read manifest {filename}: {e}")
+                    logger.warning(f"Could not read manifest {filename}: {e}")
                     continue
 
     return sourcedir_list
@@ -1138,7 +1137,9 @@ def filter_archs_with_artifacts(
 
     if len(available) < len(list(gfxarch_list)):
         missing = set(gfxarch_list) - set(available)
-        print(f"WORKAROUND: {pkg_name} missing artifacts for: {sorted(missing)}")
+        logger.warning(
+            f"WORKAROUND: {pkg_name} missing artifacts for: {sorted(missing)}"
+        )
 
     return available
 
@@ -1177,6 +1178,6 @@ def filter_dependencies_by_artifacts(
         if has_artifact_for_arch(dep, artifacts_dir, gfx_arch):
             filtered.append(dep)
         else:
-            print(f"WORKAROUND: Excluding {dep} (no artifacts for {gfx_arch})")
+            logger.warning(f"WORKAROUND: Excluding {dep} (no artifacts for {gfx_arch})")
 
     return filtered

--- a/build_tools/packaging/linux/rpm_package.py
+++ b/build_tools/packaging/linux/rpm_package.py
@@ -14,6 +14,9 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 from pathlib import Path
 
 from packaging_utils import *
+from _therock_utils.log_utils import get_logger
+
+logger = get_logger(__name__)
 
 # Setup paths
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -32,7 +35,7 @@ def create_nonversioned_rpm_package(pkg_name, config: PackageConfig):
     Returns:
     output_list: List of packages created
     """
-    print_function_name()
+    logger.debug("create_nonversioned_rpm_package")
     # Create immutable config copy with versioned_pkg=False
     build_config = replace(config, versioned_pkg=False)
 
@@ -63,7 +66,7 @@ def create_versioned_rpm_package(pkg_name, config: PackageConfig):
     Returns:
     output_list: List of packages created
     """
-    print_function_name()
+    logger.debug("create_versioned_rpm_package")
     # Explicitly ensure versioned_pkg=True
     build_config = replace(config, versioned_pkg=True)
 
@@ -90,7 +93,7 @@ def generate_spec_file(pkg_name, specfile, config: PackageConfig):
 
     Returns: None
     """
-    print_function_name()
+    logger.debug("generate_spec_file")
     os.makedirs(os.path.dirname(specfile), exist_ok=True)
 
     pkg_info = get_package_info(pkg_name)  # Raises ValueError if not found
@@ -129,8 +132,8 @@ def generate_spec_file(pkg_name, specfile, config: PackageConfig):
         # Warn if we have no artifacts for non-meta packages
         if not sourcedir_list and not is_meta and not is_gfx_meta:
             if config.enable_kpack:
-                print(
-                    f"WARNING: {pkg_name}: Empty sourcedir_list and not a meta package, creating empty RPM"
+                logger.warning(
+                    f"{pkg_name}: Empty sourcedir_list and not a meta package, creating empty RPM"
                 )
             else:
                 sys.exit(
@@ -248,7 +251,7 @@ def package_with_rpmbuild(spec_file):
 
     Returns: None
     """
-    print_function_name()
+    logger.debug("package_with_rpmbuild")
     # Build the command
     cmd = [
         "rpmbuild",
@@ -261,7 +264,7 @@ def package_with_rpmbuild(spec_file):
     # Execute the command
     try:
         subprocess.run(cmd, check=True)
-        print(f"RPM Package built successfully: {spec_file.name}")
+        logger.info(f"RPM Package built successfully: {spec_file.name}\n")
     except subprocess.CalledProcessError as e:
-        print(f"Error building RPM package: {spec_file.name}: {e}")
+        logger.error(f"Error building RPM package: {spec_file.name}: {e}")
         sys.exit(e.returncode)


### PR DESCRIPTION
 Use ProcessPoolExecutor to build packages concurrently. Each package
  builds in an isolated temp directory with its own log file, then
  artifacts are moved to the final destination. 
  
  - Add -j/--parallel flag (defaults to all CPU cores)
  - Isolate builds in temp directories to avoid conflicts
  - Per-package cleanup instead of global cleanup
  - Simplify error handling (executor handles failures)