### PR TITLE
feat(ci): Add mesa-fork submodule to bump automation

### DIFF
--- a/.github/workflows/bump_submodules.yml
+++ b/.github/workflows/bump_submodules.yml
@@ -53,7 +53,7 @@ jobs:
           app-id: ${{ secrets.ROCM_SYSTEMS_APP_ID }}
           private-key: ${{ secrets.ROCM_SYSTEMS_APP_PRIVATE_KEY }}
           owner: "ROCm"
-          # We will reuse the rocm-systems token for rocgdb for now.
+          # We will reuse the rocm-systems token for rocgdb and mesa-fork for now.
           repositories: "rocm-systems,rocgdb,mesa-fork,TheRock"
 
       - name: Generate GitHub App token rocm-libraries

--- a/.github/workflows/bump_submodules.yml
+++ b/.github/workflows/bump_submodules.yml
@@ -16,6 +16,7 @@ on:
           - rocm-systems
           - rocm-libraries
           - rocgdb
+          - mesa-fork
   schedule:
     - cron: "0 */12 * * *" # Runs every 12 hrs at 12AM and 12PM
   push:
@@ -25,6 +26,7 @@ on:
       - rocm-systems
       - rocm-libraries
       - debug-tools/rocgdb/source
+      - third-party/sysdeps/linux/amd-mesa/mesa-fork
 
 permissions:
   contents: read
@@ -52,7 +54,7 @@ jobs:
           private-key: ${{ secrets.ROCM_SYSTEMS_APP_PRIVATE_KEY }}
           owner: "ROCm"
           # We will reuse the rocm-systems token for rocgdb for now.
-          repositories: "rocm-systems,rocgdb,TheRock"
+          repositories: "rocm-systems,rocgdb,mesa-fork,TheRock"
 
       - name: Generate GitHub App token rocm-libraries
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -75,7 +77,8 @@ jobs:
             --submodule "${{ github.event.inputs.submodule || 'all' }}" \
             --systems_token "${{ steps.systems-token.outputs.token }}" \
             --libraries_token "${{ steps.librarian-token.outputs.token }}" \
-            --rocgdb_token "${{ steps.systems-token.outputs.token }}"
+            --rocgdb_token "${{ steps.systems-token.outputs.token }}" \
+            --mesa_token "${{ steps.systems-token.outputs.token }}"
 
       - name: Run push automation
         if: github.event_name == 'push'
@@ -86,4 +89,5 @@ jobs:
             --after "${{ github.sha }}" \
             --systems_token "${{ steps.systems-token.outputs.token }}" \
             --libraries_token "${{ steps.librarian-token.outputs.token }}" \
-            --rocgdb_token "${{ steps.systems-token.outputs.token }}"
+            --rocgdb_token "${{ steps.systems-token.outputs.token }}" \
+            --mesa_token "${{ steps.systems-token.outputs.token }}"

--- a/build_tools/github_actions/bump_automation.py
+++ b/build_tools/github_actions/bump_automation.py
@@ -367,7 +367,7 @@ def handle_schedule(tokens: dict[str, str], submodule: str = "all") -> None:
         create_therock_bump("debug-tools/rocgdb/source", tokens["rocgdb"])
     if submodule in ("all", "mesa-fork"):
         create_therock_bump(
-            "third-party/sysdeps/linux/amd-mesa/mesa-fork", tokens["systems"]
+            "third-party/sysdeps/linux/amd-mesa/mesa-fork", tokens["mesa-fork"]
         )
 
 
@@ -462,6 +462,7 @@ def main() -> None:
     parser.add_argument("--systems_token", required=True)
     parser.add_argument("--libraries_token", required=True)
     parser.add_argument("--rocgdb_token", required=True)
+    parser.add_argument("--mesa_token", required=True)
     args = parser.parse_args()
 
     run(["git", "config", "--global", "user.name", BOT_NAME])
@@ -471,6 +472,7 @@ def main() -> None:
         "systems": args.systems_token,
         "libraries": args.libraries_token,
         "rocgdb": args.rocgdb_token,
+        "mesa-fork": args.mesa_token,
     }
 
     if args.event_type == "schedule":

--- a/build_tools/github_actions/bump_automation.py
+++ b/build_tools/github_actions/bump_automation.py
@@ -53,6 +53,13 @@ SUBMODULE_CONFIG = {
         "token_key": "systems",
         "branch": "amd-staging-rocgdb-16",
     },
+    "third-party/sysdeps/linux/amd-mesa/mesa-fork": {
+        "repo": "ROCm/mesa-fork",
+        "files": [],
+        "updater": "submodule-only",
+        # We will reuse the rocm-systems token for now.
+        "token_key": "systems",
+    },
 }
 
 
@@ -358,6 +365,10 @@ def handle_schedule(tokens: dict[str, str], submodule: str = "all") -> None:
         create_therock_bump("rocm-libraries", tokens["libraries"])
     if submodule in ("all", "rocgdb"):
         create_therock_bump("debug-tools/rocgdb/source", tokens["rocgdb"])
