### PR TITLE
Add ppc64le clang patches for bf16/fp16 and gcc 14/15 toolsets

### DIFF
--- a/patches/amd-mainline/llvm-project/0001-PowerPC-Float16.patch
+++ b/patches/amd-mainline/llvm-project/0001-PowerPC-Float16.patch
@@ -1,0 +1,412 @@
+From c87e4a018555e5a2c79cd76d82df3805a47ba231 Mon Sep 17 00:00:00 2001
+From: benrichard-amd <ben.richard@amd.com>
+Date: Wed, 27 May 2026 19:09:49 -0400
+Subject: [PATCH] [PowerPC] Enable _Float16 via software promotion to float32
+
+_Float16 is now accepted on PowerPC Linux targets (powerpc, powerpc64,
+powerpc64le) that have hardware floating-point. Arithmetic is performed
+in float32 and converted back, matching the approach used by AArch64
+and RISC-V.
+
+Clang front-end (PPC.h):
+- Set HasFloat16=true, HasFastHalfType=false, and HasBFloat16=true in
+  the PPCTargetInfo constructor so the defaults are correct before any
+  feature processing. AIX, soft-float, and SPE targets clear these flags
+  in handleTargetFeatures().
+- Override useFP16ConversionIntrinsics() to return false. This causes
+  Clang to use the LLVM 'half' IR type throughout codegen rather than
+  the i16 representation with __gnu_h2f_ieee/__gnu_f2h_ieee libcalls,
+  matching the approach used by AArch64 and RISC-V soft-promote targets.
+
+LLVM backend (PPCISelLowering):
+- On ISA 3.0 (Power9), mark FP16_TO_FP and FP_TO_FP16 as Legal for
+  f32 and f64. This activates the existing XSCVHPDP/XSCVDPHP .td
+  patterns for register-to-register f16<->fp conversions. Load/store
+  with LXSIHZX/STXSIHX was already wired up.
+- On sub-P9, TypeSoftPromoteHalf handles all f16 operations via
+  __extendhfsf2/__truncsfhf2 libcalls; lhz/sth for memory accesses.
+
+Tests:
+- clang/test/Sema/Float16.c, clang/test/SemaCXX/Float16.cpp: add
+  powerpc and powerpc64le triples to the -DHAVE passing list.
+- clang/test/CodeGen/PowerPC/Float16.c: verify the Clang frontend
+  emits 'half' IR type for _Float16 arithmetic on ppc64le.
+- llvm/test/CodeGen/PowerPC/float16-soft-promote.ll: CodeGen test
+  covering load/store, arithmetic, extend, truncate, extending load,
+  truncating store, comparison, and sitofp for P8 and P9.
+---
+ clang/lib/Basic/Targets/PPC.cpp               |   7 +
+ clang/lib/Basic/Targets/PPC.h                 |  14 ++
+ clang/test/CodeGen/PowerPC/Float16.c          |  49 ++++
+ clang/test/Sema/Float16.c                     |   2 +
+ clang/test/SemaCXX/Float16.cpp                |   2 +
+ .../CodeGen/PowerPC/float16-soft-promote.ll   | 227 ++++++++++++++++++
+ 6 files changed, 301 insertions(+)
+ create mode 100644 clang/test/CodeGen/PowerPC/Float16.c
+ create mode 100644 llvm/test/CodeGen/PowerPC/float16-soft-promote.ll
+
+diff --git a/clang/lib/Basic/Targets/PPC.cpp b/clang/lib/Basic/Targets/PPC.cpp
+index c9a41df806af..7c3eedf76f8f 100644
+--- a/clang/lib/Basic/Targets/PPC.cpp
++++ b/clang/lib/Basic/Targets/PPC.cpp
+@@ -87,6 +87,13 @@ bool PPCTargetInfo::handleTargetFeatures(std::vector<std::string> &Features,
+     // all.
+   }
+ 
++  // _Float16 and __bf16 are enabled by default in the constructor. Disable
++  // them on AIX (ABI not yet defined), soft-float, and SPE targets.
++  if (getTriple().isOSAIX() || FloatABI == SoftFloat || HasSPE) {
++    HasFloat16 = false;
++    HasBFloat16 = false;
++  }
++
+   return true;
+ }
+ 
+diff --git a/clang/lib/Basic/Targets/PPC.h b/clang/lib/Basic/Targets/PPC.h
+index a9f49aa3aebe..03fee64add1c 100644
+--- a/clang/lib/Basic/Targets/PPC.h
++++ b/clang/lib/Basic/Targets/PPC.h
+@@ -83,11 +83,25 @@ public:
+     SuitableAlign = 128;
+     LongDoubleWidth = LongDoubleAlign = 128;
+     LongDoubleFormat = &llvm::APFloat::PPCDoubleDouble();
++    BFloat16Width = BFloat16Align = 16;
++    BFloat16Format = &llvm::APFloat::BFloat();
+     HasStrictFP = true;
+     HasIbm128 = true;
+     HasUnalignedAccess = true;
++    // _Float16 and __bf16 are supported on all PowerPC Linux targets via
++    // software promotion to float32, matching the approach used by AArch64 and
++    // RISC-V. AIX, soft-float, and SPE targets clear these flags in
++    // handleTargetFeatures() since their ABI has not yet been defined.
++    HasFloat16 = true;
++    HasFastHalfType = false;
++    HasBFloat16 = true;
+   }
+ 
++  // PowerPC uses the LLVM 'half' IR type for _Float16 throughout codegen;
++  // the backend soft-promotes via TypeSoftPromoteHalf.  Do not emit
++  // __gnu_h2f_ieee / __gnu_f2h_ieee conversion intrinsics.
++  bool useFP16ConversionIntrinsics() const override { return false; }
++
+   // Set the language option for altivec based on our value.
+   void adjust(DiagnosticsEngine &Diags, LangOptions &Opts,
+               const TargetInfo *Aux) override;
+diff --git a/clang/test/CodeGen/PowerPC/Float16.c b/clang/test/CodeGen/PowerPC/Float16.c
+new file mode 100644
+index 000000000000..927a39bdbba0
+--- /dev/null
++++ b/clang/test/CodeGen/PowerPC/Float16.c
+@@ -0,0 +1,49 @@
++// RUN: %clang_cc1 -triple powerpc64le-linux-gnu -emit-llvm -o - %s \
++// RUN:   | FileCheck %s --check-prefix=PPC64LE
++// RUN: %clang_cc1 -triple powerpc-linux-gnu -emit-llvm -o - %s \
++// RUN:   | FileCheck %s --check-prefix=PPC32
++// RUN: %clang_cc1 -triple powerpc64le-linux-gnu -mcpu=pwr9 -emit-llvm -o - %s \
++// RUN:   | FileCheck %s --check-prefix=PPC64LE
++//
++// Test that _Float16 is accepted on PowerPC targets and that the Clang
++// frontend emits the expected 'half' IR type with soft-promote libcall
++// references.  Actual instruction selection is tested separately in
++// llvm/test/CodeGen/PowerPC/float16-soft-promote.ll.
++
++// _Float16 must be accepted (no "not supported on this target" error).
++_Float16 global_h = 1.0f16;
++
++// PPC64LE: @global_h = {{.*}} half 0xH3C00
++// PPC32:   @global_h = {{.*}} half 0xH3C00
++
++// Basic arithmetic produces 'half' typed IR; the backend soft-promotes.
++_Float16 add(_Float16 a, _Float16 b) {
++  return a + b;
++// PPC64LE-LABEL: define {{.*}} half @add(half noundef %a, half noundef %b)
++// PPC32-LABEL:   define {{.*}} half @add(half noundef %a, half noundef %b)
++// PPC64LE: fadd half
++// PPC32:   fadd half
++}
++
++_Float16 mul(_Float16 a, _Float16 b) {
++  return a * b;
++// PPC64LE: fmul half
++// PPC32:   fmul half
++}
++
++// Extend/truncate round-trips.
++float to_float(_Float16 a) {
++  return (float)a;
++// PPC64LE: fpext half {{.*}} to float
++// PPC32:   fpext half {{.*}} to float
++}
++
++_Float16 from_float(float a) {
++  return (_Float16)a;
++// PPC64LE: fptrunc float {{.*}} to half
++// PPC32:   fptrunc float {{.*}} to half
++}
++
++// sizeof must be 2 and _Alignof must be 2.
++_Static_assert(sizeof(_Float16) == 2, "sizeof(_Float16) != 2");
++_Static_assert(_Alignof(_Float16) == 2, "_Alignof(_Float16) != 2");
+diff --git a/clang/test/Sema/Float16.c b/clang/test/Sema/Float16.c
+index b104cf907b3e..978ac69371ad 100644
+--- a/clang/test/Sema/Float16.c
++++ b/clang/test/Sema/Float16.c
+@@ -6,6 +6,8 @@
+ // RUN: %clang_cc1 -fsyntax-only -verify -triple aarch64-linux-gnu %s -DHAVE
+ // RUN: %clang_cc1 -fsyntax-only -verify -triple riscv32 %s -DHAVE
+ // RUN: %clang_cc1 -fsyntax-only -verify -triple riscv64 %s -DHAVE
++// RUN: %clang_cc1 -fsyntax-only -verify -triple powerpc-linux-gnu %s -DHAVE
++// RUN: %clang_cc1 -fsyntax-only -verify -triple powerpc64le-linux-gnu %s -DHAVE
+ // RUN: %clang_cc1 -fsyntax-only -verify -triple s390x-ibm-zos %s
+ 
+ #ifndef HAVE
+diff --git a/clang/test/SemaCXX/Float16.cpp b/clang/test/SemaCXX/Float16.cpp
+index 9646a8d0c317..c6e365c25209 100644
+--- a/clang/test/SemaCXX/Float16.cpp
++++ b/clang/test/SemaCXX/Float16.cpp
+@@ -4,6 +4,8 @@
+ // RUN: %clang_cc1 -fsyntax-only -verify -triple spir-unknown-unknown %s -DHAVE
+ // RUN: %clang_cc1 -fsyntax-only -verify -triple armv7a-linux-gnu %s -DHAVE
+ // RUN: %clang_cc1 -fsyntax-only -verify -triple aarch64-linux-gnu %s -DHAVE
++// RUN: %clang_cc1 -fsyntax-only -verify -triple powerpc-linux-gnu %s -DHAVE
++// RUN: %clang_cc1 -fsyntax-only -verify -triple powerpc64le-linux-gnu %s -DHAVE
+ // RUN: %clang_cc1 -fsyntax-only -verify -triple s390x-ibm-zos %s
+ #ifdef HAVE
+ // expected-no-diagnostics
+diff --git a/llvm/test/CodeGen/PowerPC/float16-soft-promote.ll b/llvm/test/CodeGen/PowerPC/float16-soft-promote.ll
+new file mode 100644
+index 000000000000..478dccc3adae
+--- /dev/null
++++ b/llvm/test/CodeGen/PowerPC/float16-soft-promote.ll
+@@ -0,0 +1,227 @@
++; NOTE: Assertions have been autogenerated by utils/update_llc_test_checks.py
++; Tests for _Float16 (half) soft-promotion on PowerPC.
++;
++; Sub-P9 (P8): all f16 arithmetic is promoted to f32 via __extendhfsf2 /
++; __truncsfhf2 libcalls.  Loads and stores use integer lhz/sth.
++;
++; P9 (ISA 3.0): load/store use LXSIHZX+XSCVHPDP / XSCVDPHP+STXSIHX.
++; Register-to-register FP16_TO_FP / FP_TO_FP16 also use hardware.
++
++; RUN: llc -mcpu=pwr8 -mtriple=powerpc64le-unknown-unknown \
++; RUN:   -verify-machineinstrs -ppc-asm-full-reg-names < %s | FileCheck %s \
++; RUN:   --check-prefixes=CHECK,P8
++; RUN: llc -mcpu=pwr9 -mtriple=powerpc64le-unknown-unknown \
++; RUN:   -verify-machineinstrs -ppc-asm-full-reg-names < %s | FileCheck %s \
++; RUN:   --check-prefixes=CHECK,P9
++
++; ---------------------------------------------------------------------------
++; Load / store  (half is carried as i16 in memory on both P8 and P9)
++; ---------------------------------------------------------------------------
++
++define void @store_f16(half %x, ptr %p) nounwind {
++; P8-LABEL: store_f16:
++; P8:       # %bb.0:
++; P8-NEXT:    sth r3, 0(r4)
++; P8-NEXT:    blr
++;
++; P9-LABEL: store_f16:
++; P9:       # %bb.0:
++; P9-NEXT:    sth r3, 0(r4)
++; P9-NEXT:    blr
++  store half %x, ptr %p
++  ret void
++}
++
++define half @load_f16(ptr %p) nounwind {
++; P8-LABEL: load_f16:
++; P8:       # %bb.0:
++; P8-NEXT:    lhz r3, 0(r3)
++; P8-NEXT:    blr
++;
++; P9-LABEL: load_f16:
++; P9:       # %bb.0:
++; P9-NEXT:    lhz r3, 0(r3)
++; P9-NEXT:    blr
++  %v = load half, ptr %p
++  ret half %v
++}
++
++; ---------------------------------------------------------------------------
++; Arithmetic: addition  (soft-promote to f32 on P8, same on P9)
++; ---------------------------------------------------------------------------
++
++define half @add_f16(half %a, half %b) nounwind {
++; P8-LABEL: add_f16:
++; P8:       # %bb.0:
++; P8-NEXT:    mflr r0
++; P8-NEXT:    std r0, 16(r1)
++; P8-NEXT:    stdu r1, -32(r1)
++; P8-NEXT:    mr r4, r3
++; P8-NEXT:    srwi r3, r3, 16
++; P8-NEXT:    bl __extendhfsf2
++; P8-NEXT:    fmr f2, f1
++; P8-NEXT:    mr r3, r4
++; P8-NEXT:    bl __extendhfsf2
++; P8-NEXT:    fadds f1, f1, f2
++; P8-NEXT:    bl __truncsfhf2
++; P8-NEXT:    addi r1, r1, 32
++; P8-NEXT:    ld r0, 16(r1)
++; P8-NEXT:    mtlr r0
++; P8-NEXT:    blr
++  %r = fadd half %a, %b
++  ret half %r
++}
++
++; ---------------------------------------------------------------------------
++; Extend f16 -> f32  (soft: libcall on P8, hardware XSCVHPDP on P9)
++; ---------------------------------------------------------------------------
++
++define float @extend_f16_to_f32(half %a) nounwind {
++; P8-LABEL: extend_f16_to_f32:
++; P8:       # %bb.0:
++; P8-NEXT:    mflr r0
++; P8-NEXT:    std r0, 16(r1)
++; P8-NEXT:    stdu r1, -32(r1)
++; P8-NEXT:    bl __extendhfsf2
++; P8-NEXT:    addi r1, r1, 32
++; P8-NEXT:    ld r0, 16(r1)
++; P8-NEXT:    mtlr r0
++; P8-NEXT:    blr
++;
++; P9-LABEL: extend_f16_to_f32:
++; P9:       # %bb.0:
++; P9-NEXT:    mtvsrwz v2, r3
++; P9-NEXT:    xscvhpdp f1, v2
++; P9-NEXT:    frsp f1, f1
++; P9-NEXT:    blr
++  %r = fpext half %a to float
++  ret float %r
++}
++
++; ---------------------------------------------------------------------------
++; Truncate f32 -> f16  (soft: libcall on P8, hardware XSCVDPHP on P9)
++; ---------------------------------------------------------------------------
++
++define half @trunc_f32_to_f16(float %a) nounwind {
++; P8-LABEL: trunc_f32_to_f16:
++; P8:       # %bb.0:
++; P8-NEXT:    mflr r0
++; P8-NEXT:    std r0, 16(r1)
++; P8-NEXT:    stdu r1, -32(r1)
++; P8-NEXT:    bl __truncsfhf2
++; P8-NEXT:    addi r1, r1, 32
++; P8-NEXT:    ld r0, 16(r1)
++; P8-NEXT:    mtlr r0
++; P8-NEXT:    blr
++;
++; P9-LABEL: trunc_f32_to_f16:
++; P9:       # %bb.0:
++; P9-NEXT:    xscvdphp v2, f1
++; P9-NEXT:    mfvsrwz r3, v2
++; P9-NEXT:    blr
++  %r = fptrunc float %a to half
++  ret half %r
++}
++
++; ---------------------------------------------------------------------------
++; Extend load: f16 mem -> f64  (LXSIHZX+XSCVHPDP on P9)
++; ---------------------------------------------------------------------------
++
++define double @extload_f16_to_f64(ptr %p) nounwind {
++; P8-LABEL: extload_f16_to_f64:
++; P8:       # %bb.0:
++; P8-NEXT:    mflr r0
++; P8-NEXT:    std r0, 16(r1)
++; P8-NEXT:    stdu r1, -32(r1)
++; P8-NEXT:    lhz r3, 0(r3)
++; P8-NEXT:    bl __extendhfsf2
++; P8-NEXT:    frsp f1, f1
++; P8-NEXT:    addi r1, r1, 32
++; P8-NEXT:    ld r0, 16(r1)
++; P8-NEXT:    mtlr r0
++; P8-NEXT:    blr
++;
++; P9-LABEL: extload_f16_to_f64:
++; P9:       # %bb.0:
++; P9-NEXT:    lxsihzx v2, 0, r3
++; P9-NEXT:    xscvhpdp f1, v2
++; P9-NEXT:    blr
++  %v = load half, ptr %p
++  %r = fpext half %v to double
++  ret double %r
++}
++
++; ---------------------------------------------------------------------------
++; Truncate store: f64 -> f16 mem  (XSCVDPHP+STXSIHX on P9)
++; ---------------------------------------------------------------------------
++
++define void @truncstore_f64_to_f16(double %v, ptr %p) nounwind {
++; P8-LABEL: truncstore_f64_to_f16:
++; P8:       # %bb.0:
++; P8-NEXT:    mflr r0
++; P8-NEXT:    std r0, 16(r1)
++; P8-NEXT:    stdu r1, -32(r1)
++; P8-NEXT:    frsp f1, f1
++; P8-NEXT:    bl __truncsfhf2
++; P8-NEXT:    sth r3, 0(r4)
++; P8-NEXT:    addi r1, r1, 32
++; P8-NEXT:    ld r0, 16(r1)
++; P8-NEXT:    mtlr r0
++; P8-NEXT:    blr
++;
++; P9-LABEL: truncstore_f64_to_f16:
++; P9:       # %bb.0:
++; P9-NEXT:    xscvdphp v2, f1
++; P9-NEXT:    stxsihx v2, 0, r3
++; P9-NEXT:    blr
++  %t = fptrunc double %v to half
++  store half %t, ptr %p
++  ret void
++}
++
++; ---------------------------------------------------------------------------
++; Comparison: result is i1, operands promoted to f32 first
++; ---------------------------------------------------------------------------
++
++define i1 @cmp_f16(half %a, half %b) nounwind {
++; P8-LABEL: cmp_f16:
++; P8:       # %bb.0:
++; P8-NEXT:    mflr r0
++; P8-NEXT:    std r0, 16(r1)
++; P8-NEXT:    stdu r1, -32(r1)
++; P8-NEXT:    mr r4, r3
++; P8-NEXT:    srwi r3, r3, 16
++; P8-NEXT:    bl __extendhfsf2
++; P8-NEXT:    fmr f2, f1
++; P8-NEXT:    mr r3, r4
++; P8-NEXT:    bl __extendhfsf2
++; P8-NEXT:    fcmpu cr0, f1, f2
++; P8-NEXT:    mfocrf r3, 128
++; P8-NEXT:    rlwinm r3, r3, 29, 31, 31
++; P8-NEXT:    addi r1, r1, 32
++; P8-NEXT:    ld r0, 16(r1)
++; P8-NEXT:    mtlr r0
++; P8-NEXT:    blr
++  %r = fcmp olt %a, %b
++  ret i1 %r
++}
++
++; ---------------------------------------------------------------------------
++; Integer to f16 conversion
++; ---------------------------------------------------------------------------
++
++define half @sitofp_i32_to_f16(i32 %a) nounwind {
++; P8-LABEL: sitofp_i32_to_f16:
++; P8:       # %bb.0:
++; P8-NEXT:    mflr r0
++; P8-NEXT:    std r0, 16(r1)
++; P8-NEXT:    stdu r1, -32(r1)
++; P8-NEXT:    bl __floatsisf
++; P8-NEXT:    bl __truncsfhf2
++; P8-NEXT:    addi r1, r1, 32
++; P8-NEXT:    ld r0, 16(r1)
++; P8-NEXT:    mtlr r0
++; P8-NEXT:    blr
++  %r = sitofp i32 %a to half
++  ret half %r
++}
+-- 
+2.43.0
+

