### PR TITLE
fix(ci): run get_url_repo_params tests and correct stale assertions

### DIFF
--- a/build_tools/packaging/linux/get_url_repo_params.py
+++ b/build_tools/packaging/linux/get_url_repo_params.py
@@ -742,7 +742,10 @@ def main(argv: list[str] | None = None) -> int:
     # get-container-image: get container image for an OS profile
     p_img = subparsers.add_parser(
         "get-container-image",
-        help="Get container image for a given OS profile (e.g. ubuntu2404 -> ubuntu:24.04).",
+        help=(
+            "Get container image for a given OS profile "
+            "(e.g. ubuntu2404 -> ghcr.io/rocm/no_rocm_image_ubuntu24_04:latest)."
+        ),
     )
     p_img.add_argument(
         "--os-profile",

--- a/build_tools/packaging/linux/native_linux_package_install_test.py
+++ b/build_tools/packaging/linux/native_linux_package_install_test.py
@@ -139,7 +139,7 @@ import subprocess
 import sys
 import traceback
 from argparse import ArgumentParser, Namespace
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 _SCRIPT_DIR = Path(__file__).resolve().parent
 if str(_SCRIPT_DIR) not in sys.path:
@@ -1073,7 +1073,10 @@ gpgcheck=0
         False if any offending path is found.
         """
         print("\nVerifying installed files are owned by root with safe permissions...")
-        install_prefix = str(Path(self.install_prefix))
+        # PurePosixPath, not Path: this is a path on the target Linux filesystem
+        # handed to find(1). Path follows the local flavour, so on Windows it
+        # renders "\opt\rocm\core" and the scan silently targets the wrong path.
+        install_prefix = str(PurePosixPath(self.install_prefix))
         try:
             result = subprocess.run(
                 [

--- a/build_tools/packaging/linux/tests/get_url_repo_params_test.py
+++ b/build_tools/packaging/linux/tests/get_url_repo_params_test.py
@@ -19,7 +19,7 @@ Coverage (trimmed suite, table-driven via ``subTest``):
   - One happy-path CLI smoke per remaining subcommand
 
 Not covered here (P2 / separate PRs): ``upload_package_repo._package_install_url``,
-#7004 container-image string assertions, full CLI error-matrix.
+full CLI error-matrix.
 
 Prerequisites:
 
@@ -331,20 +331,25 @@ class ExtractGfxArchTest(unittest.TestCase):
 
 
 class GetContainerImageTest(unittest.TestCase):
-    """Tests for ``get_container_image()`` (asserts against implementation output)."""
+    """Tests for ``get_container_image()``."""
+
+    # test_native_linux_packages_install.yml feeds this value straight into its
+    # container image, so each profile is pinned to the exact string rather than
+    # compared against another call to the function under test.
+    _EXPECTED_IMAGES = [
+        ("ubuntu2404", "ghcr.io/rocm/no_rocm_image_ubuntu24_04:latest"),
+        ("debian12", "ghcr.io/rocm/no_rocm_image_ubuntu24_04:latest"),
+        ("sles16", "registry.suse.com/bci/bci-base:16.0"),
+        ("rhel8", "registry.access.redhat.com/ubi8/ubi:8.10"),
+        ("rhel10", "registry.access.redhat.com/ubi10/ubi:10.1"),
+    ]
 
     def test_profile_mapping(self):
-        # Ubuntu/debian share one image; sles/rhel use distinct registry images.
-        ubuntu = get_url_repo_params.get_container_image("ubuntu2404")
-        self.assertEqual(get_url_repo_params.get_container_image("debian12"), ubuntu)
-        self.assertEqual(
-            get_url_repo_params.get_container_image("sles16"),
-            "registry.suse.com/bci/bci-base:16.0",
-        )
-        self.assertEqual(
-            get_url_repo_params.get_container_image("rhel10"),
-            "registry.access.redhat.com/ubi10/ubi:10.1",
-        )
+        for os_profile, expected in self._EXPECTED_IMAGES:
+            with self.subTest(os_profile=os_profile):
+                self.assertEqual(
+                    get_url_repo_params.get_container_image(os_profile), expected
+                )
 
 
 class MainSubcommandsTest(unittest.TestCase):
@@ -408,12 +413,13 @@ class MainSubcommandsTest(unittest.TestCase):
         self.assertIn("gfx_arch=gfx94x,gfx1100", output)
 
     def test_get_container_image_cli(self):
-        expected = get_url_repo_params.get_container_image("ubuntu2404")
         code, output = _run_main_with_output(
             ["get-container-image", "--os-profile", "ubuntu2404"]
         )
         self.assertEqual(code, 0)
-        self.assertIn(f"container_image={expected}", output)
+        self.assertIn(
+            "container_image=ghcr.io/rocm/no_rocm_image_ubuntu24_04:latest", output
+        )
 
 
 if __name__ == "__main__":

--- a/build_tools/pyproject.toml
+++ b/build_tools/pyproject.toml
@@ -2,6 +2,7 @@
 testpaths = [
     "tests",
     "github_actions/tests",
+    "packaging/linux/tests",
     "packaging/python/tests",
     "third_party/s3_management/tests",
 ]
@@ -14,6 +15,7 @@ source = ["."]
 omit = [
     "tests/*",
     "github_actions/tests/*",
+    "packaging/linux/tests/*",
     "packaging/python/tests/*",
     "third_party/s3_management/tests/*",
     "*/__pycache__/*",

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -30,3 +30,9 @@ sccache==0.10.0
 
 #test_artifacts_covered_by_packages requirement
 toml>=0.10.2
+
+# build_tools/packaging/linux/tests/build_package_test.py imports build_package.py,
+# which pulls these in via deb_package.py and rpm_package.py.
+# Keep the specifiers in sync with requirements.txt.
+jinja2>=3.0.0
+pyelftools>=0.29

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -32,7 +32,6 @@ sccache==0.10.0
 toml>=0.10.2
 
 # build_tools/packaging/linux/tests/build_package_test.py imports build_package.py,
-# which pulls these in via deb_package.py and rpm_package.py.
-# Keep the specifiers in sync with requirements.txt.
+# which pulls this in via deb_package.py and rpm_package.py.
+# Keep the specifier in sync with requirements.txt.
 jinja2>=3.0.0
-pyelftools>=0.29


### PR DESCRIPTION
## Motivation

The unit tests in `build_tools/packaging/linux/tests/` never run in CI, because the directory is not listed in the pytest `testpaths` in `build_tools/pyproject.toml`. That is one of the two places #6927 points at as the reason some tests are not running continuously.

This change adds that directory to `testpaths`. It was opened adding a single file, because the other two did not pass. #7017 fixed one of them and a missing test dependency accounts for the other, so all four now run.

Contributes to #6927 and #6986.

## Technical Details

The change touches five files.

`build_tools/pyproject.toml` gains `packaging/linux/tests` in `testpaths` and `packaging/linux/tests/*` in the coverage `omit` list, which keeps test files out of the coverage report as the four existing entries do. Adding the directory rather than naming files is deliberate: a file list is what let `aggregate_metadata_test.py`, added by #6981, go uncollected after this PR was opened.

`requirements-test.txt` gains `jinja2>=3.0.0`. `build_package_test.py` imports `build_package.py`, which reaches `jinja2` through `deb_package.py` and `rpm_package.py`. It is already declared in `requirements.txt` and was missing only from the file `unit_tests.yml` installs, so the test was never broken; its environment just did not match the declared runtime one. That file is also read by `test_artifacts_structure.yml` and the shared `setup_test_environment` action, and `jinja2` is a pure-Python wheel.

`get_url_repo_params_test.py` needed the container-image string assertions #7017 deferred to this PR in its own module docstring: "Not covered here (P2 / separate PRs): ... #7004 container-image string assertions". The suite it left compares `get_container_image` against itself, in both the mapping test and the CLI smoke, so neither pins a value. Since eb7319cb93 (#5795), `get_container_image()` has returned `ghcr.io/rocm/no_rocm_image_ubuntu24_04:latest` for `ubuntu*` and `debian*` profiles, and `.github/workflows/test_native_linux_packages_install.yml` feeds that value straight into its job's `container: image:`. Changing the function would change which container CI runs in, so the tests are what pin it. They now assert the exact image per profile, `rhel8` included, which the trimmed suite had dropped.

`get_url_repo_params.py` had the same stale value in the `help=` text for the `get-container-image` subparser, which advertised `ubuntu2404 -> ubuntu:24.04` while the function's own docstring was already current. The two now agree.

`native_linux_package_install_test.py` built the install prefix with `pathlib.Path`, which renders `\opt\rocm\core` on Windows. The prefix is a path on the target Linux filesystem passed to `find(1)`, so it now uses `PurePosixPath`, which is identical on Linux. Nothing was broken in practice, since the harness only runs there, but collecting the directory turned the `windows-2022` leg red on the first push and this is what it caught.

### Why the whole directory now

When this PR was opened, neither of the other two files passed. `build_package_test.py` never reached collection, for the dependency reason above. `native_linux_package_install_ut_test.py` had seven failures, two of which shelled out to real `sudo` because a mock did not intercept the write in `setup_deb_repository`. On a runner with passwordless sudo those two would have passed, turning a required check green while writing to its `/etc/apt/sources.list.d/`.

#7017 fixed that file, so the reason for leaving it out is gone, and #6927 names it specifically. It now passes 118 tests, and run as a non-root user with passwordless sudo, mirroring a GitHub runner, it writes nothing to `/etc/apt/sources.list.d`, `/etc/yum.repos.d`, `/etc/zypp/repos.d`, `/usr/share/keyrings` or `/etc/apt/keyrings`.

## Test Plan

Everything ran in a `python:3.12` container with `pip install -r requirements-test.txt`, which matches the Python version and dependency set that `unit_tests.yml` installs on its `ubuntu-24.04` leg. Each check ran twice, against a clean checkout of `main` and again with the change applied, so the two states could be compared directly.

The checks were the directory alone, the exact command CI runs from `build_tools/`, the `scan_tools` suite CI runs separately, and `pre-commit`. Three negative controls tested whether the change does anything: dropping the `testpaths` entry, removing `jinja2`, and breaking the `ubuntu` mapping. The `windows-2022` failure above was reproduced and re-checked locally by forcing the Windows path flavour through the module, which is the one part of that leg reproducible off Windows; everything else there is left to CI on this pull request.

## Test Result

The full `build_tools` suite, run in that container against both states:

| | Passed | Skipped | Failed |
|---|---|---|---|
| Clean checkout of `main` | 1401 | 33 | 0 |
| With this change | 1603 | 33 | 0 |

The difference is exactly the 202 tests in the directory. Nothing was removed, and no test outside it changed status. The skip count depends on the environment, since there is no `GITHUB_TOKEN` and a few cases are Windows only.

The negative controls:

| Control | Result |
|---|---|
| Drop the `testpaths` entry | 0 collected from the directory, against 202 with it |
| Remove `jinja2` | `build_package_test.py` fails collection |
| Break the `ubuntu` mapping | three of the new assertions fail, where the suite as #7017 left it passes 21/21 |

`scan_tools` is unaffected at 31 passed on both states, since it has its own `pyproject.toml`. `pre-commit` passes every hook without reformatting anything, and `get_url_repo_params.py --help` renders the corrected mapping.

## Note on scope

This is wider than the version that was approved. That version added one file to `testpaths`; this adds the directory, one line to `requirements-test.txt`, and a one-line path fix in `native_linux_package_install_test.py` that the `windows-2022` leg required. #7017 cleared the reason the other files were left out.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
