### PR TITLE
test(packaging): fix native install UT drift and canonicalize get_url_repo_params URLs/GPG

### DIFF
--- a/build_tools/packaging/linux/get_url_repo_params.py
+++ b/build_tools/packaging/linux/get_url_repo_params.py
@@ -3,53 +3,36 @@
 # SPDX-License-Identifier: MIT
 
 """
-GitHub Actions helper: derive native Linux packaging URL parameters.
+Canonical, unit-tested spec for native Linux install-test parameters (KEY=value → $GITHUB_OUTPUT).
 
-Used by CI workflows (see test_native_linux_packages_install.yml) to normalize
-install-test inputs. Each subcommand prints KEY=value lines suitable for
-$GITHUB_OUTPUT via gha_set_output().
+Purpose: one Python module + tests that define how CDN repo URLs, GPG paths, GPU arch
+tokens, and CI container images should be derived (per native_packaging.md and install
+workflows). Callers should converge here; upload_package_repo.py and
+install_rocm_packages.sh still embed parallel logic until get-repo-url / get-gpg-url are
+wired. Tests catch spec drift at merge time — wrong …/packages/ paths, GPG tree mismatches,
+container renames — without running the full install matrix.
 
-Layout scope:
-  - **per_family** (default): legacy GFX-specific tree from native_packaging.md
-    (…/packages/{os}, …/rocm/packages/{os}, …/deb|rpm/{YYYYMMDD-id}/).
-  - **multi_arch**: packages-multi-arch/… tree (install_rocm_packages.sh /
-    s3_buckets.md). Signed stable uses …/rocm/packages-multi-arch/{os_profile}.
+In production CI today: test_native_linux_packages_install.yml uses extract-gfx-arch and
+get-container-image only. Install repo/GPG URLs still arrive via workflow inputs from
+upload_package_repo.py.
 
-Subcommands:
-  get-base-url         scheme + netloc from any URL → repo_base_url=
-  get-gpg-url          GPG key URL from package repo URL → gpg_key_url=
-                       (--release-type omits URL for dev/nightly/ci unsigned repos)
-  get-repo-sub-folder  YYYYMMDD-<id> segment from S3 prefix → repo_sub_folder=
-  get-repo-url         install repo URL from components → repo_url=
-                       (--layout per_family default, or multi_arch)
-  extract-gfx-arch     gfx94X-dcgpu → gfx94x (lists supported) → gfx_arch=
-  get-container-image  os_profile → CI container image → container_image=
+Expected: get-repo-url → per_family or multi_arch install URLs; invalid release_type or
+layout → ValueError. get-gpg-url derives a default gpg_key_url= for workflow outputs:
+signed lines (prerelease/release) get a URL, dev/nightly/ci get empty when --release-type
+is set. That policy does not override install tests — native_linux_package_install_test.py
+and test_native_linux_packages_install.yml use any gpg_key_url / GPG_KEY_URL input as-is,
+regardless of release_type (if omitted, install runs without GPG verification).
 
-Workflow usage today:
-  extract-gfx-arch and get-container-image are called from GHA.
-  package_install_url and gpg_key_url are still passed as workflow inputs;
-  get-repo-url / get-gpg-url / get-repo-sub-folder are available for wiring.
+Subcommands: get-base-url, get-gpg-url, get-repo-sub-folder, get-repo-url, extract-gfx-arch,
+get-container-image. Run with -h for examples.
 
-Examples:
-  python build_tools/packaging/linux/get_url_repo_params.py get-base-url \\
-      --from-url https://example.com/v2/whl
-  python build_tools/packaging/linux/get_url_repo_params.py get-gpg-url \\
-      --release-type prerelease \\
-      --from-url https://rocm.prereleases.amd.com/packages/ubuntu2404
-  python build_tools/packaging/linux/get_url_repo_params.py get-repo-sub-folder \\
-      --from-s3-prefix v3/packages/deb/20260204-12345
-  python build_tools/packaging/linux/get_url_repo_params.py get-repo-url \\
-      --release-type prerelease --native-package-type deb \\
-      --repo-base-url https://rocm.prereleases.amd.com \\
-      --os-profile ubuntu2404 --repo-sub-folder ''
-  python build_tools/packaging/linux/get_url_repo_params.py get-repo-url \\
-      --layout multi_arch --release-type stable --native-package-type deb \\
-      --repo-base-url https://repo.amd.com --os-profile ubuntu2604 \\
-      --repo-sub-folder ''
-  python build_tools/packaging/linux/get_url_repo_params.py extract-gfx-arch \\
-      --artifact-group gfx94X-dcgpu
-  python build_tools/packaging/linux/get_url_repo_params.py get-container-image \\
-      --os-profile ubuntu2404
+Maintenance (when packaging or install URLs change):
+
+1. Update docs first: docs/packaging/native_packaging.md (and docs/development/s3_buckets.md
+   if S3 bucket/prefix layout changes).
+2. Change this module and get_url_repo_params_test.py together — tests are the drift alarm.
+3. Cross-check upload_package_repo.py and dockerfiles/install_rocm_packages.sh if CI or
+   manual install paths must stay in sync (minimum sanity check; full dedupe is P2).
 """
 
 import argparse
@@ -64,6 +47,9 @@ from github_actions.github_actions_api import gha_set_output
 
 LAYOUT_PER_FAMILY = "per_family"
 LAYOUT_MULTI_ARCH = "multi_arch"
+
+# Reserved dummy CDN host for docstrings, --help, and generic unit tests (RFC 2606).
+EXAMPLE_CDN_BASE = "https://sample-cdn.example"
 
 
 def normalize_layout(layout: str | None) -> str:
@@ -102,6 +88,23 @@ def _normalize_release_type(release_type: str) -> str:
         "nightlies": "nightly",
     }
     return aliases.get(rt, rt)
+
+
+_KNOWN_RELEASE_TYPES = frozenset({"prerelease", "release", "dev", "nightly", "ci"})
+
+
+def _normalize_and_validate_release_type(release_type: str) -> str:
+    """Normalize and validate ``release_type`` for :func:`get_repo_url`.
+
+    Raises:
+        ValueError: If ``release_type`` is empty or not a known workflow value.
+    """
+    if not release_type or not release_type.strip():
+        raise ValueError("release_type cannot be empty")
+    rt = _normalize_release_type(release_type)
+    if rt not in _KNOWN_RELEASE_TYPES:
+        raise ValueError(f"Unknown release_type: {release_type!r}")
+    return rt
 
 
 # --- base_url ---
@@ -156,14 +159,14 @@ def get_gpg_key_url(package_url: str) -> str:
         ValueError: If ``package_url`` is not a valid HTTP(S) URL.
 
     Examples:
-        https://rocm.prereleases.amd.com/packages/ubuntu2404
-            → https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg
-        https://repo.amd.com/rocm/packages/rhel10/x86_64/
-            → https://repo.amd.com/rocm/packages/gpg/rocm.gpg
-        https://repo.amd.com/rocm/packages-multi-arch/ubuntu2604
-            → https://repo.amd.com/rocm/packages-multi-arch/gpg/rocm.gpg
-        https://rocm.nightlies.amd.com/packages-multi-arch/deb/20260204-12345/
-            → https://rocm.nightlies.amd.com/packages-multi-arch/gpg/rocm.gpg
+        https://sample-cdn.example/packages/ubuntu2404
+            → https://sample-cdn.example/packages/gpg/rocm.gpg
+        https://sample-cdn.example/rocm/packages/rhel10/x86_64/
+            → https://sample-cdn.example/rocm/packages/gpg/rocm.gpg
+        https://sample-cdn.example/packages-multi-arch/ubuntu2604
+            → https://sample-cdn.example/packages-multi-arch/gpg/rocm.gpg
+        https://sample-cdn.example/packages-multi-arch/deb/20260204-12345/
+            → https://sample-cdn.example/packages-multi-arch/gpg/rocm.gpg
         https://repo.amd.com/
             → https://repo.amd.com/rocm/packages/gpg/rocm.gpg
     """
@@ -233,19 +236,23 @@ def get_gpg_key_url_from_release_type(
 
 
 def gpg_key_url_needed_for_release_type(release_type: str | None) -> bool:
-    """Return whether a signed-repo GPG key URL applies for this release line.
+    """Return whether ``get-gpg-url`` should derive a non-empty GPG URL.
+
+    This is a **derivation policy for this helper only**. It does not restrict
+    ``native_linux_package_install_test.py`` or workflow ``gpg_key_url`` inputs: if the
+    caller supplies a GPG URL, install uses it regardless of ``release_type``.
 
     Args:
         release_type: Workflow release type, or ``None`` for legacy callers.
 
     Returns:
-        ``True`` if a GPG URL should be emitted/derived; ``False`` for unsigned
-        lines (``dev``, ``nightly``, ``ci``, empty string).
+        ``True`` if ``get-gpg-url`` should derive from ``--from-url``; ``False`` if it
+        should emit empty ``gpg_key_url=`` for unsigned lines (``dev``, ``nightly``,
+        ``ci``, empty string).
 
     Notes:
         ``None`` means always derive from the package URL (backward compatible).
-        Signed lines: ``prerelease``, ``prereleases``, ``release``, ``stable``
-        (case-insensitive, whitespace trimmed).
+        Signed lines: ``prerelease``, ``prereleases``, ``release``, ``stable``.
     """
     if release_type is None:
         return True
@@ -254,7 +261,13 @@ def gpg_key_url_needed_for_release_type(release_type: str | None) -> bool:
 
 
 def cmd_gpg_key_url(args: argparse.Namespace) -> int:
-    """CLI: ``get-gpg-url`` → writes ``gpg_key_url=`` (or empty) to ``$GITHUB_OUTPUT``."""
+    """CLI: ``get-gpg-url`` → writes ``gpg_key_url=`` (or empty) to ``$GITHUB_OUTPUT``.
+
+    When ``--release-type`` is unsigned (dev/nightly/ci), emits empty output so workflows
+    need not pass GPG for typical unsigned repos. Omit ``--release-type`` to always
+    derive from ``--from-url``. Explicit ``gpg_key_url`` on the install workflow or CLI
+    bypasses this helper entirely.
+    """
     if not gpg_key_url_needed_for_release_type(args.release_type):
         gha_set_output({"gpg_key_url": ""})
         return 0