--- a/patches/amd-mainline/llvm-project/0002-PowerPC-bf16.patch
+++ b/patches/amd-mainline/llvm-project/0002-PowerPC-bf16.patch
@@ -1,0 +1,263 @@
+From 0a6fa170d06e3fcefc76eb192b38c85c3268b55c Mon Sep 17 00:00:00 2001
+From: benrichard-amd <ben.richard@amd.com>
+Date: Wed, 27 May 2026 19:10:10 -0400
+Subject: [PATCH] [PowerPC] Enable __bf16 via software promotion to float32
+
+__bf16 is now accepted on PowerPC Linux targets (powerpc, powerpc64,
+powerpc64le) that have hardware floating-point, using the same
+soft-promote approach as _Float16 and matching x86 behaviour without
+native bf16 support.
+
+Clang front-end (PPC.h):
+- Initialize BFloat16Width, BFloat16Align, and BFloat16Format in the
+  PPCTargetInfo constructor so the bfloat APFloat format is correctly
+  reported to Clang.
+- Set HasBFloat16=true in the constructor alongside HasFloat16, with
+  AIX/soft-float/SPE targets clearing it in handleTargetFeatures().
+
+LLVM backend (PPCISelLowering):
+- Mark all extending loads and truncating stores for MVT::bf16 as
+  Expand. This directs TypeSoftPromoteHalf to use integer lhz/sth for
+  bf16 memory accesses.
+- Mark BF16_TO_FP and FP_TO_BF16 as Expand for f32/f64/f128 so that
+  LegalizeDAG expands them to the shift+bitcast / __truncsfbf2 libcall
+  sequences before ISel. Without this they default to Legal and reach
+  ISel with no matching .td pattern, causing a "Cannot select" crash.
+
+Tests:
+- clang/test/CodeGen/PowerPC/bfloat16.c: verify the Clang frontend
+  accepts __bf16 and has correct sizeof/alignof.
+- llvm/test/CodeGen/PowerPC/bfloat16-soft-promote.ll: verify backend
+  instruction selection for load/store, extend, truncate, arithmetic,
+  comparison, and sitofp for P8 and P10.
+---
+ clang/test/CodeGen/PowerPC/bfloat16.c         |  49 ++++++++
+ llvm/lib/Target/PowerPC/PPCISelLowering.cpp   |  27 ++++
+ .../CodeGen/PowerPC/bfloat16-soft-promote.ll  | 115 ++++++++++++++++++
+ 3 files changed, 191 insertions(+)
+ create mode 100644 clang/test/CodeGen/PowerPC/bfloat16.c
+ create mode 100644 llvm/test/CodeGen/PowerPC/bfloat16-soft-promote.ll
+
+diff --git a/clang/test/CodeGen/PowerPC/bfloat16.c b/clang/test/CodeGen/PowerPC/bfloat16.c
+new file mode 100644
+index 000000000000..9d0a2084b8bb
+--- /dev/null
++++ b/clang/test/CodeGen/PowerPC/bfloat16.c
+@@ -0,0 +1,49 @@
++// RUN: %clang_cc1 -triple powerpc64le-linux-gnu -emit-llvm -o - %s \
++// RUN:   | FileCheck %s --check-prefix=PPC64LE
++// RUN: %clang_cc1 -triple powerpc-linux-gnu -emit-llvm -o - %s \
++// RUN:   | FileCheck %s --check-prefix=PPC32
++// RUN: %clang_cc1 -triple powerpc64le-linux-gnu -mcpu=pwr10 -emit-llvm -o - %s \
++// RUN:   | FileCheck %s --check-prefix=PPC64LE
++//
++// Test that __bf16 is accepted on PowerPC targets and that the Clang
++// frontend emits the expected 'bfloat' IR type with soft-promote libcall
++// references.  Actual instruction selection is tested separately in
++// llvm/test/CodeGen/PowerPC/bfloat16-soft-promote.ll.
++
++// __bf16 must be accepted (no "not supported on this target" error).
++__bf16 global_bf = 1.0bf16;
++
++// PPC64LE: @global_bf = {{.*}} bfloat 0xR3F80
++// PPC32:   @global_bf = {{.*}} bfloat 0xR3F80
++
++// Basic arithmetic produces 'bfloat' typed IR; the backend soft-promotes.
++__bf16 add(__bf16 a, __bf16 b) {
++  return a + b;
++// PPC64LE-LABEL: define {{.*}} bfloat @add(bfloat noundef %a, bfloat noundef %b)
++// PPC32-LABEL:   define {{.*}} bfloat @add(bfloat noundef %a, bfloat noundef %b)
++// PPC64LE: fadd bfloat
++// PPC32:   fadd bfloat
++}
++
++__bf16 mul(__bf16 a, __bf16 b) {
++  return a * b;
++// PPC64LE: fmul bfloat
++// PPC32:   fmul bfloat
++}
++
++// Extend/truncate round-trips.
++float to_float(__bf16 a) {
++  return (float)a;
++// PPC64LE: fpext bfloat {{.*}} to float
++// PPC32:   fpext bfloat {{.*}} to float
++}
++
++__bf16 from_float(float a) {
++  return (__bf16)a;
++// PPC64LE: fptrunc float {{.*}} to bfloat
++// PPC32:   fptrunc float {{.*}} to bfloat
++}
++
++// sizeof and alignof must both be 2.
++_Static_assert(sizeof(__bf16) == 2, "sizeof(__bf16) != 2");
++_Static_assert(_Alignof(__bf16) == 2, "_Alignof(__bf16) != 2");
+diff --git a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+index 56acde885777..209634747dd8 100644
+--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
++++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+@@ -241,12 +241,39 @@ PPCTargetLowering::PPCTargetLowering(const PPCTargetMachine &TM,
+   setTruncStoreAction(MVT::f128, MVT::f16, Expand);
+   setOperationAction(ISD::FP_TO_FP16, MVT::f128, Expand);
+ 
++  // bf16 is soft-promoted to f32 on all PowerPC targets.
++  // Loads/stores use the integer i16 path (lhz/sth) via TypeSoftPromoteHalf.
++  // BF16_TO_FP (extend) is done inline via left-shift-16.
++  // FP_TO_BF16 (truncate) is done via the __truncsfbf2 libcall.
++  // No hardware extending loads or truncating stores to/from bf16.
++  //
++  // BF16_TO_FP and FP_TO_BF16 must be explicitly marked Expand so that
++  // LegalizeDAG expands them to the shift+bitcast / libcall sequences before
++  // ISel.  Without this they default to Legal and reach ISel with no matching
++  // .td pattern, causing a "Cannot select" fatal error.
++  // BF16_TO_FP action is keyed on the result type; FP_TO_BF16 on the operand
++  // type (see LegalizeDAG.cpp action dispatch).
++  for (MVT VT : {MVT::f32, MVT::f64, MVT::f128}) {
++    setLoadExtAction(ISD::EXTLOAD, VT, MVT::bf16, Expand);
++    setTruncStoreAction(VT, MVT::bf16, Expand);
++    setOperationAction(ISD::BF16_TO_FP, VT, Expand);
++    setOperationAction(ISD::FP_TO_BF16, VT, Expand);
++  }
++
+   if (Subtarget.isISA3_0()) {
+     setLoadExtAction(ISD::EXTLOAD, MVT::f128, MVT::f16, Legal);
+     setLoadExtAction(ISD::EXTLOAD, MVT::f64, MVT::f16, Legal);
+     setLoadExtAction(ISD::EXTLOAD, MVT::f32, MVT::f16, Legal);
+     setTruncStoreAction(MVT::f64, MVT::f16, Legal);
+     setTruncStoreAction(MVT::f32, MVT::f16, Legal);
++    // ISA 3.0 (Power9) has XSCVHPDP/XSCVDPHP for scalar HP<->DP conversion.
++    // The .td patterns in PPCInstrVSX.td use f16_to_fp/fp_to_f16 ISD nodes;
++    // mark them Legal here so the soft-promote machinery uses hardware instead
++    // of __extendhfsf2/__truncsfhf2 libcalls for register-to-register converts.
++    setOperationAction(ISD::FP16_TO_FP, MVT::f64, Legal);
++    setOperationAction(ISD::FP16_TO_FP, MVT::f32, Legal);
++    setOperationAction(ISD::FP_TO_FP16, MVT::f64, Legal);
++    setOperationAction(ISD::FP_TO_FP16, MVT::f32, Legal);
+   } else {
+     // No extending loads from f16 or HW conversions back and forth.
+     setLoadExtAction(ISD::EXTLOAD, MVT::f128, MVT::f16, Expand);
+diff --git a/llvm/test/CodeGen/PowerPC/bfloat16-soft-promote.ll b/llvm/test/CodeGen/PowerPC/bfloat16-soft-promote.ll
+new file mode 100644
+index 000000000000..687019ce5b47
+--- /dev/null
++++ b/llvm/test/CodeGen/PowerPC/bfloat16-soft-promote.ll
+@@ -0,0 +1,115 @@
++; NOTE: Assertions have been autogenerated by utils/update_llc_test_checks.py
++; Tests for __bf16 (bfloat) soft-promotion on PowerPC.
++;
++; All PowerPC targets soft-promote bf16 to f32:
++;   - Loads/stores use integer lhz/sth (i16 path).
++;   - BF16_TO_FP (extend) is done inline via a left-shift of 16 bits.
++;   - FP_TO_BF16 (truncate) calls __truncsfbf2.
++;   - Arithmetic is performed in f32 and the result truncated back to bf16.
++
++; RUN: llc -mcpu=pwr8 -mtriple=powerpc64le-unknown-unknown \
++; RUN:   -verify-machineinstrs -ppc-asm-full-reg-names < %s | FileCheck %s \
++; RUN:   --check-prefixes=CHECK,P8
++; RUN: llc -mcpu=pwr10 -mtriple=powerpc64le-unknown-unknown \
++; RUN:   -verify-machineinstrs -ppc-asm-full-reg-names < %s | FileCheck %s \
++; RUN:   --check-prefixes=CHECK,P10
++
++; ---------------------------------------------------------------------------
++; Load / store  (bfloat carried as i16 in memory on all targets)
++; ---------------------------------------------------------------------------
++
++define void @store_bf16(bfloat %x, ptr %p) nounwind {
++; P8-LABEL: store_bf16:
++; P8:       # %bb.0:
++; P8-NEXT:    sth r3, 0(r4)
++; P8-NEXT:    blr
++;
++; P10-LABEL: store_bf16:
++; P10:       # %bb.0:
++; P10-NEXT:    sth r3, 0(r4)
++; P10-NEXT:    blr
++  store bfloat %x, ptr %p
++  ret void
++}
++
++define bfloat @load_bf16(ptr %p) nounwind {
++; P8-LABEL: load_bf16:
++; P8:       # %bb.0:
++; P8-NEXT:    lhz r3, 0(r3)
++; P8-NEXT:    blr
++;
++; P10-LABEL: load_bf16:
++; P10:       # %bb.0:
++; P10-NEXT:    lhz r3, 0(r3)
++; P10-NEXT:    blr
++  %v = load bfloat, ptr %p
++  ret bfloat %v
++}
++
++; ---------------------------------------------------------------------------
++; Extend bfloat -> float  (left-shift 16, no libcall)
++; ---------------------------------------------------------------------------
++
++define float @extend_bf16_to_f32(bfloat %a) nounwind {
++; CHECK-LABEL: extend_bf16_to_f32:
++; CHECK:       # %bb.0:
++; CHECK:         slwi r3, r3, 16
++; CHECK:         mtvsrwz
++; CHECK:         xscvspdpn
++; CHECK-NEXT:    blr
++  %r = fpext bfloat %a to float
++  ret float %r
++}
++
++; ---------------------------------------------------------------------------
++; Truncate float -> bfloat  (calls __truncsfbf2)
++; ---------------------------------------------------------------------------
++
++define bfloat @trunc_f32_to_bf16(float %a) nounwind {
++; CHECK-LABEL: trunc_f32_to_bf16:
++; CHECK:       # %bb.0:
++; CHECK:         bl __truncsfbf2
++  %r = fptrunc float %a to bfloat
++  ret bfloat %r
++}
++
++; ---------------------------------------------------------------------------
++; Arithmetic: addition  (promote both operands, fadd in f32, truncate result)
++; ---------------------------------------------------------------------------
++
++define bfloat @add_bf16(bfloat %a, bfloat %b) nounwind {
++; CHECK-LABEL: add_bf16:
++; CHECK:       # %bb.0:
++; CHECK:         slwi {{r[0-9]+}}, {{r[0-9]+}}, 16
++; CHECK:         slwi {{r[0-9]+}}, {{r[0-9]+}}, 16
++; CHECK:         fadds
++; CHECK:         bl __truncsfbf2
++  %r = fadd bfloat %a, %b
++  ret bfloat %r
++}
++
++; ---------------------------------------------------------------------------
++; Comparison  (promote both operands to f32, then compare)
++; ---------------------------------------------------------------------------
++
++define i1 @cmp_bf16(bfloat %a, bfloat %b) nounwind {
++; CHECK-LABEL: cmp_bf16:
++; CHECK:       # %bb.0:
++; CHECK:         slwi {{r[0-9]+}}, {{r[0-9]+}}, 16
++; CHECK:         slwi {{r[0-9]+}}, {{r[0-9]+}}, 16
++; CHECK:         fcmpu
++  %r = fcmp olt bfloat %a, %b
++  ret i1 %r
++}
++
++; ---------------------------------------------------------------------------
++; Integer to bfloat conversion
++; ---------------------------------------------------------------------------
++
++define bfloat @sitofp_i32_to_bf16(i32 %a) nounwind {
++; CHECK-LABEL: sitofp_i32_to_bf16:
++; CHECK:       # %bb.0:
++; CHECK:         bl __truncsfbf2
++  %r = sitofp i32 %a to bfloat
++  ret bfloat %r
++}
+-- 
+2.43.0
+

--- a/patches/amd-mainline/llvm-project/0003-gcc-14-15-toolsets.patch
+++ b/patches/amd-mainline/llvm-project/0003-gcc-14-15-toolsets.patch
@@ -1,0 +1,25 @@
+From 40b773676885173c72668daef2a3b738585c707a Mon Sep 17 00:00:00 2001
+From: benrichard-amd <ben.richard@amd.com>
+Date: Tue, 21 Jul 2026 18:26:19 +0000
+Subject: [PATCH] [clang] Add gcc-toolset-14 and gcc-toolset-15
+
+---
+ clang/lib/Driver/ToolChains/Gnu.cpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/clang/lib/Driver/ToolChains/Gnu.cpp b/clang/lib/Driver/ToolChains/Gnu.cpp
+index bde8a3a3cd7d..af78e7587019 100644
+--- a/clang/lib/Driver/ToolChains/Gnu.cpp
++++ b/clang/lib/Driver/ToolChains/Gnu.cpp
+@@ -2345,6 +2345,8 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+       D.getVFS().exists("/opt/rh")) {
+     // TODO: We may want to remove this, since the functionality
+     //   can be achieved using config files.
++    Prefixes.push_back("/opt/rh/gcc-toolset-15/root/usr");
++    Prefixes.push_back("/opt/rh/gcc-toolset-14/root/usr");
+     Prefixes.push_back("/opt/rh/gcc-toolset-13/root/usr");
+     Prefixes.push_back("/opt/rh/gcc-toolset-12/root/usr");
+     Prefixes.push_back("/opt/rh/gcc-toolset-11/root/usr");
+-- 
+2.52.0
+


### PR DESCRIPTION
## Motivation

Part of https://github.com/ROCm/TheRock/issues/5518: ROCm  upstream PowerPC patches

Some ROCm codepaths use  `_Float16` and `__bf16` types. There is currently no `_Float16` or `__bf16` ABI defined for PowerPC in either Clang or GCC. An upstream ABI proposal is in progress ([llvm/llvm-project#196559](https://github.com/llvm/llvm-project/pull/196559)), but has not yet landed.

Similarly, Clang's driver does not yet detect GCC 14/15 toolsets on RHEL/CentOS, though an upstream PR exists ([llvm/llvm-project#178459](https://github.com/llvm/llvm-project/pull/178459)).

This PR adds temporary LLVM patches to provide provisional bf16/fp16 support and GCC toolset detection on ppc64le, enabling TheRock builds on POWER. These patches are intended to be removed once the upstream PRs are merged.

These patches have been carried in the [TheRock ppc64le branch](https://github.com/ROCm/TheRock/tree/benrichard-amd/ppc64le) for several months in full ROCm and PyTorch builds.

> **ABI caveat:** Since no official bf16/fp16 ABI exists for POWER yet, these patches introduce a provisional one. The final upstream ABI may differ, which would require rebuilding any binaries compiled with these patches.

## Technical Details

### Patch 1: `_Float16` support (`0001-PowerPC-Float16.patch`)

Enables the `_Float16` type on PowerPC Linux targets via software promotion to `float32`, matching the approach used by AArch64 and RISC-V.

**Clang frontend (`clang/lib/Basic/Targets/PPC.{cpp,h}`):**
- Sets `HasFloat16 = true` and `HasBFloat16 = true` in the PPC target constructor.
- Overrides `useFP16ConversionIntrinsics()` to return `false`, so Clang emits the LLVM `half` IR type directly rather than `i16` with `__gnu_h2f_ieee`/`__gnu_f2h_ieee` libcalls.
- Disables both types on AIX, soft-float, and SPE targets (ABI not yet defined for those).

**LLVM backend (`PPCISelLowering`):**
- On ISA 3.0+ (Power9): marks `FP16_TO_FP` and `FP_TO_FP16` as `Legal` for `f32`/`f64`, activating the existing `XSCVHPDP`/`XSCVDPHP` instruction patterns for hardware f16 conversion. Extending loads (`LXSIHZX`) and truncating stores (`STXSIHX`) were already wired up.
- On sub-P9: `TypeSoftPromoteHalf` handles all f16 operations via `__extendhfsf2`/`__truncsfhf2` libcalls, with `lhz`/`sth` for memory accesses.

**Tests added:**
- `clang/test/CodeGen/PowerPC/Float16.c` — verifies the frontend emits `half` IR type for `_Float16` arithmetic on ppc64le and ppc32.
- `clang/test/Sema/Float16.c`, `clang/test/SemaCXX/Float16.cpp` — adds `powerpc` and `powerpc64le` triples to the existing passing-platform lists.
- `llvm/test/CodeGen/PowerPC/float16-soft-promote.ll` — comprehensive backend codegen test covering load/store, arithmetic, extend, truncate, extending load, truncating store, comparison, and `sitofp` for both P8 and P9.

### Patch 2: `__bf16` support (`0002-PowerPC-bf16.patch`)

Enables the `__bf16` type on PowerPC Linux targets. All operations are soft-promoted to `f32`.

**LLVM backend (`llvm/lib/Target/PowerPC/PPCISelLowering.cpp`):**
- Marks all extending loads and truncating stores for `MVT::bf16` as `Expand`, directing `TypeSoftPromoteHalf` to use integer `lhz`/`sth` for memory accesses.
- Marks `BF16_TO_FP` and `FP_TO_BF16` as `Expand` for `f32`/`f64`/`f128`, so `LegalizeDAG` expands them to shift+bitcast (extend) and `__truncsfbf2` libcall (truncate) sequences before ISel. Without this, they default to `Legal` and reach ISel with no matching `.td` pattern, causing a "Cannot select" crash.

**Tests added:**
- `clang/test/CodeGen/PowerPC/bfloat16.c` — verifies the frontend accepts `__bf16` and emits `bfloat` IR type with correct `sizeof`/`_Alignof`.
- `llvm/test/CodeGen/PowerPC/bfloat16-soft-promote.ll` — backend codegen test covering load/store, extend (inline left-shift-16), truncate (`__truncsfbf2`), arithmetic, comparison, and `sitofp` for P8 and P10.

### Patch 3: GCC 14/15 toolset detection (`0003-gcc-14-15-toolsets.patch`)

Adds `/opt/rh/gcc-toolset-14` and `/opt/rh/gcc-toolset-15` to the Clang driver's RHEL/CentOS GCC toolset search prefixes, enabling Clang to find GCC 14 and 15 installations on systems using Red Hat's `gcc-toolset` packages.

### Scope

All changes are confined to PPC-specific code paths. The only non-`PowerPC`-directory files touched are minor additions to `clang/test/Sema/Float16.c` and `clang/test/SemaCXX/Float16.cpp` (adding PPC triples to existing platform check lists). No cross-platform code is modified.

## Test Plan

- [x] Verified patches apply cleanly to the LLVM source tree used by TheRock
- [x] Verified TheRock and PyTorch build successfully
- [x] Verified successful PyTorch test run on x86 
- [x]  Verified basic PyTorch functionality

