### PR TITLE
[torch] Force include `_rocm_init.py` and `libomp.dll` until upstream PRs land

### DIFF
--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -1133,6 +1133,21 @@ def do_build_pytorch(
     run_command(build_backend_install + pip_install_args, cwd=pytorch_dir)
 
     build_command = [sys.executable, "-m", "build", "--wheel", "--no-isolation"]
+    pytorch_pyproject_text = (pytorch_dir / "pyproject.toml").read_text()
+    if "scikit_build_core.build" in pytorch_pyproject_text:
+        # scikit-build-core applies Git ignore rules when constructing the wheel,
+        # dropping generated, gitignored runtime files. This workaround can be
+        # removed once these fixes are merged and commonly available:
+        # https://github.com/pytorch/pytorch/pull/191625
+        # https://github.com/pytorch/pytorch/pull/191629
+        build_command.append(
+            "-Cwheel.force-include.torch/_rocm_init.py=torch/_rocm_init.py"
+        )
+        if is_windows:
+            build_command.append(
+                "-Cwheel.force-include.torch/lib/libomp140.x86_64.dll="
+                "torch/lib/libomp140.x86_64.dll"
+            )
     if is_windows:
         # The PyPI `ninja` package is unusable on Windows: 1.11.1 loops without
         # making progress and 1.13.0 has an MSVC link.exe RSP-file regression


### PR DESCRIPTION
## Motivation

This passes scikit-build-core force-include settings for our generated and .gitignore'd `_rocm_init.py` file and Windows OpenMP runtime files.

* Local patch for https://github.com/ROCm/TheRock/issues/6965
* This should be compatible with
  * https://github.com/pytorch/pytorch/pull/191625
  * https://github.com/pytorch/pytorch/pull/191632
  * https://github.com/pytorch/pytorch/pull/191629

## Technical Details

* `python -m build` backend configuration (https://build.pypa.io/en/stable/how-to/config-settings.html) documents `-C` as shorthand for `--config-setting`. It forwards `KEY=VALUE` settings to the selected PEP 517 backend.
* scikit-build-core configuration (https://scikit-build-core.readthedocs.io/en/stable/configuration/#configuration) says every setting can be supplied through `pyproject.toml`, PEP 517 config settings, or environment variables. Its examples use dotted CLI keys such as `-Ccmake.build-type=Debug` (see https://scikit-build-core.readthedocs.io/en/stable/reference/configs.html#confval-cmake.build-type)
* scikit-build-core’s `wheel.force-include` section (https://scikit-build-core.readthedocs.io/en/stable/configuration/#force-including-files) documents the source-to-destination mapping and notes that exact force-includes override exclusions.

## Test Plan

Trigger builds of pytorch on linux and windows using 'nightly', look for `_rocm_init.py` and library load succeeding

| Config | Logs | Result |
-- | -- | --
Linux 'nightly' | https://github.com/ROCm/TheRock/actions/runs/30588591418 | Pending
Linux 'release/2.12' | https://github.com/ROCm/TheRock/actions/runs/30589526077 | Pending
Windows 'nightly' | https://github.com/ROCm/TheRock/actions/runs/30588680552 | Pending

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
