### PR TITLE
fix(build): restore owner-write before patchelf on materialized files

### DIFF
--- a/build_tools/_therock_utils/py_packaging.py
+++ b/build_tools/_therock_utils/py_packaging.py
@@ -13,6 +13,7 @@ import os
 from pathlib import Path
 import platform
 import shlex
+import stat
 import subprocess
 import shutil
 import sys
@@ -490,6 +491,10 @@ class PopulatedDistPackage:
         # We have to patch many files, so we do not hard-link: always copy.
         log(f"  MATERIALIZE: {relpath} (from {src_path})", vlog=2)
         shutil.copy2(src_path, dest_path)
+        # copy2 preserves source mode bits. Some upstream files (e.g. LLVM's
+        # OMPD gdb module) are installed read-only, and patchelf below opens the
+        # file for writing, so guarantee the owner-write bit first.
+        os.chmod(dest_path, os.stat(dest_path).st_mode | stat.S_IWUSR)
         if self.files.has(relpath):
             log(f"WARNING: Path already materialized: {relpath}")
         else:

--- a/build_tools/tests/py_packaging_test.py
+++ b/build_tools/tests/py_packaging_test.py
@@ -11,6 +11,7 @@ These tests cover:
 
 import json
 import os
+import stat
 import subprocess
 import tempfile
 import unittest
@@ -1747,6 +1748,58 @@ class EnsureProfilerLibrarySymlinksTest(unittest.TestCase):
 
         link = self.lib_dir / "libprofiler-hub.so"
         self.assertEqual(os.readlink(link), "libprofiler-hub.so.99")
+
+
+# ---------------------------------------------------------------------------
+# Tests for materialize permission handling
+# ---------------------------------------------------------------------------
+
+
+def _scandir_entry(path: Path) -> os.DirEntry:
+    with os.scandir(path.parent) as it:
+        for entry in it:
+            if entry.name == path.name:
+                return entry
+    raise FileNotFoundError(path)
+
+
+class MaterializeReadOnlySourceTest(TmpDirTestCase):
+    """Regression test for materializing a read-only upstream file.
+
+    shutil.copy2 preserves the source mode bits, so a read-only source (e.g.
+    LLVM's OMPD gdb module, or any file owned by another user in a shared
+    build tree) was copied read-only. The subsequent patchelf pass then could
+    not open the file for writing. _populate_file must restore the owner-write
+    bit on the materialized file regardless of the source permissions.
+    """
+
+    def test_readonly_source_becomes_owner_writable(self):
+        # Build a package instance without running __init__ (which needs a full
+        # dist_info catalog); _populate_file only touches self.files.
+        pkg = PopulatedDistPackage.__new__(PopulatedDistPackage)
+        pkg.files = PopulatedFiles()
+
+        # Use a .txt source so get_file_type() returns "text" and the ELF
+        # rpath path (patchelf) is skipped — we only exercise the copy+chmod.
+        src = self.write_file("readonly.txt", "payload")
+        # Owner read-only (no write bit); this is the exact condition the fix
+        # handles. 0o400 rather than 0o444 keeps the temp file non-world-readable.
+        os.chmod(src, 0o400)
+
+        dest_path = self.temp_dir / "dest" / "readonly.txt"
+        pkg._populate_file(
+            "readonly.txt",
+            dest_path,
+            _scandir_entry(src),
+            resolve_src=False,
+        )
+
+        mode = stat.S_IMODE(os.stat(dest_path).st_mode)
+        self.assertEqual(dest_path.read_text(), "payload")
+        self.assertTrue(
+            mode & stat.S_IWUSR,
+            f"expected owner-write bit to be set, got mode {oct(mode)}",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #6396

## Motivation

Configure, build, and install from an existing source / build / install tree in
a container where files and directories are owned by a different user but are
writable by all users. `py_packaging.py` performs a `copy2` before modifying a
file; when the source owner differs from the destination, some mode bits are
not set properly and the subsequent `patchelf` pass cannot open the file for
writing (fails with `EPERM`/`EACCES`).

## Technical Details

`_populate_file` (`build_tools/_therock_utils/py_packaging.py`) now restores the
owner-write bit on the freshly-materialized copy before the rpath/patchelf pass
runs, regardless of the source file's permissions.

Note: this is the packaging-permissions half of #6396. The cross-owner cmake
super-project hook forwarding from the original change is handled out-of-tree
(via `CMAKE_PROJECT_TOP_LEVEL_INCLUDES`) and is intentionally not part of this PR.

## Test Plan

- Added unit test `MaterializeReadOnlySourceTest` in
  `build_tools/tests/py_packaging_test.py`: a read-only, owner-only (`0o400`)
  source is materialized and the destination is asserted to have the owner-write
  bit set.
- `python -m pytest build_tools/tests/py_packaging_test.py -q`

## Test Result

`65 passed`. Cross-owner build completes with no patchelf permission errors.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.