### PR TITLE
fix(packaging): suppress vendored TBB provides on amdrocm-profiler RPM

### DIFF
--- a/build_tools/packaging/linux/rpm_package.py
+++ b/build_tools/packaging/linux/rpm_package.py
@@ -106,6 +106,10 @@ def generate_spec_file(pkg_name, specfile, config: PackageConfig):
     # Multiple Python-version-specific binaries are included; the wrapper script
     # automatically selects the binary matching the system's Python version
     exclude_libpython_requires = pkg_name == "amdrocm-debugger"
+    # amdrocm-profiler: Exclude vendored TBB provides from auto-generated RPM metadata.
+    # rocprofiler-systems bundles TBB for Dyninst; RPM auto-provides sonames
+    # that collide with system tbb/dyninst and block dnf autoremove on EL8.
+    exclude_vendored_tbb_provides = pkg_name == "amdrocm-profiler"
 
     if config.versioned_pkg:
         # Get -> Filter -> Transform
@@ -181,6 +185,7 @@ def generate_spec_file(pkg_name, specfile, config: PackageConfig):
         "sourcedir_list": sourcedir_list,
         "rpm_scripts": rpm_scripts,
         "exclude_libpython_requires": exclude_libpython_requires,
+        "exclude_vendored_tbb_provides": exclude_vendored_tbb_provides,
     }
 
     with open(specfile, "w", encoding="utf-8") as f:

--- a/build_tools/packaging/linux/template/rpm_specfile.j2
+++ b/build_tools/packaging/linux/template/rpm_specfile.j2
@@ -16,6 +16,10 @@
 {%- if exclude_libpython_requires %}
 %define __requires_exclude libpython*.*
 {%- endif %}
+# Exclude vendored TBB provides. Used for amdrocm-profiler.
+{%- if exclude_vendored_tbb_provides %}
+%global __provides_exclude libtbb\.so\.12|libtbbmalloc\.so\.2|libtbbmalloc_proxy\.so\.2
+{%- endif %}
 %define _binary_payload w9.zstdio
 
 Name: {{ pkg_name }}

--- a/build_tools/packaging/linux/tests/build_package_test.py
+++ b/build_tools/packaging/linux/tests/build_package_test.py
@@ -49,6 +49,7 @@ PKG_CORE_SDK = "amdrocm-core-sdk"
 PKG_DEVELOPER_TOOLS = "amdrocm-developer-tools"
 PKG_RUNTIME = "amdrocm-runtime"
 PKG_DEBUGGER = "amdrocm-debugger"
+PKG_PROFILER = "amdrocm-profiler"
 PKG_CK = "amdrocm-ck"
 
 FFT_HOST_PACKAGE = "amdrocm-fft-host7.1"
@@ -56,6 +57,11 @@ FFT_DEVICE_PACKAGE = "amdrocm-fft7.1-gfx1100"
 FFT_META_PACKAGE = "amdrocm-fft7.1"
 CORE_SDK_DEVICE_PACKAGE = "amdrocm-core-sdk7.1-gfx1100"
 DEVELOPER_TOOLS_PACKAGE = "amdrocm-developer-tools7.1"
+PROFILER_PACKAGE = "amdrocm-profiler7.1"
+TBB_PROVIDES_EXCLUDE = (
+    "%global __provides_exclude libtbb\\.so\\.12|libtbbmalloc\\.so\\.2|"
+    "libtbbmalloc_proxy\\.so\\.2"
+)
 
 STAGING_PAYLOAD_NAME = "libdummy.so"
 STAGING_PAYLOAD_BYTES = b"\x00"
@@ -582,6 +588,46 @@ class CreateVersionedRpmPackageTest(BuildPackageTestCase):
         self.assertEqual(_spec_field(spec, "Name"), CORE_SDK_DEVICE_PACKAGE)
         # RPM keeps -devel naming (no debian_replace_devel_name mapping).
         self.assertIn("amdrocm-core-devel", _spec_field(spec, "Requires"))
+
+    @patch.object(rpm_package, "move_packages_to_destination", return_value=[])
+    @patch.object(rpm_package, "package_with_rpmbuild")
+    def test_profiler_spec_excludes_vendored_tbb_provides(
+        self, _mock_rpmbuild: object, _mock_move: object
+    ) -> None:
+        """Profiler spec suppresses vendored TBB auto-provides."""
+        cfg = _kpack_config(self.temp_dir, pkg_type=TEST_PKG_TYPE_RPM)
+        _stage_package_artifacts(
+            pkg_name=PKG_PROFILER,
+            artifacts_dir=cfg.artifacts_dir,
+            gfx_arch=EMPTY_GFX_ARCH,
+            enable_kpack=True,
+        )
+
+        rpm_package.create_versioned_rpm_package(pkg_name=PKG_PROFILER, config=cfg)
+
+        spec = _read_spec_file(pkg_name=PKG_PROFILER, config=cfg)
+        self.assertEqual(_spec_field(spec, "Name"), PROFILER_PACKAGE)
+        self.assertIn(TBB_PROVIDES_EXCLUDE, spec)
+
+    @patch.object(rpm_package, "move_packages_to_destination", return_value=[])
+    @patch.object(rpm_package, "package_with_rpmbuild")
+    def test_fft_spec_does_not_exclude_vendored_tbb_provides(
+        self, _mock_rpmbuild: object, _mock_move: object
+    ) -> None:
+        """Non-profiler packages must not inherit TBB provides exclusion."""
+        cfg = _kpack_config(self.temp_dir, pkg_type=TEST_PKG_TYPE_RPM)
+        _stage_package_artifacts(
+            pkg_name=PKG_FFT,
+            artifacts_dir=cfg.artifacts_dir,
+            gfx_arch=TEST_GFX_TARGET,
+            enable_kpack=True,
+        )
+        device_cfg = replace(cfg, gfx_arch=TEST_GFX_TARGET)
+
+        rpm_package.create_versioned_rpm_package(pkg_name=PKG_FFT, config=device_cfg)
+
+        spec = _read_spec_file(pkg_name=PKG_FFT, config=device_cfg)
+        self.assertNotIn("__provides_exclude", spec)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Motivation

Fixes incorrect dnf autoremove on EL8 (e.g. OL 8.10): removing `amdrocm-developer-tools` left 7 amdrocm packages installed because `amdrocm-profiler` appeared to satisfy `gcc-toolset-11-dyninst` / system `tbb` requirements for `libtbbmalloc.so.2`.

## Technical Details

- Filter auto-generated TBB **Provides** from `amdrocm-profiler` RPM specs 
- Add unit tests to ensure the profiler spec includes the exclusion 

## Test Plan

- [x] `python3.12 -m unittest build_tools/packaging/linux/tests/build_package_test.py` (23/23 OK)
- [x] Negative check: profiler UT fails without the spec change
- [ ] OL 8.10 repro: install `kernel-uek-devel` + `amdrocm-developer-tools`, remove metapackage → zero amdrocm RPMs remain
- [ ] `rpm -q --provides amdrocm-profiler` shows no `libtbb*` sonames after nightly build

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
