### PR TITLE
feat : Verify installed files use RPATH (not RUNPATH) in native package install test

### DIFF
--- a/.github/workflows/test_native_linux_packages_install.yml
+++ b/.github/workflows/test_native_linux_packages_install.yml
@@ -177,7 +177,8 @@ jobs:
               curl \
               ca-certificates \
               gpg \
-              lsb-release
+              lsb-release \
+              binutils
             if [ "$TEST_TYPE" = "full" ] || [ "$TEST_TYPE" = "comprehensive" ]; then
               echo "Extra OS packages for --test-type full/comprehensive (e.g. rdhc): pciutils, kmod, apt-utils"
               sudo apt install -y pciutils kmod apt-utils
@@ -191,7 +192,8 @@ jobs:
               ca-certificates \
               gpg2 \
               lsb-release \
-              update-alternatives
+              update-alternatives \
+              binutils
             if [ "$TEST_TYPE" = "full" ] || [ "$TEST_TYPE" = "comprehensive" ]; then
               echo "Extra OS packages for --test-type full/comprehensive on SLES (e.g. rdhc): pciutils, kmod"
               zypper install -y pciutils kmod
@@ -203,7 +205,8 @@ jobs:
               curl \
               ca-certificates \
               gnupg2 \
-              dnf-plugins-core
+              dnf-plugins-core \
+              binutils
             if [ "$TEST_TYPE" = "full" ] || [ "$TEST_TYPE" = "comprehensive" ]; then
               echo "Extra OS packages for --test-type full/comprehensive (e.g. rdhc): pciutils, kmod"
               dnf install -y --allowerasing pciutils kmod

--- a/.github/workflows/test_native_linux_packages_install.yml
+++ b/.github/workflows/test_native_linux_packages_install.yml
@@ -156,7 +156,8 @@ jobs:
               curl \
               ca-certificates \
               gpg \
-              lsb-release
+              lsb-release \
+              binutils
             if [ "$TEST_TYPE" = "full" ] || [ "$TEST_TYPE" = "comprehensive" ]; then
               echo "Extra OS packages for --test-type full/comprehensive (e.g. rdhc): pciutils, kmod, apt-utils"
               sudo apt install -y pciutils kmod apt-utils
@@ -170,7 +171,8 @@ jobs:
               ca-certificates \
               gpg2 \
               lsb-release \
-              update-alternatives
+              update-alternatives \
+              binutils
             if [ "$TEST_TYPE" = "full" ] || [ "$TEST_TYPE" = "comprehensive" ]; then
               echo "Extra OS packages for --test-type full/comprehensive on SLES (e.g. rdhc): pciutils, kmod"
               zypper install -y pciutils kmod
@@ -182,7 +184,8 @@ jobs:
               curl \
               ca-certificates \
               gnupg2 \
-              dnf-plugins-core
+              dnf-plugins-core \
+              binutils
             if [ "$TEST_TYPE" = "full" ] || [ "$TEST_TYPE" = "comprehensive" ]; then
               echo "Extra OS packages for --test-type full/comprehensive (e.g. rdhc): pciutils, kmod"
               dnf install -y --allowerasing pciutils kmod

--- a/build_tools/packaging/linux/native_linux_package_install_test.py
+++ b/build_tools/packaging/linux/native_linux_package_install_test.py
@@ -1307,15 +1307,19 @@ gpgcheck=0
             return False
 
     def verify_no_runpath(self) -> bool:
-        """Verify no installed ELF file uses DT_RUNPATH (expect DT_RPATH only).
+        """Verify installed ELF files use DT_RPATH (not DT_RUNPATH).
 
-        During packaging, RUNPATH is converted to RPATH (see runpath_to_rpath.py),
-        so any ELF file that still carries a DT_RUNPATH tag indicates the
-        conversion was missed. Files with no rpath/runpath tag at all are fine.
+        During packaging, RUNPATH is converted to RPATH (see runpath_to_rpath.py).
+        Each installed ELF's dynamic section is read with ``readelf -d`` and
+        classified by looking for DT_RPATH first, falling back to DT_RUNPATH:
 
-        Reads each ELF's dynamic section with ``readelf -d``. If ``readelf`` is
-        unavailable the check is skipped (non-fatal), matching the tolerant
-        behaviour used elsewhere in basic verification.
+        * has DT_RPATH -> converted correctly (expected)
+        * no DT_RPATH but has DT_RUNPATH -> conversion was missed (failure)
+        * neither tag -> nothing to convert; counted and reported for
+          visibility only, not treated as a failure
+
+        If ``readelf`` is unavailable the check is skipped (non-fatal), matching
+        the tolerant behaviour used elsewhere in basic verification.
 
         Returns:
         True if no installed ELF uses DT_RUNPATH (or the check could not run),