@@ -321,15 +334,18 @@ def get_repo_url_per_family(
         release_type: ``prerelease`` / ``prereleases``, ``release`` / ``stable``,
             or unsigned lines ``dev``, ``nightly``, ``ci`` (aliases normalized).
         native_package_type: ``deb`` or ``rpm``.
-        repo_base_url: Scheme + host (e.g. ``https://rocm.prereleases.amd.com``).
+        repo_base_url: Scheme + host (e.g. ``https://sample-cdn.example``).
         os_profile: OS profile slug (e.g. ``ubuntu2404``, ``rhel10``).
         repo_sub_folder: ``YYYYMMDD-<id>`` for dev/nightly; empty for signed lines.
 
     Returns:
         HTTPS URL pointing at the apt/dnf repo root (RPM URLs include ``/x86_64/``).
+
+    Raises:
+        ValueError: If ``release_type`` is empty or unknown.
     """
     base = repo_base_url.rstrip("/")
-    rt = _normalize_release_type(release_type)
+    rt = _normalize_and_validate_release_type(release_type)
 
     if rt == "prerelease":
         if native_package_type == "deb":
@@ -374,9 +390,12 @@ def get_repo_url_multi_arch(
         - release deb: ``{base}/rocm/packages-multi-arch/{os_profile}``
         - nightly deb: ``{base}/packages-multi-arch/deb/{repo_sub_folder}``
         - nightly rpm: ``{base}/packages-multi-arch/rpm/{repo_sub_folder}/x86_64``
+
+    Raises:
+        ValueError: If ``release_type`` is empty or unknown.
     """
     base = repo_base_url.rstrip("/")
-    rt = _normalize_release_type(release_type)
+    rt = _normalize_and_validate_release_type(release_type)
 
     if rt == "prerelease":
         if native_package_type == "deb":
@@ -418,6 +437,9 @@ def get_repo_url(
     Returns:
         HTTPS URL pointing at the apt/dnf repo root.
 
+    Raises:
+        ValueError: If ``layout`` or ``release_type`` is invalid.
+
     See Also:
         :func:`get_repo_url_per_family`, :func:`get_repo_url_multi_arch`.
     """
@@ -450,7 +472,7 @@ def cmd_repo_url(args: argparse.Namespace) -> int:
             repo_sub_folder=args.repo_sub_folder or "",
             layout=args.layout,
         )
-    except (ValueError, TypeError) as e:
+    except ValueError as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
     gha_set_output({"repo_url": url})
@@ -607,27 +629,43 @@ def main(argv: list[str] | None = None) -> int:
         type=str,
         required=True,
         metavar="URL",
-        help="Any URL to derive base URL from (scheme + netloc only; e.g. https://example.com/v2/whl → https://example.com)",
+        help=(
+            "Any URL to derive base URL from (scheme + netloc only; e.g. "
+            "https://sample-cdn.example/v2/whl → https://sample-cdn.example)"
+        ),
     )
     p_base.set_defaults(func=cmd_base_url)
 
     # get-gpg-url: get GPG key URL from package repository URL
     p_gpg = subparsers.add_parser(
         "get-gpg-url",
-        help="Print gpg_key_url= for GITHUB_OUTPUT. With --release-type, only prerelease/release get a non-empty URL; otherwise gpg_key_url=. Omit --release-type to always derive from --from-url.",
+        help=(
+            "Derive gpg_key_url= for GITHUB_OUTPUT from --from-url. With --release-type, "
+            "only signed lines get a non-empty URL; dev/nightly/ci emit gpg_key_url=. "
+            "Does not affect install when gpg_key_url is passed explicitly in the workflow."
+        ),
     )
     p_gpg.add_argument(
         "--from-url",
         type=str,
         required=True,
         metavar="URL",
-        help="Package repository URL to derive GPG key URL from when needed (per-family or packages-multi-arch paths; e.g. …/packages/ubuntu2404 → …/packages/gpg/rocm.gpg)",
+        help=(
+            "Package repository URL to derive GPG key URL from when needed "
+            "(e.g. https://sample-cdn.example/packages/ubuntu2404 → "
+            "…/packages/gpg/rocm.gpg)"
+        ),
     )
     p_gpg.add_argument(
         "--release-type",
         type=str,
         default=None,
-        help="If set, emit non-empty GPG URL only for signed lines (prerelease/release/stable); for dev/nightly/ci print gpg_key_url=. If omitted, always derive from --from-url.",
+        help=(
+            "If set, emit non-empty GPG URL only for signed lines (prerelease/release/stable); "
+            "for dev/nightly/ci print gpg_key_url= (typical unsigned repos). If omitted, "
+            "always derive from --from-url. Install tests still honor an explicit gpg_key_url "
+            "workflow input regardless of this flag."
+        ),
     )
     p_gpg.set_defaults(func=cmd_gpg_key_url)
 

--- a/build_tools/packaging/linux/get_url_repo_params.py
+++ b/build_tools/packaging/linux/get_url_repo_params.py
@@ -72,14 +72,31 @@ def get_gpg_key_url(package_url: str) -> str:
     """
     Get GPG key URL from package repository URL.
 
-    Extracts base URL and appends /gpg/rocm.gpg path.
+    Keys live beside the packages tree (see install_rocm_packages.sh):
+    - prerelease-style hosts: .../packages/gpg/rocm.gpg
+    - stable (repo.amd.com): .../rocm/packages/gpg/rocm.gpg
 
     Examples:
-        https://rocm.prereleases.amd.com/packages/ubuntu2404 -> https://rocm.prereleases.amd.com/gpg/rocm.gpg
-        https://repo.amd.com/rocm/packages/rhel10/x86_64/ -> https://repo.amd.com/gpg/rocm.gpg
+        https://rocm.prereleases.amd.com/packages/ubuntu2404
+            -> https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg
+        https://repo.amd.com/rocm/packages/rhel10/x86_64/
+            -> https://repo.amd.com/rocm/packages/gpg/rocm.gpg
+        https://rocm.nightlies.amd.com/deb/20260204-12345/
+            -> https://rocm.nightlies.amd.com/packages/gpg/rocm.gpg
     """
-    base_url = get_base_url(package_url)
-    return f"{base_url}/gpg/rocm.gpg"
+    parsed = urlparse(package_url)
+    if not parsed.scheme or not parsed.netloc:
+        raise ValueError(f"Invalid URL: {package_url!r}")
+    origin = f"{parsed.scheme}://{parsed.netloc}"
+    path = parsed.path or ""
+
+    if "/rocm/packages/" in path or path.rstrip("/").endswith("/rocm/packages"):
+        return f"{origin}/rocm/packages/gpg/rocm.gpg"
+    if "/packages/" in path or path.rstrip("/").endswith("/packages"):
+        return f"{origin}/packages/gpg/rocm.gpg"
+    if parsed.netloc == "repo.amd.com":
+        return f"{origin}/rocm/packages/gpg/rocm.gpg"
+    return f"{origin}/packages/gpg/rocm.gpg"
 
 
 def gpg_key_url_needed_for_release_type(release_type: str | None) -> bool:
@@ -95,7 +112,7 @@ def gpg_key_url_needed_for_release_type(release_type: str | None) -> bool:
     if release_type is None:
         return True
     rt = release_type.strip().lower()
-    return rt in ("prerelease", "release")
+    return rt in ("prerelease", "prereleases", "release", "stable")
 
 
 def cmd_gpg_key_url(args: argparse.Namespace) -> int:
@@ -136,6 +153,16 @@ def cmd_repo_sub_folder(args: argparse.Namespace) -> int:
 # --- repo_url ---
 
 
+def _normalize_release_type(release_type: str) -> str:
+    rt = release_type.strip().lower()
+    aliases = {
+        "prereleases": "prerelease",
+        "stable": "release",
+        "nightlies": "nightly",
+    }
+    return aliases.get(rt, rt)
+
+
 def get_repo_url(
     release_type: str,
     native_package_type: str,
@@ -144,17 +171,28 @@ def get_repo_url(
     repo_sub_folder: str,
 ) -> str:
     """
-    Return the full repo URL for install tests.
-    - prerelease + deb: repo_base_url / os_profile
-    - prerelease + rpm: repo_base_url / os_profile / x86_64/
-    - non-prerelease + deb: repo_base_url / deb / repo_sub_folder /
-    - non-prerelease + rpm: repo_base_url / rpm / repo_sub_folder / x86_64/
+    Return the full per-family repo URL for install tests (native_packaging.md).
+
+    - prerelease + deb: {base}/packages/{os_profile}
+    - prerelease + rpm: {base}/packages/{os_profile}/x86_64/
+    - release/stable + deb: {base}/rocm/packages/{os_profile}
+    - release/stable + rpm: {base}/rocm/packages/{os_profile}/x86_64/
+    - dev/nightly/ci + deb: {base}/deb/{repo_sub_folder}/
+    - dev/nightly/ci + rpm: {base}/rpm/{repo_sub_folder}/x86_64/
     """
     base = repo_base_url.rstrip("/")
-    if release_type == "prerelease":
+    rt = _normalize_release_type(release_type)
+
+    if rt == "prerelease":
         if native_package_type == "deb":
-            return f"{base}/{os_profile}"
-        return f"{base}/{os_profile}/x86_64/"
+            return f"{base}/packages/{os_profile}"
+        return f"{base}/packages/{os_profile}/x86_64/"
+
+    if rt == "release":
+        if native_package_type == "deb":
+            return f"{base}/rocm/packages/{os_profile}"
+        return f"{base}/rocm/packages/{os_profile}/x86_64/"
+
     if native_package_type == "deb":
         return f"{base}/deb/{repo_sub_folder}/"
     return f"{base}/rpm/{repo_sub_folder}/x86_64/"
@@ -300,7 +338,7 @@ def main(argv: list[str] | None = None) -> int:
         type=str,
         required=True,
         metavar="URL",
-        help="Package repository URL to derive GPG key URL from when needed (e.g. https://rocm.prereleases.amd.com/packages/ubuntu2404 → https://rocm.prereleases.amd.com/gpg/rocm.gpg)",
+        help="Package repository URL to derive GPG key URL from when needed (e.g. https://rocm.prereleases.amd.com/packages/ubuntu2404 → https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg)",
     )
     p_gpg.add_argument(
         "--release-type",

--- a/build_tools/packaging/linux/get_url_repo_params.py
+++ b/build_tools/packaging/linux/get_url_repo_params.py
@@ -9,18 +9,19 @@ Used by CI workflows (see test_native_linux_packages_install.yml) to normalize
 install-test inputs. Each subcommand prints KEY=value lines suitable for
 $GITHUB_OUTPUT via gha_set_output().
 
-Layout scope (today):
-  - get-repo-url / get-gpg-url implement the **per-family** URL tree from
-    docs/packaging/native_packaging.md (…/packages/{os}, …/rocm/packages/{os},
-    …/deb|rpm/{YYYYMMDD-id}/). Multi-arch packages-multi-arch/… URLs are not
-    modeled here yet (see install_rocm_packages.sh for that layout).
+Layout scope:
+  - **per_family** (default): legacy GFX-specific tree from native_packaging.md
+    (…/packages/{os}, …/rocm/packages/{os}, …/deb|rpm/{YYYYMMDD-id}/).
+  - **multi_arch**: packages-multi-arch/… tree (install_rocm_packages.sh /
+    s3_buckets.md). Signed stable uses …/rocm/packages-multi-arch/{os_profile}.
 
 Subcommands:
   get-base-url         scheme + netloc from any URL → repo_base_url=
   get-gpg-url          GPG key URL from package repo URL → gpg_key_url=
                        (--release-type omits URL for dev/nightly/ci unsigned repos)
   get-repo-sub-folder  YYYYMMDD-<id> segment from S3 prefix → repo_sub_folder=
-  get-repo-url         per-family install repo URL from components → repo_url=
+  get-repo-url         install repo URL from components → repo_url=
+                       (--layout per_family default, or multi_arch)
   extract-gfx-arch     gfx94X-dcgpu → gfx94x (lists supported) → gfx_arch=
   get-container-image  os_profile → CI container image → container_image=
 
@@ -41,6 +42,10 @@ Examples:
       --release-type prerelease --native-package-type deb \\
       --repo-base-url https://rocm.prereleases.amd.com \\
       --os-profile ubuntu2404 --repo-sub-folder ''
+  python build_tools/packaging/linux/get_url_repo_params.py get-repo-url \\
+      --layout multi_arch --release-type stable --native-package-type deb \\
+      --repo-base-url https://repo.amd.com --os-profile ubuntu2604 \\
+      --repo-sub-folder ''
   python build_tools/packaging/linux/get_url_repo_params.py extract-gfx-arch \\
       --artifact-group gfx94X-dcgpu
   python build_tools/packaging/linux/get_url_repo_params.py get-container-image \\
@@ -56,6 +61,47 @@ from urllib.parse import urlparse
 
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent.parent))
 from github_actions.github_actions_api import gha_set_output
+
+LAYOUT_PER_FAMILY = "per_family"
+LAYOUT_MULTI_ARCH = "multi_arch"
+
+
+def normalize_layout(layout: str | None) -> str:
+    """Normalize a layout selector to :data:`LAYOUT_PER_FAMILY` or :data:`LAYOUT_MULTI_ARCH`.
+
+    Args:
+        layout: ``None``/empty → per-family; aliases ``legacy``, ``multiarch``.
+
+    Raises:
+        ValueError: If ``layout`` is not recognized.
+    """
+    if layout is None or not layout.strip():
+        return LAYOUT_PER_FAMILY
+    key = layout.strip().lower().replace("-", "_")
+    aliases = {
+        "legacy": LAYOUT_PER_FAMILY,
+        "perfamily": LAYOUT_PER_FAMILY,
+        "multiarch": LAYOUT_MULTI_ARCH,
+    }
+    normalized = aliases.get(key, key)
+    if normalized not in (LAYOUT_PER_FAMILY, LAYOUT_MULTI_ARCH):
+        raise ValueError(f"Unknown layout: {layout!r}")
+    return normalized
+
+
+def _normalize_release_type(release_type: str) -> str:
+    """Normalize workflow release-type strings to canonical names.
+
+    Maps ``prereleases`` → ``prerelease``, ``stable`` → ``release``,
+    ``nightlies`` → ``nightly``; other values are lowercased as-is.
+    """
+    rt = release_type.strip().lower()
+    aliases = {
+        "prereleases": "prerelease",
+        "stable": "release",
+        "nightlies": "nightly",
+    }
+    return aliases.get(rt, rt)
 
 
 # --- base_url ---
@@ -96,8 +142,9 @@ def cmd_base_url(args: argparse.Namespace) -> int:
 def get_gpg_key_url(package_url: str) -> str:
     """Derive the AMD repo signing-key URL from a package repository URL.
 
-    Per-family layout only: keys sit under ``…/packages/gpg/`` or
-    ``…/rocm/packages/gpg/`` (not ``packages-multi-arch/gpg/``).
+    Keys sit beside the packages tree in the URL path:
+    ``…/packages/gpg/``, ``…/rocm/packages/gpg/``, or
+    ``…/packages-multi-arch/gpg/`` (stable: ``…/rocm/packages-multi-arch/gpg/``).
 
     Args:
         package_url: Full or partial native Linux package repo URL.
@@ -113,8 +160,10 @@ def get_gpg_key_url(package_url: str) -> str:
             → https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg
         https://repo.amd.com/rocm/packages/rhel10/x86_64/
             → https://repo.amd.com/rocm/packages/gpg/rocm.gpg
-        https://rocm.nightlies.amd.com/deb/20260204-12345/
-            → https://rocm.nightlies.amd.com/packages/gpg/rocm.gpg
+        https://repo.amd.com/rocm/packages-multi-arch/ubuntu2604
+            → https://repo.amd.com/rocm/packages-multi-arch/gpg/rocm.gpg
+        https://rocm.nightlies.amd.com/packages-multi-arch/deb/20260204-12345/
+            → https://rocm.nightlies.amd.com/packages-multi-arch/gpg/rocm.gpg
         https://repo.amd.com/
             → https://repo.amd.com/rocm/packages/gpg/rocm.gpg
     """
@@ -124,6 +173,14 @@ def get_gpg_key_url(package_url: str) -> str:
     origin = f"{parsed.scheme}://{parsed.netloc}"
     path = parsed.path or ""
 
+    if "/rocm/packages-multi-arch/" in path or path.rstrip("/").endswith(
+        "/rocm/packages-multi-arch"
+    ):
+        return f"{origin}/rocm/packages-multi-arch/gpg/rocm.gpg"
+    if "/packages-multi-arch/" in path or path.rstrip("/").endswith(
+        "/packages-multi-arch"
+    ):
+        return f"{origin}/packages-multi-arch/gpg/rocm.gpg"
     if "/rocm/packages/" in path or path.rstrip("/").endswith("/rocm/packages"):
         return f"{origin}/rocm/packages/gpg/rocm.gpg"
     if "/packages/" in path or path.rstrip("/").endswith("/packages"):
@@ -131,6 +188,48 @@ def get_gpg_key_url(package_url: str) -> str:
     if parsed.netloc == "repo.amd.com":
         return f"{origin}/rocm/packages/gpg/rocm.gpg"
     return f"{origin}/packages/gpg/rocm.gpg"
+
+
+def get_gpg_key_url_from_release_type(
+    release_type: str,
+    layout: str | None = None,
+) -> str:
+    """Return the canonical GPG key URL for a signed release line and layout.
+
+    Args:
+        release_type: ``prerelease`` / ``prereleases``, ``release`` / ``stable``.
+        layout: ``multi_arch`` or per-family (default).
+
+    Returns:
+        HTTPS URL to ``rocm.gpg`` for the release host and layout.
+
+    Raises:
+        ValueError: If ``release_type`` is unsigned or unknown.
+
+    Examples:
+        prerelease + per_family
+            → https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg
+        stable + multi_arch
+            → https://repo.amd.com/rocm/packages-multi-arch/gpg/rocm.gpg
+    """
+    rt = _normalize_release_type(release_type)
+    layout_norm = normalize_layout(layout)
+
+    if layout_norm == LAYOUT_MULTI_ARCH:
+        if rt == "prerelease":
+            return "https://rocm.prereleases.amd.com/packages-multi-arch/gpg/rocm.gpg"
+        if rt == "release":
+            return "https://repo.amd.com/rocm/packages-multi-arch/gpg/rocm.gpg"
+        raise ValueError(
+            f"GPG key URL not defined for release_type={release_type!r} "
+            f"with layout={layout!r}"
+        )
+
+    if rt == "prerelease":
+        return "https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg"
+    if rt == "release":
+        return "https://repo.amd.com/rocm/packages/gpg/rocm.gpg"
+    raise ValueError(f"Unknown or unsigned release_type: {release_type!r}")
 
 
 def gpg_key_url_needed_for_release_type(release_type: str | None) -> bool:
@@ -176,8 +275,8 @@ DATE_ARTIFACT_PATTERN = re.compile(r"^\d{8}-\d+$")
 def get_repo_sub_folder(s3_prefix: str) -> str:
     """Extract ``YYYYMMDD-<id>`` from an S3 key prefix when present.
 
-    Used to build dev/nightly per-family CDN URLs via :func:`get_repo_url`.
-    Scans the **last** path segment only.
+    Used to build dev/nightly CDN URLs via :func:`get_repo_url` (per-family or
+    multi-arch layout). Scans the **last** path segment only.
 
     Args:
         s3_prefix: S3 key prefix (with or without leading/trailing slashes).
@@ -209,22 +308,7 @@ def cmd_repo_sub_folder(args: argparse.Namespace) -> int:
 # --- repo_url ---
 
 
-def _normalize_release_type(release_type: str) -> str:
-    """Normalize workflow release-type strings to canonical names.
-
-    Maps ``prereleases`` → ``prerelease``, ``stable`` → ``release``,
-    ``nightlies`` → ``nightly``; other values are lowercased as-is.
-    """
-    rt = release_type.strip().lower()
-    aliases = {
-        "prereleases": "prerelease",
-        "stable": "release",
-        "nightlies": "nightly",
-    }
-    return aliases.get(rt, rt)
-
-
-def get_repo_url(
+def get_repo_url_per_family(
     release_type: str,
     native_package_type: str,
     repo_base_url: str,
@@ -243,14 +327,6 @@ def get_repo_url(
 
     Returns:
         HTTPS URL pointing at the apt/dnf repo root (RPM URLs include ``/x86_64/``).
-
-    Layout (per-family only):
-        - prerelease deb: ``{base}/packages/{os_profile}``
-        - prerelease rpm: ``{base}/packages/{os_profile}/x86_64/``
-        - release deb: ``{base}/rocm/packages/{os_profile}``
-        - release rpm: ``{base}/rocm/packages/{os_profile}/x86_64/``
-        - dev/nightly deb: ``{base}/deb/{repo_sub_folder}/``
-        - dev/nightly rpm: ``{base}/rpm/{repo_sub_folder}/x86_64/``
     """
     base = repo_base_url.rstrip("/")
     rt = _normalize_release_type(release_type)
@@ -270,6 +346,99 @@ def get_repo_url(
     return f"{base}/rpm/{repo_sub_folder}/x86_64/"
 
 
+def get_repo_url_multi_arch(
+    release_type: str,
+    native_package_type: str,
+    repo_base_url: str,
+    os_profile: str,
+    repo_sub_folder: str,
+) -> str:
+    """Build a multi-arch native Linux package repo URL (``packages-multi-arch/``).
+
+    Matches ``dockerfiles/install_rocm_packages.sh`` ``build_repo_url`` when
+    ``multi_arch=1``.
+
+    Args:
+        release_type: ``prerelease``, ``release`` / ``stable``, or unsigned
+            ``dev`` / ``nightly`` / ``ci`` (aliases normalized).
+        native_package_type: ``deb`` or ``rpm``.
+        repo_base_url: Scheme + host.
+        os_profile: OS profile for signed lines (e.g. ``ubuntu2604``, ``rhel10``).
+        repo_sub_folder: ``YYYYMMDD-<id>`` for unsigned lines; ignored for signed.
+
+    Returns:
+        HTTPS URL pointing at the apt/dnf repo root.
+
+    Layout:
+        - prerelease deb: ``{base}/packages-multi-arch/{os_profile}``
+        - release deb: ``{base}/rocm/packages-multi-arch/{os_profile}``
+        - nightly deb: ``{base}/packages-multi-arch/deb/{repo_sub_folder}``
+        - nightly rpm: ``{base}/packages-multi-arch/rpm/{repo_sub_folder}/x86_64``
+    """
+    base = repo_base_url.rstrip("/")
+    rt = _normalize_release_type(release_type)
+
+    if rt == "prerelease":
+        if native_package_type == "deb":
+            return f"{base}/packages-multi-arch/{os_profile}"
+        return f"{base}/packages-multi-arch/{os_profile}/x86_64/"
+
+    if rt == "release":
+        if native_package_type == "deb":
+            return f"{base}/rocm/packages-multi-arch/{os_profile}"
+        return f"{base}/rocm/packages-multi-arch/{os_profile}/x86_64/"
+
+    if native_package_type == "deb":
+        if repo_sub_folder:
+            return f"{base}/packages-multi-arch/deb/{repo_sub_folder}"
+        return f"{base}/packages-multi-arch/deb"
+    if repo_sub_folder:
+        return f"{base}/packages-multi-arch/rpm/{repo_sub_folder}/x86_64"
+    return f"{base}/packages-multi-arch/rpm/x86_64"
+
+
+def get_repo_url(
+    release_type: str,
+    native_package_type: str,
+    repo_base_url: str,
+    os_profile: str,
+    repo_sub_folder: str,
+    layout: str | None = None,
+) -> str:
+    """Build a native Linux package repo URL for the selected layout.
+
+    Args:
+        release_type: Workflow release type (aliases normalized).
+        native_package_type: ``deb`` or ``rpm``.
+        repo_base_url: Scheme + host.
+        os_profile: OS profile slug (e.g. ``ubuntu2404``, ``rhel10``).
+        repo_sub_folder: ``YYYYMMDD-<id>`` for unsigned lines; empty for signed.
+        layout: ``per_family`` (default) or ``multi_arch`` (aliases accepted).
+
+    Returns:
+        HTTPS URL pointing at the apt/dnf repo root.
+
+    See Also:
+        :func:`get_repo_url_per_family`, :func:`get_repo_url_multi_arch`.
+    """
+    layout_norm = normalize_layout(layout)
+    if layout_norm == LAYOUT_MULTI_ARCH:
+        return get_repo_url_multi_arch(
+            release_type=release_type,
+            native_package_type=native_package_type,
+            repo_base_url=repo_base_url,
+            os_profile=os_profile,
+            repo_sub_folder=repo_sub_folder,
+        )
+    return get_repo_url_per_family(
+        release_type=release_type,
+        native_package_type=native_package_type,
+        repo_base_url=repo_base_url,
+        os_profile=os_profile,
+        repo_sub_folder=repo_sub_folder,
+    )
+
+
 def cmd_repo_url(args: argparse.Namespace) -> int:
     """CLI: ``get-repo-url`` → writes ``repo_url=`` to ``$GITHUB_OUTPUT``."""
     try:
@@ -279,6 +448,7 @@ def cmd_repo_url(args: argparse.Namespace) -> int:
             repo_base_url=args.repo_base_url,
             os_profile=args.os_profile,
             repo_sub_folder=args.repo_sub_folder or "",
+            layout=args.layout,
         )
     except (ValueError, TypeError) as e:
         print(f"Error: {e}", file=sys.stderr)
@@ -404,7 +574,10 @@ Testing (unit tests)
     python3 -m unittest \\
       build_tools.packaging.linux.tests.get_url_repo_params_test -v
 
-  Pass: all tests OK (container-image assertions must match get_container_image()).
+  Pass: per-family and multi_arch layout tests OK. Container-image tests expect
+  get_container_image() output (align with #7004 if those three tests fail).
+
+  Layout: get-repo-url accepts --layout per_family (default) or multi_arch.
 
   Optional: export GITHUB_OUTPUT=/tmp/out.txt to inspect CLI output locally.
 """
@@ -448,7 +621,7 @@ def main(argv: list[str] | None = None) -> int:
         type=str,
         required=True,
         metavar="URL",
-        help="Package repository URL to derive GPG key URL from when needed (e.g. https://rocm.prereleases.amd.com/packages/ubuntu2404 → https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg)",
+        help="Package repository URL to derive GPG key URL from when needed (per-family or packages-multi-arch paths; e.g. …/packages/ubuntu2404 → …/packages/gpg/rocm.gpg)",
     )
     p_gpg.add_argument(
         "--release-type",
@@ -475,7 +648,11 @@ def main(argv: list[str] | None = None) -> int:
     # get-repo-url: full repo URL from components (replaces inline logic in workflows)
     p_url = subparsers.add_parser(
         "get-repo-url",
-        help="Get full repo URL from release_type, native_package_type, repo_base_url, os_profile, repo_sub_folder.",
+        help=(
+            "Get full repo URL from release_type, native_package_type, "
+            "repo_base_url, os_profile, repo_sub_folder; optional --layout "
+            "(per_family or multi_arch)."
+        ),
     )
     p_url.add_argument(
         "--release-type",
@@ -508,6 +685,12 @@ def main(argv: list[str] | None = None) -> int:
         type=str,
         default="",
         help="Repo subfolder (e.g. YYYYMMDD-<id> for dev/nightly; empty for prerelease)",
+    )
+    p_url.add_argument(
+        "--layout",
+        type=str,
+        default=None,
+        help="Repo layout: per_family (default) or multi_arch (packages-multi-arch/…)",
     )
     p_url.set_defaults(func=cmd_repo_url)
 

--- a/build_tools/packaging/linux/get_url_repo_params.py
+++ b/build_tools/packaging/linux/get_url_repo_params.py
@@ -548,20 +548,14 @@ _EXACT_PROFILE_PREFIXES = frozenset({"rhel8"})
 
 
 def get_container_image(os_profile: str) -> str:
-    """Map an OS profile slug to the CI container image for install tests.
-
-    Args:
-        os_profile: Profile name (e.g. ``ubuntu2404``, ``rhel10``, ``sles16``).
-
-    Returns:
-        Container image reference used by ``test_native_linux_packages_install.yml``.
+    """Return the container image for a given OS profile.
 
     Examples:
-        ``ubuntu2404`` → ``ghcr.io/rocm/no_rocm_image_ubuntu24_04:latest``
-        ``debian12``   → ``ghcr.io/rocm/no_rocm_image_ubuntu24_04:latest``
-        ``sles16``     → ``registry.suse.com/bci/bci-base:16.0``
-        ``rhel8``      → ``registry.access.redhat.com/ubi8/ubi:8.10``
-        ``rhel10``     → ``registry.access.redhat.com/ubi10/ubi:10.1``
+        ubuntu2404  -> ghcr.io/rocm/no_rocm_image_ubuntu24_04:latest
+        debian12    -> ghcr.io/rocm/no_rocm_image_ubuntu24_04:latest
+        sles16      -> registry.suse.com/bci/bci-base:16.0
+        rhel8       -> registry.access.redhat.com/ubi8/ubi:8.10
+        rhel10      -> registry.access.redhat.com/ubi10/ubi:10.1
     """
     profile = os_profile.lower()
     for prefixes, image in _OS_PROFILE_TO_IMAGE:
@@ -596,8 +590,7 @@ Testing (unit tests)
     python3 -m unittest \\
       build_tools.packaging.linux.tests.get_url_repo_params_test -v
 
-  Pass: per-family and multi_arch layout tests OK. Container-image tests expect
-  get_container_image() output (align with #7004 if those three tests fail).
+  Pass: per-family and multi_arch layout tests OK via subTests in get_url_repo_params_test.py.
 
   Layout: get-repo-url accepts --layout per_family (default) or multi_arch.
 
@@ -749,7 +742,7 @@ def main(argv: list[str] | None = None) -> int:
     # get-container-image: get container image for an OS profile
     p_img = subparsers.add_parser(
         "get-container-image",
-        help="Get container image for a given OS profile (e.g. ubuntu2404 → ghcr.io/rocm/no_rocm_image_ubuntu24_04:latest).",
+        help="Get container image for a given OS profile (e.g. ubuntu2404 -> ubuntu:24.04).",
     )
     p_img.add_argument(
         "--os-profile",

--- a/build_tools/packaging/linux/get_url_repo_params.py
+++ b/build_tools/packaging/linux/get_url_repo_params.py
@@ -3,34 +3,48 @@
 # SPDX-License-Identifier: MIT
 
 """
-Get URL/repo parameters: base URL from any URL, repo_sub_folder from an S3 prefix, or full repo URL from components.
+GitHub Actions helper: derive native Linux packaging URL parameters.
 
-Output is always KEY=value (suitable for GITHUB_OUTPUT).
+Used by CI workflows (see test_native_linux_packages_install.yml) to normalize
+install-test inputs. Each subcommand prints KEY=value lines suitable for
+$GITHUB_OUTPUT via gha_set_output().
 
-Subcommands (get operations):
+Layout scope (today):
+  - get-repo-url / get-gpg-url implement the **per-family** URL tree from
+    docs/packaging/native_packaging.md (…/packages/{os}, …/rocm/packages/{os},
+    …/deb|rpm/{YYYYMMDD-id}/). Multi-arch packages-multi-arch/… URLs are not
+    modeled here yet (see install_rocm_packages.sh for that layout).
 
-  get-base-url         Get base URL (scheme + netloc) from an input URL. Prints repo_base_url=<value>.
-  get-gpg-url          Get GPG key URL for GITHUB_OUTPUT. With --release-type, emits a non-empty URL only for prerelease/release; otherwise gpg_key_url=. Without --release-type, always derives from --from-url (legacy).
-  get-repo-sub-folder  Get repo_sub_folder from an S3 prefix (last segment if YYYYMMDD-<id>, else empty). Prints repo_sub_folder=<value>.
-  get-repo-url         Get full repo URL from components(release_type, native_package_type, repo_base_url, os_profile, repo_sub_folder). Prints repo_url=<value>.
-  extract-gfx-arch     Extract and normalize GPU architecture from artifact group. Prints gfx_arch=<value>.
-  get-container-image  Get container image for a given OS profile. Prints container_image=<value>.
+Subcommands:
+  get-base-url         scheme + netloc from any URL → repo_base_url=
+  get-gpg-url          GPG key URL from package repo URL → gpg_key_url=
+                       (--release-type omits URL for dev/nightly/ci unsigned repos)
+  get-repo-sub-folder  YYYYMMDD-<id> segment from S3 prefix → repo_sub_folder=
+  get-repo-url         per-family install repo URL from components → repo_url=
+  extract-gfx-arch     gfx94X-dcgpu → gfx94x (lists supported) → gfx_arch=
+  get-container-image  os_profile → CI container image → container_image=
 
-Usage:
-  python build_tools/packaging/linux/get_url_repo_params.py get-base-url --from-url <url>
-  python build_tools/packaging/linux/get_url_repo_params.py get-gpg-url --from-url <url> [--release-type <type>]
-  python build_tools/packaging/linux/get_url_repo_params.py get-repo-sub-folder --from-s3-prefix <prefix>
-  python build_tools/packaging/linux/get_url_repo_params.py get-repo-url ...
-  python build_tools/packaging/linux/get_url_repo_params.py extract-gfx-arch --artifact-group <group>
-  python build_tools/packaging/linux/get_url_repo_params.py get-container-image --os-profile <profile>
+Workflow usage today:
+  extract-gfx-arch and get-container-image are called from GHA.
+  package_install_url and gpg_key_url are still passed as workflow inputs;
+  get-repo-url / get-gpg-url / get-repo-sub-folder are available for wiring.
 
 Examples:
-  python build_tools/packaging/linux/get_url_repo_params.py get-base-url --from-url https://example.com/v2/whl
-  python build_tools/packaging/linux/get_url_repo_params.py get-gpg-url --release-type prerelease --from-url https://rocm.prereleases.amd.com/packages/ubuntu2404
-  python build_tools/packaging/linux/get_url_repo_params.py get-repo-sub-folder --from-s3-prefix v3/packages/deb/20260204-12345
-  python build_tools/packaging/linux/get_url_repo_params.py get-repo-url --release-type prerelease --native-package-type deb --repo-base-url https://x.com --os-profile ubuntu2404 --repo-sub-folder ''
-  python build_tools/packaging/linux/get_url_repo_params.py extract-gfx-arch --artifact-group gfx94X-dcgpu
-  python build_tools/packaging/linux/get_url_repo_params.py get-container-image --os-profile ubuntu2404
+  python build_tools/packaging/linux/get_url_repo_params.py get-base-url \\
+      --from-url https://example.com/v2/whl
+  python build_tools/packaging/linux/get_url_repo_params.py get-gpg-url \\
+      --release-type prerelease \\
+      --from-url https://rocm.prereleases.amd.com/packages/ubuntu2404
+  python build_tools/packaging/linux/get_url_repo_params.py get-repo-sub-folder \\
+      --from-s3-prefix v3/packages/deb/20260204-12345
+  python build_tools/packaging/linux/get_url_repo_params.py get-repo-url \\
+      --release-type prerelease --native-package-type deb \\
+      --repo-base-url https://rocm.prereleases.amd.com \\
+      --os-profile ubuntu2404 --repo-sub-folder ''
+  python build_tools/packaging/linux/get_url_repo_params.py extract-gfx-arch \\
+      --artifact-group gfx94X-dcgpu
+  python build_tools/packaging/linux/get_url_repo_params.py get-container-image \\
+      --os-profile ubuntu2404
 """
 
 import argparse
@@ -48,7 +62,17 @@ from github_actions.github_actions_api import gha_set_output
 
 
 def get_base_url(url: str) -> str:
-    """Return base URL (scheme + netloc only). No path, query, or fragment."""
+    """Return scheme and netloc only (strip path, query, and fragment).
+
+    Args:
+        url: Any HTTP(S) URL (e.g. package repo, S3 HTTPS, or CDN index URL).
+
+    Returns:
+        Base URL string ``{scheme}://{netloc}``.
+
+    Raises:
+        ValueError: If ``url`` has no scheme or netloc.
+    """
     parsed = urlparse(url)
     if not parsed.scheme or not parsed.netloc:
         raise ValueError(f"Invalid URL: {url!r}")
@@ -56,6 +80,7 @@ def get_base_url(url: str) -> str:
 
 
 def cmd_base_url(args: argparse.Namespace) -> int:
+    """CLI: ``get-base-url`` → writes ``repo_base_url=`` to ``$GITHUB_OUTPUT``."""
     try:
         base_url = get_base_url(args.from_url)
     except ValueError as e:
@@ -69,20 +94,29 @@ def cmd_base_url(args: argparse.Namespace) -> int:
 
 
 def get_gpg_key_url(package_url: str) -> str:
-    """
-    Get GPG key URL from package repository URL.
+    """Derive the AMD repo signing-key URL from a package repository URL.
 
-    Keys live beside the packages tree (see install_rocm_packages.sh):
-    - prerelease-style hosts: .../packages/gpg/rocm.gpg
-    - stable (repo.amd.com): .../rocm/packages/gpg/rocm.gpg
+    Per-family layout only: keys sit under ``…/packages/gpg/`` or
+    ``…/rocm/packages/gpg/`` (not ``packages-multi-arch/gpg/``).
+
+    Args:
+        package_url: Full or partial native Linux package repo URL.
+
+    Returns:
+        HTTPS URL to ``rocm.gpg`` beside the matching packages tree.
+
+    Raises:
+        ValueError: If ``package_url`` is not a valid HTTP(S) URL.
 
     Examples:
         https://rocm.prereleases.amd.com/packages/ubuntu2404
-            -> https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg
+            → https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg
         https://repo.amd.com/rocm/packages/rhel10/x86_64/
-            -> https://repo.amd.com/rocm/packages/gpg/rocm.gpg
+            → https://repo.amd.com/rocm/packages/gpg/rocm.gpg
         https://rocm.nightlies.amd.com/deb/20260204-12345/
-            -> https://rocm.nightlies.amd.com/packages/gpg/rocm.gpg
+            → https://rocm.nightlies.amd.com/packages/gpg/rocm.gpg
+        https://repo.amd.com/
+            → https://repo.amd.com/rocm/packages/gpg/rocm.gpg
     """
     parsed = urlparse(package_url)
     if not parsed.scheme or not parsed.netloc:
@@ -100,14 +134,19 @@ def get_gpg_key_url(package_url: str) -> str:
 
 
 def gpg_key_url_needed_for_release_type(release_type: str | None) -> bool:
-    """
-    Whether install workflows should use a repo GPG key URL for this release line.
+    """Return whether a signed-repo GPG key URL applies for this release line.
 
-    When release_type is None, callers treat this as "legacy / unspecified" and always
-    derive the GPG URL from the package URL.
+    Args:
+        release_type: Workflow release type, or ``None`` for legacy callers.
 
-    When release_type is set (e.g. from GitHub Actions), only prerelease and release
-    lines use signed-repo GPG keys; dev/nightly/ci/etc. omit it (empty gpg_key_url).
+    Returns:
+        ``True`` if a GPG URL should be emitted/derived; ``False`` for unsigned
+        lines (``dev``, ``nightly``, ``ci``, empty string).
+
+    Notes:
+        ``None`` means always derive from the package URL (backward compatible).
+        Signed lines: ``prerelease``, ``prereleases``, ``release``, ``stable``
+        (case-insensitive, whitespace trimmed).
     """
     if release_type is None:
         return True
@@ -116,6 +155,7 @@ def gpg_key_url_needed_for_release_type(release_type: str | None) -> bool:
 
 
 def cmd_gpg_key_url(args: argparse.Namespace) -> int:
+    """CLI: ``get-gpg-url`` → writes ``gpg_key_url=`` (or empty) to ``$GITHUB_OUTPUT``."""
     if not gpg_key_url_needed_for_release_type(args.release_type):
         gha_set_output({"gpg_key_url": ""})
         return 0
@@ -134,7 +174,22 @@ DATE_ARTIFACT_PATTERN = re.compile(r"^\d{8}-\d+$")
 
 
 def get_repo_sub_folder(s3_prefix: str) -> str:
-    """Return last path segment if it matches YYYYMMDD-<id>, else empty."""
+    """Extract ``YYYYMMDD-<id>`` from an S3 key prefix when present.
+
+    Used to build dev/nightly per-family CDN URLs via :func:`get_repo_url`.
+    Scans the **last** path segment only.
+
+    Args:
+        s3_prefix: S3 key prefix (with or without leading/trailing slashes).
+
+    Returns:
+        The last segment if it matches ``YYYYMMDD-<digits>``; otherwise ``""``.
+
+    Examples:
+        ``v3/packages/deb/20260204-12345`` → ``20260204-12345``
+        ``12345678-linux/packages/deb/20260204-12345`` → ``20260204-12345``
+        ``v3/packages/deb/`` → ``""``
+    """
     segments = [p for p in s3_prefix.strip("/").split("/") if p]
     if not segments:
         return ""
@@ -145,6 +200,7 @@ def get_repo_sub_folder(s3_prefix: str) -> str:
 
 
 def cmd_repo_sub_folder(args: argparse.Namespace) -> int:
+    """CLI: ``get-repo-sub-folder`` → writes ``repo_sub_folder=`` to ``$GITHUB_OUTPUT``."""
     repo_sub_folder = get_repo_sub_folder(args.from_s3_prefix)
     gha_set_output({"repo_sub_folder": repo_sub_folder})
     return 0
@@ -154,6 +210,11 @@ def cmd_repo_sub_folder(args: argparse.Namespace) -> int:
 
 
 def _normalize_release_type(release_type: str) -> str:
+    """Normalize workflow release-type strings to canonical names.
+
+    Maps ``prereleases`` → ``prerelease``, ``stable`` → ``release``,
+    ``nightlies`` → ``nightly``; other values are lowercased as-is.
+    """
     rt = release_type.strip().lower()
     aliases = {
         "prereleases": "prerelease",
@@ -170,15 +231,26 @@ def get_repo_url(
     os_profile: str,
     repo_sub_folder: str,
 ) -> str:
-    """
-    Return the full per-family repo URL for install tests (native_packaging.md).
+    """Build a per-family native Linux package repo URL (``native_packaging.md``).
 
-    - prerelease + deb: {base}/packages/{os_profile}
-    - prerelease + rpm: {base}/packages/{os_profile}/x86_64/
-    - release/stable + deb: {base}/rocm/packages/{os_profile}
-    - release/stable + rpm: {base}/rocm/packages/{os_profile}/x86_64/
-    - dev/nightly/ci + deb: {base}/deb/{repo_sub_folder}/
-    - dev/nightly/ci + rpm: {base}/rpm/{repo_sub_folder}/x86_64/
+    Args:
+        release_type: ``prerelease`` / ``prereleases``, ``release`` / ``stable``,
+            or unsigned lines ``dev``, ``nightly``, ``ci`` (aliases normalized).
+        native_package_type: ``deb`` or ``rpm``.
+        repo_base_url: Scheme + host (e.g. ``https://rocm.prereleases.amd.com``).
+        os_profile: OS profile slug (e.g. ``ubuntu2404``, ``rhel10``).
+        repo_sub_folder: ``YYYYMMDD-<id>`` for dev/nightly; empty for signed lines.
+
+    Returns:
+        HTTPS URL pointing at the apt/dnf repo root (RPM URLs include ``/x86_64/``).
+
+    Layout (per-family only):
+        - prerelease deb: ``{base}/packages/{os_profile}``
+        - prerelease rpm: ``{base}/packages/{os_profile}/x86_64/``
+        - release deb: ``{base}/rocm/packages/{os_profile}``
+        - release rpm: ``{base}/rocm/packages/{os_profile}/x86_64/``
+        - dev/nightly deb: ``{base}/deb/{repo_sub_folder}/``
+        - dev/nightly rpm: ``{base}/rpm/{repo_sub_folder}/x86_64/``
     """
     base = repo_base_url.rstrip("/")
     rt = _normalize_release_type(release_type)
@@ -199,6 +271,7 @@ def get_repo_url(
 
 
 def cmd_repo_url(args: argparse.Namespace) -> int:
+    """CLI: ``get-repo-url`` → writes ``repo_url=`` to ``$GITHUB_OUTPUT``."""
     try:
         url = get_repo_url(
             release_type=args.release_type,
@@ -218,18 +291,25 @@ def cmd_repo_url(args: argparse.Namespace) -> int:
 
 
 def extract_gfx_arch(artifact_group: str) -> str:
-    """
-    Extract and normalize GPU architecture from artifact group(s).
+    """Normalize GPU architecture token(s) from CI artifact group name(s).
 
-    Supports both single and comma/semicolon-separated artifact groups.
-    Output is always comma-separated.
+    Takes the substring before the first ``-`` in each group, lowercases it,
+    and joins multiple groups with commas.
+
+    Args:
+        artifact_group: One group or comma/semicolon-separated list
+            (e.g. ``gfx94X-dcgpu`` or ``gfx94X-dcgpu;gfx1100-consumer``).
+
+    Returns:
+        Comma-separated gfx tokens (e.g. ``gfx94x,gfx1100``).
+
+    Raises:
+        ValueError: If ``artifact_group`` is empty or yields no tokens.
 
     Examples:
-        gfx94X-dcgpu -> gfx94x
-        gfx1100-consumer -> gfx1100
-        GFX942-server -> gfx942
-        gfx94X-dcgpu,gfx1100-consumer -> gfx94x,gfx1100
-        gfx94X-dcgpu;gfx1100-consumer -> gfx94x,gfx1100
+        ``gfx94X-dcgpu`` → ``gfx94x``
+        ``GFX942-server`` → ``gfx942``
+        ``gfx94X-dcgpu,gfx1100-consumer`` → ``gfx94x,gfx1100``
     """
     if not artifact_group:
         raise ValueError("artifact_group cannot be empty")
@@ -249,6 +329,7 @@ def extract_gfx_arch(artifact_group: str) -> str:
 
 
 def cmd_extract_gfx_arch(args: argparse.Namespace) -> int:
+    """CLI: ``extract-gfx-arch`` → writes ``gfx_arch=`` to ``$GITHUB_OUTPUT``."""
     try:
         gfx_arch = extract_gfx_arch(args.artifact_group)
     except ValueError as e:
@@ -275,14 +356,20 @@ _EXACT_PROFILE_PREFIXES = frozenset({"rhel8"})
 
 
 def get_container_image(os_profile: str) -> str:
-    """Return the container image for a given OS profile.
+    """Map an OS profile slug to the CI container image for install tests.
+
+    Args:
+        os_profile: Profile name (e.g. ``ubuntu2404``, ``rhel10``, ``sles16``).
+
+    Returns:
+        Container image reference used by ``test_native_linux_packages_install.yml``.
 
     Examples:
-        ubuntu2404  -> ghcr.io/rocm/no_rocm_image_ubuntu24_04:latest
-        debian12    -> ghcr.io/rocm/no_rocm_image_ubuntu24_04:latest
-        sles16      -> registry.suse.com/bci/bci-base:16.0
-        rhel8       -> registry.access.redhat.com/ubi8/ubi:8.10
-        rhel10      -> registry.access.redhat.com/ubi10/ubi:10.1
+        ``ubuntu2404`` → ``ghcr.io/rocm/no_rocm_image_ubuntu24_04:latest``
+        ``debian12``   → ``ghcr.io/rocm/no_rocm_image_ubuntu24_04:latest``
+        ``sles16``     → ``registry.suse.com/bci/bci-base:16.0``
+        ``rhel8``      → ``registry.access.redhat.com/ubi8/ubi:8.10``
+        ``rhel10``     → ``registry.access.redhat.com/ubi10/ubi:10.1``
     """
     profile = os_profile.lower()
     for prefixes, image in _OS_PROFILE_TO_IMAGE:
@@ -298,6 +385,7 @@ def get_container_image(os_profile: str) -> str:
 
 
 def cmd_container_image(args: argparse.Namespace) -> int:
+    """CLI: ``get-container-image`` → writes ``container_image=`` to ``$GITHUB_OUTPUT``."""
     image = get_container_image(args.os_profile)
     gha_set_output({"container_image": image})
     return 0
@@ -305,10 +393,32 @@ def cmd_container_image(args: argparse.Namespace) -> int:
 
 # --- main ---
 
+_CLI_EPILOG = """
+Testing (unit tests)
+  Prerequisites:
+    - Python 3.10 or newer
+    - Run from the TheROCK repository root
+    - No extra pip packages (tests mock $GITHUB_OUTPUT; stdlib only)
+
+  From repo root:
+    python3 -m unittest \\
+      build_tools.packaging.linux.tests.get_url_repo_params_test -v
+
+  Pass: all tests OK (container-image assertions must match get_container_image()).
+
+  Optional: export GITHUB_OUTPUT=/tmp/out.txt to inspect CLI output locally.
+"""
+
 
 def main(argv: list[str] | None = None) -> int:
+    """Parse CLI subcommands and dispatch to the matching ``cmd_*`` handler."""
     parser = argparse.ArgumentParser(
-        description="Get URL/repo parameters: base URL (from any URL) or repo_sub_folder (from S3 prefix). Output is KEY=value for GITHUB_OUTPUT.",
+        description=(
+            "Derive native Linux packaging URL parameters for GitHub Actions "
+            "(output is KEY=value for $GITHUB_OUTPUT)."
+        ),
+        epilog=_CLI_EPILOG,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     subparsers = parser.add_subparsers(
         dest="command", required=True, help="Get operation to run"
@@ -344,7 +454,7 @@ def main(argv: list[str] | None = None) -> int:
         "--release-type",
         type=str,
         default=None,
-        help="If set, emit non-empty GPG URL only for 'prerelease' or 'release'; for dev/nightly/etc. print gpg_key_url=. If omitted, always derive from --from-url.",
+        help="If set, emit non-empty GPG URL only for signed lines (prerelease/release/stable); for dev/nightly/ci print gpg_key_url=. If omitted, always derive from --from-url.",
     )
     p_gpg.set_defaults(func=cmd_gpg_key_url)
 
@@ -368,7 +478,10 @@ def main(argv: list[str] | None = None) -> int:
         help="Get full repo URL from release_type, native_package_type, repo_base_url, os_profile, repo_sub_folder.",
     )
     p_url.add_argument(
-        "--release-type", type=str, required=True, help="e.g. prerelease, dev, nightly"
+        "--release-type",
+        type=str,
+        required=True,
+        help="e.g. prerelease, prereleases, release, stable, dev, nightly, ci",
     )
     p_url.add_argument(
         "--native-package-type",
@@ -415,7 +528,7 @@ def main(argv: list[str] | None = None) -> int:
     # get-container-image: get container image for an OS profile
     p_img = subparsers.add_parser(
         "get-container-image",
-        help="Get container image for a given OS profile (e.g. ubuntu2404 -> ubuntu:24.04).",
+        help="Get container image for a given OS profile (e.g. ubuntu2404 → ghcr.io/rocm/no_rocm_image_ubuntu24_04:latest).",
     )
     p_img.add_argument(
         "--os-profile",

--- a/build_tools/packaging/linux/tests/get_url_repo_params_test.py
+++ b/build_tools/packaging/linux/tests/get_url_repo_params_test.py
@@ -71,30 +71,33 @@ class GetGpgKeyUrlTest(unittest.TestCase):
     """Tests for get_gpg_key_url()."""
 
     def test_extracts_base_and_adds_gpg_path(self):
-        # Test that get_gpg_key_url extracts base URL and appends /gpg/rocm.gpg.
         self.assertEqual(
             get_url_repo_params.get_gpg_key_url(
                 "https://rocm.prereleases.amd.com/packages/ubuntu2404"
             ),
-            "https://rocm.prereleases.amd.com/gpg/rocm.gpg",
+            "https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg",
         )
 
     def test_strips_path_from_url(self):
-        # Test that get_gpg_key_url strips path and query from URL.
         self.assertEqual(
             get_url_repo_params.get_gpg_key_url(
                 "https://repo.amd.com/rocm/packages/rhel10/x86_64/"
             ),
-            "https://repo.amd.com/gpg/rocm.gpg",
+            "https://repo.amd.com/rocm/packages/gpg/rocm.gpg",
         )
 
     def test_handles_nightly_url(self):
-        # Test that get_gpg_key_url works with nightly URLs.
         self.assertEqual(
             get_url_repo_params.get_gpg_key_url(
                 "https://rocm.nightlies.amd.com/deb/20260204-12345/"
             ),
-            "https://rocm.nightlies.amd.com/gpg/rocm.gpg",
+            "https://rocm.nightlies.amd.com/packages/gpg/rocm.gpg",
+        )
+
+    def test_repo_amd_com_without_packages_segment(self):
+        self.assertEqual(
+            get_url_repo_params.get_gpg_key_url("https://repo.amd.com/"),
+            "https://repo.amd.com/rocm/packages/gpg/rocm.gpg",
         )
 
 
@@ -109,7 +112,13 @@ class GpgKeyUrlNeededForReleaseTypeTest(unittest.TestCase):
             get_url_repo_params.gpg_key_url_needed_for_release_type("prerelease")
         )
         self.assertTrue(
+            get_url_repo_params.gpg_key_url_needed_for_release_type("prereleases")
+        )
+        self.assertTrue(
             get_url_repo_params.gpg_key_url_needed_for_release_type("release")
+        )
+        self.assertTrue(
+            get_url_repo_params.gpg_key_url_needed_for_release_type("stable")
         )
         self.assertTrue(
             get_url_repo_params.gpg_key_url_needed_for_release_type("  Prerelease  ")
@@ -159,32 +168,66 @@ class GetRepoSubFolderTest(unittest.TestCase):
 
 
 class GetRepoUrlTest(unittest.TestCase):
-    """Tests for get_repo_url()."""
+    """Tests for get_repo_url() per-family layout."""
+
+    def test_prereleases_alias_matches_prerelease(self):
+        self.assertEqual(
+            get_url_repo_params.get_repo_url(
+                release_type="prereleases",
+                native_package_type="deb",
+                repo_base_url="https://rocm.prereleases.amd.com",
+                os_profile="ubuntu2404",
+                repo_sub_folder="",
+            ),
+            "https://rocm.prereleases.amd.com/packages/ubuntu2404",
+        )
 
     def test_prerelease_deb(self):
-        # Test that prerelease + deb yields base/os_profile.
         self.assertEqual(
             get_url_repo_params.get_repo_url(
                 release_type="prerelease",
                 native_package_type="deb",
-                repo_base_url="https://x.com",
+                repo_base_url="https://rocm.prereleases.amd.com",
                 os_profile="ubuntu2404",
                 repo_sub_folder="",
             ),
-            "https://x.com/ubuntu2404",
+            "https://rocm.prereleases.amd.com/packages/ubuntu2404",
         )
 
     def test_prerelease_rpm(self):
-        # Test that prerelease + rpm yields base/os_profile/x86_64/
         self.assertEqual(
             get_url_repo_params.get_repo_url(
                 release_type="prerelease",
                 native_package_type="rpm",
-                repo_base_url="https://x.com",
+                repo_base_url="https://rocm.prereleases.amd.com",
                 os_profile="rhel8",
                 repo_sub_folder="",
             ),
-            "https://x.com/rhel8/x86_64/",
+            "https://rocm.prereleases.amd.com/packages/rhel8/x86_64/",
+        )
+
+    def test_release_deb_matches_native_packaging_doc(self):
+        self.assertEqual(
+            get_url_repo_params.get_repo_url(
+                release_type="release",
+                native_package_type="deb",
+                repo_base_url="https://repo.amd.com",
+                os_profile="ubuntu2404",
+                repo_sub_folder="",
+            ),
+            "https://repo.amd.com/rocm/packages/ubuntu2404",
+        )
+
+    def test_stable_rpm_matches_native_packaging_doc(self):
+        self.assertEqual(
+            get_url_repo_params.get_repo_url(
+                release_type="stable",
+                native_package_type="rpm",
+                repo_base_url="https://repo.amd.com",
+                os_profile="rhel10",
+                repo_sub_folder="",
+            ),
+            "https://repo.amd.com/rocm/packages/rhel10/x86_64/",
         )
 
     def test_nightly_deb(self):
@@ -214,16 +257,15 @@ class GetRepoUrlTest(unittest.TestCase):
         )
 
     def test_strips_trailing_slash_from_base(self):
-        # Test that repo_base_url trailing slash is stripped.
         self.assertEqual(
             get_url_repo_params.get_repo_url(
                 release_type="prerelease",
                 native_package_type="deb",
-                repo_base_url="https://x.com/",
+                repo_base_url="https://rocm.prereleases.amd.com/",
                 os_profile="ubuntu2404",
                 repo_sub_folder="",
             ),
-            "https://x.com/ubuntu2404",
+            "https://rocm.prereleases.amd.com/packages/ubuntu2404",
         )
 
 
@@ -335,7 +377,7 @@ class MainSubcommandsTest(unittest.TestCase):
                 "--native-package-type",
                 "deb",
                 "--repo-base-url",
-                "https://x.com",
+                "https://rocm.prereleases.amd.com",
                 "--os-profile",
                 "ubuntu2404",
                 "--repo-sub-folder",
@@ -343,7 +385,7 @@ class MainSubcommandsTest(unittest.TestCase):
             ]
         )
         self.assertEqual(code, 0)
-        self.assertIn("repo_url=https://x.com/ubuntu2404", output)
+        self.assertIn("repo_url=https://rocm.prereleases.amd.com/packages/ubuntu2404", output)
 
     def test_get_repo_url_error_returns_one(self):
         # Test that get-repo-url returns 1 and prints error when get_repo_url raises.
@@ -419,7 +461,8 @@ class MainSubcommandsTest(unittest.TestCase):
         )
         self.assertEqual(code, 0)
         self.assertIn(
-            "gpg_key_url=https://rocm.prereleases.amd.com/gpg/rocm.gpg", output
+            "gpg_key_url=https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg",
+            output,
         )
 
     def test_get_gpg_url_with_release_type_dev_emits_empty(self):
@@ -461,7 +504,8 @@ class MainSubcommandsTest(unittest.TestCase):
         )
         self.assertEqual(code, 0)
         self.assertIn(
-            "gpg_key_url=https://rocm.prereleases.amd.com/gpg/rocm.gpg", output
+            "gpg_key_url=https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg",
+            output,
         )
 
     def test_get_gpg_url_with_release_type_release(self):
@@ -475,7 +519,9 @@ class MainSubcommandsTest(unittest.TestCase):
             ]
         )
         self.assertEqual(code, 0)
-        self.assertIn("gpg_key_url=https://repo.amd.com/gpg/rocm.gpg", output)
+        self.assertIn(
+            "gpg_key_url=https://repo.amd.com/rocm/packages/gpg/rocm.gpg", output
+        )
 
 
 class GetContainerImageTest(unittest.TestCase):

--- a/build_tools/packaging/linux/tests/get_url_repo_params_test.py
+++ b/build_tools/packaging/linux/tests/get_url_repo_params_test.py
@@ -3,34 +3,36 @@
 # SPDX-License-Identifier: MIT
 
 """
-Unit tests for build_tools/packaging/linux/get_url_repo_params.py.
+Unit tests for ``build_tools/packaging/linux/get_url_repo_params.py``.
 
-API under test — helpers and CLI subcommands:
-  get_base_url, get_gpg_key_url, gpg_key_url_needed_for_release_type,
-  get_repo_sub_folder, get_repo_url, get_repo_url_per_family, get_repo_url_multi_arch,
-  normalize_layout, get_gpg_key_url_from_release_type,
-  extract_gfx_arch, get_container_image, and main() GITHUB_OUTPUT wiring.
+Canonical spec coverage for native Linux install-test parameters (repo URLs,
+GPG paths, GPU arch tokens, container images). Exercises helpers and CLI
+subcommands that write ``KEY=value`` lines for ``$GITHUB_OUTPUT``.
 
-Per-family coverage (native_packaging.md GFX URLs):
-  - prerelease/prereleases → …/packages/{os_profile}
-  - release/stable → …/rocm/packages/{os_profile}
-  - dev/nightly → …/deb|rpm/{repo_sub_folder}/
-  - GPG beside packages tree (…/packages/gpg/ or …/rocm/packages/gpg/)
-  - get-gpg-url derivation policy (signed vs unsigned); install honors explicit gpg_key_url input
+Coverage (trimmed suite, table-driven via ``subTest``):
 
-Multi-arch coverage (layout=multi_arch, packages-multi-arch/…):
-  - prerelease → …/packages-multi-arch/{os_profile}
-  - release/stable → …/rocm/packages-multi-arch/{os_profile}
-  - dev/nightly → …/packages-multi-arch/deb|rpm/{repo_sub_folder}
-  - GPG → …/packages-multi-arch/gpg/ or …/rocm/packages-multi-arch/gpg/
+  - P0 per-family repo URLs (``…/packages/``, ``…/rocm/packages/``, nightly deb|rpm)
+  - P1 multi-arch layout (``packages-multi-arch/…``)
+  - GPG beside packages tree + signed-line hosts + derivation policy
+  - ``normalize_layout``, fail-fast ``release_type`` / unknown layout
+  - Wired CI today: ``extract-gfx-arch``, ``get-container-image`` (+ CLI smoke each)
+  - One happy-path CLI smoke per remaining subcommand
+
+Not covered here (P2 / separate PRs): ``upload_package_repo._package_install_url``,
+#7004 container-image string assertions, full CLI error-matrix.
 
 Prerequisites:
-  - Python 3.10 or newer
-  - stdlib only; tests mock $GITHUB_OUTPUT
 
-How to run (from TheROCK repo root):
+  - Python 3.10 or newer
+  - Run from TheROCK repository root
+  - Stdlib only; ``$GITHUB_OUTPUT`` is mocked to a temp file
+
+Run::
+
   python3 -m unittest \\
     build_tools.packaging.linux.tests.get_url_repo_params_test -v
+
+  python3.12 build_tools/packaging/linux/tests/get_url_repo_params_test.py -v
 """
 
 import os
@@ -40,9 +42,15 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
-sys.path.insert(0, os.fspath(Path(__file__).parent.parent.parent.parent))
-import get_url_repo_params
+# Resolve packaging modules from linux/ and build_tools/ (style guide).
+_LINUX_DIR = Path(__file__).resolve().parent.parent
+_BUILD_TOOLS_DIR = _LINUX_DIR.parent.parent
+for _path in (_BUILD_TOOLS_DIR, _LINUX_DIR):
+    _path_str = os.fspath(_path)
+    if _path_str not in sys.path:
+        sys.path.insert(0, _path_str)
+
+import get_url_repo_params  # noqa: E402
 
 _EXAMPLE = get_url_repo_params.EXAMPLE_CDN_BASE
 
@@ -60,579 +68,303 @@ def _run_main_with_output(argv: list[str]) -> tuple[int, str]:
     return code, contents
 
 
+def _repo_url(**kwargs: str) -> str:
+    """Shorthand for get_repo_url with common defaults."""
+    defaults = {
+        "release_type": "prerelease",
+        "native_package_type": "deb",
+        "repo_base_url": _EXAMPLE,
+        "os_profile": "ubuntu2404",
+        "repo_sub_folder": "",
+    }
+    defaults.update(kwargs)
+    layout = defaults.pop("layout", None)
+    return get_url_repo_params.get_repo_url(**defaults, layout=layout)
+
+
 class GetBaseUrlTest(unittest.TestCase):
-    """Tests for get_base_url()."""
+    """Tests for ``get_base_url()``."""
 
-    def test_returns_scheme_and_netloc(self):
-        # Test that get_base_url returns scheme and netloc only, stripping path.
+    def test_strips_to_scheme_and_netloc(self):
         self.assertEqual(
-            get_url_repo_params.get_base_url(f"{_EXAMPLE}/v2/whl"),
-            _EXAMPLE,
+            get_url_repo_params.get_base_url(f"{_EXAMPLE}/v2/whl?q=1#x"), _EXAMPLE
         )
 
-    def test_strips_query_and_fragment(self):
-        # Test that get_base_url strips query string and fragment.
-        self.assertEqual(
-            get_url_repo_params.get_base_url(f"{_EXAMPLE}/path?q=1#anchor"),
-            _EXAMPLE,
-        )
-
-    def test_http_url(self):
-        # Test that get_base_url works with http.
-        self.assertEqual(
-            get_url_repo_params.get_base_url("http://sample-cdn.example/artifacts"),
-            "http://sample-cdn.example",
-        )
-
-    def test_invalid_url_no_scheme_raises(self):
-        # Test that get_base_url raises ValueError when URL has no scheme.
-        with self.assertRaises(ValueError) as ctx:
-            get_url_repo_params.get_base_url("not-a-url")
-        self.assertIn("Invalid URL", str(ctx.exception))
-
-    def test_invalid_url_empty_raises(self):
-        # Test that get_base_url raises ValueError for empty or invalid URL.
+    def test_invalid_url_raises(self):
         with self.assertRaises(ValueError):
-            get_url_repo_params.get_base_url("")
+            get_url_repo_params.get_base_url("not-a-url")
 
 
 class GetGpgKeyUrlTest(unittest.TestCase):
-    """Tests for get_gpg_key_url()."""
+    """Tests for ``get_gpg_key_url()``."""
 
-    def test_extracts_base_and_adds_gpg_path(self):
-        self.assertEqual(
-            get_url_repo_params.get_gpg_key_url(f"{_EXAMPLE}/packages/ubuntu2404"),
-            f"{_EXAMPLE}/packages/gpg/rocm.gpg",
-        )
-
-    def test_strips_path_from_url(self):
-        self.assertEqual(
-            get_url_repo_params.get_gpg_key_url(
-                f"{_EXAMPLE}/rocm/packages/rhel10/x86_64/"
+    def test_gpg_paths_beside_packages_tree(self):
+        cases = [
+            (
+                f"{_EXAMPLE}/packages/ubuntu2404",
+                f"{_EXAMPLE}/packages/gpg/rocm.gpg",
             ),
-            f"{_EXAMPLE}/rocm/packages/gpg/rocm.gpg",
-        )
-
-    def test_handles_nightly_url(self):
-        self.assertEqual(
-            get_url_repo_params.get_gpg_key_url(f"{_EXAMPLE}/deb/20260204-12345/"),
-            f"{_EXAMPLE}/packages/gpg/rocm.gpg",
-        )
-
-    def test_repo_amd_com_without_packages_segment(self):
-        self.assertEqual(
-            get_url_repo_params.get_gpg_key_url("https://repo.amd.com/"),
-            "https://repo.amd.com/rocm/packages/gpg/rocm.gpg",
-        )
-
-    def test_handles_multi_arch_repo_url(self):
-        self.assertEqual(
-            get_url_repo_params.get_gpg_key_url(
-                f"{_EXAMPLE}/packages-multi-arch/deb/20260204-12345/"
+            (
+                f"{_EXAMPLE}/rocm/packages/rhel10/x86_64/",
+                f"{_EXAMPLE}/rocm/packages/gpg/rocm.gpg",
             ),
-            f"{_EXAMPLE}/packages-multi-arch/gpg/rocm.gpg",
-        )
-
-    def test_handles_stable_multi_arch_repo_url(self):
-        self.assertEqual(
-            get_url_repo_params.get_gpg_key_url(
-                f"{_EXAMPLE}/rocm/packages-multi-arch/ubuntu2604"
+            (
+                f"{_EXAMPLE}/packages-multi-arch/deb/20260204-12345/",
+                f"{_EXAMPLE}/packages-multi-arch/gpg/rocm.gpg",
             ),
-            f"{_EXAMPLE}/rocm/packages-multi-arch/gpg/rocm.gpg",
-        )
+            (
+                f"{_EXAMPLE}/rocm/packages-multi-arch/ubuntu2404",
+                f"{_EXAMPLE}/rocm/packages-multi-arch/gpg/rocm.gpg",
+            ),
+            (
+                "https://repo.amd.com/",
+                "https://repo.amd.com/rocm/packages/gpg/rocm.gpg",
+            ),
+        ]
+        for repo_url, gpg_url in cases:
+            with self.subTest(repo_url=repo_url):
+                self.assertEqual(get_url_repo_params.get_gpg_key_url(repo_url), gpg_url)
 
 
 class GetGpgKeyUrlFromReleaseTypeTest(unittest.TestCase):
-    """Tests for get_gpg_key_url_from_release_type()."""
+    """Tests for ``get_gpg_key_url_from_release_type()``."""
 
-    def test_per_family_prerelease_and_release(self):
-        self.assertEqual(
-            get_url_repo_params.get_gpg_key_url_from_release_type("prerelease"),
-            "https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg",
-        )
-        self.assertEqual(
-            get_url_repo_params.get_gpg_key_url_from_release_type("stable"),
-            "https://repo.amd.com/rocm/packages/gpg/rocm.gpg",
-        )
-
-    def test_multi_arch_layout_hosts(self):
-        self.assertEqual(
-            get_url_repo_params.get_gpg_key_url_from_release_type(
-                "prerelease", layout="multi_arch"
+    def test_signed_release_hosts(self):
+        cases = [
+            (
+                "prerelease",
+                None,
+                "https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg",
             ),
-            "https://rocm.prereleases.amd.com/packages-multi-arch/gpg/rocm.gpg",
-        )
-        self.assertEqual(
-            get_url_repo_params.get_gpg_key_url_from_release_type(
-                "stable", layout="multiarch"
+            ("stable", None, "https://repo.amd.com/rocm/packages/gpg/rocm.gpg"),
+            (
+                "prerelease",
+                "multi_arch",
+                "https://rocm.prereleases.amd.com/packages-multi-arch/gpg/rocm.gpg",
             ),
-            "https://repo.amd.com/rocm/packages-multi-arch/gpg/rocm.gpg",
-        )
-
-    def test_unsigned_raises(self):
+            (
+                "stable",
+                "multiarch",
+                "https://repo.amd.com/rocm/packages-multi-arch/gpg/rocm.gpg",
+            ),
+        ]
+        for release_type, layout, expected in cases:
+            with self.subTest(release_type=release_type, layout=layout):
+                self.assertEqual(
+                    get_url_repo_params.get_gpg_key_url_from_release_type(
+                        release_type, layout=layout
+                    ),
+                    expected,
+                )
         with self.assertRaises(ValueError):
             get_url_repo_params.get_gpg_key_url_from_release_type("ci")
 
 
 class NormalizeLayoutTest(unittest.TestCase):
-    """Tests for normalize_layout()."""
+    """Tests for ``normalize_layout()``."""
 
-    def test_defaults_to_per_family(self):
-        self.assertEqual(
-            get_url_repo_params.normalize_layout(None),
-            get_url_repo_params.LAYOUT_PER_FAMILY,
-        )
-        self.assertEqual(
-            get_url_repo_params.normalize_layout(""),
-            get_url_repo_params.LAYOUT_PER_FAMILY,
-        )
-
-    def test_aliases(self):
-        self.assertEqual(
-            get_url_repo_params.normalize_layout("legacy"),
-            get_url_repo_params.LAYOUT_PER_FAMILY,
-        )
-        self.assertEqual(
-            get_url_repo_params.normalize_layout("multiarch"),
-            get_url_repo_params.LAYOUT_MULTI_ARCH,
-        )
-
-    def test_unknown_raises(self):
+    def test_normalize_layout(self):
+        per_family = get_url_repo_params.LAYOUT_PER_FAMILY
+        multi_arch = get_url_repo_params.LAYOUT_MULTI_ARCH
+        for layout, expected in [
+            (None, per_family),
+            ("", per_family),
+            ("legacy", per_family),
+            ("multiarch", multi_arch),
+        ]:
+            with self.subTest(layout=layout):
+                self.assertEqual(get_url_repo_params.normalize_layout(layout), expected)
         with self.assertRaises(ValueError):
             get_url_repo_params.normalize_layout("unknown")
 
 
 class GpgKeyUrlNeededForReleaseTypeTest(unittest.TestCase):
-    """Tests for gpg_key_url_needed_for_release_type()."""
+    """Tests for ``gpg_key_url_needed_for_release_type()``."""
 
-    def test_none_means_always_derive(self):
+    def test_derivation_policy(self):
         self.assertTrue(get_url_repo_params.gpg_key_url_needed_for_release_type(None))
-
-    def test_prerelease_and_release(self):
-        self.assertTrue(
-            get_url_repo_params.gpg_key_url_needed_for_release_type("prerelease")
-        )
-        self.assertTrue(
-            get_url_repo_params.gpg_key_url_needed_for_release_type("prereleases")
-        )
-        self.assertTrue(
-            get_url_repo_params.gpg_key_url_needed_for_release_type("release")
-        )
-        self.assertTrue(
-            get_url_repo_params.gpg_key_url_needed_for_release_type("stable")
-        )
-        self.assertTrue(
-            get_url_repo_params.gpg_key_url_needed_for_release_type("  Prerelease  ")
-        )
-
-    def test_dev_nightly_ci_empty(self):
-        self.assertFalse(get_url_repo_params.gpg_key_url_needed_for_release_type("dev"))
-        self.assertFalse(
-            get_url_repo_params.gpg_key_url_needed_for_release_type("nightly")
-        )
-        self.assertFalse(get_url_repo_params.gpg_key_url_needed_for_release_type("ci"))
-        self.assertFalse(get_url_repo_params.gpg_key_url_needed_for_release_type(""))
+        for signed in ("prerelease", "prereleases", "release", "stable"):
+            with self.subTest(release_type=signed):
+                self.assertTrue(
+                    get_url_repo_params.gpg_key_url_needed_for_release_type(signed)
+                )
+        for unsigned in ("dev", "nightly", "ci", ""):
+            with self.subTest(release_type=unsigned):
+                self.assertFalse(
+                    get_url_repo_params.gpg_key_url_needed_for_release_type(unsigned)
+                )
 
 
 class GetRepoSubFolderTest(unittest.TestCase):
-    """Tests for get_repo_sub_folder()."""
+    """Tests for ``get_repo_sub_folder()``."""
 
-    def test_returns_last_segment_when_yyyyMMdd_artifact(self):
-        # Test that get_repo_sub_folder returns last segment when it matches YYYYMMDD-\d+.
+    def test_extracts_date_artifact_from_last_segment(self):
         self.assertEqual(
             get_url_repo_params.get_repo_sub_folder("v3/packages/deb/20260204-12345"),
             "20260204-12345",
         )
 
-    def test_returns_empty_when_last_segment_not_date_artifact(self):
-        # Test that get_repo_sub_folder returns empty when last segment does not match pattern.
+    def test_non_matching_last_segment_returns_empty(self):
         self.assertEqual(
-            get_url_repo_params.get_repo_sub_folder("v3/packages/deb/"),
-            "",
-        )
-        self.assertEqual(
-            get_url_repo_params.get_repo_sub_folder("v3/packages/deb/stable"),
-            "",
+            get_url_repo_params.get_repo_sub_folder("v3/packages/deb/"), ""
         )
 
-    def test_strips_slashes(self):
-        # Test that leading/trailing slashes are stripped before splitting.
-        self.assertEqual(
-            get_url_repo_params.get_repo_sub_folder("/v3/deb/20260204-999/"),
-            "20260204-999",
-        )
 
-    def test_empty_prefix_returns_empty(self):
-        # Test that empty or slash-only prefix returns empty string.
-        self.assertEqual(get_url_repo_params.get_repo_sub_folder(""), "")
-        self.assertEqual(get_url_repo_params.get_repo_sub_folder("/"), "")
+class GetRepoUrlPerFamilyTest(unittest.TestCase):
+    """Tests for ``get_repo_url()`` per-family layout."""
 
-
-class GetRepoUrlTest(unittest.TestCase):
-    """Tests for get_repo_url() per-family layout."""
-
-    def test_prereleases_alias_matches_prerelease(self):
-        self.assertEqual(
-            get_url_repo_params.get_repo_url(
-                release_type="prereleases",
-                native_package_type="deb",
-                repo_base_url=_EXAMPLE,
-                os_profile="ubuntu2404",
-                repo_sub_folder="",
+    def test_url_shapes(self):
+        cases = [
+            ("prereleases", "deb", "ubuntu2404", "", f"{_EXAMPLE}/packages/ubuntu2404"),
+            ("prerelease", "rpm", "rhel8", "", f"{_EXAMPLE}/packages/rhel8/x86_64/"),
+            (
+                "release",
+                "deb",
+                "ubuntu2404",
+                "",
+                f"{_EXAMPLE}/rocm/packages/ubuntu2404",
             ),
-            f"{_EXAMPLE}/packages/ubuntu2404",
-        )
-
-    def test_prerelease_deb(self):
-        self.assertEqual(
-            get_url_repo_params.get_repo_url(
-                release_type="prerelease",
-                native_package_type="deb",
-                repo_base_url=_EXAMPLE,
-                os_profile="ubuntu2404",
-                repo_sub_folder="",
+            ("stable", "rpm", "rhel10", "", f"{_EXAMPLE}/rocm/packages/rhel10/x86_64/"),
+            (
+                "nightly",
+                "deb",
+                "ubuntu2404",
+                "20260204-12345",
+                f"{_EXAMPLE}/deb/20260204-12345/",
             ),
-            f"{_EXAMPLE}/packages/ubuntu2404",
-        )
-
-    def test_prerelease_rpm(self):
-        self.assertEqual(
-            get_url_repo_params.get_repo_url(
-                release_type="prerelease",
-                native_package_type="rpm",
-                repo_base_url=_EXAMPLE,
-                os_profile="rhel8",
-                repo_sub_folder="",
+            (
+                "nightly",
+                "rpm",
+                "rhel8",
+                "20260204-12345",
+                f"{_EXAMPLE}/rpm/20260204-12345/x86_64/",
             ),
-            f"{_EXAMPLE}/packages/rhel8/x86_64/",
-        )
+        ]
+        for release_type, pkg_type, os_profile, sub_folder, expected in cases:
+            with self.subTest(release_type=release_type, pkg_type=pkg_type):
+                self.assertEqual(
+                    _repo_url(
+                        release_type=release_type,
+                        native_package_type=pkg_type,
+                        repo_sub_folder=sub_folder,
+                        os_profile=os_profile,
+                    ),
+                    expected,
+                )
 
-    def test_release_deb_matches_native_packaging_doc(self):
-        self.assertEqual(
-            get_url_repo_params.get_repo_url(
-                release_type="release",
-                native_package_type="deb",
-                repo_base_url=_EXAMPLE,
-                os_profile="ubuntu2404",
-                repo_sub_folder="",
-            ),
-            f"{_EXAMPLE}/rocm/packages/ubuntu2404",
-        )
-
-    def test_stable_rpm_matches_native_packaging_doc(self):
-        self.assertEqual(
-            get_url_repo_params.get_repo_url(
-                release_type="stable",
-                native_package_type="rpm",
-                repo_base_url=_EXAMPLE,
-                os_profile="rhel10",
-                repo_sub_folder="",
-            ),
-            f"{_EXAMPLE}/rocm/packages/rhel10/x86_64/",
-        )
-
-    def test_nightly_deb(self):
-        # Test that non-prerelease + deb yields base/deb/repo_sub_folder/
-        self.assertEqual(
-            get_url_repo_params.get_repo_url(
-                release_type="nightly",
-                native_package_type="deb",
-                repo_base_url=_EXAMPLE,
-                os_profile="ubuntu2404",
-                repo_sub_folder="20260204-12345",
-            ),
-            f"{_EXAMPLE}/deb/20260204-12345/",
-        )
-
-    def test_nightly_rpm(self):
-        # Test that non-prerelease + rpm yields base/rpm/repo_sub_folder/x86_64/
-        self.assertEqual(
-            get_url_repo_params.get_repo_url(
-                release_type="nightly",
-                native_package_type="rpm",
-                repo_base_url=_EXAMPLE,
-                os_profile="rhel8",
-                repo_sub_folder="20260204-12345",
-            ),
-            f"{_EXAMPLE}/rpm/20260204-12345/x86_64/",
-        )
-
-    def test_strips_trailing_slash_from_base(self):
-        self.assertEqual(
-            get_url_repo_params.get_repo_url(
-                release_type="prerelease",
-                native_package_type="deb",
-                repo_base_url=f"{_EXAMPLE}/",
-                os_profile="ubuntu2404",
-                repo_sub_folder="",
-            ),
-            f"{_EXAMPLE}/packages/ubuntu2404",
-        )
-
-    def test_explicit_per_family_layout_matches_default(self):
-        self.assertEqual(
-            get_url_repo_params.get_repo_url(
-                release_type="nightly",
-                native_package_type="deb",
-                repo_base_url=_EXAMPLE,
-                os_profile="ubuntu2404",
-                repo_sub_folder="20260204-12345",
-                layout="per_family",
-            ),
-            get_url_repo_params.get_repo_url(
-                release_type="nightly",
-                native_package_type="deb",
-                repo_base_url=_EXAMPLE,
-                os_profile="ubuntu2404",
-                repo_sub_folder="20260204-12345",
-            ),
-        )
-
-    def test_unknown_release_type_raises(self):
-        with self.assertRaises(ValueError) as ctx:
-            get_url_repo_params.get_repo_url(
-                release_type="typo-channel",
-                native_package_type="deb",
-                repo_base_url=_EXAMPLE,
-                os_profile="ubuntu2404",
-                repo_sub_folder="",
-            )
-        self.assertIn("Unknown release_type", str(ctx.exception))
-
-    def test_empty_release_type_raises(self):
-        with self.assertRaises(ValueError) as ctx:
-            get_url_repo_params.get_repo_url(
-                release_type="   ",
-                native_package_type="deb",
-                repo_base_url=_EXAMPLE,
-                os_profile="ubuntu2404",
-                repo_sub_folder="",
-            )
-        self.assertIn("cannot be empty", str(ctx.exception))
+    def test_fail_fast_on_bad_release_type(self):
+        for release_type, msg in [
+            ("typo-channel", "Unknown release_type"),
+            ("", "cannot be empty"),
+        ]:
+            with self.subTest(release_type=release_type):
+                with self.assertRaises(ValueError) as ctx:
+                    _repo_url(release_type=release_type)
+                self.assertIn(msg, str(ctx.exception))
 
 
 class GetRepoUrlMultiArchTest(unittest.TestCase):
-    """Tests for get_repo_url(..., layout=multi_arch)."""
+    """Tests for ``get_repo_url(..., layout=multi_arch)``."""
 
-    def test_stable_deb_matches_production_url(self):
-        self.assertEqual(
-            get_url_repo_params.get_repo_url(
-                release_type="stable",
-                native_package_type="deb",
-                repo_base_url=_EXAMPLE,
-                os_profile="ubuntu2604",
-                repo_sub_folder="",
-                layout="multi_arch",
+    def test_url_shapes(self):
+        cases = [
+            (
+                "stable",
+                "deb",
+                "ubuntu2404",
+                "",
+                f"{_EXAMPLE}/rocm/packages-multi-arch/ubuntu2404",
             ),
-            f"{_EXAMPLE}/rocm/packages-multi-arch/ubuntu2604",
-        )
-
-    def test_stable_rpm_matches_production_url(self):
-        self.assertEqual(
-            get_url_repo_params.get_repo_url(
-                release_type="release",
-                native_package_type="rpm",
-                repo_base_url=_EXAMPLE,
-                os_profile="rhel10",
-                repo_sub_folder="",
-                layout="multi_arch",
+            (
+                "prerelease",
+                "deb",
+                "ubuntu2404",
+                "",
+                f"{_EXAMPLE}/packages-multi-arch/ubuntu2404",
             ),
-            f"{_EXAMPLE}/rocm/packages-multi-arch/rhel10/x86_64/",
-        )
-
-    def test_prerelease_deb(self):
-        self.assertEqual(
-            get_url_repo_params.get_repo_url(
-                release_type="prerelease",
-                native_package_type="deb",
-                repo_base_url=_EXAMPLE,
-                os_profile="ubuntu2404",
-                repo_sub_folder="",
-                layout="multi_arch",
+            (
+                "nightly",
+                "deb",
+                "ubuntu2404",
+                "20260501-25200531110",
+                f"{_EXAMPLE}/packages-multi-arch/deb/20260501-25200531110",
             ),
-            f"{_EXAMPLE}/packages-multi-arch/ubuntu2404",
-        )
-
-    def test_nightly_deb_with_subfolder(self):
-        self.assertEqual(
-            get_url_repo_params.get_repo_url(
-                release_type="nightly",
-                native_package_type="deb",
-                repo_base_url=_EXAMPLE,
-                os_profile="ubuntu2404",
-                repo_sub_folder="20260501-25200531110",
-                layout="multi_arch",
+            (
+                "nightly",
+                "rpm",
+                "rhel10",
+                "20260501-25200531110",
+                f"{_EXAMPLE}/packages-multi-arch/rpm/20260501-25200531110/x86_64",
             ),
-            f"{_EXAMPLE}/packages-multi-arch/deb/20260501-25200531110",
-        )
-
-    def test_nightly_rpm_with_subfolder(self):
-        self.assertEqual(
-            get_url_repo_params.get_repo_url(
-                release_type="nightly",
-                native_package_type="rpm",
-                repo_base_url=_EXAMPLE,
-                os_profile="rhel10",
-                repo_sub_folder="20260501-25200531110",
-                layout="multi_arch",
-            ),
-            f"{_EXAMPLE}/packages-multi-arch/rpm/20260501-25200531110/x86_64",
-        )
-
-    def test_empty_subfolder_index_urls(self):
-        self.assertEqual(
-            get_url_repo_params.get_repo_url_multi_arch(
-                release_type="nightly",
-                native_package_type="deb",
-                repo_base_url=_EXAMPLE,
-                os_profile="ubuntu2404",
-                repo_sub_folder="",
-            ),
-            f"{_EXAMPLE}/packages-multi-arch/deb",
-        )
-        self.assertEqual(
-            get_url_repo_params.get_repo_url_multi_arch(
-                release_type="nightly",
-                native_package_type="rpm",
-                repo_base_url=f"{_EXAMPLE}/",
-                os_profile="rhel10",
-                repo_sub_folder="",
-            ),
-            f"{_EXAMPLE}/packages-multi-arch/rpm/x86_64",
-        )
-
-    def test_unknown_release_type_raises(self):
-        with self.assertRaises(ValueError) as ctx:
-            get_url_repo_params.get_repo_url(
-                release_type="unknown",
-                native_package_type="deb",
-                repo_base_url=_EXAMPLE,
-                os_profile="ubuntu2604",
-                repo_sub_folder="",
-                layout="multi_arch",
-            )
-        self.assertIn("Unknown release_type", str(ctx.exception))
+        ]
+        for release_type, pkg_type, os_profile, sub_folder, expected in cases:
+            with self.subTest(release_type=release_type, pkg_type=pkg_type):
+                self.assertEqual(
+                    _repo_url(
+                        release_type=release_type,
+                        native_package_type=pkg_type,
+                        repo_sub_folder=sub_folder,
+                        os_profile=os_profile,
+                        layout="multi_arch",
+                    ),
+                    expected,
+                )
 
 
 class ExtractGfxArchTest(unittest.TestCase):
-    """Tests for extract_gfx_arch()."""
+    """Tests for ``extract_gfx_arch()``."""
 
-    def test_extracts_and_lowercases_gfx_arch(self):
-        # Test that extract_gfx_arch returns the first segment lowercased.
-        self.assertEqual(
-            get_url_repo_params.extract_gfx_arch("gfx94X-dcgpu"),
-            "gfx94x",
-        )
+    def test_single_artifact_group(self):
+        self.assertEqual(get_url_repo_params.extract_gfx_arch("gfx94X-dcgpu"), "gfx94x")
 
-    def test_handles_lowercase_input(self):
-        # Test that extract_gfx_arch works with already-lowercase input.
-        self.assertEqual(
-            get_url_repo_params.extract_gfx_arch("gfx1100-consumer"),
-            "gfx1100",
-        )
+    def test_list_artifact_groups(self):
+        for groups, expected in [
+            ("gfx94X-dcgpu,gfx1100-consumer", "gfx94x,gfx1100"),
+            ("gfx94X-dcgpu;gfx1100-consumer", "gfx94x,gfx1100"),
+        ]:
+            with self.subTest(groups=groups):
+                self.assertEqual(get_url_repo_params.extract_gfx_arch(groups), expected)
 
-    def test_handles_uppercase_prefix(self):
-        # Test that extract_gfx_arch lowercases uppercase prefix.
-        self.assertEqual(
-            get_url_repo_params.extract_gfx_arch("GFX942-server"),
-            "gfx942",
-        )
-
-    def test_handles_no_dash(self):
-        # Test that extract_gfx_arch returns the whole string if no dash present.
-        self.assertEqual(
-            get_url_repo_params.extract_gfx_arch("gfx1100"),
-            "gfx1100",
-        )
-
-    def test_empty_string_raises(self):
-        # Test that extract_gfx_arch raises ValueError for empty string.
-        with self.assertRaises(ValueError) as ctx:
+    def test_empty_raises(self):
+        with self.assertRaises(ValueError):
             get_url_repo_params.extract_gfx_arch("")
-        self.assertIn("cannot be empty", str(ctx.exception))
 
-    def test_handles_multiple_dashes(self):
-        # Test that extract_gfx_arch only takes first segment when multiple dashes.
+
+class GetContainerImageTest(unittest.TestCase):
+    """Tests for ``get_container_image()`` (asserts against implementation output)."""
+
+    def test_profile_mapping(self):
+        # Ubuntu/debian share one image; sles/rhel use distinct registry images.
+        ubuntu = get_url_repo_params.get_container_image("ubuntu2404")
+        self.assertEqual(get_url_repo_params.get_container_image("debian12"), ubuntu)
         self.assertEqual(
-            get_url_repo_params.extract_gfx_arch("gfx94X-dcgpu-extra-info"),
-            "gfx94x",
+            get_url_repo_params.get_container_image("sles16"),
+            "registry.suse.com/bci/bci-base:16.0",
         )
-
-    def test_comma_separated_list(self):
-        # Test that extract_gfx_arch handles comma-separated artifact groups.
         self.assertEqual(
-            get_url_repo_params.extract_gfx_arch("gfx94X-dcgpu,gfx1100-consumer"),
-            "gfx94x,gfx1100",
-        )
-
-    def test_semicolon_separated_list(self):
-        # Test that extract_gfx_arch handles semicolon-separated artifact groups.
-        self.assertEqual(
-            get_url_repo_params.extract_gfx_arch("gfx94X-dcgpu;gfx1100-consumer"),
-            "gfx94x,gfx1100",
-        )
-
-    def test_mixed_case_list(self):
-        # Test that extract_gfx_arch lowercases all items in list.
-        self.assertEqual(
-            get_url_repo_params.extract_gfx_arch("GFX942-server,GFX1100-consumer"),
-            "gfx942,gfx1100",
-        )
-
-    def test_list_with_spaces(self):
-        # Test that extract_gfx_arch strips whitespace from list items.
-        self.assertEqual(
-            get_url_repo_params.extract_gfx_arch("gfx94X-dcgpu , gfx1100-consumer"),
-            "gfx94x,gfx1100",
+            get_url_repo_params.get_container_image("rhel10"),
+            "registry.access.redhat.com/ubi10/ubi:10.1",
         )
 
 
 class MainSubcommandsTest(unittest.TestCase):
-    """Tests for main() subcommands (get-base-url, get-repo-sub-folder, get-repo-url)."""
+    """One happy-path CLI smoke per subcommand (GITHUB_OUTPUT wiring)."""
 
-    def test_get_base_url_success(self):
-        # Test that get-base-url subcommand writes repo_base_url= to GITHUB_OUTPUT.
+    def test_get_base_url_cli(self):
         code, output = _run_main_with_output(
             ["get-base-url", "--from-url", f"{_EXAMPLE}/v2/whl"]
         )
         self.assertEqual(code, 0)
         self.assertIn(f"repo_base_url={_EXAMPLE}", output)
 
-    def test_get_base_url_invalid_returns_one(self):
-        # Test that get-base-url with invalid URL returns 1 and prints error.
-        with patch("sys.stderr"):
-            code = get_url_repo_params.main(["get-base-url", "--from-url", "not-a-url"])
-        self.assertEqual(code, 1)
-
-    def test_get_repo_sub_folder_success(self):
-        # Test that get-repo-sub-folder writes repo_sub_folder= to GITHUB_OUTPUT.
+    def test_get_repo_sub_folder_cli(self):
         code, output = _run_main_with_output(
             ["get-repo-sub-folder", "--from-s3-prefix", "v3/deb/20260204-12345"]
         )
         self.assertEqual(code, 0)
         self.assertIn("repo_sub_folder=20260204-12345", output)
 
-    def test_get_repo_url_success(self):
-        # Test that get-repo-url writes repo_url= to GITHUB_OUTPUT.
-        code, output = _run_main_with_output(
-            [
-                "get-repo-url",
-                "--release-type",
-                "prerelease",
-                "--native-package-type",
-                "deb",
-                "--repo-base-url",
-                _EXAMPLE,
-                "--os-profile",
-                "ubuntu2404",
-                "--repo-sub-folder",
-                "",
-            ]
-        )
-        self.assertEqual(code, 0)
-        self.assertIn(f"repo_url={_EXAMPLE}/packages/ubuntu2404", output)
-
-    def test_get_repo_url_multi_arch_layout_cli(self):
+    def test_get_repo_url_cli(self):
         code, output = _run_main_with_output(
             [
                 "get-repo-url",
@@ -645,133 +377,17 @@ class MainSubcommandsTest(unittest.TestCase):
                 "--repo-base-url",
                 _EXAMPLE,
                 "--os-profile",
-                "ubuntu2604",
+                "ubuntu2404",
                 "--repo-sub-folder",
                 "",
             ]
         )
         self.assertEqual(code, 0)
         self.assertIn(
-            f"repo_url={_EXAMPLE}/rocm/packages-multi-arch/ubuntu2604",
-            output,
+            f"repo_url={_EXAMPLE}/rocm/packages-multi-arch/ubuntu2404", output
         )
 
-    def test_get_repo_url_unknown_release_type_returns_one(self):
-        with patch("sys.stderr"):
-            code = get_url_repo_params.main(
-                [
-                    "get-repo-url",
-                    "--release-type",
-                    "typo-channel",
-                    "--native-package-type",
-                    "deb",
-                    "--repo-base-url",
-                    _EXAMPLE,
-                    "--os-profile",
-                    "ubuntu2404",
-                    "--repo-sub-folder",
-                    "",
-                ]
-            )
-        self.assertEqual(code, 1)
-
-    def test_get_repo_url_unknown_layout_returns_one(self):
-        with patch("sys.stderr"):
-            code = get_url_repo_params.main(
-                [
-                    "get-repo-url",
-                    "--layout",
-                    "unknown",
-                    "--release-type",
-                    "nightly",
-                    "--native-package-type",
-                    "deb",
-                    "--repo-base-url",
-                    _EXAMPLE,
-                    "--os-profile",
-                    "ubuntu2404",
-                    "--repo-sub-folder",
-                    "20260204-12345",
-                ]
-            )
-        self.assertEqual(code, 1)
-
-    def test_get_repo_url_error_returns_one(self):
-        # Test that get-repo-url returns 1 and prints error when get_repo_url raises.
-        with patch(
-            "get_url_repo_params.get_repo_url", side_effect=ValueError("bad params")
-        ):
-            with patch("sys.stderr"):
-                code = get_url_repo_params.main(
-                    [
-                        "get-repo-url",
-                        "--release-type",
-                        "prerelease",
-                        "--native-package-type",
-                        "deb",
-                        "--repo-base-url",
-                        _EXAMPLE,
-                        "--os-profile",
-                        "ubuntu2404",
-                        "--repo-sub-folder",
-                        "",
-                    ]
-                )
-        self.assertEqual(code, 1)
-
-    def test_extract_gfx_arch_success(self):
-        # Test that extract-gfx-arch writes gfx_arch= to GITHUB_OUTPUT.
-        code, output = _run_main_with_output(
-            ["extract-gfx-arch", "--artifact-group", "gfx94X-dcgpu"]
-        )
-        self.assertEqual(code, 0)
-        self.assertIn("gfx_arch=gfx94x", output)
-
-    def test_extract_gfx_arch_lowercase(self):
-        # Test that extract-gfx-arch handles already-lowercase input.
-        code, output = _run_main_with_output(
-            ["extract-gfx-arch", "--artifact-group", "gfx1100-consumer"]
-        )
-        self.assertEqual(code, 0)
-        self.assertIn("gfx_arch=gfx1100", output)
-
-    def test_extract_gfx_arch_empty_returns_one(self):
-        # Test that extract-gfx-arch with empty artifact_group returns 1.
-        with patch("sys.stderr"):
-            code = get_url_repo_params.main(
-                ["extract-gfx-arch", "--artifact-group", ""]
-            )
-        self.assertEqual(code, 1)
-
-    def test_extract_gfx_arch_comma_list(self):
-        # Test that extract-gfx-arch handles comma-separated list.
-        code, output = _run_main_with_output(
-            ["extract-gfx-arch", "--artifact-group", "gfx94X-dcgpu,gfx1100-consumer"]
-        )
-        self.assertEqual(code, 0)
-        self.assertIn("gfx_arch=gfx94x,gfx1100", output)
-
-    def test_extract_gfx_arch_semicolon_list(self):
-        # Test that extract-gfx-arch handles semicolon-separated list.
-        code, output = _run_main_with_output(
-            ["extract-gfx-arch", "--artifact-group", "gfx94X-dcgpu;gfx1100-consumer"]
-        )
-        self.assertEqual(code, 0)
-        self.assertIn("gfx_arch=gfx94x,gfx1100", output)
-
-    def test_get_gpg_url_success(self):
-        # Test that get-gpg-url writes gpg_key_url= to GITHUB_OUTPUT.
-        code, output = _run_main_with_output(
-            [
-                "get-gpg-url",
-                "--from-url",
-                f"{_EXAMPLE}/packages/ubuntu2404",
-            ]
-        )
-        self.assertEqual(code, 0)
-        self.assertIn(f"gpg_key_url={_EXAMPLE}/packages/gpg/rocm.gpg", output)
-
-    def test_get_gpg_url_with_release_type_dev_emits_empty(self):
+    def test_get_gpg_url_cli(self):
         code, output = _run_main_with_output(
             [
                 "get-gpg-url",
@@ -782,89 +398,22 @@ class MainSubcommandsTest(unittest.TestCase):
             ]
         )
         self.assertEqual(code, 0)
-        self.assertIn("gpg_key_url=", output)
-        self.assertNotIn("rocm.gpg", output)
-
-    def test_get_gpg_url_with_release_type_dev_ignores_invalid_url(self):
-        code, output = _run_main_with_output(
-            [
-                "get-gpg-url",
-                "--release-type",
-                "nightly",
-                "--from-url",
-                "not-a-valid-url",
-            ]
-        )
-        self.assertEqual(code, 0)
         self.assertEqual(output.strip(), "gpg_key_url=")
 
-    def test_get_gpg_url_with_release_type_prerelease(self):
+    def test_extract_gfx_arch_cli(self):
         code, output = _run_main_with_output(
-            [
-                "get-gpg-url",
-                "--release-type",
-                "prerelease",
-                "--from-url",
-                f"{_EXAMPLE}/packages/ubuntu2404",
-            ]
+            ["extract-gfx-arch", "--artifact-group", "gfx94X-dcgpu,gfx1100-consumer"]
         )
         self.assertEqual(code, 0)
-        self.assertIn(f"gpg_key_url={_EXAMPLE}/packages/gpg/rocm.gpg", output)
+        self.assertIn("gfx_arch=gfx94x,gfx1100", output)
 
-    def test_get_gpg_url_with_release_type_release(self):
-        code, output = _run_main_with_output(
-            [
-                "get-gpg-url",
-                "--release-type",
-                "release",
-                "--from-url",
-                f"{_EXAMPLE}/rocm/packages/rhel10/x86_64/",
-            ]
-        )
-        self.assertEqual(code, 0)
-        self.assertIn(f"gpg_key_url={_EXAMPLE}/rocm/packages/gpg/rocm.gpg", output)
-
-
-class GetContainerImageTest(unittest.TestCase):
-    """Tests for get_container_image()."""
-
-    def test_ubuntu_returns_ubuntu_image(self):
-        self.assertEqual(
-            get_url_repo_params.get_container_image("ubuntu2404"),
-            "ubuntu:24.04",
-        )
-
-    def test_debian_returns_ubuntu_image(self):
-        self.assertEqual(
-            get_url_repo_params.get_container_image("debian12"),
-            "ubuntu:24.04",
-        )
-
-    def test_sles_returns_bci_image(self):
-        self.assertEqual(
-            get_url_repo_params.get_container_image("sles16"),
-            "registry.suse.com/bci/bci-base:16.0",
-        )
-
-    def test_rhel8_returns_ubi8_image(self):
-        self.assertEqual(
-            get_url_repo_params.get_container_image("rhel8"),
-            "registry.access.redhat.com/ubi8/ubi:8.10",
-        )
-
-    def test_rhel_returns_ubi_image(self):
-        self.assertEqual(
-            get_url_repo_params.get_container_image("rhel10"),
-            "registry.access.redhat.com/ubi10/ubi:10.1",
-        )
-
-    def test_get_container_image_subcommand(self):
-        # Test that get-container-image writes container_image= to GITHUB_OUTPUT.
+    def test_get_container_image_cli(self):
+        expected = get_url_repo_params.get_container_image("ubuntu2404")
         code, output = _run_main_with_output(
             ["get-container-image", "--os-profile", "ubuntu2404"]
         )
         self.assertEqual(code, 0)
-        self.assertIn("container_image=ubuntu:24.04", output)
+        self.assertIn(f"container_image={expected}", output)
 
 
 if __name__ == "__main__":

--- a/build_tools/packaging/linux/tests/get_url_repo_params_test.py
+++ b/build_tools/packaging/linux/tests/get_url_repo_params_test.py
@@ -16,6 +16,7 @@ Per-family coverage (native_packaging.md GFX URLs):
   - release/stable → …/rocm/packages/{os_profile}
   - dev/nightly → …/deb|rpm/{repo_sub_folder}/
   - GPG beside packages tree (…/packages/gpg/ or …/rocm/packages/gpg/)
+  - get-gpg-url derivation policy (signed vs unsigned); install honors explicit gpg_key_url input
 
 Multi-arch coverage (layout=multi_arch, packages-multi-arch/…):
   - prerelease → …/packages-multi-arch/{os_profile}
@@ -43,6 +44,8 @@ sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent.parent.parent))
 import get_url_repo_params
 
+_EXAMPLE = get_url_repo_params.EXAMPLE_CDN_BASE
+
 
 def _run_main_with_output(argv: list[str]) -> tuple[int, str]:
     """Run main() with a temp GITHUB_OUTPUT file; return (exit_code, file_contents)."""
@@ -63,22 +66,22 @@ class GetBaseUrlTest(unittest.TestCase):
     def test_returns_scheme_and_netloc(self):
         # Test that get_base_url returns scheme and netloc only, stripping path.
         self.assertEqual(
-            get_url_repo_params.get_base_url("https://example.com/v2/whl"),
-            "https://example.com",
+            get_url_repo_params.get_base_url(f"{_EXAMPLE}/v2/whl"),
+            _EXAMPLE,
         )
 
     def test_strips_query_and_fragment(self):
         # Test that get_base_url strips query string and fragment.
         self.assertEqual(
-            get_url_repo_params.get_base_url("https://example.com/path?q=1#anchor"),
-            "https://example.com",
+            get_url_repo_params.get_base_url(f"{_EXAMPLE}/path?q=1#anchor"),
+            _EXAMPLE,
         )
 
     def test_http_url(self):
         # Test that get_base_url works with http.
         self.assertEqual(
-            get_url_repo_params.get_base_url("http://repo.local/artifacts"),
-            "http://repo.local",
+            get_url_repo_params.get_base_url("http://sample-cdn.example/artifacts"),
+            "http://sample-cdn.example",
         )
 
     def test_invalid_url_no_scheme_raises(self):
@@ -98,26 +101,22 @@ class GetGpgKeyUrlTest(unittest.TestCase):
 
     def test_extracts_base_and_adds_gpg_path(self):
         self.assertEqual(
-            get_url_repo_params.get_gpg_key_url(
-                "https://rocm.prereleases.amd.com/packages/ubuntu2404"
-            ),
-            "https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg",
+            get_url_repo_params.get_gpg_key_url(f"{_EXAMPLE}/packages/ubuntu2404"),
+            f"{_EXAMPLE}/packages/gpg/rocm.gpg",
         )
 
     def test_strips_path_from_url(self):
         self.assertEqual(
             get_url_repo_params.get_gpg_key_url(
-                "https://repo.amd.com/rocm/packages/rhel10/x86_64/"
+                f"{_EXAMPLE}/rocm/packages/rhel10/x86_64/"
             ),
-            "https://repo.amd.com/rocm/packages/gpg/rocm.gpg",
+            f"{_EXAMPLE}/rocm/packages/gpg/rocm.gpg",
         )
 
     def test_handles_nightly_url(self):
         self.assertEqual(
-            get_url_repo_params.get_gpg_key_url(
-                "https://rocm.nightlies.amd.com/deb/20260204-12345/"
-            ),
-            "https://rocm.nightlies.amd.com/packages/gpg/rocm.gpg",
+            get_url_repo_params.get_gpg_key_url(f"{_EXAMPLE}/deb/20260204-12345/"),
+            f"{_EXAMPLE}/packages/gpg/rocm.gpg",
         )
 
     def test_repo_amd_com_without_packages_segment(self):
@@ -129,17 +128,17 @@ class GetGpgKeyUrlTest(unittest.TestCase):
     def test_handles_multi_arch_repo_url(self):
         self.assertEqual(
             get_url_repo_params.get_gpg_key_url(
-                "https://rocm.nightlies.amd.com/packages-multi-arch/deb/20260204-12345/"
+                f"{_EXAMPLE}/packages-multi-arch/deb/20260204-12345/"
             ),
-            "https://rocm.nightlies.amd.com/packages-multi-arch/gpg/rocm.gpg",
+            f"{_EXAMPLE}/packages-multi-arch/gpg/rocm.gpg",
         )
 
     def test_handles_stable_multi_arch_repo_url(self):
         self.assertEqual(
             get_url_repo_params.get_gpg_key_url(
-                "https://repo.amd.com/rocm/packages-multi-arch/ubuntu2604"
+                f"{_EXAMPLE}/rocm/packages-multi-arch/ubuntu2604"
             ),
-            "https://repo.amd.com/rocm/packages-multi-arch/gpg/rocm.gpg",
+            f"{_EXAMPLE}/rocm/packages-multi-arch/gpg/rocm.gpg",
         )
 
 
@@ -277,11 +276,11 @@ class GetRepoUrlTest(unittest.TestCase):
             get_url_repo_params.get_repo_url(
                 release_type="prereleases",
                 native_package_type="deb",
-                repo_base_url="https://rocm.prereleases.amd.com",
+                repo_base_url=_EXAMPLE,
                 os_profile="ubuntu2404",
                 repo_sub_folder="",
             ),
-            "https://rocm.prereleases.amd.com/packages/ubuntu2404",
+            f"{_EXAMPLE}/packages/ubuntu2404",
         )
 
     def test_prerelease_deb(self):
@@ -289,11 +288,11 @@ class GetRepoUrlTest(unittest.TestCase):
             get_url_repo_params.get_repo_url(
                 release_type="prerelease",
                 native_package_type="deb",
-                repo_base_url="https://rocm.prereleases.amd.com",
+                repo_base_url=_EXAMPLE,
                 os_profile="ubuntu2404",
                 repo_sub_folder="",
             ),
-            "https://rocm.prereleases.amd.com/packages/ubuntu2404",
+            f"{_EXAMPLE}/packages/ubuntu2404",
         )
 
     def test_prerelease_rpm(self):
@@ -301,11 +300,11 @@ class GetRepoUrlTest(unittest.TestCase):
             get_url_repo_params.get_repo_url(
                 release_type="prerelease",
                 native_package_type="rpm",
-                repo_base_url="https://rocm.prereleases.amd.com",
+                repo_base_url=_EXAMPLE,
                 os_profile="rhel8",
                 repo_sub_folder="",
             ),
-            "https://rocm.prereleases.amd.com/packages/rhel8/x86_64/",
+            f"{_EXAMPLE}/packages/rhel8/x86_64/",
         )
 
     def test_release_deb_matches_native_packaging_doc(self):
@@ -313,11 +312,11 @@ class GetRepoUrlTest(unittest.TestCase):
             get_url_repo_params.get_repo_url(
                 release_type="release",
                 native_package_type="deb",
-                repo_base_url="https://repo.amd.com",
+                repo_base_url=_EXAMPLE,
                 os_profile="ubuntu2404",
                 repo_sub_folder="",
             ),
-            "https://repo.amd.com/rocm/packages/ubuntu2404",
+            f"{_EXAMPLE}/rocm/packages/ubuntu2404",
         )
 
     def test_stable_rpm_matches_native_packaging_doc(self):
@@ -325,11 +324,11 @@ class GetRepoUrlTest(unittest.TestCase):
             get_url_repo_params.get_repo_url(
                 release_type="stable",
                 native_package_type="rpm",
-                repo_base_url="https://repo.amd.com",
+                repo_base_url=_EXAMPLE,
                 os_profile="rhel10",
                 repo_sub_folder="",
             ),
-            "https://repo.amd.com/rocm/packages/rhel10/x86_64/",
+            f"{_EXAMPLE}/rocm/packages/rhel10/x86_64/",
         )
 
     def test_nightly_deb(self):
@@ -338,11 +337,11 @@ class GetRepoUrlTest(unittest.TestCase):
             get_url_repo_params.get_repo_url(
                 release_type="nightly",
                 native_package_type="deb",
-                repo_base_url="https://x.com",
+                repo_base_url=_EXAMPLE,
                 os_profile="ubuntu2404",
                 repo_sub_folder="20260204-12345",
             ),
-            "https://x.com/deb/20260204-12345/",
+            f"{_EXAMPLE}/deb/20260204-12345/",
         )
 
     def test_nightly_rpm(self):
@@ -351,11 +350,11 @@ class GetRepoUrlTest(unittest.TestCase):
             get_url_repo_params.get_repo_url(
                 release_type="nightly",
                 native_package_type="rpm",
-                repo_base_url="https://x.com",
+                repo_base_url=_EXAMPLE,
                 os_profile="rhel8",
                 repo_sub_folder="20260204-12345",
             ),
-            "https://x.com/rpm/20260204-12345/x86_64/",
+            f"{_EXAMPLE}/rpm/20260204-12345/x86_64/",
         )
 
     def test_strips_trailing_slash_from_base(self):
@@ -363,11 +362,11 @@ class GetRepoUrlTest(unittest.TestCase):
             get_url_repo_params.get_repo_url(
                 release_type="prerelease",
                 native_package_type="deb",
-                repo_base_url="https://rocm.prereleases.amd.com/",
+                repo_base_url=f"{_EXAMPLE}/",
                 os_profile="ubuntu2404",
                 repo_sub_folder="",
             ),
-            "https://rocm.prereleases.amd.com/packages/ubuntu2404",
+            f"{_EXAMPLE}/packages/ubuntu2404",
         )
 
     def test_explicit_per_family_layout_matches_default(self):
@@ -375,7 +374,7 @@ class GetRepoUrlTest(unittest.TestCase):
             get_url_repo_params.get_repo_url(
                 release_type="nightly",
                 native_package_type="deb",
-                repo_base_url="https://x.com",
+                repo_base_url=_EXAMPLE,
                 os_profile="ubuntu2404",
                 repo_sub_folder="20260204-12345",
                 layout="per_family",
@@ -383,11 +382,33 @@ class GetRepoUrlTest(unittest.TestCase):
             get_url_repo_params.get_repo_url(
                 release_type="nightly",
                 native_package_type="deb",
-                repo_base_url="https://x.com",
+                repo_base_url=_EXAMPLE,
                 os_profile="ubuntu2404",
                 repo_sub_folder="20260204-12345",
             ),
         )
+
+    def test_unknown_release_type_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            get_url_repo_params.get_repo_url(
+                release_type="typo-channel",
+                native_package_type="deb",
+                repo_base_url=_EXAMPLE,
+                os_profile="ubuntu2404",
+                repo_sub_folder="",
+            )
+        self.assertIn("Unknown release_type", str(ctx.exception))
+
+    def test_empty_release_type_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            get_url_repo_params.get_repo_url(
+                release_type="   ",
+                native_package_type="deb",
+                repo_base_url=_EXAMPLE,
+                os_profile="ubuntu2404",
+                repo_sub_folder="",
+            )
+        self.assertIn("cannot be empty", str(ctx.exception))
 
 
 class GetRepoUrlMultiArchTest(unittest.TestCase):
@@ -398,12 +419,12 @@ class GetRepoUrlMultiArchTest(unittest.TestCase):
             get_url_repo_params.get_repo_url(
                 release_type="stable",
                 native_package_type="deb",
-                repo_base_url="https://repo.amd.com",
+                repo_base_url=_EXAMPLE,
                 os_profile="ubuntu2604",
                 repo_sub_folder="",
                 layout="multi_arch",
             ),
-            "https://repo.amd.com/rocm/packages-multi-arch/ubuntu2604",
+            f"{_EXAMPLE}/rocm/packages-multi-arch/ubuntu2604",
         )
 
     def test_stable_rpm_matches_production_url(self):
@@ -411,12 +432,12 @@ class GetRepoUrlMultiArchTest(unittest.TestCase):
             get_url_repo_params.get_repo_url(
                 release_type="release",
                 native_package_type="rpm",
-                repo_base_url="https://repo.amd.com",
+                repo_base_url=_EXAMPLE,
                 os_profile="rhel10",
                 repo_sub_folder="",
                 layout="multi_arch",
             ),
-            "https://repo.amd.com/rocm/packages-multi-arch/rhel10/x86_64/",
+            f"{_EXAMPLE}/rocm/packages-multi-arch/rhel10/x86_64/",
         )
 
     def test_prerelease_deb(self):
@@ -424,12 +445,12 @@ class GetRepoUrlMultiArchTest(unittest.TestCase):
             get_url_repo_params.get_repo_url(
                 release_type="prerelease",
                 native_package_type="deb",
-                repo_base_url="https://rocm.prereleases.amd.com",
+                repo_base_url=_EXAMPLE,
                 os_profile="ubuntu2404",
                 repo_sub_folder="",
                 layout="multi_arch",
             ),
-            "https://rocm.prereleases.amd.com/packages-multi-arch/ubuntu2404",
+            f"{_EXAMPLE}/packages-multi-arch/ubuntu2404",
         )
 
     def test_nightly_deb_with_subfolder(self):
@@ -437,12 +458,12 @@ class GetRepoUrlMultiArchTest(unittest.TestCase):
             get_url_repo_params.get_repo_url(
                 release_type="nightly",
                 native_package_type="deb",
-                repo_base_url="https://rocm.nightlies.amd.com",
+                repo_base_url=_EXAMPLE,
                 os_profile="ubuntu2404",
                 repo_sub_folder="20260501-25200531110",
                 layout="multi_arch",
             ),
-            "https://rocm.nightlies.amd.com/packages-multi-arch/deb/20260501-25200531110",
+            f"{_EXAMPLE}/packages-multi-arch/deb/20260501-25200531110",
         )
 
     def test_nightly_rpm_with_subfolder(self):
@@ -450,12 +471,12 @@ class GetRepoUrlMultiArchTest(unittest.TestCase):
             get_url_repo_params.get_repo_url(
                 release_type="nightly",
                 native_package_type="rpm",
-                repo_base_url="https://rocm.nightlies.amd.com",
+                repo_base_url=_EXAMPLE,
                 os_profile="rhel10",
                 repo_sub_folder="20260501-25200531110",
                 layout="multi_arch",
             ),
-            "https://rocm.nightlies.amd.com/packages-multi-arch/rpm/20260501-25200531110/x86_64",
+            f"{_EXAMPLE}/packages-multi-arch/rpm/20260501-25200531110/x86_64",
         )
 
     def test_empty_subfolder_index_urls(self):
@@ -463,22 +484,34 @@ class GetRepoUrlMultiArchTest(unittest.TestCase):
             get_url_repo_params.get_repo_url_multi_arch(
                 release_type="nightly",
                 native_package_type="deb",
-                repo_base_url="https://repo_url.com",
+                repo_base_url=_EXAMPLE,
                 os_profile="ubuntu2404",
                 repo_sub_folder="",
             ),
-            "https://repo_url.com/packages-multi-arch/deb",
+            f"{_EXAMPLE}/packages-multi-arch/deb",
         )
         self.assertEqual(
             get_url_repo_params.get_repo_url_multi_arch(
                 release_type="nightly",
                 native_package_type="rpm",
-                repo_base_url="https://repo_url.com/",
+                repo_base_url=f"{_EXAMPLE}/",
                 os_profile="rhel10",
                 repo_sub_folder="",
             ),
-            "https://repo_url.com/packages-multi-arch/rpm/x86_64",
+            f"{_EXAMPLE}/packages-multi-arch/rpm/x86_64",
         )
