### PR TITLE
fix(pytorch): expose ROCm DLLs to Windows BLAS probes

### DIFF
--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -485,6 +485,7 @@ def find_dir_containing(file_name: str, *possible_paths: Path) -> Path:
 
 def _setup_common_build_env(
     cmake_prefix: Path,
+    bin_dir: Path,
     rocm_dir: Path,
     pytorch_rocm_arch: str,
     triton_dir: Path | None,
@@ -498,6 +499,9 @@ def _setup_common_build_env(
         "ROCM_PATH": str(rocm_dir),
         "PYTORCH_ROCM_ARCH": pytorch_rocm_arch,
         "USE_KINETO": os.environ.get("USE_KINETO", "ON" if not is_windows else "OFF"),
+        # Make ROCm tools discoverable on all platforms and ROCm DLLs
+        # discoverable by the Windows loader.
+        "PATH": str(bin_dir) + os.path.pathsep + os.environ.get("PATH", ""),
     }
 
     env["USE_GLOO"] = "ON"
@@ -656,9 +660,6 @@ def do_build(args: argparse.Namespace):
     print(f"  BIN = {bin_dir}")
     print(f"  ROCM_HOME = {rocm_dir}")
 
-    system_path = str(bin_dir) + os.path.pathsep + os.environ.get("PATH", "")
-    print(f"  PATH = {system_path}")
-
     # Priority: --pytorch-rocm-arch > PYTORCH_ROCM_ARCH env > `rocm-sdk targets`
     # fallback (legacy; see TODO on get_rocm_sdk_targets()).
     pytorch_rocm_arch = args.pytorch_rocm_arch or os.environ.get("PYTORCH_ROCM_ARCH")
@@ -683,12 +684,9 @@ def do_build(args: argparse.Namespace):
     pytorch_rocm_arch = pytorch_rocm_arch.replace(",", ";")
 
     env = _setup_common_build_env(
-        cmake_prefix, rocm_dir, pytorch_rocm_arch, triton_dir, is_windows
+        cmake_prefix, bin_dir, rocm_dir, pytorch_rocm_arch, triton_dir, is_windows
     )
-    if is_windows:
-        # CMake's BLAS ABI probes execute binaries linked against ROCm DLLs.
-        # Make those DLLs discoverable by the Windows loader.
-        env["PATH"] = system_path
+    print(f"  PATH = {env['PATH']}")
 
     if args.use_ccache:
         if not shutil.which("ccache"):

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -685,6 +685,10 @@ def do_build(args: argparse.Namespace):
     env = _setup_common_build_env(
         cmake_prefix, rocm_dir, pytorch_rocm_arch, triton_dir, is_windows
     )
+    if is_windows:
+        # CMake's BLAS ABI probes execute binaries linked against ROCm DLLs.
+        # Make those DLLs discoverable by the Windows loader.
+        env["PATH"] = system_path
 
     if args.use_ccache:
         if not shutil.which("ccache"):


### PR DESCRIPTION
Ensure CMake runtime checks detect the CBLAS complex dot ABI instead of falling back to the incompatible Fortran ABI.

## Motivation

JIRA ID: ROCM-26467
https://amd-hub.atlassian.net/browse/ROCM-26467

PyTorch's CMake BLAS ABI probes execute small binaries linked against ROCm OpenBLAS. During Windows wheel builds, the subprocess environment did not include the ROCm `bin` directory in `PATH`, so these binaries could not load `rocm-openblas.dll`.
This caused `BLAS_USE_CBLAS_DOT` to be detected as `FALSE`, making PyTorch use the ABI-incompatible `cdotc_` fallback. Complex64 `torch.linalg.vecdot` and `torch.vdot` operations could then terminate with `0xC0000005`.


## Technical Details

Pass the existing `system_path`, which prepends the ROCm `bin` directory, to the PyTorch build environment on Windows.
This allows the Windows loader to find ROCm DLLs while CMake runs the BLAS ABI probes. 

## Test Plan

Validated on TheRock main at commit 6a7a3edf, using:

PyTorch release/2.12
Python 3.12
ROCm SDK 7.14.0a20260615

Tested these reported cases:

test_out_requires_grad_error_linalg_vecdot_cpu_complex64
test_dtypes_linalg_vecdot_cpu
test_noncontiguous_samples_linalg_vecdot_cpu_complex64
Also ran the wheel sanity checker and direct numerical checks for torch.vdot and torch.linalg.vecdot.

## Test Result

Without the fix:

BLAS_USE_CBLAS_DOT: FALSE
AT_BLAS_USE_CBLAS_DOT() = 0
All three tests terminate with 0xC0000005 in rocm-openblas.dll!cdotc_

With the fix:

BLAS_USE_CBLAS_DOT: TRUE
AT_BLAS_USE_CBLAS_DOT() = 1
All three tests pass
torch.vdot and torch.linalg.vecdot return the expected 70-8j
Wheel sanity check passes
GPU import and detection work successfully

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.


[ROCM-26467]: https://amd-hub.atlassian.net/browse/ROCM-26467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