@@ -1323,7 +1327,9 @@ gpgcheck=0
         """
         print("\nVerifying installed ELF files use RPATH (not RUNPATH)...")
         install_path = Path(self.install_prefix)
-        offending: list[str] = []
+        runpath_only: list[str] = []
+        no_path: list[str] = []
+        rpath_count = 0
         for root, _dirs, files in os.walk(install_path):
             for name in files:
                 filepath = Path(root) / name
@@ -1353,14 +1359,33 @@ gpgcheck=0
                         f" [WARN] readelf failed for {filepath}: {result.stderr.strip()}"
                     )
                     continue
-                if "(RUNPATH)" in result.stdout:
-                    offending.append(str(filepath))
-        if offending:
-            print(f" [FAIL] {len(offending)} ELF file(s) still using DT_RUNPATH:")
-            for entry in offending[:10]:
+                # Confirm DT_RPATH is present; only fall back to DT_RUNPATH if
+                # it is not. Note "(RPATH)" is not a substring of "(RUNPATH)".
+                if "(RPATH)" in result.stdout:
+                    rpath_count += 1
+                elif "(RUNPATH)" in result.stdout:
+                    runpath_only.append(str(filepath))
+                else:
+                    no_path.append(str(filepath))
+        print(
+            f" Scanned ELF files: {rpath_count} with DT_RPATH, "
+            f"{len(runpath_only)} with DT_RUNPATH only, "
+            f"{len(no_path)} with neither"
+        )
+        if no_path:
+            print(
+                f" [INFO] {len(no_path)} ELF file(s) have neither DT_RPATH nor DT_RUNPATH:"
+            )
+            for entry in no_path[:10]:
                 print(f"   {entry}")
-            if len(offending) > 10:
-                print(f"   ... and {len(offending) - 10} more")
+            if len(no_path) > 10:
+                print(f"   ... and {len(no_path) - 10} more")
+        if runpath_only:
+            print(f" [FAIL] {len(runpath_only)} ELF file(s) still using DT_RUNPATH:")
+            for entry in runpath_only[:10]:
+                print(f"   {entry}")
+            if len(runpath_only) > 10:
+                print(f"   ... and {len(runpath_only) - 10} more")
             return False
         print(" [PASS] No installed ELF files use DT_RUNPATH")
         return True

--- a/build_tools/packaging/linux/native_linux_package_install_test.py
+++ b/build_tools/packaging/linux/native_linux_package_install_test.py
@@ -192,8 +192,6 @@ ROCMINFO_TIMEOUT_SEC = 30
 # separately via ``--skip-optional-cluster-checks`` in ``test_rdhc``.
 RDHC_TIMEOUT_SEC = 600  # 10 minutes
 VERIFY_MIN_COMPONENTS = 2
-# Per-file readelf timeout for the RPATH/RUNPATH verification scan.
-RUNPATH_READELF_TIMEOUT_SEC = 30
 _TEST_TYPE_MAP = {
     "": "sanity",
     "quick": "sanity",
@@ -1339,21 +1337,23 @@ gpgcheck=0
                 except OSError:
                     continue
                 try:
-                    out = subprocess.run(
+                    result = subprocess.run(
                         ["readelf", "-d", str(filepath)],
                         stdout=subprocess.PIPE,
-                        stderr=subprocess.DEVNULL,
+                        stderr=subprocess.PIPE,
                         text=True,
-                        timeout=RUNPATH_READELF_TIMEOUT_SEC,
-                    ).stdout
-                except subprocess.TimeoutExpired:
-                    continue
+                    )
                 except OSError as e:
                     print(
                         f" [WARN] 'readelf' unavailable ({e}); skipping RUNPATH check"
                     )
                     return True
-                if "(RUNPATH)" in out:
+                if result.returncode != 0:
+                    print(
+                        f" [WARN] readelf failed for {filepath}: {result.stderr.strip()}"
+                    )
+                    continue
+                if "(RUNPATH)" in result.stdout:
                     offending.append(str(filepath))
         if offending:
             print(f" [FAIL] {len(offending)} ELF file(s) still using DT_RUNPATH:")

--- a/build_tools/packaging/linux/native_linux_package_install_test.py
+++ b/build_tools/packaging/linux/native_linux_package_install_test.py
@@ -1063,6 +1063,12 @@ gpgcheck=0
         * neither tag -> nothing to convert; counted and reported for
           visibility only, not treated as a failure
 
+        For files that do have DT_RPATH, the rpath value is additionally
+        inspected for entries that are not ``$ORIGIN``-relative (i.e. fixed or
+        absolute paths). A relocatable package should only use
+        ``$ORIGIN``-relative rpaths, so fixed paths are reported for visibility
+        but are not treated as a failure here.
+
         If ``readelf`` is unavailable the check is skipped (non-fatal), matching
         the tolerant behaviour used elsewhere in basic verification.
 
@@ -1074,6 +1080,7 @@ gpgcheck=0
         install_path = Path(self.install_prefix)
         runpath_only: list[str] = []
         no_path: list[str] = []
+        fixed_rpath: list[tuple[str, list[str]]] = []
         rpath_count = 0
         for root, _dirs, files in os.walk(install_path):
             for name in files:
@@ -1108,6 +1115,9 @@ gpgcheck=0
                 # it is not. Note "(RPATH)" is not a substring of "(RUNPATH)".
                 if "(RPATH)" in result.stdout:
                     rpath_count += 1
+                    fixed = self._fixed_rpath_entries(result.stdout)
+                    if fixed:
+                        fixed_rpath.append((str(filepath), fixed))
                 elif "(RUNPATH)" in result.stdout:
                     runpath_only.append(str(filepath))
                 else:
@@ -1125,6 +1135,15 @@ gpgcheck=0
                 print(f"   {entry}")
             if len(no_path) > 10:
                 print(f"   ... and {len(no_path) - 10} more")
+        if fixed_rpath:
+            print(
+                f" [WARN] {len(fixed_rpath)} ELF file(s) have DT_RPATH entries that are "
+                "not $ORIGIN-relative (fixed/absolute paths):"
+            )
+            for path, entries in fixed_rpath[:10]:
+                print(f"   {path}: {':'.join(entries)}")
+            if len(fixed_rpath) > 10:
+                print(f"   ... and {len(fixed_rpath) - 10} more")
         if runpath_only:
             print(f" [FAIL] {len(runpath_only)} ELF file(s) still using DT_RUNPATH:")
             for entry in runpath_only[:10]:
@@ -1134,6 +1153,21 @@ gpgcheck=0
             return False
         print(" [PASS] No installed ELF files use DT_RUNPATH")
         return True
+
+    @staticmethod
+    def _fixed_rpath_entries(readelf_output: str) -> list[str]:
+        """Return DT_RPATH entries that are not ``$ORIGIN``-relative.
+
+        Parses the ``Library rpath: [...]`` value from ``readelf -d`` output and
+        returns each colon-separated entry that does not reference ``$ORIGIN``
+        (i.e. fixed or absolute paths). Returns an empty list if there is no
+        rpath value or all entries are ``$ORIGIN``-relative.
+        """
+        match = re.search(r"\(RPATH\)\s+Library rpath: \[([^\]]*)\]", readelf_output)
+        if not match:
+            return []
+        entries = [entry for entry in match.group(1).split(":") if entry]
+        return [entry for entry in entries if "$ORIGIN" not in entry]
 
 
 _CLI_EXAMPLES_EPILOG = """

--- a/build_tools/packaging/linux/native_linux_package_install_test.py
+++ b/build_tools/packaging/linux/native_linux_package_install_test.py
@@ -1052,15 +1052,19 @@ gpgcheck=0
             return False
 
     def verify_no_runpath(self) -> bool:
-        """Verify no installed ELF file uses DT_RUNPATH (expect DT_RPATH only).
+        """Verify installed ELF files use DT_RPATH (not DT_RUNPATH).
 
-        During packaging, RUNPATH is converted to RPATH (see runpath_to_rpath.py),
-        so any ELF file that still carries a DT_RUNPATH tag indicates the
-        conversion was missed. Files with no rpath/runpath tag at all are fine.
+        During packaging, RUNPATH is converted to RPATH (see runpath_to_rpath.py).
+        Each installed ELF's dynamic section is read with ``readelf -d`` and
+        classified by looking for DT_RPATH first, falling back to DT_RUNPATH:
 
-        Reads each ELF's dynamic section with ``readelf -d``. If ``readelf`` is
-        unavailable the check is skipped (non-fatal), matching the tolerant
-        behaviour used elsewhere in basic verification.
+        * has DT_RPATH -> converted correctly (expected)
+        * no DT_RPATH but has DT_RUNPATH -> conversion was missed (failure)
+        * neither tag -> nothing to convert; counted and reported for
+          visibility only, not treated as a failure
+
+        If ``readelf`` is unavailable the check is skipped (non-fatal), matching
+        the tolerant behaviour used elsewhere in basic verification.
 
         Returns:
         True if no installed ELF uses DT_RUNPATH (or the check could not run),