+
+    def test_unknown_release_type_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            get_url_repo_params.get_repo_url(
+                release_type="unknown",
+                native_package_type="deb",
+                repo_base_url=_EXAMPLE,
+                os_profile="ubuntu2604",
+                repo_sub_folder="",
+                layout="multi_arch",
+            )
+        self.assertIn("Unknown release_type", str(ctx.exception))
 
 
 class ExtractGfxArchTest(unittest.TestCase):
@@ -560,10 +593,10 @@ class MainSubcommandsTest(unittest.TestCase):
     def test_get_base_url_success(self):
         # Test that get-base-url subcommand writes repo_base_url= to GITHUB_OUTPUT.
         code, output = _run_main_with_output(
-            ["get-base-url", "--from-url", "https://example.com/v2/whl"]
+            ["get-base-url", "--from-url", f"{_EXAMPLE}/v2/whl"]
         )
         self.assertEqual(code, 0)
-        self.assertIn("repo_base_url=https://example.com", output)
+        self.assertIn(f"repo_base_url={_EXAMPLE}", output)
 
     def test_get_base_url_invalid_returns_one(self):
         # Test that get-base-url with invalid URL returns 1 and prints error.
@@ -589,7 +622,7 @@ class MainSubcommandsTest(unittest.TestCase):
                 "--native-package-type",
                 "deb",
                 "--repo-base-url",
