### PR TITLE
fix(ci): Guard libhipcxx amdsmi runtime dep on the target existing

### DIFF
--- a/math-libs/CMakeLists.txt
+++ b/math-libs/CMakeLists.txt
@@ -516,7 +516,7 @@ if(THEROCK_ENABLE_LIBHIPCXX)
   ##############################################################################
 
   set(libhipcxx_runtime_deps)
-  if(NOT WIN32)
+  if(NOT WIN32 AND TARGET amdsmi)
     # Required on Linux.
     list(APPEND libhipcxx_runtime_deps amdsmi)
   endif()

--- a/math-libs/CMakeLists.txt
+++ b/math-libs/CMakeLists.txt
@@ -516,8 +516,12 @@ if(THEROCK_ENABLE_LIBHIPCXX)
   ##############################################################################
 
   set(libhipcxx_runtime_deps)
+  # Used on Linux when amd-smi is available. amdsmi is only declared when
+  # THEROCK_ENABLE_CORE_AMDSMI is ON (see core/CMakeLists.txt), so guard on the
+  # target existing to keep narrow configs (e.g. THEROCK_ENABLE_LIBHIPCXX=ON /
+  # THEROCK_ENABLE_ALL=OFF, as in the hipThreads nightly) from referencing a
+  # non-existent target.
   if(NOT WIN32 AND TARGET amdsmi)
-    # Required on Linux.
     list(APPEND libhipcxx_runtime_deps amdsmi)
   endif()
 


### PR DESCRIPTION
## Summary

The hipThreads Linux nightly has been failing at CMake configure since Jul 29 with `get_target_property() called with non-existent target "amdsmi"`. `THEROCK_ENABLE_HIPTHREADS=ON` implicitly pulls in libhipcxx, which adds `amdsmi` to its runtime deps unconditionally on Linux, but the `amdsmi` target is only declared under `THEROCK_ENABLE_CORE_AMDSMI`. In the narrow nightly graph (`THEROCK_ENABLE_ALL=OFF`) that feature is off, so the dep dangles and configure fails before anything compiles.

Fix: guard the dep with `AND TARGET amdsmi`, matching the prim/rand recipes in the same file.

Closes #7036

## Risk Assessment

Risk 2. One-line, configure-time guard in `math-libs/CMakeLists.txt` with no device or product code touched. In any configuration where `CORE_AMDSMI` is enabled, `TARGET amdsmi` is true and the resulting dependency graph is byte-for-byte what it was before, so full builds are unaffected. The only behavior change is in narrow graphs that previously could not configure at all.

Known trade-off, stated deliberately: the guard makes the dependency silently absent when the target does not exist, rather than failing loudly. That is the same trade-off the prim-libs guard a few hundred lines up in this file already makes. If a narrow configuration ever genuinely needs libhipcxx to have amdsmi at runtime, this will produce a quietly under-linked libhipcxx instead of an error. I think that is acceptable here because libhipcxx in a hipThreads-only graph has no consumer that needs amd-smi, but it is worth a reviewer's eye.

## Related

- Work tracking: https://github.com/ROCm/TheRock/issues/7036
- Introduced by: #6389 (added the unconditional Linux dep; correct for every configuration that existed at the time)
- Exposed by: #6769 (hipThreads build recipe) and ROCm/rocm-libraries#9705 (nightly matrix entry)
- Failing runs: https://github.com/ROCm/rocm-libraries/actions/runs/30614819132 (also red Jul 29 and Jul 30)
- Related follow-up: ROCm/rocm-libraries#10218 (`hipthreads` is not registered in `repos-config.json`, so TheRock CI skips PRs touching `projects/hipthreads`)

## Device / Architecture Coverage

Architecture-independent. This is a configure-time CMake guard; no kernel, dispatch, default-selection, or support-surface change, so no device sweep is warranted.

Two different things need verifying, and PR CI only covers the first:

1. **No regression to the full graph.** Covered by this PR's own CI, which builds the full dependency graph across the Linux and Windows math-libs stages.
2. **The narrow hipThreads graph now configures.** Not covered by PR CI. The hipThreads group only runs in the rocm-libraries nightly, so confirmation comes from the next nightly on `gfx94X-dcgpu` and `gfx950-dcgpu`.

## Testing Summary

- Full-graph build via PR CI, confirming the guard does not change behavior where `amdsmi` is present.
- Local configure of the failing narrow configuration, confirming the reported error is gone.
- Nightly confirmation on the two affected hipThreads lanes, which is the only place the regression is actually observable.

## Testing Checklist

- [x] pre-commit - `pre-commit run --all-files` - Status: Passed
- [x] Unit Tests - ubuntu-24.04 and windows-2022 - Status: Passed
- [x] Linux math-libs stages - gfx110X-all, gfx1151, gfx120X-all - Status: Passed
- [ ] Linux math-libs stage - gfx94X-dcgpu - Status: Pending
- [ ] Windows math-libs stages - gfx110X-all, gfx1151, gfx120X-all - Status: Pending
- [ ] Local narrow-config repro - `cmake -B build -GNinja . -DTHEROCK_AMDGPU_FAMILIES=gfx950-dcgpu -DTHEROCK_ENABLE_HIPTHREADS=ON -DTHEROCK_ENABLE_ALL=OFF` - Status: Pending
- [ ] rocm-libraries nightly, hipThreads Linux lanes - Devices: gfx94X-dcgpu, gfx950-dcgpu - Status: Pending

## Flags / Guardrails

None. No new option or default is introduced.

## Adjacent Tests Considered

The same guard pattern already exists in this file for the prim libs (`if(WIN32 OR NOT TARGET amdsmi)`), which was added for the equivalent `THEROCK_ENABLE_ALL=OFF / THEROCK_ENABLE_PRIM=ON` group. Those recipes are unaffected by this change.

After this change nothing in `math-libs/CMakeLists.txt` declares `amdsmi` without a guard, but other files still do. `math-libs/BLAS/CMakeLists.txt` (hipBLASLt and hipSPARSELt) and `profiler/CMakeLists.txt` carry the same unguarded pattern, and are safe today only because their artifacts declare `core-amdsmi` in `BUILD_TOPOLOGY.toml`. That is out of scope here and tracked separately in #7037.

## Risk Acceptance / Waivers

`W-BUILD` — build-configuration-only change with no product behavior. No new automated test is added because the regression is a configure-time failure that the existing hipThreads nightly lane already detects; a new test would duplicate a lane we already run. The reproduction evidence is the three consecutive red nightlies before the change and the narrow-config configure after it.

## Technical Changes

- `math-libs/CMakeLists.txt`: change the libhipcxx runtime-dep guard from `if(NOT WIN32)` to `if(NOT WIN32 AND TARGET amdsmi)` so the dep is only declared when `CORE_AMDSMI` actually provided the target.