@@ -1068,7 +1072,9 @@ gpgcheck=0
         """
         print("\nVerifying installed ELF files use RPATH (not RUNPATH)...")
         install_path = Path(self.install_prefix)
-        offending: list[str] = []
+        runpath_only: list[str] = []
+        no_path: list[str] = []
+        rpath_count = 0
         for root, _dirs, files in os.walk(install_path):
             for name in files:
                 filepath = Path(root) / name
@@ -1098,14 +1104,33 @@ gpgcheck=0
                         f" [WARN] readelf failed for {filepath}: {result.stderr.strip()}"
                     )
                     continue
-                if "(RUNPATH)" in result.stdout:
-                    offending.append(str(filepath))
-        if offending:
-            print(f" [FAIL] {len(offending)} ELF file(s) still using DT_RUNPATH:")
-            for entry in offending[:10]:
+                # Confirm DT_RPATH is present; only fall back to DT_RUNPATH if
+                # it is not. Note "(RPATH)" is not a substring of "(RUNPATH)".
+                if "(RPATH)" in result.stdout:
+                    rpath_count += 1
+                elif "(RUNPATH)" in result.stdout:
+                    runpath_only.append(str(filepath))
+                else:
+                    no_path.append(str(filepath))
+        print(
+            f" Scanned ELF files: {rpath_count} with DT_RPATH, "
+            f"{len(runpath_only)} with DT_RUNPATH only, "
+            f"{len(no_path)} with neither"
+        )
+        if no_path:
+            print(
+                f" [INFO] {len(no_path)} ELF file(s) have neither DT_RPATH nor DT_RUNPATH:"
+            )
+            for entry in no_path[:10]:
                 print(f"   {entry}")
-            if len(offending) > 10:
-                print(f"   ... and {len(offending) - 10} more")
+            if len(no_path) > 10:
+                print(f"   ... and {len(no_path) - 10} more")
+        if runpath_only:
+            print(f" [FAIL] {len(runpath_only)} ELF file(s) still using DT_RUNPATH:")
+            for entry in runpath_only[:10]:
+                print(f"   {entry}")
+            if len(runpath_only) > 10:
+                print(f"   ... and {len(runpath_only) - 10} more")
             return False
         print(" [PASS] No installed ELF files use DT_RUNPATH")
         return True

--- a/build_tools/packaging/linux/native_linux_package_install_test.py
+++ b/build_tools/packaging/linux/native_linux_package_install_test.py
@@ -1318,6 +1318,12 @@ gpgcheck=0
         * neither tag -> nothing to convert; counted and reported for
           visibility only, not treated as a failure
 
+        For files that do have DT_RPATH, the rpath value is additionally
+        inspected for entries that are not ``$ORIGIN``-relative (i.e. fixed or
+        absolute paths). A relocatable package should only use
+        ``$ORIGIN``-relative rpaths, so fixed paths are reported for visibility
+        but are not treated as a failure here.
+
         If ``readelf`` is unavailable the check is skipped (non-fatal), matching
         the tolerant behaviour used elsewhere in basic verification.
 
@@ -1329,6 +1335,7 @@ gpgcheck=0
         install_path = Path(self.install_prefix)
         runpath_only: list[str] = []
         no_path: list[str] = []
+        fixed_rpath: list[tuple[str, list[str]]] = []
         rpath_count = 0
         for root, _dirs, files in os.walk(install_path):
             for name in files:
@@ -1363,6 +1370,9 @@ gpgcheck=0
                 # it is not. Note "(RPATH)" is not a substring of "(RUNPATH)".
                 if "(RPATH)" in result.stdout:
                     rpath_count += 1
+                    fixed = self._fixed_rpath_entries(result.stdout)
+                    if fixed:
+                        fixed_rpath.append((str(filepath), fixed))
                 elif "(RUNPATH)" in result.stdout:
                     runpath_only.append(str(filepath))
                 else:
@@ -1380,6 +1390,15 @@ gpgcheck=0
                 print(f"   {entry}")
             if len(no_path) > 10:
                 print(f"   ... and {len(no_path) - 10} more")
+        if fixed_rpath:
+            print(
+                f" [WARN] {len(fixed_rpath)} ELF file(s) have DT_RPATH entries that are "
+                "not $ORIGIN-relative (fixed/absolute paths):"
+            )
+            for path, entries in fixed_rpath[:10]:
+                print(f"   {path}: {':'.join(entries)}")
+            if len(fixed_rpath) > 10:
+                print(f"   ... and {len(fixed_rpath) - 10} more")
         if runpath_only:
             print(f" [FAIL] {len(runpath_only)} ELF file(s) still using DT_RUNPATH:")
             for entry in runpath_only[:10]:
@@ -1389,6 +1408,21 @@ gpgcheck=0
             return False
         print(" [PASS] No installed ELF files use DT_RUNPATH")
         return True
+
+    @staticmethod
+    def _fixed_rpath_entries(readelf_output: str) -> list[str]:
+        """Return DT_RPATH entries that are not ``$ORIGIN``-relative.
+
+        Parses the ``Library rpath: [...]`` value from ``readelf -d`` output and
+        returns each colon-separated entry that does not reference ``$ORIGIN``
+        (i.e. fixed or absolute paths). Returns an empty list if there is no
+        rpath value or all entries are ``$ORIGIN``-relative.
+        """
+        match = re.search(r"\(RPATH\)\s+Library rpath: \[([^\]]*)\]", readelf_output)
+        if not match:
+            return []
+        entries = [entry for entry in match.group(1).split(":") if entry]
+        return [entry for entry in entries if "$ORIGIN" not in entry]
 
 
 _CLI_EXAMPLES_EPILOG = """

--- a/build_tools/packaging/linux/native_linux_package_install_test.py
+++ b/build_tools/packaging/linux/native_linux_package_install_test.py
@@ -1383,22 +1383,18 @@ gpgcheck=0
             f"{len(no_path)} with neither"
         )
         if no_path:
+            # Count only; the individual files are not interesting to list.
             print(
-                f" [INFO] {len(no_path)} ELF file(s) have neither DT_RPATH nor DT_RUNPATH:"
+                f" [INFO] {len(no_path)} ELF file(s) have neither DT_RPATH nor DT_RUNPATH"
             )
-            for entry in no_path[:10]:
-                print(f"   {entry}")
-            if len(no_path) > 10:
-                print(f"   ... and {len(no_path) - 10} more")
         if fixed_rpath:
+            # List every offending file and its non-$ORIGIN entries in full.
             print(
                 f" [WARN] {len(fixed_rpath)} ELF file(s) have DT_RPATH entries that are "
                 "not $ORIGIN-relative (fixed/absolute paths):"
             )
-            for path, entries in fixed_rpath[:10]:
+            for path, entries in fixed_rpath:
                 print(f"   {path}: {':'.join(entries)}")
-            if len(fixed_rpath) > 10:
-                print(f"   ... and {len(fixed_rpath) - 10} more")
         if runpath_only:
             print(f" [FAIL] {len(runpath_only)} ELF file(s) still using DT_RUNPATH:")
             for entry in runpath_only[:10]:

--- a/build_tools/packaging/linux/native_linux_package_install_test.py
+++ b/build_tools/packaging/linux/native_linux_package_install_test.py
@@ -192,6 +192,8 @@ ROCMINFO_TIMEOUT_SEC = 30
 # separately via ``--skip-optional-cluster-checks`` in ``test_rdhc``.
 RDHC_TIMEOUT_SEC = 600  # 10 minutes
 VERIFY_MIN_COMPONENTS = 2