-                "https://rocm.prereleases.amd.com",
+                _EXAMPLE,
                 "--os-profile",
                 "ubuntu2404",
                 "--repo-sub-folder",
@@ -597,9 +630,7 @@ class MainSubcommandsTest(unittest.TestCase):
             ]
         )
         self.assertEqual(code, 0)
-        self.assertIn(
-            "repo_url=https://rocm.prereleases.amd.com/packages/ubuntu2404", output
-        )
+        self.assertIn(f"repo_url={_EXAMPLE}/packages/ubuntu2404", output)
 
     def test_get_repo_url_multi_arch_layout_cli(self):
         code, output = _run_main_with_output(
@@ -612,7 +643,7 @@ class MainSubcommandsTest(unittest.TestCase):
                 "--native-package-type",
                 "deb",
                 "--repo-base-url",
-                "https://repo.amd.com",
+                _EXAMPLE,
                 "--os-profile",
                 "ubuntu2604",
                 "--repo-sub-folder",
@@ -621,9 +652,49 @@ class MainSubcommandsTest(unittest.TestCase):
         )
         self.assertEqual(code, 0)
         self.assertIn(
-            "repo_url=https://repo.amd.com/rocm/packages-multi-arch/ubuntu2604",
+            f"repo_url={_EXAMPLE}/rocm/packages-multi-arch/ubuntu2604",
             output,
         )
