### PR TITLE
fix(build): remove stage.prebuilt marker on subproject expunge

### DIFF
--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -1126,10 +1126,12 @@ function(therock_cmake_subproject_activate target_name)
   add_custom_target("${target_name}+dist")
 
   # expunge target
+  # The prebuilt marker sits next to the stage dir, not inside it, so it has to
+  # be deleted here too or the project stays disabled.
   add_custom_target(
     "${target_name}+expunge"
     COMMAND
-      ${CMAKE_COMMAND} -E rm -rf "${_binary_dir}" "${_stage_dir}" "${_stamp_dir}" "${_dist_dir}"
+      ${CMAKE_COMMAND} -E rm -rf "${_binary_dir}" "${_stage_dir}" "${_stamp_dir}" "${_dist_dir}" "${_prebuilt_file}"
   )
   add_dependencies(therock-expunge "${target_name}+expunge")
 


### PR DESCRIPTION
## Motivation

`buildctl.py disable` writes a `stage.prebuilt` marker next to a project's `stage/` dir. `+expunge` deletes the build, stage, stamp and dist dirs, but the marker sits next to `stage/` instead of inside it, so it survived. The next configure picked it up and the project stayed disabled. Only way out was deleting the file by hand.

ISSUE ID: #2653

## Technical Details

Adds `${_prebuilt_file}` to the paths `+expunge` deletes.

## Test Plan

`build_tools/tests/therock_subproject_expunge_test.py` builds a small project that includes the real `cmake/therock_subproject.cmake`, drops the marker, runs `+expunge` and checks it's gone. Needs cmake and ninja, which the `unit_tests.yml` runners already have.

## Test Result

Fails on main but passes with change.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.

Written with AI but I reviewed.