### PR TITLE
fix(tarball-indexer): allow generation of empty indexes

### DIFF
--- a/build_tools/index_generation_s3_tar.py
+++ b/build_tools/index_generation_s3_tar.py
@@ -51,14 +51,15 @@ def extract_gpu_details(files):
     return sorted(list(gpu_families))
 
 
-def generate_index_s3(s3_client, bucket_name, prefix: str, upload: bool = False) -> str:
+def generate_index_s3(s3_client, bucket_name, prefix: str, upload: bool = False, allow_empty: bool = False) -> str:
     """Generate index.html for direct-child .tar.gz files at s3://bucket_name/prefix.
 
     With upload=True the index is PUT to s3://bucket_name/<prefix>/index.html
     and the HTTPS URL is returned. Otherwise the index is written to
     ./index.html and the local path is returned.
-
-    Raises FileNotFoundError when the prefix has no .tar.gz files.
+    
+    With allow_empty=True, an empty index is generated when the prefix
+    contains no .tar.gz files. Otherwise, FileNotFoundError is raised.
     """
     # Strip any leading or trailing slash from the prefix to standardize the directory path used to filter object.
     prefix = prefix.lstrip("/").rstrip("/")
@@ -92,7 +93,7 @@ def generate_index_s3(s3_client, bucket_name, prefix: str, upload: bool = False)
                     (key.removeprefix(f"{prefix}/"), obj["LastModified"].timestamp())
                 )
 
-    if not files:
+    if not files and not allow_empty:
         raise FileNotFoundError(f"No .tar.gz files found in bucket {bucket_name}.")
 
     # Page title

--- a/build_tools/index_generation_s3_tar.py
+++ b/build_tools/index_generation_s3_tar.py
@@ -51,13 +51,15 @@ def extract_gpu_details(files):
     return sorted(list(gpu_families))
 
 
-def generate_index_s3(s3_client, bucket_name, prefix: str, upload: bool = False, allow_empty: bool = False) -> str:
+def generate_index_s3(
+    s3_client, bucket_name, prefix: str, upload: bool = False, allow_empty: bool = False
+) -> str:
     """Generate index.html for direct-child .tar.gz files at s3://bucket_name/prefix.
 
     With upload=True the index is PUT to s3://bucket_name/<prefix>/index.html
     and the HTTPS URL is returned. Otherwise the index is written to
     ./index.html and the local path is returned.
-    
+
     With allow_empty=True, an empty index is generated when the prefix
     contains no .tar.gz files. Otherwise, FileNotFoundError is raised.
     """

