### PR TITLE
fix(profiler): link correct rocSHMEM in rocprofiler-systems examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -515,6 +515,7 @@ add_subdirectory(emulation)
 # Data center tools (RDC, etc.)
 add_subdirectory(dctools)
 add_subdirectory(comm-libs)
+include(profiler/rocprofiler-systems-examples.cmake)
 add_subdirectory(math-libs)
 add_subdirectory(ml-libs)
 

--- a/comm-libs/CMakeLists.txt
+++ b/comm-libs/CMakeLists.txt
@@ -184,7 +184,7 @@ if(THEROCK_ENABLE_ROCSHMEM)
     SUBDIRS
       src
   )
-  therock_cmake_subproject_provide_package(rocshmem ROCSHMEM lib/cmake/rocshmem)
+  therock_cmake_subproject_provide_package(rocshmem rocshmem lib/cmake/rocshmem)
   therock_cmake_subproject_activate(rocshmem)
   list(APPEND _rocshmem_subproject_names rocshmem)
 

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -386,49 +386,4 @@ if(THEROCK_ENABLE_ROCPROFSYS)
       rocprofiler-sdk
       rocprofiler-systems
     )
-
-
-  # TODO: This should be built as target-specific, but that's not currently possible as
-  # the artifact splitter strips per-arch HIP offload bundles out of the example binaries,
-  # preventing llvm-objdump (used in our tests) from detecting the offload architectures
-  # See https://github.com/ROCm/TheRock/issues/4848
-  if(THEROCK_BUILD_TESTING)
-    # Escape semicolons in GPU targets list to prevent shell interpretation
-    if (THEROCK_TEST_AMDGPU_TARGETS STREQUAL "THEROCK_TEST_AMDGPU_TARGETS-NOTFOUND")
-      set(_ROCPROFSYS_GFX_TARGETS_ESCAPED "")
-    else()
-      string(REPLACE ";" "\\;" _ROCPROFSYS_GFX_TARGETS_ESCAPED "${THEROCK_TEST_AMDGPU_TARGETS}")
-    endif()
-
-    therock_cmake_subproject_declare(rocprofiler-systems-examples
-      USE_TEST_AMDGPU_TARGETS
-      EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rocprofiler-systems/examples"
-      BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rocprofiler-systems-examples"
-      BACKGROUND_BUILD
-      CMAKE_ARGS
-        -DROCPROFSYS_GFX_TARGETS="${_ROCPROFSYS_GFX_TARGETS_ESCAPED}"
-        -DROCPROFSYS_DISABLE_EXAMPLES="lulesh\\;openmp-target\\;causal"
-      COMPILER_TOOLCHAIN
-        amd-hip
-      INSTALL_RPATH_DIRS
-        "lib"
-        "lib/rocprofiler-systems"
-        "lib/llvm/lib"
-      RUNTIME_DEPS
-        rocprofiler-systems
-    )
-    therock_cmake_subproject_glob_c_sources(rocprofiler-systems-examples
-      SUBDIRS .
-    )
-    therock_cmake_subproject_activate(rocprofiler-systems-examples)
-
-    therock_provide_artifact(rocprofiler-systems-examples
-      TARGET_NEUTRAL
-      DESCRIPTOR "${CMAKE_SOURCE_DIR}/profiler/artifact-rocprofiler-systems-examples.toml"
-      COMPONENTS
-        test
-      SUBPROJECT_DEPS
-        rocprofiler-systems-examples
-    )
-  endif()
 endif(THEROCK_ENABLE_ROCPROFSYS)