+# Per-file readelf timeout for the RPATH/RUNPATH verification scan.
+RUNPATH_READELF_TIMEOUT_SEC = 30
 _TEST_TYPE_MAP = {
     "": "sanity",
     "quick": "sanity",
@@ -966,6 +968,11 @@ gpgcheck=0
         except subprocess.CalledProcessError:
             print(" [WARN] Could not query installed packages")
 
+        # Verify installed ELF files use RPATH and not RUNPATH.
+        if not self.verify_no_runpath():
+            print("\n[FAIL] Basic verification FAILED (ELF files still using RUNPATH)")
+            return False
+
         # Try to run rocminfo if available
         rocminfo_path = install_path / "bin" / "rocminfo"
         if rocminfo_path.exists():
@@ -1300,6 +1307,63 @@ gpgcheck=0
         except OSError as e:
             print(f" [WARN] Could not run rdhc.py: {e}")
             return False
+
+    def verify_no_runpath(self) -> bool:
+        """Verify no installed ELF file uses DT_RUNPATH (expect DT_RPATH only).
+
+        During packaging, RUNPATH is converted to RPATH (see runpath_to_rpath.py),
+        so any ELF file that still carries a DT_RUNPATH tag indicates the
+        conversion was missed. Files with no rpath/runpath tag at all are fine.
+
+        Reads each ELF's dynamic section with ``readelf -d``. If ``readelf`` is
+        unavailable the check is skipped (non-fatal), matching the tolerant
+        behaviour used elsewhere in basic verification.
+
+        Returns:
+        True if no installed ELF uses DT_RUNPATH (or the check could not run),
+        False if any offending file is found.
+        """
+        print("\nVerifying installed ELF files use RPATH (not RUNPATH)...")
+        install_path = Path(self.install_prefix)
+        offending: list[str] = []
+        for root, _dirs, files in os.walk(install_path):
+            for name in files:
+                filepath = Path(root) / name
+                if filepath.is_symlink():
+                    continue
+                try:
+                    # Cheap ELF magic check before invoking readelf.
+                    with open(filepath, "rb") as f:
+                        if f.read(4) != b"\x7fELF":
+                            continue
+                except OSError:
+                    continue
+                try:
+                    out = subprocess.run(
+                        ["readelf", "-d", str(filepath)],
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.DEVNULL,
+                        text=True,
+                        timeout=RUNPATH_READELF_TIMEOUT_SEC,
+                    ).stdout
+                except subprocess.TimeoutExpired:
+                    continue
+                except OSError as e:
+                    print(
+                        f" [WARN] 'readelf' unavailable ({e}); skipping RUNPATH check"
+                    )
+                    return True
+                if "(RUNPATH)" in out:
+                    offending.append(str(filepath))
+        if offending:
+            print(f" [FAIL] {len(offending)} ELF file(s) still using DT_RUNPATH:")
+            for entry in offending[:10]:
+                print(f"   {entry}")
+            if len(offending) > 10:
+                print(f"   ... and {len(offending) - 10} more")
+            return False
+        print(" [PASS] No installed ELF files use DT_RUNPATH")
+        return True
 
 
 _CLI_EXAMPLES_EPILOG = """

--- a/build_tools/packaging/linux/native_linux_package_install_test.py
+++ b/build_tools/packaging/linux/native_linux_package_install_test.py
@@ -1128,22 +1128,18 @@ gpgcheck=0
             f"{len(no_path)} with neither"
         )
         if no_path:
+            # Count only; the individual files are not interesting to list.
             print(
-                f" [INFO] {len(no_path)} ELF file(s) have neither DT_RPATH nor DT_RUNPATH:"
+                f" [INFO] {len(no_path)} ELF file(s) have neither DT_RPATH nor DT_RUNPATH"
             )
-            for entry in no_path[:10]:
-                print(f"   {entry}")
-            if len(no_path) > 10:
-                print(f"   ... and {len(no_path) - 10} more")
         if fixed_rpath:
+            # List every offending file and its non-$ORIGIN entries in full.
             print(
                 f" [WARN] {len(fixed_rpath)} ELF file(s) have DT_RPATH entries that are "
                 "not $ORIGIN-relative (fixed/absolute paths):"
             )
-            for path, entries in fixed_rpath[:10]:
+            for path, entries in fixed_rpath:
                 print(f"   {path}: {':'.join(entries)}")
-            if len(fixed_rpath) > 10:
-                print(f"   ... and {len(fixed_rpath) - 10} more")
         if runpath_only:
             print(f" [FAIL] {len(runpath_only)} ELF file(s) still using DT_RUNPATH:")
             for entry in runpath_only[:10]:

--- a/build_tools/packaging/linux/native_linux_package_install_test.py
+++ b/build_tools/packaging/linux/native_linux_package_install_test.py
@@ -191,6 +191,8 @@ ROCMINFO_TIMEOUT_SEC = 30
 # separately via ``--skip-optional-cluster-checks`` in ``test_rdhc``.
 RDHC_TIMEOUT_SEC = 600  # 10 minutes
 VERIFY_MIN_COMPONENTS = 2
+# Per-file readelf timeout for the RPATH/RUNPATH verification scan.
+RUNPATH_READELF_TIMEOUT_SEC = 30
 _TEST_TYPE_MAP = {
     "": "sanity",
     "quick": "sanity",
@@ -941,6 +943,11 @@ gpgcheck=0
         except subprocess.CalledProcessError:
             print(" [WARN] Could not query installed packages")
 
+        # Verify installed ELF files use RPATH and not RUNPATH.
+        if not self.verify_no_runpath():
+            print("\n[FAIL] Basic verification FAILED (ELF files still using RUNPATH)")
+            return False
+
         # Try to run rocminfo if available
         rocminfo_path = install_path / "bin" / "rocminfo"
         if rocminfo_path.exists():
@@ -1045,6 +1052,63 @@ gpgcheck=0
         except OSError as e:
             print(f" [WARN] Could not run rdhc.py: {e}")
             return False
+
+    def verify_no_runpath(self) -> bool:
+        """Verify no installed ELF file uses DT_RUNPATH (expect DT_RPATH only).
+
+        During packaging, RUNPATH is converted to RPATH (see runpath_to_rpath.py),
+        so any ELF file that still carries a DT_RUNPATH tag indicates the
+        conversion was missed. Files with no rpath/runpath tag at all are fine.
+
+        Reads each ELF's dynamic section with ``readelf -d``. If ``readelf`` is
+        unavailable the check is skipped (non-fatal), matching the tolerant
+        behaviour used elsewhere in basic verification.
+
+        Returns:
+        True if no installed ELF uses DT_RUNPATH (or the check could not run),
+        False if any offending file is found.
+        """
+        print("\nVerifying installed ELF files use RPATH (not RUNPATH)...")
+        install_path = Path(self.install_prefix)
+        offending: list[str] = []
+        for root, _dirs, files in os.walk(install_path):
+            for name in files:
+                filepath = Path(root) / name
+                if filepath.is_symlink():
+                    continue
+                try:
+                    # Cheap ELF magic check before invoking readelf.
+                    with open(filepath, "rb") as f:
+                        if f.read(4) != b"\x7fELF":
+                            continue
+                except OSError:
+                    continue
+                try:
+                    out = subprocess.run(
+                        ["readelf", "-d", str(filepath)],
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.DEVNULL,
+                        text=True,
+                        timeout=RUNPATH_READELF_TIMEOUT_SEC,
+                    ).stdout
+                except subprocess.TimeoutExpired:
+                    continue
+                except OSError as e:
+                    print(
+                        f" [WARN] 'readelf' unavailable ({e}); skipping RUNPATH check"
+                    )
+                    return True
+                if "(RUNPATH)" in out:
+                    offending.append(str(filepath))
+        if offending:
+            print(f" [FAIL] {len(offending)} ELF file(s) still using DT_RUNPATH:")
+            for entry in offending[:10]:
+                print(f"   {entry}")
+            if len(offending) > 10:
+                print(f"   ... and {len(offending) - 10} more")
+            return False
+        print(" [PASS] No installed ELF files use DT_RUNPATH")
+        return True
 
 
 _CLI_EXAMPLES_EPILOG = """

--- a/build_tools/packaging/linux/native_linux_package_install_test.py
+++ b/build_tools/packaging/linux/native_linux_package_install_test.py
@@ -191,8 +191,6 @@ ROCMINFO_TIMEOUT_SEC = 30
 # separately via ``--skip-optional-cluster-checks`` in ``test_rdhc``.
 RDHC_TIMEOUT_SEC = 600  # 10 minutes
 VERIFY_MIN_COMPONENTS = 2
-# Per-file readelf timeout for the RPATH/RUNPATH verification scan.
-RUNPATH_READELF_TIMEOUT_SEC = 30
 _TEST_TYPE_MAP = {
     "": "sanity",
     "quick": "sanity",
@@ -1084,21 +1082,23 @@ gpgcheck=0
                 except OSError:
                     continue
                 try:
-                    out = subprocess.run(
+                    result = subprocess.run(
                         ["readelf", "-d", str(filepath)],
                         stdout=subprocess.PIPE,
-                        stderr=subprocess.DEVNULL,
+                        stderr=subprocess.PIPE,
                         text=True,
-                        timeout=RUNPATH_READELF_TIMEOUT_SEC,
-                    ).stdout
-                except subprocess.TimeoutExpired:
-                    continue
+                    )
                 except OSError as e:
                     print(
                         f" [WARN] 'readelf' unavailable ({e}); skipping RUNPATH check"
                     )
                     return True
-                if "(RUNPATH)" in out:
+                if result.returncode != 0:
+                    print(
+                        f" [WARN] readelf failed for {filepath}: {result.stderr.strip()}"
+                    )
+                    continue
+                if "(RUNPATH)" in result.stdout:
                     offending.append(str(filepath))
         if offending:
             print(f" [FAIL] {len(offending)} ELF file(s) still using DT_RUNPATH:")

--- a/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
+++ b/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
@@ -1556,5 +1556,118 @@ class RunStreamingTest(unittest.TestCase):
         mock_proc.kill.assert_called_once()
 
 
+class VerifyNoRunpathTest(unittest.TestCase):
+    """Tests for NativeLinuxPackageInstallTest.verify_no_runpath()."""
+
+    def _make(self, install_prefix="/opt/rocm/core"):
+        return native_linux_package_install_test.NativeLinuxPackageInstallTest(
+            repo_url="https://example.com",
+            os_profile="ubuntu2404",
+            install_prefix=install_prefix,
+        )
+
+    def _elf_tree(self, d):
+        # Create two files with ELF magic and one non-ELF file under d.
+        (Path(d) / "bin").mkdir()
+        (Path(d) / "lib").mkdir()
+        (Path(d) / "bin" / "hipcc").write_bytes(b"\x7fELF" + b"\x00" * 32)
+        (Path(d) / "lib" / "libamdhip64.so").write_bytes(b"\x7fELF" + b"\x00" * 32)
+        (Path(d) / "readme.txt").write_text("not an elf file")
+
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_passes_when_no_elf_uses_runpath(self, mock_run):
+        # readelf output showing (RPATH) for every ELF -> pass.
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=" 0x000000000000000f (RPATH) Library rpath: [$ORIGIN/../lib]\n",
+        )
+        with tempfile.TemporaryDirectory() as d:
+            self._elf_tree(d)
+            with _suppress_script_output():
+                self.assertTrue(self._make(d).verify_no_runpath())
+        # readelf invoked for the two ELF files only, not the .txt file.
+        self.assertEqual(mock_run.call_count, 2)
+
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_fails_when_an_elf_uses_runpath(self, mock_run):
+        # Any (RUNPATH) line marks the file as offending -> fail.
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=" 0x000000000000001d (RUNPATH) Library runpath: [$ORIGIN/../lib]\n",
+        )
+        with tempfile.TemporaryDirectory() as d:
+            self._elf_tree(d)
+            with _suppress_script_output():
+                self.assertFalse(self._make(d).verify_no_runpath())
+
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_passes_when_elf_has_no_dynamic_path(self, mock_run):
+        # ELF with neither RPATH nor RUNPATH is acceptable.
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=" 0x0000000000000001 (NEEDED) Shared library: [libc.so.6]\n",
+        )
+        with tempfile.TemporaryDirectory() as d:
+            self._elf_tree(d)
+            with _suppress_script_output():
+                self.assertTrue(self._make(d).verify_no_runpath())
+
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_skips_non_elf_files(self, mock_run):
+        # A tree with no ELF files performs no readelf calls and passes.
+        mock_run.return_value = MagicMock(returncode=0, stdout="")
+        with tempfile.TemporaryDirectory() as d:
+            (Path(d) / "a.txt").write_text("plain")
+            (Path(d) / "b.json").write_text("{}")
+            with _suppress_script_output():
+                self.assertTrue(self._make(d).verify_no_runpath())
+        mock_run.assert_not_called()
+
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_returns_true_when_readelf_unavailable(self, mock_run):
+        # If readelf cannot be executed (OSError), the check is skipped (non-fatal).
+        mock_run.side_effect = OSError("readelf not found")
+        with tempfile.TemporaryDirectory() as d:
+            self._elf_tree(d)
+            with _suppress_script_output():
+                self.assertTrue(self._make(d).verify_no_runpath())
+
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_readelf_timeout_skips_file(self, mock_run):
+        # A readelf timeout on a file is non-fatal; that file is skipped.
+        import subprocess
+
+        mock_run.side_effect = subprocess.TimeoutExpired("readelf", 30)
+        with tempfile.TemporaryDirectory() as d:
+            self._elf_tree(d)
+            with _suppress_script_output():
+                self.assertTrue(self._make(d).verify_no_runpath())
+
+    @patch.object(
+        native_linux_package_install_test.NativeLinuxPackageInstallTest,
+        "verify_no_runpath",
+        return_value=False,
+    )
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_basic_verification_fails_when_runpath_check_fails(
+        self, mock_run, mock_rpath
+    ):
+        # Even with enough components present, a failed RUNPATH check fails Step 2.
+        mock_run.return_value = MagicMock(returncode=0, stdout="ii rocm-pkg 1.0\n")
+        with tempfile.TemporaryDirectory() as d:
+            (Path(d) / "bin").mkdir()
+            (Path(d) / "lib").mkdir()
+            (Path(d) / "bin" / "rocminfo").write_text("")
+            (Path(d) / "bin" / "hipcc").write_text("")
+            t = native_linux_package_install_test.NativeLinuxPackageInstallTest(
+                repo_url="https://example.com",
+                os_profile="ubuntu2404",
+                install_prefix=d,
+            )
+            with _suppress_script_output():
+                self.assertFalse(t.run_basic_verification())
+        mock_rpath.assert_called_once()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
+++ b/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
@@ -2023,15 +2023,20 @@ class VerifyNoRunpathTest(unittest.TestCase):
                 self.assertTrue(self._make(d).verify_no_runpath())
 
     @patch("native_linux_package_install_test.subprocess.run")