--- a/build_tools/index_generation_s3_tar.py
+++ b/build_tools/index_generation_s3_tar.py
@@ -150,6 +150,14 @@ def generate_index_s3(
             function renderFiles(fileList) {{
                 const ul = document.getElementById('fileList');
                 ul.innerHTML = '';
+
+                if (fileList.length === 0) {{
+                    const li = document.createElement('li');
+                    li.textContent = 'No tarballs available.';
+                    ul.appendChild(li);
+                    return;
+                }}
+
                 fileList.forEach(file => {{
                     const li = document.createElement('li');
                     const href = encodeURIComponent(file.name).replace(/%2F/g, '/');

--- a/build_tools/tests/index_generation_s3_tar_test.py
+++ b/build_tools/tests/index_generation_s3_tar_test.py
@@ -94,10 +94,7 @@ class IndexGenerationS3TarTest(unittest.TestCase):
 
         self.assertEqual(
             result,
-            (
-                f"https://{self.bucket_name}.s3.amazonaws.com/"
-                f"{self.index_key}"
-            ),
+            (f"https://{self.bucket_name}.s3.amazonaws.com/" f"{self.index_key}"),
         )
         self.assertEqual(self.s3_client.put_object.call_count, 2)
 

--- a/build_tools/tests/index_generation_s3_tar_test.py
+++ b/build_tools/tests/index_generation_s3_tar_test.py
@@ -1,0 +1,116 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for build_tools/index_generation_s3_tar.py."""
+
+import os
+import sys
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
+
+import index_generation_s3_tar
+
+
+class IndexGenerationS3TarTest(unittest.TestCase):
+    bucket_name = "tarball-index-test-bucket"
+    prefix = "v5/rocm/extras/rvs/tarball"
+    index_key = f"{prefix}/index.html"
+
+    def setUp(self) -> None:
+        self.s3_client = mock.MagicMock()
+        self.paginator = self.s3_client.get_paginator.return_value
+        self.s3_client.meta.region_name = "us-east-2"
+        self._set_contents([])
+
+    def _set_contents(self, contents: list[dict[str, object]]) -> None:
+        self.paginator.paginate.return_value = [{"Contents": contents}]
+
+    def _uploaded_html(self, call_index: int = -1) -> str:
+        put_call = self.s3_client.put_object.call_args_list[call_index]
+        body = put_call.kwargs["Body"]
+        self.assertIsInstance(body, bytes)
+        return body.decode("utf-8")
+
+    def test_empty_prefix_raises_by_default(self) -> None:
+        """Existing callers must continue to reject an empty prefix."""
+        with self.assertRaises(FileNotFoundError) as raised:
+            index_generation_s3_tar.generate_index_s3(
+                s3_client=self.s3_client,
+                bucket_name=self.bucket_name,
+                prefix=self.prefix,
+                upload=True,
+            )
+
+        self.assertEqual(
+            str(raised.exception),
+            f"No .tar.gz files found in bucket {self.bucket_name}.",
+        )
+        self.s3_client.put_object.assert_not_called()
+
+    def test_deleting_last_tarball_uploads_empty_index_when_allowed(self) -> None:
+        """Removing the last tarball must replace the stale index."""
+        tarball_key = f"{self.prefix}/test-rvs.tar.gz"
+
+        # Generate an index while the final tarball still exists.
+        self._set_contents(
+            [
+                {
+                    "Key": tarball_key,
+                    "LastModified": datetime(
+                        2026,
+                        7,
+                        31,
+                        tzinfo=timezone.utc,
+                    ),
+                }
+            ]
+        )
+
+        index_generation_s3_tar.generate_index_s3(
+            s3_client=self.s3_client,
+            bucket_name=self.bucket_name,
+            prefix=self.prefix,
+            upload=True,
+            allow_empty=True,
+        )
+
+        populated_html = self._uploaded_html()
+        self.assertIn('"name": "test-rvs.tar.gz"', populated_html)
+
+        # Simulate the Lambda running after that final tarball is deleted.
+        self._set_contents([])
+
+        result = index_generation_s3_tar.generate_index_s3(
+            s3_client=self.s3_client,
+            bucket_name=self.bucket_name,
+            prefix=self.prefix,
+            upload=True,
+            allow_empty=True,
+        )
+
+        self.assertEqual(
+            result,
+            (
+                f"https://{self.bucket_name}.s3.amazonaws.com/"
+                f"{self.index_key}"
+            ),
+        )
+        self.assertEqual(self.s3_client.put_object.call_count, 2)
+
+        empty_upload = self.s3_client.put_object.call_args_list[-1]
+        self.assertEqual(empty_upload.kwargs["Bucket"], self.bucket_name)
+        self.assertEqual(empty_upload.kwargs["Key"], self.index_key)
+        self.assertEqual(empty_upload.kwargs["ContentType"], "text/html")
+
+        empty_html = self._uploaded_html()
+        self.assertIn("const files = [];", empty_html)
+        self.assertIn("No tarballs available.", empty_html)
+        self.assertNotIn('"name": "test-rvs.tar.gz"', empty_html)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add an optional `allow_empty` parameter to `generate_index_s3()`.

When enabled, the index generator creates and uploads an empty `index.html` when no `.tar.gz` files remain under the requested prefix. This allows the server-side tarball indexer to remove stale listings after the final tarball is deleted.

The parameter defaults to `False`, preserving the existing CLI and manual-repair behavior of raising `FileNotFoundError` for an empty prefix.


ISSUE ID : https://github.com/ROCm/TheRock/issues/7188

## Testing

```console
python -m pytest -v tests/test_lambda_function.py

https://github.com/ROCm/TheRock-Infra/pull/560

=============================================================================== test session starts ================================================================================
platform linux -- Python 3.12.13, pytest-9.1.1, pluggy-1.6.0 -- /home/arravikum/TheRock-Infra-tarball/TheRock-Infra/.venv/bin/python
cachedir: .pytest_cache
rootdir: /home/arravikum/TheRock-Infra-tarball/TheRock-Infra/tools/tarball-structured-index-updater/lambda
collected 16 items

tests/test_lambda_function.py::EventTypeTest::test_normalizes_supported_event_types
tests/test_lambda_function.py::EventTypeTest::test_normalizes_supported_event_types PASSED                                                                                   [  6%]
tests/test_lambda_function.py::EventExtractionTest::test_extracts_and_decodes_direct_s3_event PASSED                                                                         [ 12%]
tests/test_lambda_function.py::EventExtractionTest::test_extracts_direct_eventbridge_event PASSED                                                                            [ 18%]
tests/test_lambda_function.py::EventExtractionTest::test_extracts_sqs_wrapped_classic_s3_event PASSED                                                                        [ 25%]
tests/test_lambda_function.py::EventExtractionTest::test_extracts_sqs_wrapped_eventbridge_event PASSED                                                                       [ 31%]
tests/test_lambda_function.py::EventExtractionTest::test_rejects_excessive_nesting PASSED                                                                                    [ 37%]
tests/test_lambda_function.py::EventExtractionTest::test_rejects_invalid_sqs_json PASSED                                                                                     [ 43%]
tests/test_lambda_function.py::EventExtractionTest::test_rejects_malformed_s3_event PASSED                                                                                   [ 50%]
tests/test_lambda_function.py::EventExtractionTest::test_skips_unsupported_events PASSED                                                                                     [ 56%]
tests/test_lambda_function.py::PrefixMatchingTest::test_accepts_product_local_tarball PASSED                                                                                 [ 62%]
tests/test_lambda_function.py::PrefixMatchingTest::test_rejects_nonmatching_keys
tests/test_lambda_function.py::PrefixMatchingTest::test_rejects_nonmatching_keys PASSED                                                                                      [ 68%]
tests/test_lambda_function.py::LambdaHandlerIntegrationTest::test_delete_event_removes_deleted_object_from_index PASSED                                                      [ 75%]
tests/test_lambda_function.py::LambdaHandlerIntegrationTest::test_delete_last_tarball_creates_empty_index PASSED                                                             [ 81%]
tests/test_lambda_function.py::LambdaHandlerIntegrationTest::test_non_tarball_event_does_not_access_s3 PASSED                                                                [ 87%]
tests/test_lambda_function.py::LambdaHandlerIntegrationTest::test_regenerates_index_from_current_s3_state PASSED                                                             [ 93%]
tests/test_lambda_function.py::LambdaHandlerIntegrationTest::test_s3_failure_fails_the_invocation PASSED                                                                     [100%]

====================================================================== 16 passed, 14 subtests passed in 1.21s ======================================================================

16 passed, 14 subtests passed

```
Test run for the unit tests added in TheRock

```

(.venv) arravikum@aravind-azure-testVM:~/TheRock_tarball_index_empty/TheRock$ python -m pytest -v   build_tools/tests/index_generation_s3_tar_test.py
================================================= test session starts ==================================================
platform linux -- Python 3.10.12, pytest-8.4.2, pluggy-1.6.0 -- /home/arravikum/TheRock_new/TheRock/.venv/bin/python
cachedir: .pytest_cache
rootdir: /home/arravikum/TheRock_tarball_index_empty/TheRock/build_tools
configfile: pyproject.toml
collected 2 items

build_tools/tests/index_generation_s3_tar_test.py::IndexGenerationS3TarTest::test_deleting_last_tarball_uploads_empty_index_when_allowed PASSED [ 50%]
build_tools/tests/index_generation_s3_tar_test.py::IndexGenerationS3TarTest::test_empty_prefix_raises_by_default PASSED [100%]

================================================== 2 passed in 0.11s ===================================================

```

The tests verify that deleting the final tarball generates an empty index instead of leaving the previous index unchanged.