+
+    def test_get_repo_url_unknown_release_type_returns_one(self):
+        with patch("sys.stderr"):
+            code = get_url_repo_params.main(
+                [
+                    "get-repo-url",
+                    "--release-type",
+                    "typo-channel",
+                    "--native-package-type",
+                    "deb",
+                    "--repo-base-url",
+                    _EXAMPLE,
+                    "--os-profile",
+                    "ubuntu2404",
+                    "--repo-sub-folder",
+                    "",
+                ]
+            )
+        self.assertEqual(code, 1)
+
+    def test_get_repo_url_unknown_layout_returns_one(self):
+        with patch("sys.stderr"):
+            code = get_url_repo_params.main(
+                [
+                    "get-repo-url",
+                    "--layout",
+                    "unknown",
+                    "--release-type",
+                    "nightly",
+                    "--native-package-type",
+                    "deb",
+                    "--repo-base-url",
+                    _EXAMPLE,
+                    "--os-profile",
+                    "ubuntu2404",
+                    "--repo-sub-folder",
+                    "20260204-12345",
+                ]
+            )
+        self.assertEqual(code, 1)
 
     def test_get_repo_url_error_returns_one(self):
         # Test that get-repo-url returns 1 and prints error when get_repo_url raises.
@@ -639,7 +710,7 @@ class MainSubcommandsTest(unittest.TestCase):
                         "--native-package-type",
                         "deb",
                         "--repo-base-url",