-    def test_readelf_timeout_skips_file(self, mock_run):
-        # A readelf timeout on a file is non-fatal; that file is skipped.
-        import subprocess
-
-        mock_run.side_effect = subprocess.TimeoutExpired("readelf", 30)
+    def test_skips_file_when_readelf_returns_nonzero(self, mock_run):
+        # readelf returning non-zero (corrupt ELF, etc.) is non-fatal; the file
+        # is skipped with a warning and the overall check still passes.
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stdout="",
+            stderr="readelf: Error: Not an ELF file\n",
+        )
         with tempfile.TemporaryDirectory() as d:
             self._elf_tree(d)
             with _suppress_script_output():
                 self.assertTrue(self._make(d).verify_no_runpath())
+        # readelf was invoked for both ELF files despite the non-zero exit.
+        self.assertEqual(mock_run.call_count, 2)
 
     @patch.object(
         native_linux_package_install_test.NativeLinuxPackageInstallTest,

--- a/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
+++ b/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
@@ -7,8 +7,11 @@
 
 import contextlib
 import importlib.util
+import io
 import os
 import stat
+import shutil
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -2144,6 +2147,94 @@ class VerifyNoRunpathTest(unittest.TestCase):
             with _suppress_script_output():
                 self.assertFalse(t.run_basic_verification())
         mock_rpath.assert_called_once()
+
+
+_ELF_TOOLCHAIN_AVAILABLE = bool(shutil.which("cc") and shutil.which("readelf"))
+
+
+@unittest.skipUnless(
+    _ELF_TOOLCHAIN_AVAILABLE,
+    "requires a C compiler (cc) and readelf to build/inspect real ELF fixtures",
+)
+class VerifyNoRunpathRealElfTest(unittest.TestCase):
+    """End-to-end tests for verify_no_runpath() against real ELF files.
+
+    Unlike VerifyNoRunpathTest, which mocks readelf, these compile small shared
+    objects with known DT_RPATH/DT_RUNPATH tags and run the real ``readelf`` so
+    the actual subprocess code path is exercised. They are skipped where ``cc``
+    or ``readelf`` are unavailable (for example the windows-2022 CI leg). Error
+    paths that cannot be produced from a real file (readelf missing, non-zero
+    exit) remain covered by the mocked VerifyNoRunpathTest.
+    """
+
+    def _compile_so(self, directory, name, *link_flags):
+        # $ORIGIN is passed literally (no shell), so the linker records it as-is.
+        src = Path(directory) / "src.c"
+        if not src.exists():
+            src.write_text("int f(void) { return 0; }\n")
+        out = Path(directory) / name
+        subprocess.run(
+            ["cc", "-shared", "-fPIC", "-o", str(out), *link_flags, str(src)],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        return out
+
+    def _make(self, install_prefix):
+        return native_linux_package_install_test.NativeLinuxPackageInstallTest(
+            repo_url="https://example.com",
+            os_profile="ubuntu2404",
+            install_prefix=install_prefix,
+        )
+
+    def test_real_rpath_origin_relative_passes(self):
+        # DT_RPATH with an $ORIGIN-relative value -> pass.
+        with tempfile.TemporaryDirectory() as d:
+            self._compile_so(
+                d,
+                "librpath.so",
+                "-Wl,-rpath,$ORIGIN/../lib",
+                "-Wl,--disable-new-dtags",
+            )
+            with _suppress_script_output():
+                self.assertTrue(self._make(d).verify_no_runpath())
+
+    def test_real_runpath_fails(self):
+        # DT_RUNPATH (new dtags) with no DT_RPATH -> conversion missed -> fail.
+        with tempfile.TemporaryDirectory() as d:
+            self._compile_so(
+                d,
+                "librunpath.so",
+                "-Wl,-rpath,$ORIGIN/../lib",
+                "-Wl,--enable-new-dtags",
+            )
+            with _suppress_script_output():
+                self.assertFalse(self._make(d).verify_no_runpath())
+
+    def test_real_neither_tag_passes(self):
+        # No rpath/runpath tag at all -> pass (nothing to convert).
+        with tempfile.TemporaryDirectory() as d:
+            self._compile_so(d, "libnone.so")
+            with _suppress_script_output():
+                self.assertTrue(self._make(d).verify_no_runpath())
+
+    def test_real_fixed_rpath_is_reported_but_not_fatal(self):
+        # DT_RPATH with a non-$ORIGIN (absolute) entry -> warned, not fatal.
+        with tempfile.TemporaryDirectory() as d:
+            self._compile_so(
+                d,
+                "libfixed.so",
+                "-Wl,-rpath,/opt/rocm/lib",
+                "-Wl,--disable-new-dtags",
+            )
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                result = self._make(d).verify_no_runpath()
+        output = buf.getvalue()
+        self.assertTrue(result)
+        self.assertIn("not $ORIGIN-relative", output)
+        self.assertIn("/opt/rocm/lib", output)
 
 
 if __name__ == "__main__":

--- a/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
+++ b/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
@@ -1633,15 +1633,20 @@ class VerifyNoRunpathTest(unittest.TestCase):
                 self.assertTrue(self._make(d).verify_no_runpath())
 
     @patch("native_linux_package_install_test.subprocess.run")
-    def test_readelf_timeout_skips_file(self, mock_run):
-        # A readelf timeout on a file is non-fatal; that file is skipped.
-        import subprocess
-
-        mock_run.side_effect = subprocess.TimeoutExpired("readelf", 30)
+    def test_skips_file_when_readelf_returns_nonzero(self, mock_run):
+        # readelf returning non-zero (corrupt ELF, etc.) is non-fatal; the file
+        # is skipped with a warning and the overall check still passes.
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stdout="",
+            stderr="readelf: Error: Not an ELF file\n",
+        )
         with tempfile.TemporaryDirectory() as d:
             self._elf_tree(d)
             with _suppress_script_output():
                 self.assertTrue(self._make(d).verify_no_runpath())
+        # readelf was invoked for both ELF files despite the non-zero exit.
+        self.assertEqual(mock_run.call_count, 2)
 
     @patch.object(
         native_linux_package_install_test.NativeLinuxPackageInstallTest,

--- a/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
+++ b/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
@@ -18,6 +18,10 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
+# Used only by the real-ELF fixture tests (VerifyNoRunpathRealElfTest) below.
+import shutil
+import subprocess
+
 # Load the module: look in same dir as this file, then parent (covers linux/ or linux/tests/ layout).
 _this_file = Path(__file__).resolve()
 _search_dirs = [_this_file.parent, _this_file.parent.parent]

--- a/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
+++ b/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
@@ -1946,6 +1946,118 @@ class BuildVariantPackageNamesTest(unittest.TestCase):
             ["amdrocm7.15-gfx942", "amdrocm-core-sdk7.15-gfx942"],
         )
 
+class VerifyNoRunpathTest(unittest.TestCase):
+    """Tests for NativeLinuxPackageInstallTest.verify_no_runpath()."""
+
+    def _make(self, install_prefix="/opt/rocm/core"):
+        return native_linux_package_install_test.NativeLinuxPackageInstallTest(
+            repo_url="https://example.com",
+            os_profile="ubuntu2404",
+            install_prefix=install_prefix,
+        )
+
+    def _elf_tree(self, d):
+        # Create two files with ELF magic and one non-ELF file under d.
+        (Path(d) / "bin").mkdir()
+        (Path(d) / "lib").mkdir()
+        (Path(d) / "bin" / "hipcc").write_bytes(b"\x7fELF" + b"\x00" * 32)
+        (Path(d) / "lib" / "libamdhip64.so").write_bytes(b"\x7fELF" + b"\x00" * 32)
+        (Path(d) / "readme.txt").write_text("not an elf file")
+
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_passes_when_no_elf_uses_runpath(self, mock_run):
+        # readelf output showing (RPATH) for every ELF -> pass.
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=" 0x000000000000000f (RPATH) Library rpath: [$ORIGIN/../lib]\n",
+        )
+        with tempfile.TemporaryDirectory() as d:
+            self._elf_tree(d)
+            with _suppress_script_output():
+                self.assertTrue(self._make(d).verify_no_runpath())
+        # readelf invoked for the two ELF files only, not the .txt file.
+        self.assertEqual(mock_run.call_count, 2)
+
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_fails_when_an_elf_uses_runpath(self, mock_run):
+        # Any (RUNPATH) line marks the file as offending -> fail.
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=" 0x000000000000001d (RUNPATH) Library runpath: [$ORIGIN/../lib]\n",
+        )
+        with tempfile.TemporaryDirectory() as d:
+            self._elf_tree(d)
+            with _suppress_script_output():
+                self.assertFalse(self._make(d).verify_no_runpath())
+
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_passes_when_elf_has_no_dynamic_path(self, mock_run):
+        # ELF with neither RPATH nor RUNPATH is acceptable.
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=" 0x0000000000000001 (NEEDED) Shared library: [libc.so.6]\n",
+        )
+        with tempfile.TemporaryDirectory() as d:
+            self._elf_tree(d)
+            with _suppress_script_output():
+                self.assertTrue(self._make(d).verify_no_runpath())
+
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_skips_non_elf_files(self, mock_run):
+        # A tree with no ELF files performs no readelf calls and passes.
+        mock_run.return_value = MagicMock(returncode=0, stdout="")
+        with tempfile.TemporaryDirectory() as d:
+            (Path(d) / "a.txt").write_text("plain")
+            (Path(d) / "b.json").write_text("{}")
+            with _suppress_script_output():
+                self.assertTrue(self._make(d).verify_no_runpath())
+        mock_run.assert_not_called()
+
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_returns_true_when_readelf_unavailable(self, mock_run):
+        # If readelf cannot be executed (OSError), the check is skipped (non-fatal).
+        mock_run.side_effect = OSError("readelf not found")
+        with tempfile.TemporaryDirectory() as d:
+            self._elf_tree(d)
+            with _suppress_script_output():
+                self.assertTrue(self._make(d).verify_no_runpath())
+
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_readelf_timeout_skips_file(self, mock_run):
+        # A readelf timeout on a file is non-fatal; that file is skipped.
+        import subprocess
+
+        mock_run.side_effect = subprocess.TimeoutExpired("readelf", 30)
+        with tempfile.TemporaryDirectory() as d:
+            self._elf_tree(d)
+            with _suppress_script_output():
+                self.assertTrue(self._make(d).verify_no_runpath())
+
+    @patch.object(
+        native_linux_package_install_test.NativeLinuxPackageInstallTest,
+        "verify_no_runpath",
+        return_value=False,
+    )
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_basic_verification_fails_when_runpath_check_fails(
+        self, mock_run, mock_rpath
+    ):
+        # Even with enough components present, a failed RUNPATH check fails Step 2.
+        mock_run.return_value = MagicMock(returncode=0, stdout="ii rocm-pkg 1.0\n")
+        with tempfile.TemporaryDirectory() as d:
+            (Path(d) / "bin").mkdir()
+            (Path(d) / "lib").mkdir()
+            (Path(d) / "bin" / "rocminfo").write_text("")
+            (Path(d) / "bin" / "hipcc").write_text("")
+            t = native_linux_package_install_test.NativeLinuxPackageInstallTest(
+                repo_url="https://example.com",
+                os_profile="ubuntu2404",
+                install_prefix=d,
+            )
+            with _suppress_script_output():
+                self.assertFalse(t.run_basic_verification())
+        mock_rpath.assert_called_once()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
+++ b/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
@@ -2087,6 +2087,39 @@ class VerifyNoRunpathTest(unittest.TestCase):
                 self.assertTrue(self._make(d).verify_no_runpath())
         self.assertEqual(mock_run.call_count, 2)
 
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_fixed_path_rpath_is_reported_but_not_fatal(self, mock_run):
+        # An rpath with a non-$ORIGIN (fixed/absolute) entry is warned about but
+        # does not fail the check.
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=" 0x000000000000000f (RPATH) Library rpath: [/opt/rocm/lib]\n",
+        )
+        with tempfile.TemporaryDirectory() as d:
+            self._elf_tree(d)
+            with _suppress_script_output():
+                self.assertTrue(self._make(d).verify_no_runpath())
+
+    def test_fixed_rpath_entries_helper(self):
+        # Helper flags only entries that lack $ORIGIN, preserving order.
+        fn = (
+            native_linux_package_install_test.NativeLinuxPackageInstallTest._fixed_rpath_entries
+        )
+        # Pure $ORIGIN-relative rpath -> nothing flagged.
+        self.assertEqual(
+            fn(" 0x0f (RPATH) Library rpath: [$ORIGIN/../lib:$ORIGIN/../lib64]\n"),
+            [],
+        )
+        # Mixed rpath -> only the fixed entries are returned.
+        self.assertEqual(
+            fn(
+                " 0x0f (RPATH) Library rpath: [$ORIGIN/../lib:/opt/rocm/lib:/usr/lib]\n"
+            ),
+            ["/opt/rocm/lib", "/usr/lib"],
+        )
+        # No rpath value present -> empty.
+        self.assertEqual(fn(" 0x01 (NEEDED) Shared library: [libc.so.6]\n"), [])
+
     @patch.object(
         native_linux_package_install_test.NativeLinuxPackageInstallTest,
         "verify_no_runpath",

--- a/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
+++ b/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
@@ -2038,6 +2038,55 @@ class VerifyNoRunpathTest(unittest.TestCase):
         # readelf was invoked for both ELF files despite the non-zero exit.
         self.assertEqual(mock_run.call_count, 2)
 
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_rpath_present_is_not_flagged_even_with_runpath(self, mock_run):
+        # DT_RPATH is checked first; a file that reports both tags is treated as
+        # converted (RPATH present) and is not flagged.
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=(
+                " 0x000000000000000f (RPATH) Library rpath: [$ORIGIN/../lib]\n"
+                " 0x000000000000001d (RUNPATH) Library runpath: [$ORIGIN/../lib]\n"
+            ),
+        )
+        with tempfile.TemporaryDirectory() as d:
+            self._elf_tree(d)
+            with _suppress_script_output():
+                self.assertTrue(self._make(d).verify_no_runpath())
+
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_fails_when_only_some_files_are_runpath_only(self, mock_run):
+        # A mixed tree (one RPATH file, one RUNPATH-only file) still fails
+        # because at least one ELF is missing RPATH and carries RUNPATH.
+        def fake_readelf(cmd, **kwargs):
+            filepath = cmd[-1]
+            if filepath.endswith("libamdhip64.so"):
+                stdout = (
+                    " 0x000000000000001d (RUNPATH) Library runpath: [$ORIGIN/../lib]\n"
+                )
+            else:
+                stdout = " 0x000000000000000f (RPATH) Library rpath: [$ORIGIN/../lib]\n"
+            return MagicMock(returncode=0, stdout=stdout)
+
+        mock_run.side_effect = fake_readelf
+        with tempfile.TemporaryDirectory() as d:
+            self._elf_tree(d)
+            with _suppress_script_output():
+                self.assertFalse(self._make(d).verify_no_runpath())
+
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_files_with_neither_tag_pass_and_are_counted(self, mock_run):
+        # ELFs with neither DT_RPATH nor DT_RUNPATH are reported but not fatal.
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=" 0x0000000000000001 (NEEDED) Shared library: [libc.so.6]\n",
+        )
+        with tempfile.TemporaryDirectory() as d:
+            self._elf_tree(d)
+            with _suppress_script_output():
+                self.assertTrue(self._make(d).verify_no_runpath())
+        self.assertEqual(mock_run.call_count, 2)
+
     @patch.object(
         native_linux_package_install_test.NativeLinuxPackageInstallTest,
         "verify_no_runpath",

--- a/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
+++ b/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
@@ -1697,6 +1697,39 @@ class VerifyNoRunpathTest(unittest.TestCase):
                 self.assertTrue(self._make(d).verify_no_runpath())
         self.assertEqual(mock_run.call_count, 2)
 
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_fixed_path_rpath_is_reported_but_not_fatal(self, mock_run):
+        # An rpath with a non-$ORIGIN (fixed/absolute) entry is warned about but
+        # does not fail the check.
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=" 0x000000000000000f (RPATH) Library rpath: [/opt/rocm/lib]\n",
+        )
+        with tempfile.TemporaryDirectory() as d:
+            self._elf_tree(d)
+            with _suppress_script_output():
+                self.assertTrue(self._make(d).verify_no_runpath())
+
+    def test_fixed_rpath_entries_helper(self):
+        # Helper flags only entries that lack $ORIGIN, preserving order.
+        fn = (
+            native_linux_package_install_test.NativeLinuxPackageInstallTest._fixed_rpath_entries
+        )
+        # Pure $ORIGIN-relative rpath -> nothing flagged.
+        self.assertEqual(
+            fn(" 0x0f (RPATH) Library rpath: [$ORIGIN/../lib:$ORIGIN/../lib64]\n"),
+            [],
+        )
+        # Mixed rpath -> only the fixed entries are returned.
+        self.assertEqual(
+            fn(
+                " 0x0f (RPATH) Library rpath: [$ORIGIN/../lib:/opt/rocm/lib:/usr/lib]\n"
+            ),
+            ["/opt/rocm/lib", "/usr/lib"],
+        )
+        # No rpath value present -> empty.
+        self.assertEqual(fn(" 0x01 (NEEDED) Shared library: [libc.so.6]\n"), [])
+
     @patch.object(
         native_linux_package_install_test.NativeLinuxPackageInstallTest,
         "verify_no_runpath",

--- a/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
+++ b/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
@@ -2153,22 +2153,29 @@ class VerifyNoRunpathTest(unittest.TestCase):
         mock_rpath.assert_called_once()
 
 
-_ELF_TOOLCHAIN_AVAILABLE = bool(shutil.which("cc") and shutil.which("readelf"))
+# These fixtures build real ELF shared objects with GNU-ld options like
+# -Wl,-rpath and --disable-new-dtags. That only works with a Linux-targeting
+# toolchain: on Windows the runner ships MinGW (cc/readelf are on PATH) but its
+# ld targets PE/COFF and rejects those ELF-only options, so gate on Linux too.
+_ELF_TOOLCHAIN_AVAILABLE = bool(
+    sys.platform.startswith("linux") and shutil.which("cc") and shutil.which("readelf")
+)
 
 
 @unittest.skipUnless(
     _ELF_TOOLCHAIN_AVAILABLE,
-    "requires a C compiler (cc) and readelf to build/inspect real ELF fixtures",
+    "real-ELF fixtures are Linux-only and require cc + readelf",
 )
 class VerifyNoRunpathRealElfTest(unittest.TestCase):
     """End-to-end tests for verify_no_runpath() against real ELF files.
 
     Unlike VerifyNoRunpathTest, which mocks readelf, these compile small shared
     objects with known DT_RPATH/DT_RUNPATH tags and run the real ``readelf`` so
-    the actual subprocess code path is exercised. They are skipped where ``cc``
-    or ``readelf`` are unavailable (for example the windows-2022 CI leg). Error
-    paths that cannot be produced from a real file (readelf missing, non-zero
-    exit) remain covered by the mocked VerifyNoRunpathTest.
+    the actual subprocess code path is exercised. They only run on Linux with a
+    C compiler and readelf, and are skipped elsewhere (for example the
+    windows-2022 CI leg, whose MinGW ld cannot produce ELF with these options).
+    Error paths that cannot be produced from a real file (readelf missing,
+    non-zero exit) remain covered by the mocked VerifyNoRunpathTest.
     """
 
     def _compile_so(self, directory, name, *link_flags):

--- a/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
+++ b/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
@@ -1953,6 +1953,7 @@ class BuildVariantPackageNamesTest(unittest.TestCase):
             ["amdrocm7.15-gfx942", "amdrocm-core-sdk7.15-gfx942"],
         )
 