--- a/profiler/rocprofiler-systems-examples.cmake
+++ b/profiler/rocprofiler-systems-examples.cmake
@@ -1,0 +1,67 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+if(NOT THEROCK_ENABLE_ROCPROFSYS OR NOT THEROCK_BUILD_TESTING)
+  return()
+endif()
+
+set(_rocprofiler_systems_examples_runtime_deps
+  rocprofiler-systems
+)
+set(_ROCPROFSYS_DISABLED_EXAMPLES
+  lulesh
+  openmp-target
+  causal
+)
+if(THEROCK_ENABLE_ROCSHMEM)
+  list(APPEND _rocprofiler_systems_examples_runtime_deps rocshmem)
+else()
+  list(APPEND _ROCPROFSYS_DISABLED_EXAMPLES rocshmem)
+endif()
+
+# Escape semicolons in lists to prevent shell interpretation.
+if(THEROCK_TEST_AMDGPU_TARGETS STREQUAL "THEROCK_TEST_AMDGPU_TARGETS-NOTFOUND")
+  set(_ROCPROFSYS_GFX_TARGETS_ESCAPED "")
+else()
+  string(REPLACE ";" "\;" _ROCPROFSYS_GFX_TARGETS_ESCAPED
+    "${THEROCK_TEST_AMDGPU_TARGETS}"
+  )
+endif()
+string(REPLACE ";" "\;" _ROCPROFSYS_DISABLED_EXAMPLES_ESCAPED
+  "${_ROCPROFSYS_DISABLED_EXAMPLES}"
+)
+
+# TODO: This should be built as target-specific, but that is not currently possible because
+# the artifact splitter strips per-arch HIP offload bundles out of the example binaries,
+# preventing llvm-objdump (used in our tests) from detecting the offload architectures.
+# See https://github.com/ROCm/TheRock/issues/4848.
+therock_cmake_subproject_declare(rocprofiler-systems-examples
+  USE_TEST_AMDGPU_TARGETS
+  EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rocprofiler-systems/examples"
+  BINARY_DIR "${CMAKE_BINARY_DIR}/profiler/rocprofiler-systems-examples"
+  BACKGROUND_BUILD
+  CMAKE_ARGS
+    -DROCPROFSYS_GFX_TARGETS="${_ROCPROFSYS_GFX_TARGETS_ESCAPED}"
+    -DROCPROFSYS_DISABLE_EXAMPLES="${_ROCPROFSYS_DISABLED_EXAMPLES_ESCAPED}"
+  COMPILER_TOOLCHAIN
+    amd-hip
+  INSTALL_RPATH_DIRS
+    "lib"
+    "lib/rocprofiler-systems"
+    "lib/llvm/lib"
+  RUNTIME_DEPS
+    ${_rocprofiler_systems_examples_runtime_deps}
+)
+therock_cmake_subproject_glob_c_sources(rocprofiler-systems-examples
+  SUBDIRS .
+)
+therock_cmake_subproject_activate(rocprofiler-systems-examples)
+
+therock_provide_artifact(rocprofiler-systems-examples
+  TARGET_NEUTRAL
+  DESCRIPTOR "${CMAKE_SOURCE_DIR}/profiler/artifact-rocprofiler-systems-examples.toml"
+  COMPONENTS
+    test
+  SUBPROJECT_DEPS
+    rocprofiler-systems-examples
+)


### PR DESCRIPTION
Rocprofiler systems examples tried to link with
the wrong version of rocSHEMEM from /opt/rocm folder

Move the rocprofiler-systems examples declaration
after comm-libs so the rocSHMEM subproject exists
before the examples dependency is declared.

Register the package using the lowercase rocshmem
name expected by find_package(rocshmem). Disable the example when rocSHMEM is not enabled.

This prevents fallback to /opt/rocm, which caused:

[rocprofiler-systems-examples] lld: error: undefined symbol: ROCSHMEM_TEAM_WORLD
[rocprofiler-systems-examples] >>> referenced by /tmp/rocshmem-gfx1250-223d86.out.lto.o:(__clang_gpu_used_external)
[rocprofiler-systems-examples] clang++: error: amdgcn-link command failed with exit code 1 (use -v to see invocation)
[rocprofiler-systems-examples] ninja: build stopped: subcommand failed.
[rocprofiler-systems-examples FAILED WITH CODE 1 in 15 seconds]

Tested:
- Configured TheRock successfully.
- Built rocprofiler-systems-examples successfully.

## Motivation

Fixes therock build error.

## Technical Details

rocprofiles-systems-examples were build before the comm-libs
providing the rocshmem and rocshmem was also not defined as
a runtime dependency for the rocm-systems examples. This
caused linking to try to fallback to link the wrong rocshmem version 
it that was available in /opt/rocm directory. 

Sometimes this could cause a build break, sometimes it could work by luck if the
library versions are similar enough.

Fixes issue: https://github.com/ROCm/TheRock/issues/7064

## Test Plan

Test that build sucecess

## Test Result

Build works now for me. 