-                        "https://x.com",
+                        _EXAMPLE,
                         "--os-profile",
                         "ubuntu2404",
                         "--repo-sub-folder",
@@ -694,14 +765,11 @@ class MainSubcommandsTest(unittest.TestCase):
             [
                 "get-gpg-url",
                 "--from-url",
-                "https://rocm.prereleases.amd.com/packages/ubuntu2404",
+                f"{_EXAMPLE}/packages/ubuntu2404",
             ]
         )
         self.assertEqual(code, 0)
-        self.assertIn(
-            "gpg_key_url=https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg",
-            output,
-        )
+        self.assertIn(f"gpg_key_url={_EXAMPLE}/packages/gpg/rocm.gpg", output)
 
     def test_get_gpg_url_with_release_type_dev_emits_empty(self):
         code, output = _run_main_with_output(
@@ -710,7 +778,7 @@ class MainSubcommandsTest(unittest.TestCase):
                 "--release-type",
                 "dev",
                 "--from-url",
-                "https://rocm.prereleases.amd.com/packages/ubuntu2404",
+                f"{_EXAMPLE}/packages/ubuntu2404",
             ]
         )
         self.assertEqual(code, 0)
@@ -737,14 +805,11 @@ class MainSubcommandsTest(unittest.TestCase):
                 "--release-type",
                 "prerelease",
                 "--from-url",
