### PR TITLE
fix(pytorch): Add libamd_smi to the Linux library wheel preload list

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,10 @@
+# gitleaks fingerprint suppressions for historical findings.
+# Each line is a fingerprint: commit:file:rule:line
+# These are false positives — variable names that match secret patterns but
+# contain no real secrets. Keep this file shrinking by fixing the source
+# when possible; use this only for findings in already-merged commits.
+
+# aggregate_metadata_test.py: variable named 'key' holding a test NEVRA string
+# "key = 'pkg1_2.0_amd64'" is a test NEVRA key, not an API key.
+# Fixed in source: renamed to 'nevra' in subsequent commit.
+8a41fc81026a3a5d0321c3a5c389d21e7cfa3520:build_tools/packaging/linux/tests/aggregate_metadata_test.py:generic-api-key:270

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -164,6 +164,7 @@ LLVM_BASE_URL = "https://oaitriton.blob.core.windows.net/public/llvm-builds"
 # List of library preloads for Linux to generate into _rocm_init.py
 LINUX_LIBRARY_PRELOADS = [
     "amd_comgr",
+    "amd_smi",  # Preload with RTLD_GLOBAL so IntraNodeComm::getNvlMesh can resolve amdsmi symbols via dlsym(RTLD_DEFAULT, ...)
     "amdhip64",
     "rocprofiler-sdk",  # Linux only: needed by torch since kineto uses rocprofiler-sdk.
     "rocprofiler-sdk-roctx",  # Linux only for the moment.


### PR DESCRIPTION
## Summary

Add `libamd_smi` to the Linux library preload list in the PyTorch wheel build
so that amdsmi symbols are available via `dlsym(RTLD_DEFAULT, ...)` in
`IntraNodeComm::getNvlMesh`.

JIRA ID : ROCM-27833

## Motivation

Two distributed NCCL tests hang and timeout after 300 seconds on ROCm Python
wheel installs (ROCM-27833):

- `CommTest::test_intra_node_comm_all_reduce_custom_group_name_False`
- `CommTest::test_intra_node_comm_all_reduce_custom_group_name_True`

Root cause: `IntraNodeComm::getNvlMesh` calls `dlopen("libamd_smi.so")` to
load amdsmi for NVLink/xGMI mesh detection. In ROCm Python wheel installs,
only the versioned `libamd_smi.so.26` exists in `_rocm_sdk_core/lib/` — there
is no unversioned `libamd_smi.so` in the runtime package. `dlopen` by
unversioned name fails, causing the intra-node communication path to break.

## Technical Details

`_rocm_init.py` (generated by `get_rocm_init_contents()` and injected into
the torch wheel at build time) calls `rocm_sdk.initialize_process()` with a
list of library shortnames on `import torch`. Each library is loaded via
`ctypes.CDLL(path, mode=RTLD_GLOBAL)`, which exports all its symbols into
the process-wide global symbol table.

Adding `"amd_smi"` to `LINUX_LIBRARY_PRELOADS` causes `libamd_smi.so.26` to
be loaded with `RTLD_GLOBAL` on torch import. The paired PyTorch change
(`intra_node_comm.cpp`) then uses `dlsym(RTLD_DEFAULT, "amdsmi_init")` as the
primary lookup — which finds the symbol in the global table regardless of
what filename the library was opened with — and falls back to `dlopen` for
system ROCm installs where the library is not preloaded.

## Test Plan

- Rebuild PyTorch wheel with this change
- Install wheel without `rocm-sdk-devel`:
  ```bash
  pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
      "torch[device-gfx942]"
