### PR TITLE
ci(hipkernelprovider): add test filter standardization

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -590,11 +590,12 @@ test_matrix = {
             "windows": 1,
         },
     },
+    # hip-kernel-provider tests
     "hipkernelprovider": {
         "job_name": "hipkernelprovider",
         "fetch_artifact_args": "--hipdnn --hipkernelprovider --hipdnn-integration-tests --tests",
         "timeout_minutes": 30,
-        "test_script": f"python {_get_script_path('test_hipkernelprovider.py')}",
+        "test_script": f"python {_get_script_path('test_runner.py')}",
         "platform": ["linux", "windows"],
         "total_shards_dict": {
             "linux": 1,

--- a/build_tools/github_actions/test_executable_scripts/test_runner.py
+++ b/build_tools/github_actions/test_executable_scripts/test_runner.py
@@ -83,6 +83,7 @@ COMPONENT_DIR_MAPPING = {
     "rocroller": "rocroller",
     "hipblas": "hipblas",
     "hipblasltprovider": "hipblaslt_plugin",
+    "hipkernelprovider": "hip_kernel_provider",
     "hiptensor": "hiptensor",
     # Add more mappings as needed
 }


### PR DESCRIPTION
## Summary

Switches TheRock's `hipkernelprovider` test job from the bespoke `test_hipkernelprovider.py` to the shared `test_runner.py`, so hip-kernel-provider tests are selected by the standardized `quick`/`standard`/`comprehensive`/`full` CTest category labels instead of an ad hoc `GTEST_FILTER=-Full*`. This mirrors the miopen-provider standardization in [PR #5775](https://github.com/ROCm/TheRock/pull/5775). The labeled `bin/hip_kernel_provider/CTestTestfile.cmake` this relies on comes in through the regular `rocm-libraries` submodule pointer on `main`; this PR no longer bumps the submodule itself.

JIRA ID : ALMIOPEN-2278

## Risk Assessment

Low risk. CI configuration only — no product code, no public API, no build wiring, no submodule movement. The behavioral change is which tests the `hipkernelprovider` job selects; a mislabeled or missing CTest label surfaces as tests being skipped rather than as a build or product failure.

## ASIC Coverage

TheRock PR CI runs the `hipkernelprovider` component job on all supported GPU families (the job declares no `exclude_family`), so passing PR CI is the required coverage; no separate multi-arch sweep is needed. The label-driven selection is arch-independent — `HIP_MLOPS_ENGINE_test_categories.yaml` matches on GTest names, not architecture — so no arch-scoped gate applies.

## Testing Summary

- Unit coverage for the CI configuration generator, confirming the `hipkernelprovider` entry still produces a valid test configuration after the `test_script` swap.
- Runtime validation of the new path (label discovery, `ctest -L ^quick$` selection, install-dir resolution) is deferred to PR CI, which is the only place the built artifact exists.
- Requires the `rocm-libraries` pointer on `main` to already carry the labeled install-tree `CTestTestfile.cmake`; if PR CI reports zero selected tests, that pointer has not landed yet.

## Testing Checklist

- [x] CI config generator unit tests - `pytest build_tools/github_actions/tests/fetch_test_configurations_test.py` - Status: Passed
- [ ] hipkernelprovider component tests - `test_runner.py` with `TEST_COMPONENT=hipkernelprovider` - Status: Pending
- [ ] Test coverage for the new `COMPONENT_DIR_MAPPING` entry - Status: Not added
- [ ] PR CI - GitHub PR checks - Status: Pending

## Technical Changes

- `fetch_test_configurations.py`: `hipkernelprovider` `test_script` now points at `test_runner.py`, so the generic runner drives `ctest` from `THEROCK_BIN_DIR/hip_kernel_provider` using the category labels, replacing the legacy `test_hipkernelprovider.py` one-off.
- `test_runner.py`: adds `hipkernelprovider -> hip_kernel_provider` to `COMPONENT_DIR_MAPPING`. `TEST_COMPONENT` is set from the job name, which does not match the provider's install directory name under `THEROCK_BIN_DIR`.
- `rocm-libraries`: no longer touched. The earlier bump to `8e3b05a0dd51` has been reverted to the base pointer; the labeled `CTestTestfile.cmake` and tiered GTest/external-integration/rocKE labels arrive via the normal submodule advance on `main`.
- `ml-libs/artifact-hipkernelprovider.toml` intentionally unchanged: unlike the miopen-provider manifest, its test component already ships `CTestTestfile.cmake`, both GTest binaries, the engine config TOMLs, and the rocKE test payload, so no include broadening is required.