-                "https://rocm.prereleases.amd.com/packages/ubuntu2404",
+                f"{_EXAMPLE}/packages/ubuntu2404",
             ]
         )
         self.assertEqual(code, 0)
-        self.assertIn(
-            "gpg_key_url=https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg",
-            output,
-        )
+        self.assertIn(f"gpg_key_url={_EXAMPLE}/packages/gpg/rocm.gpg", output)
 
     def test_get_gpg_url_with_release_type_release(self):
         code, output = _run_main_with_output(
@@ -753,13 +818,11 @@ class MainSubcommandsTest(unittest.TestCase):
                 "--release-type",
                 "release",
                 "--from-url",
-                "https://repo.amd.com/rocm/packages/rhel10/x86_64/",
+                f"{_EXAMPLE}/rocm/packages/rhel10/x86_64/",
             ]
         )
         self.assertEqual(code, 0)
-        self.assertIn(
-            "gpg_key_url=https://repo.amd.com/rocm/packages/gpg/rocm.gpg", output
-        )
+        self.assertIn(f"gpg_key_url={_EXAMPLE}/rocm/packages/gpg/rocm.gpg", output)
 
 
 class GetContainerImageTest(unittest.TestCase):

--- a/build_tools/packaging/linux/tests/get_url_repo_params_test.py
+++ b/build_tools/packaging/linux/tests/get_url_repo_params_test.py
@@ -2,9 +2,30 @@
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-# Unit test coverage for get_url_repo_params.py:
-#   get_base_url, get_gpg_key_url, gpg_key_url_needed_for_release_type, get_repo_sub_folder,
-#   get_repo_url, extract_gfx_arch, and main() subcommands.
+"""
+Unit tests for build_tools/packaging/linux/get_url_repo_params.py.
+
+API under test — helpers and CLI subcommands:
+  get_base_url, get_gpg_key_url, gpg_key_url_needed_for_release_type,
+  get_repo_sub_folder, get_repo_url (per-family layout),
+  extract_gfx_arch, get_container_image, and main() GITHUB_OUTPUT wiring.
+
+Per-family coverage (native_packaging.md GFX URLs):
+  - prerelease/prereleases → …/packages/{os_profile}
+  - release/stable → …/rocm/packages/{os_profile}
+  - dev/nightly → …/deb|rpm/{repo_sub_folder}/
+  - GPG beside packages tree (…/packages/gpg/ or …/rocm/packages/gpg/)
+
+Not covered here yet: layout=multi_arch (packages-multi-arch/…).
+
+Prerequisites:
+  - Python 3.10 or newer
+  - stdlib only; tests mock $GITHUB_OUTPUT
+
+How to run (from TheROCK repo root):
+  python3 -m unittest \\
+    build_tools.packaging.linux.tests.get_url_repo_params_test -v
+"""
 
 import os
 import sys
@@ -385,7 +406,9 @@ class MainSubcommandsTest(unittest.TestCase):
             ]
         )
         self.assertEqual(code, 0)
-        self.assertIn("repo_url=https://rocm.prereleases.amd.com/packages/ubuntu2404", output)
+        self.assertIn(
+            "repo_url=https://rocm.prereleases.amd.com/packages/ubuntu2404", output
+        )
 
     def test_get_repo_url_error_returns_one(self):
         # Test that get-repo-url returns 1 and prints error when get_repo_url raises.

