### PR TITLE
[debug-tools] Update rocgdb test container image digest

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -129,7 +129,7 @@ _rocgdb_common = {
     "timeout_minutes": 30,
     "platform": ["linux"],
     "total_shards": 1,
-    "container_image": "ghcr.io/rocm/no_rocm_image_ubuntu24_04_rocgdb@sha256:7063e922b4b9145c92f20011674571f1c97b8fad6faaeb0b7d2d165b0bd9ae8b",  # 2026-04-02T21:47:07.506375216Z
+    "container_image": "ghcr.io/rocm/no_rocm_image_ubuntu24_04_rocgdb@sha256:aa3f8966fcdefca04d4c04fb10ae7f8b654d1bb1cc6a894ea7089e5a01953197",  # 2026-07-22T15:21:18.527038581Z
     "container_options": ["--cap-add=SYS_PTRACE"],
 }
 


### PR DESCRIPTION
Container image: ghcr.io/rocm/no_rocm_image_ubuntu24_04_rocgdb
  sha256:7063e922b4b9... -> sha256:aa3f8966fcde...

Created: 2026-07-22T15:21:18.527038581Z