### PR TITLE
fix(packaging): Include unversioned `libamd_smi.so` in `rocm-sdk-core` package

### DIFF
--- a/build_tools/_therock_utils/py_packaging.py
+++ b/build_tools/_therock_utils/py_packaging.py
@@ -38,6 +38,15 @@ assert DIST_INFO_PATH.exists()
 
 ENABLED_VLOG_LEVEL: int = 5
 
+# Unversioned .so symlinks that must be present in the runtime package (not
+# just in devel) because they are dlopen'd at runtime by their unversioned name.
+# Example: PyTorch's IntraNodeComm::getNvlMesh calls dlopen("libamd_smi.so").
+_RUNTIME_DLOPEN_UNVERSIONED_LIBS: frozenset[str] = frozenset(
+    [
+        "libamd_smi.so",
+    ]
+)
+
 
 def log(*args, vlog: int = 0, **kwargs):
     if vlog > ENABLED_VLOG_LEVEL:
@@ -450,6 +459,11 @@ class PopulatedDistPackage:
         # Case 2: Shared library.
         if file_type == "so" and (soname := get_soname(link_target)):
             if soname == src_entry.name:
+                self._populate_file(relpath, dest_path, src_entry, resolve_src=True)
+            elif src_entry.name in _RUNTIME_DLOPEN_UNVERSIONED_LIBS:
+                # Some libraries are dlopen'd at runtime using their unversioned
+                # name (e.g. dlopen("libamd_smi.so")). Materialize the unversioned
+                # symlink in the runtime package so devel is not required for this.
                 self._populate_file(relpath, dest_path, src_entry, resolve_src=True)
             else:
                 self.files.soname_aliases[relpath] = soname


### PR DESCRIPTION
## Summary

Materialize the unversioned `libamd_smi.so` in `rocm-sdk-core` so that
`dlopen("libamd_smi.so")` works at runtime without requiring `rocm-sdk-devel`
or `rocm-sdk init`.

JIRA ID : https://amd-hub.atlassian.net/browse/ROCM-27833

## Motivation

PyTorch's `IntraNodeComm::getNvlMesh` calls `dlopen("libamd_smi.so")` (unversioned
name) during NVLink mesh detection for intra-node all-reduce. This caused two
distributed NCCL tests to hang and timeout after 300 seconds:

- `CommTest::test_intra_node_comm_all_reduce_custom_group_name_False`
- `CommTest::test_intra_node_comm_all_reduce_custom_group_name_True`

The unversioned `libamd_smi.so` symlink only existed in `_rocm_sdk_devel/lib/`
(after `rocm-sdk init`), but `LD_LIBRARY_PATH` covers `_rocm_sdk_core/lib/` —
not the devel tree. So `dlopen` failed at runtime even when `rocm-sdk-devel` was
installed and initialized.

## Technical Details

`_populate_runtime_symlink` in `py_packaging.py` handles symlinks from the ROCm
install tree when building wheels (which cannot contain symlinks). It materializes
a symlink as a real file only when the symlink name equals the SONAME. The
unversioned `.so` (e.g. `libamd_smi.so`) has a different name from the SONAME
(`libamd_smi.so.26`), so it was silently deferred to the devel expansion path.

Fix: add a `_RUNTIME_DLOPEN_UNVERSIONED_LIBS` allowlist. Libraries in this set
have their unversioned `.so` materialized as a real file copy in the runtime
package, placing them under `_rocm_sdk_core/lib/` and making them reachable via
`LD_LIBRARY_PATH` without devel.

The tradeoff is a duplicate copy of the library bytes in `rocm-sdk-core`
(`libamd_smi.so` and `libamd_smi.so.26` contain the same bytes). 

**File changed:** `build_tools/_therock_utils/py_packaging.py`

## Test Plan

1. Build `rocm-sdk-core` wheel with this fix
2. Install wheel without `rocm-sdk-devel`:
   ```bash
   pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
       "rocm[libraries,device-gfx942]"

## Test Results
Before fix — only versioned file in core, unversioned only after devel init:


$ find . -name "libamd_smi.so*"
./_rocm_sdk_devel/share/amd_smi/amdsmi/libamd_smi.so
./_rocm_sdk_devel/lib/libamd_smi.so.26.5.0
./_rocm_sdk_devel/lib/libamd_smi.so
./_rocm_sdk_devel/lib/libamd_smi.so.26
./_rocm_sdk_core/lib/libamd_smi.so.26
After fix — unversioned file present in core without devel:


$ find . -name "libamd_smi.so*"
./_rocm_sdk_core/lib/libamd_smi.so        ← NEW: dlopen("libamd_smi.so") now resolves
./_rocm_sdk_core/lib/libamd_smi.so.26