### PR TITLE
[Windows] Fix torch_hip.dll import: preload rocblas/rocsolver + ship aotriton_v2.dll

### DIFF
--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
@@ -284,13 +284,13 @@ LibraryEntry("rccl", "libraries", "librccl.so*", "")
 LibraryEntry("miopen", "libraries", "libMIOpen.so*", "MIOpen*.dll")
 LibraryEntry("origami", "libraries", "liborigami.so*", "origami*.dll")
 LibraryEntry("hipdnn", "libraries", "libhipdnn_backend.so*", "hipdnn_backend*.dll")
+LibraryEntry("rocblas", "libraries", "librocblas.so*", "rocblas*.dll")
+LibraryEntry("rocsolver", "libraries", "librocsolver.so*", "rocsolver*.dll")
 
 # Others we may want:
 # hiprtc-builtins
-# rocblas
 # rocfft
 # rocrand
-# rocsolver
 # rocsparse
 
 # Overall ROCM package version.

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -190,6 +190,12 @@ LINUX_LIBRARY_PRELOADS = [
 WINDOWS_LIBRARY_PRELOADS = [
     "amd_comgr",
     "amdhip64",
+    # rocblas and rocsolver are direct load-time deps of torch_hip.dll on
+    # Windows (verified via dumpbin). Preload them (after amdhip64, and rocblas
+    # before rocsolver which depends on it) so they are resolved in-namespace
+    # before torch loads torch_hip.dll. On Linux these resolve via RPATH.
+    "rocblas",
+    "rocsolver",
     "hiprtc",
     "hipblas",
     "hipfft",

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -1206,6 +1206,16 @@ def do_build_pytorch(
                 "-Cwheel.force-include.torch/lib/libomp140.x86_64.dll="
                 "torch/lib/libomp140.x86_64.dll"
             )
+            # aotriton_v2.dll is a direct load-time dependency of torch_hip.dll
+            # when Flash Attention is enabled. CMake installs it into
+            # torch/lib, but scikit-build-core drops it from the wheel (same
+            # gitignore-driven class of bug as _rocm_init.py), so torch_hip.dll
+            # fails to load with WinError 126. Force-include it when present.
+            if use_flash_attention == "1":
+                build_command.append(
+                    "-Cwheel.force-include.torch/lib/aotriton_v2.dll="
+                    "torch/lib/aotriton_v2.dll"
+                )
     if is_windows:
         # The PyPI `ninja` package is unusable on Windows: 1.11.1 loops without
         # making progress and 1.13.0 has an MSVC link.exe RSP-file regression


### PR DESCRIPTION
ISSUE ID: https://github.com/ROCm/TheRock/issues/6965

## Problem

Windows ROCm PyTorch wheels fail the `import torch` sanity check with:

```
OSError: [WinError 126] The specified module could not be found.
Error loading ".../torch/lib/torch_hip.dll" or one of its dependencies.
```

A `dumpbin` dependency-tree walk of `torch_hip.dll` shows several Windows-side gaps in how its runtime dependencies reach the process at load time. On Linux these all resolve via RPATH; Windows has no equivalent, so each dependency must either be preloaded into the process namespace or shipped in `torch/lib`:

1. `torch_hip.dll` links `rocblas.dll` and `rocsolver.dll` **directly**. The generated `torch/_rocm_init.py` preloads every *other* ROCm dependency, but `rocblas`/`rocsolver` were absent from the Windows preload list and could not be added because they had **no registered `rocm_sdk` shortname** in `_dist_info.py`.
2. When Flash Attention is enabled, `torch_hip.dll` also links `aotriton_v2.dll` **directly**. CMake installs it into `torch/lib`, but scikit-build-core drops it from the wheel (same gitignore-driven class of bug as `_rocm_init.py`), so it is missing at import time.
3. `aotriton_v2.dll` in turn links `liblzma.dll` (used to decompress its GPU kernels). On Windows PyTorch builds this from its bundled xz into `build/xz-install/bin`, and it is never copied into `torch/lib`, so once `aotriton_v2.dll` is shipped it becomes the next `NOT FOUND` leaf.

## Changes

1. `build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py`: register `rocblas` and `rocsolver` as `rocm_sdk` `LibraryEntry` shortnames.
2. `external-builds/pytorch/build_prod_wheels.py`:
   - add `rocblas` and `rocsolver` to `WINDOWS_LIBRARY_PRELOADS`, ordered after `amdhip64` and with `rocblas` before `rocsolver` (which depends on it), so `rocm_sdk.initialize_process()` preloads them (`RTLD_GLOBAL`) before torch loads `torch_hip.dll`;
   - force-include `torch/lib/aotriton_v2.dll` into the Windows wheel when Flash Attention is enabled;
   - force-include `build/xz-install/bin/liblzma.dll` into `torch/lib` when Flash Attention is enabled, next to `aotriton_v2.dll`.

On Linux, `rocblas`/`rocsolver` resolve via RPATH and `aotriton`/`liblzma` are packaged already, so `LINUX_LIBRARY_PRELOADS` and Linux packaging are unchanged.

## Companion PR — both are required for Windows `import torch`

The preload half of this PR only takes effect if `torch/_rocm_init.py` is present in the wheel and executes. That inclusion is provided by the upstream PyTorch change:

- **pytorch/pytorch#191632** — ships `torch/_rocm_init.py` in the wheel (scikit-build-core drops it otherwise). Equivalent to the CMake `install(FILES ...)` alternative in pytorch/pytorch#191625.

Neither PR is sufficient alone on Windows: #191632 gets `_rocm_init.py` into the wheel; this PR makes the initializer preload `rocblas`/`rocsolver` and ships the missing `aotriton_v2.dll` + `liblzma.dll`. Both must be present for `import torch` to succeed.

## Validation

Validated iteratively on the TheRock multi-arch Windows PyTorch wheels workflow (gfx1100, py3.12, torch nightly), with the nightly checkout path building pytorch/pytorch#191632 so `_rocm_init.py` is in the wheel. A `dumpbin` dependency-tree diagnostic of `torch_hip.dll` was run each iteration to identify the next unresolved leaf:

- [TheRock Actions run 30944161464](https://github.com/ROCm/TheRock/actions/runs/30944161464) — after `rocblas`/`rocsolver` are preloaded, the diagnostic showed `aotriton_v2.dll` as the single remaining `NOT FOUND` dependency.
- [TheRock Actions run 30952311829](https://github.com/ROCm/TheRock/actions/runs/30952311829) — with the `aotriton_v2.dll` force-include added (plus a shim simulating a post-merge `rocm_sdk` nightly carrying the `_dist_info.py` registration). This confirmed `aotriton_v2.dll` is now shipped (`-> torch/lib`), but **import still failed** and the diagnostic revealed `liblzma.dll` as the next and only remaining `NOT FOUND` leaf (`aotriton_v2.dll` links it).
- Confirming run with the `liblzma.dll` force-include: **pending** (to verify the full dependency tree resolves and `import torch` succeeds).

Note: because the `rocblas`/`rocsolver` shortname registration lives in the published `rocm_sdk` nightly (installed via `--index-url`), a fully clean end-to-end validation of this PR without the shim requires a ROCm nightly built after this `_dist_info.py` change lands (an older `rocm_sdk` would raise `Unknown rocm library 'rocblas'`).