+    if submodule in ("all", "mesa-fork"):
+        create_therock_bump(
+            "third-party/sysdeps/linux/amd-mesa/mesa-fork", tokens["systems"]
+        )
 
 
 def handle_push(before: str, after: str, tokens: dict[str, str]) -> None:
@@ -444,7 +455,7 @@ def main() -> None:
     parser.add_argument(
         "--submodule",
         default="all",
-        choices=["all", "rocm-systems", "rocm-libraries", "rocgdb"],
+        choices=["all", "rocm-systems", "rocm-libraries", "rocgdb", "mesa-fork"],
     )
     parser.add_argument("--before")
     parser.add_argument("--after")

--- a/build_tools/github_actions/tests/bump_automation_test.py
+++ b/build_tools/github_actions/tests/bump_automation_test.py
@@ -311,6 +311,38 @@ class HandlePushTest(unittest.TestCase):
         # bail out before cloning the upstream repo.
         mock_tmp.assert_not_called()
 
+    def test_mesa_fork_submodule_only_closes_stale_prs_then_returns(self):
+        """mesa-fork is submodule-only: handle_push must close stale PRs using
+        the systems token and skip cloning the upstream repo."""
+
+        def changed(before, after, path):
+            return path == "third-party/sysdeps/linux/amd-mesa/mesa-fork"
+
+        with patch("bump_automation.submodule_changed", side_effect=changed):
+            with patch(
+                "bump_automation.get_submodule_sha", return_value="oldsha1234567"
+            ):
+                with patch("bump_automation.close_stale_prs") as mock_close:
+                    with patch(
+                        "bump_automation.tempfile.TemporaryDirectory"
+                    ) as mock_tmp:
+                        handle_push(
+                            "before",
+                            "after",
+                            {
+                                "systems": "systems-token",
+                                "libraries": "libraries-token",
+                                "rocgdb": "rocgdb-token",
+                                "mesa-fork": "systems-token",
+                            },
+                        )
+
+        mock_close.assert_called_once()
+        # mesa-fork reuses the systems token.
+        self.assertEqual(mock_close.call_args.args[2], "systems-token")
+        # submodule-only: must not clone any upstream repo.
+        mock_tmp.assert_not_called()
+
 
 class CreateTheRockBumpTest(unittest.TestCase):
     def test_skips_when_pr_already_open(self):
@@ -426,6 +458,41 @@ class HandleScheduleTest(unittest.TestCase):
         called_submodules = [c.args[0] for c in mock_bump.call_args_list]
         self.assertNotIn("rocm-systems", called_submodules)
         self.assertNotIn("rocm-libraries", called_submodules)
+
+    def test_mesa_fork_maps_to_correct_submodule_and_token(self):
+        """handle_schedule('mesa-fork') must call create_therock_bump with
+        'third-party/sysdeps/linux/amd-mesa/mesa-fork' and tokens['mesa-fork']."""
+        tokens = {
+            "systems": "systems-token",
+            "libraries": "libraries-token",
+            "rocgdb": "rocgdb-token",
+            "mesa-fork": "mesa-fork-token",
+        }
+        with patch("bump_automation.create_therock_bump") as mock_bump:
+            from bump_automation import handle_schedule
+
+            handle_schedule(tokens, "mesa-fork")
+
+        mock_bump.assert_called_once_with(
+            "third-party/sysdeps/linux/amd-mesa/mesa-fork", "mesa-fork-token"
+        )
+
+    def test_mesa_fork_does_not_invoke_other_submodules(self):
+        tokens = {
+            "systems": "systems-token",
+            "libraries": "libraries-token",
+            "rocgdb": "rocgdb-token",
+            "mesa-fork": "mesa-fork-token",
+        }
+        with patch("bump_automation.create_therock_bump") as mock_bump:
+            from bump_automation import handle_schedule
+
+            handle_schedule(tokens, "mesa-fork")
+
+        called_submodules = [c.args[0] for c in mock_bump.call_args_list]
+        self.assertNotIn("rocm-systems", called_submodules)
+        self.assertNotIn("rocm-libraries", called_submodules)
+        self.assertNotIn("debug-tools/rocgdb/source", called_submodules)
 
 
 class CreateTheRockBumpRocgdbConfigTest(unittest.TestCase):


### PR DESCRIPTION
## Motivation

Extends the submodule bump automation to track ROCm/mesa-fork at third-party/sysdeps/linux/amd-mesa/mesa-fork, using the same submodule-only pattern as existing submodule-only entries (no back-ref files to update in the upstream repo).

<!-- Most pull requests should be associated with at least one GitHub issue -->

ISSUE ID https://github.com/ROCm/TheRock/issues/7076

## Technical Details

Changes:
- bump_automation.py: add mesa-fork entry to SUBMODULE_CONFIG with updater="submodule-only" and token_key="systems"; wire it into handle_schedule; add "mesa-fork" to the --submodule CLI choices.
- bump_submodules.yml: add mesa-fork to workflow_dispatch choices and push path triggers; extend the rocm-systems GitHub App token to also cover the mesa-fork repository; pass --mesa_token reusing the systems token in both script invocations.


## Test Plan

RocDecode and RocJPEG tests should pass when bumping the mesa-fork submodule.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
