### PR TITLE
fix(pytorch): Add libamd_smi to the Linux library wheel preload list

### DIFF
--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -161,10 +161,14 @@ is_windows = platform.system() == "Windows"
 # LLVM download URL for triton-windows
 LLVM_BASE_URL = "https://oaitriton.blob.core.windows.net/public/llvm-builds"
 
-# List of library preloads for Linux to generate into _rocm_init.py
+# List of library preloads for Linux to generate into _rocm_init.py.
+# These are loaded with RTLD_GLOBAL on `import torch` via _rocm_init.py so
+# that their symbols are available via dlsym(RTLD_DEFAULT, ...) without
+# requiring a successful dlopen by unversioned name (which fails in wheel
+# installs where only the versioned .so exists in the runtime package).
 LINUX_LIBRARY_PRELOADS = [
     "amd_comgr",
-    "amd_smi",  # Preload with RTLD_GLOBAL so amdsmi symbols are resolvable via dlsym(RTLD_DEFAULT, ...)
+    "amd_smi",
     "amdhip64",
     "rocprofiler-sdk",  # Linux only: needed by torch since kineto uses rocprofiler-sdk.
     "rocprofiler-sdk-roctx",  # Linux only for the moment.

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -164,6 +164,7 @@ LLVM_BASE_URL = "https://oaitriton.blob.core.windows.net/public/llvm-builds"
 # List of library preloads for Linux to generate into _rocm_init.py
 LINUX_LIBRARY_PRELOADS = [
     "amd_comgr",
+    "amd_smi",  # Preload with RTLD_GLOBAL so amdsmi symbols are resolvable via dlsym(RTLD_DEFAULT, ...)
     "amdhip64",
     "rocprofiler-sdk",  # Linux only: needed by torch since kineto uses rocprofiler-sdk.
     "rocprofiler-sdk-roctx",  # Linux only for the moment.

--- a/external-builds/pytorch/smoke-tests/pytorch_smoke_test.py
+++ b/external-builds/pytorch/smoke-tests/pytorch_smoke_test.py
@@ -1,10 +1,13 @@
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
+import ctypes
 import logging
-import torch
-import pytest
+import platform
 import re
+
+import pytest
+import torch
 
 
 class TestROCmAvailability:
@@ -158,3 +161,68 @@ class TestOpenBLASAvailability:
         assert output_u.device == torch.device("cpu")
         assert output_s.device == torch.device("cpu")
         assert output_vh.device == torch.device("cpu")
+
+
+@pytest.mark.skipif(platform.system() != "Linux", reason="Linux only")
+class TestRocmSdkLibraries:
+    """Verify rocm_sdk library packaging and preload correctness on Linux.
+
+    Two layers of checks:
+
+    1. Packaging (test_all_exported_libraries_findable):
+       Verifies every installed rocm_sdk library resolves to an existing file
+       via rocm_sdk.find_libraries. Catches files missing from a package.
+
+    2. Runtime preload (test_amdsmi_symbol_resolvable_via_rtld_default):
+       import torch triggers _rocm_init.py which calls rocm_sdk.initialize_process,
+       preloading libamd_smi.so with RTLD_GLOBAL. Verifies amdsmi symbols are
+       resolvable via dlsym(RTLD_DEFAULT, ...) so IntraNodeComm::getNvlMesh can
+       resolve them without needing dlopen("libamd_smi.so") to succeed by filename.
+       See ROCM-27833.
+    """
+
+    # ctypes.CDLL(None) is the Python equivalent of dlsym(RTLD_DEFAULT, ...)
+    _rtld_default = ctypes.CDLL(None)
+
+    _AMDSMI_SYMBOLS = [
+        "amdsmi_init",
+        "amdsmi_get_socket_handles",
+        "amdsmi_get_processor_handles",
+        "amdsmi_is_P2P_accessible",
+    ]
+
+    def test_all_exported_libraries_findable(self):
+        """Verify all installed rocm_sdk libraries are findable — packaging layer check.
+
+        Iterates over every library declared in _dist_info.ALL_LIBRARIES whose
+        package is installed and verifies it resolves to an existing file via
+        rocm_sdk.find_libraries. Libraries whose package is not installed are
+        skipped (e.g. rocm-sdk-libraries may not be present in all test configs).
+        If this fails, a library is missing from an installed package which is a
+        packaging issue. If this passes but the dlsym tests fail, the library
+        exists but was not preloaded with RTLD_GLOBAL.
+        """
+        import importlib
+
+        import rocm_sdk
+        from rocm_sdk import _dist_info
+
+        for shortname, entry in _dist_info.ALL_LIBRARIES.items():
+            if entry.optional:
+                continue  # skip optional libs (e.g. rocdxg — WSL only)
+            # Skip if the package that provides this library is not installed
+            py_package_name = entry.package.pure_py_package_name
+            if importlib.util.find_spec(py_package_name) is None:
+                continue
+            paths = rocm_sdk.find_libraries(shortname)
+            assert paths, f"rocm_sdk.find_libraries('{shortname}') returned no paths"
+            assert paths[0].exists(), f"Library '{shortname}' not found at {paths[0]}"
+
+    @pytest.mark.parametrize("symbol", _AMDSMI_SYMBOLS)
+    def test_amdsmi_symbol_resolvable_via_rtld_default(self, symbol):
+        fn = getattr(self._rtld_default, symbol, None)
+        addr = ctypes.cast(fn, ctypes.c_void_p).value
+        assert addr, (
+            f"dlsym(RTLD_DEFAULT, '{symbol}') returned NULL — "
+            f"libamd_smi was not preloaded with RTLD_GLOBAL by _rocm_init.py"
+        )

--- a/external-builds/pytorch/smoke-tests/pytorch_smoke_test.py
+++ b/external-builds/pytorch/smoke-tests/pytorch_smoke_test.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 
 import ctypes
+import importlib
+import importlib.util
 import logging
 import platform
 import re
@@ -165,64 +167,65 @@ class TestOpenBLASAvailability:
 
 @pytest.mark.skipif(platform.system() != "Linux", reason="Linux only")
 class TestRocmSdkLibraries:
-    """Verify rocm_sdk library packaging and preload correctness on Linux.
+    """Verify that import torch preloads ROCm libraries with RTLD_GLOBAL on Linux.
 
-    Two layers of checks:
+    import torch triggers _rocm_init.py (injected into the torch wheel by TheRock)
+    which calls rocm_sdk.initialize_process, loading each library in
+    LINUX_LIBRARY_PRELOADS with RTLD_GLOBAL. This makes their symbols available
+    via dlsym(RTLD_DEFAULT, ...) so native code can resolve them without needing
+    dlopen by unversioned name (which fails in wheel installs where only the
+    versioned .so exists). See ROCM-27833.
 
-    1. Packaging (test_all_exported_libraries_findable):
-       Verifies every installed rocm_sdk library resolves to an existing file
-       via rocm_sdk.find_libraries. Catches files missing from a package.
-
-    2. Runtime preload (test_amdsmi_symbol_resolvable_via_rtld_default):
-       import torch triggers _rocm_init.py which calls rocm_sdk.initialize_process,
-       preloading libamd_smi.so with RTLD_GLOBAL. Verifies amdsmi symbols are
-       resolvable via dlsym(RTLD_DEFAULT, ...) so IntraNodeComm::getNvlMesh can
-       resolve them without needing dlopen("libamd_smi.so") to succeed by filename.
-       See ROCM-27833.
+    Libraries tested:
+      - rocm-sdk-core libraries (amd_smi, amdhip64): always installed with torch.
+      - rocm-sdk-libraries (hipblas): installed as a torch dependency but not
+        guaranteed in all configurations (e.g. narrow installs). Skipped when
+        rocm_sdk_libraries is not importable.
     """
 
     # ctypes.CDLL(None) is the Python equivalent of dlsym(RTLD_DEFAULT, ...)
     _rtld_default = ctypes.CDLL(None)
 
-    _AMDSMI_SYMBOLS = [
-        "amdsmi_init",
-        "amdsmi_get_socket_handles",
-        "amdsmi_get_processor_handles",
-        "amdsmi_is_P2P_accessible",
+    # Symbols from rocm-sdk-core — always installed with torch, no skip needed.
+    _CORE_PRELOAD_SYMBOLS = [
+        (
+            "amd_smi",
+            "amdsmi_init",
+        ),  # ROCM-27833: dlopen by name fails in wheel installs
+        ("amd_smi", "amdsmi_get_socket_handles"),
+        ("amd_smi", "amdsmi_get_processor_handles"),
+        ("amd_smi", "amdsmi_is_P2P_accessible"),
+        ("amdhip64", "hipGetDeviceCount"),  # HIP runtime — core dependency of torch
     ]
 
-    def test_all_exported_libraries_findable(self):
-        """Verify all installed rocm_sdk libraries are findable — packaging layer check.
+    # Symbols from rocm-sdk-libraries — installed as a torch dependency but may
+    # be absent in narrow configurations (e.g. rocm[core] only). Skipped when
+    # rocm_sdk_libraries is not importable so narrow installs don't fail here.
+    _LIBRARIES_PRELOAD_SYMBOLS = [
+        ("hipblas", "hipblasCreate"),
+    ]
 
-        Iterates over every library declared in _dist_info.ALL_LIBRARIES whose
-        package is installed and verifies it resolves to an existing file via
-        rocm_sdk.find_libraries. Libraries whose package is not installed are
-        skipped (e.g. rocm-sdk-libraries may not be present in all test configs).
-        If this fails, a library is missing from an installed package which is a
-        packaging issue. If this passes but the dlsym tests fail, the library
-        exists but was not preloaded with RTLD_GLOBAL.
-        """
-        import importlib
-
-        import rocm_sdk
-        from rocm_sdk import _dist_info
-
-        for shortname, entry in _dist_info.ALL_LIBRARIES.items():
-            if entry.optional:
-                continue  # skip optional libs (e.g. rocdxg — WSL only)
-            # Skip if the package that provides this library is not installed
-            py_package_name = entry.package.pure_py_package_name
-            if importlib.util.find_spec(py_package_name) is None:
-                continue
-            paths = rocm_sdk.find_libraries(shortname)
-            assert paths, f"rocm_sdk.find_libraries('{shortname}') returned no paths"
-            assert paths[0].exists(), f"Library '{shortname}' not found at {paths[0]}"
-
-    @pytest.mark.parametrize("symbol", _AMDSMI_SYMBOLS)
-    def test_amdsmi_symbol_resolvable_via_rtld_default(self, symbol):
+    @pytest.mark.parametrize("lib,symbol", _CORE_PRELOAD_SYMBOLS)
+    def test_core_preloaded_symbol_resolvable_via_rtld_default(self, lib, symbol):
         fn = getattr(self._rtld_default, symbol, None)
         addr = ctypes.cast(fn, ctypes.c_void_p).value
         assert addr, (
             f"dlsym(RTLD_DEFAULT, '{symbol}') returned NULL — "
-            f"libamd_smi was not preloaded with RTLD_GLOBAL by _rocm_init.py"
+            f"'{lib}' was not preloaded with RTLD_GLOBAL by _rocm_init.py"
+        )
+
+    @pytest.mark.skipif(
+        # rocm-sdk-libraries is installed as a torch dependency in normal
+        # configurations, but may be absent in narrow installs (e.g. rocm[core]
+        # only). Skip rather than fail so narrow configs stay green.
+        importlib.util.find_spec("rocm_sdk_libraries") is None,
+        reason="rocm-sdk-libraries not installed",
+    )
+    @pytest.mark.parametrize("lib,symbol", _LIBRARIES_PRELOAD_SYMBOLS)
+    def test_libraries_preloaded_symbol_resolvable_via_rtld_default(self, lib, symbol):
+        fn = getattr(self._rtld_default, symbol, None)
+        addr = ctypes.cast(fn, ctypes.c_void_p).value
+        assert addr, (
+            f"dlsym(RTLD_DEFAULT, '{symbol}') returned NULL — "
+            f"'{lib}' was not preloaded with RTLD_GLOBAL by _rocm_init.py"
         )


### PR DESCRIPTION
## Summary

Add `libamd_smi` to the Linux library preload list in the PyTorch wheel build
so that amdsmi symbols are available via `dlsym(RTLD_DEFAULT, ...)` in
`IntraNodeComm::getNvlMesh`.

JIRA ID : ROCM-27833

## Motivation

Two distributed NCCL tests hang and timeout after 300 seconds on ROCm Python
wheel installs (ROCM-27833):

- `CommTest::test_intra_node_comm_all_reduce_custom_group_name_False`
- `CommTest::test_intra_node_comm_all_reduce_custom_group_name_True`

Root cause: `IntraNodeComm::getNvlMesh` calls `dlopen("libamd_smi.so")` to
load amdsmi for NVLink/xGMI mesh detection. In ROCm Python wheel installs,
only the versioned `libamd_smi.so.26` exists in `_rocm_sdk_core/lib/` — there
is no unversioned `libamd_smi.so` in the runtime package. `dlopen` by
unversioned name fails, causing the intra-node communication path to break.

## Technical Details

`_rocm_init.py` (generated by `get_rocm_init_contents()` and injected into
the torch wheel at build time) calls `rocm_sdk.initialize_process()` with a
list of library shortnames on `import torch`. Each library is loaded via
`ctypes.CDLL(path, mode=RTLD_GLOBAL)`, which exports all its symbols into
the process-wide global symbol table.

Adding `"amd_smi"` to `LINUX_LIBRARY_PRELOADS` causes `libamd_smi.so.26` to
be loaded with `RTLD_GLOBAL` on torch import. The paired PyTorch change
(`intra_node_comm.cpp`) then uses `dlsym(RTLD_DEFAULT, "amdsmi_init")` as the
primary lookup — which finds the symbol in the global table regardless of
what filename the library was opened with — and falls back to `dlopen` for
system ROCm installs where the library is not preloaded.

## Test Plan

- Rebuild PyTorch wheel with this change
- Install wheel without `rocm-sdk-devel`:
  ```bash
  pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
      "torch[device-gfx942]"
