### PR TITLE
Exclude hsakmt-staticdrm from Windows CLR artifacts

### DIFF
--- a/core/artifact-core-hip.toml
+++ b/core/artifact-core-hip.toml
@@ -25,6 +25,7 @@ exclude = [
   "lib/cmake/hsakmt/**",
   "lib/hsa-runtime64.lib",
   "lib/hsakmt.lib",
+  "lib/hsakmt-staticdrm.lib",
   "lib/wkmi.lib",
 ]
 [components.doc."core/clr/stage"]

--- a/core/artifact-core-ocl.toml
+++ b/core/artifact-core-ocl.toml
@@ -24,6 +24,7 @@ exclude = [
   "lib/cmake/hsakmt/**",
   "lib/hsa-runtime64.lib",
   "lib/hsakmt.lib",
+  "lib/hsakmt-staticdrm.lib",
   "lib/wkmi.lib",
 ]
 [components.doc."core/ocl-clr/stage"]


### PR DESCRIPTION
## Motivation

GitHub issue: https://github.com/ROCm/rocm-systems/issues/7923

ROCm/rocm-systems#9598 re-enables Windows installation of ROCR runtime components. Both `hip-clr` and `ocl-clr` build HSA statically and consequently stage `hsakmt-staticdrm.lib`.

Packaging that internal library in both `core-hip` and `core-ocl` causes TheRock's artifact-structure validation to report a cross-artifact overlap.

Related upstream PR: https://github.com/ROCm/rocm-systems/pull/9598

## Technical Details

Exclude `lib/hsakmt-staticdrm.lib` from the development components of both the `core-hip` and `core-ocl` artifacts.

The library is consumed while linking the statically embedded HSA runtimes into the HIP and OpenCL DLLs. It is not required as a separately distributed CLR artifact.

The exclusion is unconditional because both CLR projects build static HSA regardless of whether the optional standalone Windows shared HSA runtime is enabled.

## Test Plan

Validated locally on Windows with the rocm-systems submodule checked out at the head of ROCm/rocm-systems#9598 (`fd7a9f298d`).

Regenerated and archived the affected core artifacts, then ran:

```powershell
$env:PLATFORM = "windows"
python -m pytest tests/test_artifact_structure.py `
  -v --log-cli-level=info --timeout=300
```

Tested both supported configurations:

1. `THEROCK_FLAG_HSA_WINDOWS_SHARED_RUNTIME=ON` with `THEROCK_ENABLE_CORE_RUNTIME=ON`.
2. `THEROCK_FLAG_HSA_WINDOWS_SHARED_RUNTIME=OFF` with `THEROCK_ENABLE_CORE_RUNTIME=OFF`.

## Test Result

Shared HSA runtime enabled:

- 16 archives across `core-runtime`, `core-hip`, and `core-ocl`
- 182 unique paths
- No cross-artifact or within-artifact component overlaps
- 2 passed, 1 Windows-specific package-coverage skip

Shared HSA runtime disabled:

- 11 archives across `core-hip` and `core-ocl`
- 137 unique paths
- No cross-artifact or within-artifact component overlaps
- 2 passed, 1 Windows-specific package-coverage skip

## Submission Checklist

- [x] Looked over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.