### PR TITLE
fix(tests): rename 'key' variable to 'nevra' to avoid gitleaks false positive

### DIFF
--- a/build_tools/packaging/linux/tests/aggregate_metadata_test.py
+++ b/build_tools/packaging/linux/tests/aggregate_metadata_test.py
@@ -267,8 +267,8 @@ class TestDebNevraCollision(unittest.TestCase):
 
     def test_different_versions_no_collision(self):
         declared = {"pkg1_1.0_amd64": "core"}
-        key = "pkg1_2.0_amd64"
-        self.assertNotIn(key, declared)
+        nevra = "pkg1_2.0_amd64"
+        self.assertNotIn(nevra, declared)
 
 
 class TestDebStanzaRoundTrip(unittest.TestCase):
@@ -398,9 +398,9 @@ class TestRpmNevraCollision(unittest.TestCase):
     def test_same_nevra_different_sources_detected(self):
         pkg = self._make_pkg("mypkg", "0", "1.0", "1.el8", "x86_64")
         declared = {self._nevra_key(pkg): "core"}
-        key = self._nevra_key(pkg)
-        self.assertIn(key, declared)
-        self.assertNotEqual(declared[key], "rvs")
+        nevra = self._nevra_key(pkg)
+        self.assertIn(nevra, declared)
+        self.assertNotEqual(declared[nevra], "rvs")
 
     def test_different_versions_no_collision(self):
         pkg1 = self._make_pkg("mypkg", "0", "1.0", "1.el8", "x86_64")


### PR DESCRIPTION
##Summary
Rename 'key' variable to 'nevra' to avoid gitleaks false positive. The variable name 'key = ...' was triggering the gitleaks generic-api-key rule. Renamed to 'nevra' which accurately describes its purpose.

JIRA ID : https://amd-hub.atlassian.net/browse/ROCM-25115

## Motivation

Gitleaks uses pattern matching to detect secrets. The generic-api-key rule matches any line that looks like a key assignment — specifically patterns like:

key = "some_value"
It uses entropy + pattern matching: key is a known secret-related keyword, and the value "pkg1_2.0_amd64" has enough character entropy to trigger the rule. 

## Technical Details

rename key variable to a different name(nevra)
File changed : build_tools/packaging/linux/tests/aggregate_metadata_test.py

## Test Plan
The git leaks scan should pass in ci