--- a/build_tools/packaging/linux/tests/get_url_repo_params_test.py
+++ b/build_tools/packaging/linux/tests/get_url_repo_params_test.py
@@ -7,7 +7,8 @@ Unit tests for build_tools/packaging/linux/get_url_repo_params.py.
 
 API under test — helpers and CLI subcommands:
   get_base_url, get_gpg_key_url, gpg_key_url_needed_for_release_type,
-  get_repo_sub_folder, get_repo_url (per-family layout),
+  get_repo_sub_folder, get_repo_url, get_repo_url_per_family, get_repo_url_multi_arch,
+  normalize_layout, get_gpg_key_url_from_release_type,
   extract_gfx_arch, get_container_image, and main() GITHUB_OUTPUT wiring.
 
 Per-family coverage (native_packaging.md GFX URLs):
@@ -16,7 +17,11 @@ Per-family coverage (native_packaging.md GFX URLs):
   - dev/nightly → …/deb|rpm/{repo_sub_folder}/
   - GPG beside packages tree (…/packages/gpg/ or …/rocm/packages/gpg/)
 
-Not covered here yet: layout=multi_arch (packages-multi-arch/…).
+Multi-arch coverage (layout=multi_arch, packages-multi-arch/…):
+  - prerelease → …/packages-multi-arch/{os_profile}
+  - release/stable → …/rocm/packages-multi-arch/{os_profile}
+  - dev/nightly → …/packages-multi-arch/deb|rpm/{repo_sub_folder}
+  - GPG → …/packages-multi-arch/gpg/ or …/rocm/packages-multi-arch/gpg/
 
 Prerequisites:
   - Python 3.10 or newer
@@ -120,6 +125,82 @@ class GetGpgKeyUrlTest(unittest.TestCase):
             get_url_repo_params.get_gpg_key_url("https://repo.amd.com/"),
             "https://repo.amd.com/rocm/packages/gpg/rocm.gpg",
         )
+
+    def test_handles_multi_arch_repo_url(self):
+        self.assertEqual(
+            get_url_repo_params.get_gpg_key_url(
+                "https://rocm.nightlies.amd.com/packages-multi-arch/deb/20260204-12345/"
+            ),
+            "https://rocm.nightlies.amd.com/packages-multi-arch/gpg/rocm.gpg",
+        )
+
+    def test_handles_stable_multi_arch_repo_url(self):
+        self.assertEqual(
+            get_url_repo_params.get_gpg_key_url(
+                "https://repo.amd.com/rocm/packages-multi-arch/ubuntu2604"
+            ),
+            "https://repo.amd.com/rocm/packages-multi-arch/gpg/rocm.gpg",
+        )
+
+
+class GetGpgKeyUrlFromReleaseTypeTest(unittest.TestCase):
+    """Tests for get_gpg_key_url_from_release_type()."""
+
+    def test_per_family_prerelease_and_release(self):
+        self.assertEqual(
+            get_url_repo_params.get_gpg_key_url_from_release_type("prerelease"),
+            "https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg",
+        )
+        self.assertEqual(
+            get_url_repo_params.get_gpg_key_url_from_release_type("stable"),
+            "https://repo.amd.com/rocm/packages/gpg/rocm.gpg",
+        )
+
+    def test_multi_arch_layout_hosts(self):
+        self.assertEqual(
+            get_url_repo_params.get_gpg_key_url_from_release_type(
+                "prerelease", layout="multi_arch"
+            ),
+            "https://rocm.prereleases.amd.com/packages-multi-arch/gpg/rocm.gpg",
+        )
+        self.assertEqual(
+            get_url_repo_params.get_gpg_key_url_from_release_type(
+                "stable", layout="multiarch"
+            ),
+            "https://repo.amd.com/rocm/packages-multi-arch/gpg/rocm.gpg",
+        )
+
+    def test_unsigned_raises(self):
+        with self.assertRaises(ValueError):
+            get_url_repo_params.get_gpg_key_url_from_release_type("ci")
+
+
+class NormalizeLayoutTest(unittest.TestCase):
+    """Tests for normalize_layout()."""
+
+    def test_defaults_to_per_family(self):
+        self.assertEqual(
+            get_url_repo_params.normalize_layout(None),
+            get_url_repo_params.LAYOUT_PER_FAMILY,
+        )
+        self.assertEqual(
+            get_url_repo_params.normalize_layout(""),
+            get_url_repo_params.LAYOUT_PER_FAMILY,
+        )
+
+    def test_aliases(self):
+        self.assertEqual(
+            get_url_repo_params.normalize_layout("legacy"),
+            get_url_repo_params.LAYOUT_PER_FAMILY,
+        )
+        self.assertEqual(
+            get_url_repo_params.normalize_layout("multiarch"),
+            get_url_repo_params.LAYOUT_MULTI_ARCH,
+        )
+
+    def test_unknown_raises(self):
+        with self.assertRaises(ValueError):
+            get_url_repo_params.normalize_layout("unknown")
 
 
 class GpgKeyUrlNeededForReleaseTypeTest(unittest.TestCase):
@@ -289,6 +370,116 @@ class GetRepoUrlTest(unittest.TestCase):
             "https://rocm.prereleases.amd.com/packages/ubuntu2404",
         )
 
+    def test_explicit_per_family_layout_matches_default(self):
+        self.assertEqual(
+            get_url_repo_params.get_repo_url(
+                release_type="nightly",
+                native_package_type="deb",
+                repo_base_url="https://x.com",
+                os_profile="ubuntu2404",
+                repo_sub_folder="20260204-12345",
+                layout="per_family",
+            ),
+            get_url_repo_params.get_repo_url(
+                release_type="nightly",
+                native_package_type="deb",
+                repo_base_url="https://x.com",
+                os_profile="ubuntu2404",
+                repo_sub_folder="20260204-12345",
+            ),
+        )
+
+
+class GetRepoUrlMultiArchTest(unittest.TestCase):
+    """Tests for get_repo_url(..., layout=multi_arch)."""
+
+    def test_stable_deb_matches_production_url(self):
+        self.assertEqual(
+            get_url_repo_params.get_repo_url(
+                release_type="stable",
+                native_package_type="deb",
+                repo_base_url="https://repo.amd.com",
+                os_profile="ubuntu2604",
+                repo_sub_folder="",
+                layout="multi_arch",
+            ),
+            "https://repo.amd.com/rocm/packages-multi-arch/ubuntu2604",
+        )
+
+    def test_stable_rpm_matches_production_url(self):
+        self.assertEqual(
+            get_url_repo_params.get_repo_url(
+                release_type="release",
+                native_package_type="rpm",
+                repo_base_url="https://repo.amd.com",
+                os_profile="rhel10",
+                repo_sub_folder="",
+                layout="multi_arch",
+            ),
+            "https://repo.amd.com/rocm/packages-multi-arch/rhel10/x86_64/",
+        )
+
+    def test_prerelease_deb(self):
+        self.assertEqual(
+            get_url_repo_params.get_repo_url(
+                release_type="prerelease",
+                native_package_type="deb",
+                repo_base_url="https://rocm.prereleases.amd.com",
+                os_profile="ubuntu2404",
+                repo_sub_folder="",
+                layout="multi_arch",
+            ),
+            "https://rocm.prereleases.amd.com/packages-multi-arch/ubuntu2404",
+        )
+
+    def test_nightly_deb_with_subfolder(self):
+        self.assertEqual(
+            get_url_repo_params.get_repo_url(
+                release_type="nightly",
+                native_package_type="deb",
+                repo_base_url="https://rocm.nightlies.amd.com",
+                os_profile="ubuntu2404",
+                repo_sub_folder="20260501-25200531110",
+                layout="multi_arch",
+            ),
+            "https://rocm.nightlies.amd.com/packages-multi-arch/deb/20260501-25200531110",
+        )
+
+    def test_nightly_rpm_with_subfolder(self):
+        self.assertEqual(
+            get_url_repo_params.get_repo_url(
+                release_type="nightly",
+                native_package_type="rpm",
+                repo_base_url="https://rocm.nightlies.amd.com",
+                os_profile="rhel10",
+                repo_sub_folder="20260501-25200531110",
+                layout="multi_arch",
+            ),
+            "https://rocm.nightlies.amd.com/packages-multi-arch/rpm/20260501-25200531110/x86_64",
+        )
+
+    def test_empty_subfolder_index_urls(self):
+        self.assertEqual(
+            get_url_repo_params.get_repo_url_multi_arch(
+                release_type="nightly",
+                native_package_type="deb",
+                repo_base_url="https://repo_url.com",
+                os_profile="ubuntu2404",
+                repo_sub_folder="",
+            ),
+            "https://repo_url.com/packages-multi-arch/deb",
+        )
+        self.assertEqual(
+            get_url_repo_params.get_repo_url_multi_arch(
+                release_type="nightly",
+                native_package_type="rpm",
+                repo_base_url="https://repo_url.com/",
+                os_profile="rhel10",
+                repo_sub_folder="",
+            ),
+            "https://repo_url.com/packages-multi-arch/rpm/x86_64",
+        )
+
 
 class ExtractGfxArchTest(unittest.TestCase):
     """Tests for extract_gfx_arch()."""
@@ -408,6 +599,30 @@ class MainSubcommandsTest(unittest.TestCase):
         self.assertEqual(code, 0)
         self.assertIn(
             "repo_url=https://rocm.prereleases.amd.com/packages/ubuntu2404", output
+        )
+
+    def test_get_repo_url_multi_arch_layout_cli(self):
+        code, output = _run_main_with_output(
+            [
+                "get-repo-url",
+                "--layout",
+                "multi_arch",
+                "--release-type",
+                "stable",
+                "--native-package-type",
+                "deb",
+                "--repo-base-url",
+                "https://repo.amd.com",
+                "--os-profile",
+                "ubuntu2604",
+                "--repo-sub-folder",
+                "",
+            ]
+        )
+        self.assertEqual(code, 0)
+        self.assertIn(
+            "repo_url=https://repo.amd.com/rocm/packages-multi-arch/ubuntu2604",
+            output,
         )
 
     def test_get_repo_url_error_returns_one(self):

--- a/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
+++ b/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
@@ -878,6 +878,7 @@ class RunTestsTestTypeTest(unittest.TestCase):
             gpg_key_url=None,
             packages_dir=None,
             pkg_type=None,
+            rocm_version=None,
         )
 
     @patch.object(
@@ -1081,10 +1082,9 @@ class SetupGpgKeyTest(unittest.TestCase):
         )
         self.assertTrue(t.setup_gpg_key())
 
-    @patch("native_linux_package_install_test.os.chmod")
     @patch("native_linux_package_install_test.subprocess.run")
-    def test_returns_true_for_deb_when_mock_succeeds(self, mock_run, mock_chmod):
-        # Test that for DEB with gpg_key_url, setup_gpg_key returns True when mkdir and pipeline succeed.
+    def test_returns_true_for_deb_when_mock_succeeds(self, mock_run):
+        # Test that for DEB with gpg_key_url, setup_gpg_key returns True when mkdir, pipeline, and chmod succeed.
         mock_run.return_value = MagicMock(returncode=0)
         t = native_linux_package_install_test.NativeLinuxPackageInstallTest(
             repo_url="https://example.com",
@@ -1092,7 +1092,7 @@ class SetupGpgKeyTest(unittest.TestCase):
             gpg_key_url="https://example.com/rocm.gpg",
         )
         self.assertTrue(t.setup_gpg_key())
-        self.assertEqual(mock_run.call_count, 2)  # mkdir, then pipeline
+        self.assertEqual(mock_run.call_count, 3)  # mkdir, pipeline, chmod
 
     @patch("native_linux_package_install_test.subprocess.run")
     def test_returns_false_for_deb_when_subprocess_fails(self, mock_run):
@@ -1114,11 +1114,12 @@ class SetupDebRepositoryTest(unittest.TestCase):
     """Tests for NativeLinuxPackageInstallTest.setup_deb_repository()."""
 
     @patch("native_linux_package_install_test._run_streaming")
-    @patch("native_linux_package_install_test.Path.write_text")
+    @patch("native_linux_package_install_test.subprocess.run")
     def test_returns_true_when_apt_update_succeeds_no_gpg(
-        self, mock_write_text, mock_streaming
+        self, mock_run, mock_streaming
     ):
-        # Test that setup_deb_repository writes repo entry (trusted=yes) and returns True when apt update returns 0.
+        # Test that setup_deb_repository writes repo entry via sudo tee (trusted=yes) and returns True when apt update returns 0.
+        mock_run.return_value = MagicMock(returncode=0)
         mock_streaming.return_value = 0
         t = native_linux_package_install_test.NativeLinuxPackageInstallTest(
             repo_url="https://repo.example.com",
@@ -1127,8 +1128,9 @@ class SetupDebRepositoryTest(unittest.TestCase):
             gfx_arch="gfx94x",
         )
         self.assertTrue(t.setup_deb_repository())
-        mock_write_text.assert_called_once()
-        written = mock_write_text.call_args[0][0]
+        mock_run.assert_called_once()
+        self.assertEqual(mock_run.call_args[0][0][:2], ["sudo", "tee"])
+        written = mock_run.call_args.kwargs["input"].decode()
         self.assertIn("trusted=yes", written)
         self.assertIn("https://repo.example.com", written)
 
@@ -1138,11 +1140,12 @@ class SetupDebRepositoryTest(unittest.TestCase):
         "setup_gpg_key",
         return_value=True,
     )
-    @patch("native_linux_package_install_test.Path.write_text")
+    @patch("native_linux_package_install_test.subprocess.run")
     def test_returns_true_with_gpg_when_apt_update_succeeds(
-        self, mock_write_text, mock_gpg, mock_streaming
+        self, mock_run, mock_gpg, mock_streaming
     ):
         # Test that with gpg_key_url, setup_gpg_key is called and repo entry uses signed-by.
+        mock_run.return_value = MagicMock(returncode=0)
         mock_streaming.return_value = 0
         t = native_linux_package_install_test.NativeLinuxPackageInstallTest(
             repo_url="https://repo.example.com",
@@ -1152,7 +1155,7 @@ class SetupDebRepositoryTest(unittest.TestCase):
         )
         self.assertTrue(t.setup_deb_repository())
         mock_gpg.assert_called_once()
-        written = mock_write_text.call_args[0][0]
+        written = mock_run.call_args.kwargs["input"].decode()
         self.assertIn("signed-by", written)
 
     @patch.object(
@@ -1169,13 +1172,14 @@ class SetupDebRepositoryTest(unittest.TestCase):
         )
         self.assertFalse(t.setup_deb_repository())
 
-    @patch("native_linux_package_install_test._run_streaming")
-    @patch(
-        "native_linux_package_install_test.Path.write_text",
-        side_effect=OSError("Permission denied"),
-    )
-    def test_returns_false_when_open_raises(self, mock_write_text, mock_streaming):
-        # Test that setup_deb_repository returns False when writing sources list raises OSError.
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_returns_false_when_open_raises(self, mock_run):
+        # Test that setup_deb_repository returns False when sudo tee fails.
+        import subprocess
+
+        mock_run.side_effect = subprocess.CalledProcessError(
+            1, "tee", stderr=b"permission denied"
+        )
         t = native_linux_package_install_test.NativeLinuxPackageInstallTest(
             repo_url="https://repo.example.com",
             os_profile="ubuntu2404",
@@ -1185,9 +1189,10 @@ class SetupDebRepositoryTest(unittest.TestCase):
         self.assertFalse(t.setup_deb_repository())
 
     @patch("native_linux_package_install_test._run_streaming")
-    @patch("native_linux_package_install_test.Path.write_text")
-    def test_returns_false_when_apt_update_fails(self, mock_write_text, mock_streaming):
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_returns_false_when_apt_update_fails(self, mock_run, mock_streaming):
         # Test that setup_deb_repository returns False when apt update returns non-zero.
+        mock_run.return_value = MagicMock(returncode=0)
         mock_streaming.return_value = 1
         t = native_linux_package_install_test.NativeLinuxPackageInstallTest(
             repo_url="https://repo.example.com",
@@ -1198,13 +1203,12 @@ class SetupDebRepositoryTest(unittest.TestCase):
         self.assertFalse(t.setup_deb_repository())
 
     @patch("native_linux_package_install_test._run_streaming")
-    @patch("native_linux_package_install_test.Path.write_text")
-    def test_returns_false_when_apt_update_times_out(
-        self, mock_write_text, mock_streaming
-    ):
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_returns_false_when_apt_update_times_out(self, mock_run, mock_streaming):
         # Test that setup_deb_repository returns False when _run_streaming raises TimeoutExpired.
         import subprocess
 
+        mock_run.return_value = MagicMock(returncode=0)
         mock_streaming.side_effect = subprocess.TimeoutExpired("apt", 120)
         t = native_linux_package_install_test.NativeLinuxPackageInstallTest(
             repo_url="https://repo.example.com",
@@ -1302,7 +1306,7 @@ class InstallDebPackagesTest(unittest.TestCase):
         )
         self.assertTrue(t.install_deb_packages())
         call_args = mock_streaming.call_args[0][0]
-        self.assertEqual(call_args[0], "apt")
+        self.assertEqual(call_args[:4], ["sudo", "apt", "install", "-y"])
         self.assertIn("amdrocm", call_args)
 
     @patch("native_linux_package_install_test._run_streaming")
@@ -1319,7 +1323,7 @@ class InstallDebPackagesTest(unittest.TestCase):
         with _suppress_script_output():
             self.assertTrue(t.install_deb_packages())
         cmd = mock_streaming.call_args[0][0]
-        self.assertEqual(cmd[:3], ["apt", "install", "-y"])
+        self.assertEqual(cmd[:4], ["sudo", "apt", "install", "-y"])
         self.assertIn("amdrocm7.13-gfx94x", cmd)
         self.assertIn("amdrocm-core-sdk7.13-gfx94x", cmd)
         self.assertIn("amdrocm7.13-gfx1100", cmd)


### PR DESCRIPTION
## Motivation

This PR restores green unit coverage for the install driver and establishes get_url_repo_params.py plus its tests as the canonical, merge-time-checked spec for install repo URLs, GPG paths, and multi-arch layout—so URL/GPG regressions are caught in CI without running the full install matrix.

## Technical Details

- Align native_linux_package_install_ut_test.py with current install-test behavior 
- Correct per-family and multi-arch install repo URL and GPG path derivation in get_url_repo_params.py to match latest pkging specs. 
- Replace the expanded get_url_repo_params_test.py suite with a trimmed table-driven set covering URL/GPG paths, layout normalization, release-type policy, and CI-wired subcommands.
- replaces https://github.com/ROCm/TheRock/pull/4932

Part of 
#7028 
https://github.com/ROCm/TheRock/issues/7028


## Test Plan

[] python3 -m unittest build_tools.packaging.linux.tests.native_linux_package_install_ut_test -v — expect Ran 100 tests 
[] python3 -m unittest build_tools.packaging.linux.tests.get_url_repo_params_test -v — expect Ran 21 tests 
[] CI: test_native_linux_packages_install.yml — confirm wired subcommands still pass

## Test Result
CI: test_native_linux_packages_install.yml results: Success
https://github.com/ROCm/TheRock/actions/runs/30609387941
https://github.com/ROCm/TheRock/actions/runs/30660268891
https://github.com/ROCm/TheRock/actions/runs/30660389291
https://github.com/ROCm/TheRock/actions/runs/30660714020

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