+
 class VerifyNoRunpathTest(unittest.TestCase):
     """Tests for NativeLinuxPackageInstallTest.verify_no_runpath()."""
 

--- a/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
+++ b/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
@@ -1648,6 +1648,55 @@ class VerifyNoRunpathTest(unittest.TestCase):
         # readelf was invoked for both ELF files despite the non-zero exit.
         self.assertEqual(mock_run.call_count, 2)
 
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_rpath_present_is_not_flagged_even_with_runpath(self, mock_run):
+        # DT_RPATH is checked first; a file that reports both tags is treated as
+        # converted (RPATH present) and is not flagged.
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=(
+                " 0x000000000000000f (RPATH) Library rpath: [$ORIGIN/../lib]\n"
+                " 0x000000000000001d (RUNPATH) Library runpath: [$ORIGIN/../lib]\n"
+            ),
+        )
+        with tempfile.TemporaryDirectory() as d:
+            self._elf_tree(d)
+            with _suppress_script_output():
+                self.assertTrue(self._make(d).verify_no_runpath())
+
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_fails_when_only_some_files_are_runpath_only(self, mock_run):
+        # A mixed tree (one RPATH file, one RUNPATH-only file) still fails
+        # because at least one ELF is missing RPATH and carries RUNPATH.
+        def fake_readelf(cmd, **kwargs):
+            filepath = cmd[-1]
+            if filepath.endswith("libamdhip64.so"):
+                stdout = (
+                    " 0x000000000000001d (RUNPATH) Library runpath: [$ORIGIN/../lib]\n"
+                )
+            else:
+                stdout = " 0x000000000000000f (RPATH) Library rpath: [$ORIGIN/../lib]\n"
+            return MagicMock(returncode=0, stdout=stdout)
+
+        mock_run.side_effect = fake_readelf
+        with tempfile.TemporaryDirectory() as d:
+            self._elf_tree(d)
+            with _suppress_script_output():
+                self.assertFalse(self._make(d).verify_no_runpath())
+
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_files_with_neither_tag_pass_and_are_counted(self, mock_run):
+        # ELFs with neither DT_RPATH nor DT_RUNPATH are reported but not fatal.
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=" 0x0000000000000001 (NEEDED) Shared library: [libc.so.6]\n",
+        )
+        with tempfile.TemporaryDirectory() as d:
+            self._elf_tree(d)
+            with _suppress_script_output():
+                self.assertTrue(self._make(d).verify_no_runpath())
+        self.assertEqual(mock_run.call_count, 2)
+
     @patch.object(
         native_linux_package_install_test.NativeLinuxPackageInstallTest,
         "verify_no_runpath",

--- a/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
+++ b/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
@@ -9,13 +9,15 @@ import contextlib
 import importlib.util
 import io
 import os
-import shutil
-import subprocess
 import sys
 import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import patch, MagicMock
+
+# Used only by the real-ELF fixture tests (VerifyNoRunpathRealElfTest) below.
+import shutil
+import subprocess
 
 # Load the module: look in same dir as this file, then parent (covers linux/ or linux/tests/ layout).
 _this_file = Path(__file__).resolve()

--- a/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
+++ b/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
@@ -7,7 +7,10 @@
 
 import contextlib
 import importlib.util
+import io
 import os
+import shutil
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -1754,6 +1757,94 @@ class VerifyNoRunpathTest(unittest.TestCase):
             with _suppress_script_output():
                 self.assertFalse(t.run_basic_verification())
         mock_rpath.assert_called_once()
+
+
+_ELF_TOOLCHAIN_AVAILABLE = bool(shutil.which("cc") and shutil.which("readelf"))
+
+
+@unittest.skipUnless(
+    _ELF_TOOLCHAIN_AVAILABLE,
+    "requires a C compiler (cc) and readelf to build/inspect real ELF fixtures",
+)
+class VerifyNoRunpathRealElfTest(unittest.TestCase):
+    """End-to-end tests for verify_no_runpath() against real ELF files.
+
+    Unlike VerifyNoRunpathTest, which mocks readelf, these compile small shared
+    objects with known DT_RPATH/DT_RUNPATH tags and run the real ``readelf`` so
+    the actual subprocess code path is exercised. They are skipped where ``cc``
+    or ``readelf`` are unavailable (for example the windows-2022 CI leg). Error
+    paths that cannot be produced from a real file (readelf missing, non-zero
+    exit) remain covered by the mocked VerifyNoRunpathTest.
+    """
+
+    def _compile_so(self, directory, name, *link_flags):
+        # $ORIGIN is passed literally (no shell), so the linker records it as-is.
+        src = Path(directory) / "src.c"
+        if not src.exists():
+            src.write_text("int f(void) { return 0; }\n")
+        out = Path(directory) / name
+        subprocess.run(
+            ["cc", "-shared", "-fPIC", "-o", str(out), *link_flags, str(src)],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        return out
+
+    def _make(self, install_prefix):
+        return native_linux_package_install_test.NativeLinuxPackageInstallTest(
+            repo_url="https://example.com",
+            os_profile="ubuntu2404",
+            install_prefix=install_prefix,
+        )
+
+    def test_real_rpath_origin_relative_passes(self):
+        # DT_RPATH with an $ORIGIN-relative value -> pass.
+        with tempfile.TemporaryDirectory() as d:
+            self._compile_so(
+                d,
+                "librpath.so",
+                "-Wl,-rpath,$ORIGIN/../lib",
+                "-Wl,--disable-new-dtags",
+            )
+            with _suppress_script_output():
+                self.assertTrue(self._make(d).verify_no_runpath())
+
+    def test_real_runpath_fails(self):
+        # DT_RUNPATH (new dtags) with no DT_RPATH -> conversion missed -> fail.
+        with tempfile.TemporaryDirectory() as d:
+            self._compile_so(
+                d,
+                "librunpath.so",
+                "-Wl,-rpath,$ORIGIN/../lib",
+                "-Wl,--enable-new-dtags",
+            )
+            with _suppress_script_output():
+                self.assertFalse(self._make(d).verify_no_runpath())
+
+    def test_real_neither_tag_passes(self):
+        # No rpath/runpath tag at all -> pass (nothing to convert).
+        with tempfile.TemporaryDirectory() as d:
+            self._compile_so(d, "libnone.so")
+            with _suppress_script_output():
+                self.assertTrue(self._make(d).verify_no_runpath())
+
+    def test_real_fixed_rpath_is_reported_but_not_fatal(self):
+        # DT_RPATH with a non-$ORIGIN (absolute) entry -> warned, not fatal.
+        with tempfile.TemporaryDirectory() as d:
+            self._compile_so(
+                d,
+                "libfixed.so",
+                "-Wl,-rpath,/opt/rocm/lib",
+                "-Wl,--disable-new-dtags",
+            )
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                result = self._make(d).verify_no_runpath()
+        output = buf.getvalue()
+        self.assertTrue(result)
+        self.assertIn("not $ORIGIN-relative", output)
+        self.assertIn("/opt/rocm/lib", output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add a post-install `verify_no_runpath()` check to `run_basic_verification()` in `native_linux_package_install_test.py` so both `sanity` and `full` test modes confirm no installed ELF file still carries a `DT_RUNPATH` tag (packaging converts RUNPATH to RPATH — see `runpath_to_rpath.py` / #6944).
- Walks the install tree, does a cheap ELF-magic pre-check, and inspects each ELF's dynamic section with `readelf -d`; fails basic verification (prints the first 10 offenders) if any `(RUNPATH)` is found. Files with no rpath/runpath tag are fine.
- A missing `readelf` or a per-file `readelf` timeout is treated as a non-fatal skip (matching the tolerant behaviour of the existing `rocminfo` check).

## Relationship to #6974
This is intentionally structured to be **conflict-free with #6974** (the root-ownership check) regardless of which lands first:
- Branched from `main` (independent of `users/dravindr/pkg_owner`).
- Edits are placed in regions disjoint from #6974: the timeout constant is anchored after `VERIFY_MIN_COMPONENTS` (vs `ROCMINFO_TIMEOUT_SEC`), the wiring sits between the package-listing and `rocminfo` blocks (vs after the components loop + the return block), and the new method is appended after `test_rdhc` (vs after `run_basic_verification`). New tests are appended at the end of the UT file.
- Verified locally: trial-merging the two branches auto-merges with **no conflicts**, the merged source compiles, and all 23 relevant tests pass (ownership + runpath + basic verification).

## Test plan
- [ ] Run against a real repo install (e.g. `--test-type sanity --os-profile ubuntu2404 ...`) inside a matching container and confirm the new `Verifying installed ELF files use RPATH (not RUNPATH)...` step reports `[PASS]`.
- [ ] Confirm an ELF deliberately left with `DT_RUNPATH` causes basic verification to `[FAIL]`.
- [ ] Unit tests: `python3 -m pytest build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py::VerifyNoRunpathTest` (7 pass locally).
- [ ] `pre-commit` passes (verified locally).

Results:

https://github.com/ROCm/TheRock/actions/runs/32167284025 - RH8
https://github.com/ROCm/TheRock/actions/runs/32167669026 - RH10
https://github.com/ROCm/TheRock/actions/runs/32167888496 - SLES16
https://github.com/ROCm/TheRock/actions/runs/32156823354 - SLES-ASAN

Unit Test: 
----------------------------------------------------------------------
Ran 139 tests in 0.485s

OK

## Notes
- The install-test container must have `readelf` (binutils) for this check to actually run; otherwise it is skipped with a `[WARN]`. If we want it enforced in CI, the workflow should install binutils in the test containers.
- Like #6974, this walks the install tree; the dominant cost is one `readelf` per ELF file. See discussion — the traversal itself is cheap; `readelf` spawns dominate.

Made with [Cursor](https://cursor.com)