### PR TITLE
ci(jax): teach the installed JAX stack about new ROCm major versions

### DIFF
--- a/.github/workflows/test_linux_jax_wheels.yml
+++ b/.github/workflows/test_linux_jax_wheels.yml
@@ -275,6 +275,13 @@ jobs:
             pip install jax==${JAX_VERSION} jaxlib==${JAX_VERSION}
           fi
 
+      # jaxlib comes from upstream PyPI and only knows the ROCm majors that
+      # existed when it was released, so it has to be taught about newer ones.
+      - name: Patch installed JAX for the ROCm major version
+        run: |
+          python external-builds/jax/patch_installed_jax_rocm_plugin_names.py \
+            --plugin-package "${JAX_PLUGIN_PACKAGE}"
+
       - name: Run JAX tests
         env:
           JAX_PLATFORMS: rocm

--- a/.github/workflows/test_linux_jax_wheels_partial.yml
+++ b/.github/workflows/test_linux_jax_wheels_partial.yml
@@ -264,6 +264,13 @@ jobs:
               "jaxlib==${JAX_VERSION}"
           fi
 
+      # jaxlib comes from upstream PyPI and only knows the ROCm majors that
+      # existed when it was released, so it has to be taught about newer ones.
+      - name: Patch installed JAX for the ROCm major version
+        run: |
+          python external-builds/jax/patch_installed_jax_rocm_plugin_names.py \
+            --plugin-package "${JAX_PLUGIN_PACKAGE}"
+
       - name: Run JAX tests
         timeout-minutes: 60
         env:

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -455,6 +455,22 @@ print(jax.devices())
 # [RocmDevice(id=0), RocmDevice(id=1), ...]
 ```
 
+> [!NOTE]
+> On ROCm 10, a released `jaxlib` (0.10.0 through 0.11.0) does not know the
+> `jax_rocm10_plugin` name, so the GPU kernel modules resolve to `None` and no FFI
+> handlers are registered. Symptoms are `'NoneType' object has no attribute ...` and
+> `No FFI handler registered for hipsolver_*`. Those versions predate the upstream fix
+> ([jax-ml/jax#39634](https://github.com/jax-ml/jax/pull/39634)); until a `jaxlib`
+> carrying it ships, teach the installed copy about the new major:
+>
+> ```bash
+> python external-builds/jax/patch_installed_jax_rocm_plugin_names.py \
+>     --plugin-package "jax_rocm${ROCM_MAJOR}_plugin"
+> ```
+>
+> The script edits the installed files in place, is idempotent, and is a no-op on ROCm 7
+> or once a fixed `jaxlib` is installed.
+
 ### Installing multi-arch native packages
 
 Native packages are installable via operating system package managers.

--- a/build_tools/github_actions/tests/patch_installed_jax_rocm_plugin_names_test.py
+++ b/build_tools/github_actions/tests/patch_installed_jax_rocm_plugin_names_test.py
@@ -1,0 +1,316 @@
+"""
+Unit tests for external-builds/jax/patch_installed_jax_rocm_plugin_names.py
+"""
+
+import importlib
+import os
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+THIS_DIR = Path(__file__).resolve().parent
+JAX_DIR = THIS_DIR.parents[2] / "external-builds" / "jax"
+
+sys.path.insert(0, os.fspath(JAX_DIR))
+
+import patch_installed_jax_rocm_plugin_names as patcher
+
+# jaxlib/plugin_support.py as released in jaxlib 0.10.0 through 0.11.0, i.e.
+# before jax-ml/jax#39634.
+JAXLIB_RELEASED = textwrap.dedent(
+    '''\
+    from collections.abc import Sequence
+    import importlib
+    import re
+
+    _PLUGIN_MODULE_NAMES = {
+        "cuda": ["jax_cuda13_plugin", "jax_cuda12_plugin"],
+        "rocm": ["jax_rocm7_plugin", "jax_rocm60_plugin"],
+        "oneapi": ["jax_oneapi_plugin"],
+    }
+
+
+    def import_from_plugin(plugin_name: str, submodule_name: str):
+      """Docstring mentioning "rocm": ["..."] should not confuse the patch."""
+      return _PLUGIN_MODULE_NAMES[plugin_name]
+    '''
+)
+
+# The same file once a jaxlib carrying jax-ml/jax#39634 ships.
+JAXLIB_FIXED = textwrap.dedent(
+    '''\
+    _PLUGIN_MODULE_NAMES = {
+        "cuda": ["jax_cuda13_plugin", "jax_cuda12_plugin"],
+        "rocm": ["jax_rocm10_plugin", "jax_rocm7_plugin", "jax_rocm60_plugin"],
+        "oneapi": ["jax_oneapi_plugin"],
+    }
+
+
+    @functools.cache
+    def _discovered_rocm_plugin_module_names() -> tuple[str, ...]:
+      """Finds installed ROCm plugin packages not listed above."""
+      return ()
+    '''
+)
+
+# jax_plugins/rocm/__init__.py before the ROCm/jax fix, installed as
+# jax_plugins/xla_rocm<major>/__init__.py.
+SHIM_RELEASED = textwrap.dedent(
+    """\
+    import importlib
+    import jax._src.xla_bridge as xb
+
+    # rocm_plugin_extension locates inside jaxlib. `jaxlib` is for testing without
+    # preinstalled jax rocm plugin packages.
+    for pkg_name in ['jax_rocm7_plugin', 'jax_rocm60_plugin', 'jaxlib.rocm']:
+      try:
+        rocm_plugin_extension = importlib.import_module(
+            f'{pkg_name}.rocm_plugin_extension'
+        )
+      except ImportError:
+        rocm_plugin_extension = None
+      else:
+        break
+    """
+)
+
+# The same file with the ROCm/jax fix, which every rocm-jaxlib-v0.10.x and
+# v0.11.0 branch now carries.
+SHIM_FIXED = textwrap.dedent(
+    """\
+    import importlib
+
+    _pkg_names = [
+        'jax_rocm10_plugin', 'jax_rocm7_plugin', 'jax_rocm60_plugin', 'jaxlib.rocm'
+    ]
+
+    _rocm_major = (__package__ or '').rpartition('xla_rocm')[2]
+    if _rocm_major.isdigit() and f'jax_rocm{_rocm_major}_plugin' not in _pkg_names:
+      _pkg_names.insert(0, f'jax_rocm{_rocm_major}_plugin')
+
+    for pkg_name in _pkg_names:
+      try:
+        rocm_plugin_extension = importlib.import_module(
+            f'{pkg_name}.rocm_plugin_extension'
+        )
+      except ImportError:
+        rocm_plugin_extension = None
+      else:
+        break
+    """
+)
+
+
+class RewriteJaxlibTest(unittest.TestCase):
+    def test_plugin_is_inserted_first(self) -> None:
+        result = patcher.rewrite_jaxlib_plugin_names(
+            JAXLIB_RELEASED, "jax_rocm10_plugin"
+        )
+
+        self.assertIn(
+            '"rocm": ["jax_rocm10_plugin", "jax_rocm7_plugin", "jax_rocm60_plugin"]',
+            result.text,
+        )
+        self.assertIn("jax_rocm10_plugin", result.detail)
+
+    def test_other_platforms_are_untouched(self) -> None:
+        result = patcher.rewrite_jaxlib_plugin_names(
+            JAXLIB_RELEASED, "jax_rocm10_plugin"
+        )
+
+        self.assertIn('"cuda": ["jax_cuda13_plugin", "jax_cuda12_plugin"]', result.text)
+        self.assertIn('"oneapi": ["jax_oneapi_plugin"]', result.text)
+
+    def test_result_is_valid_python(self) -> None:
+        result = patcher.rewrite_jaxlib_plugin_names(
+            JAXLIB_RELEASED, "jax_rocm10_plugin"
+        )
+
+        compile(result.text, "plugin_support.py", "exec")
+
+    def test_wrapped_list_is_rewritten(self) -> None:
+        wrapped = textwrap.dedent(
+            """\
+            _PLUGIN_MODULE_NAMES = {
+                "rocm": [
+                    "jax_rocm7_plugin",
+                    "jax_rocm60_plugin",
+                ],
+            }
+            """
+        )
+
+        result = patcher.rewrite_jaxlib_plugin_names(wrapped, "jax_rocm10_plugin")
+
+        self.assertIn('"jax_rocm10_plugin", "jax_rocm7_plugin"', result.text)
+        compile(result.text, "plugin_support.py", "exec")
+
+    def test_rewrite_is_idempotent(self) -> None:
+        once = patcher.rewrite_jaxlib_plugin_names(JAXLIB_RELEASED, "jax_rocm10_plugin")
+        twice = patcher.rewrite_jaxlib_plugin_names(once.text, "jax_rocm10_plugin")
+
+        self.assertIsNone(twice.text)
+        self.assertIn("already lists jax_rocm10_plugin", twice.detail)
+
+    def test_fixed_jaxlib_is_left_alone(self) -> None:
+        result = patcher.rewrite_jaxlib_plugin_names(JAXLIB_FIXED, "jax_rocm99_plugin")
+
+        self.assertIsNone(result.text)
+        self.assertIn("discovers", result.detail)
+
+    def test_unexpected_layout_raises(self) -> None:
+        with self.assertRaisesRegex(ValueError, "plugin list"):
+            patcher.rewrite_jaxlib_plugin_names(
+                "_PLUGIN_MODULE_NAMES = load_plugin_names()\n", "jax_rocm10_plugin"
+            )
+
+
+class RewritePjrtShimTest(unittest.TestCase):
+    def test_plugin_is_inserted_first(self) -> None:
+        result = patcher.rewrite_pjrt_shim_plugin_names(
+            SHIM_RELEASED, "jax_rocm10_plugin"
+        )
+
+        self.assertIn(
+            "for pkg_name in ['jax_rocm10_plugin', 'jax_rocm7_plugin',"
+            " 'jax_rocm60_plugin', 'jaxlib.rocm']:",
+            result.text,
+        )
+        compile(result.text, "__init__.py", "exec")
+
+    def test_rewrite_is_idempotent(self) -> None:
+        once = patcher.rewrite_pjrt_shim_plugin_names(
+            SHIM_RELEASED, "jax_rocm10_plugin"
+        )
+        twice = patcher.rewrite_pjrt_shim_plugin_names(once.text, "jax_rocm10_plugin")
+
+        self.assertIsNone(twice.text)
+        self.assertIn("already lists jax_rocm10_plugin", twice.detail)
+
+    def test_fixed_shim_is_left_alone(self) -> None:
+        result = patcher.rewrite_pjrt_shim_plugin_names(SHIM_FIXED, "jax_rocm99_plugin")
+
+        self.assertIsNone(result.text)
+        self.assertIn("derives the plugin name", result.detail)
+
+    def test_unexpected_layout_raises(self) -> None:
+        with self.assertRaisesRegex(ValueError, "plugin list"):
+            patcher.rewrite_pjrt_shim_plugin_names(
+                "rocm_plugin_extension = None\n", "jax_rocm10_plugin"
+            )
+
+
+class MainTest(unittest.TestCase):
+    """Drives main() against a fake install on sys.path."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.site_packages = Path(self._tmp.name)
+
+        self._saved_path = list(sys.path)
+        self._saved_modules = {
+            name: module for name, module in sys.modules.items() if self._is_faked(name)
+        }
+        self.addCleanup(self._restore_import_state)
+
+        # A real jaxlib or plugin in this environment must not shadow the fake
+        # one, and neither must a module cached by an earlier test.
+        for name in self._saved_modules:
+            del sys.modules[name]
+        sys.path.insert(0, os.fspath(self.site_packages))
+        importlib.invalidate_caches()
+
+        self.jaxlib_path = self._write_package(
+            "jaxlib", "plugin_support.py", JAXLIB_RELEASED
+        )
+        self.shim_path = self._write_package(
+            "jax_plugins/xla_rocm10", "__init__.py", SHIM_RELEASED
+        )
+        # The plugin wheel itself, which main() requires to be installed.
+        self._write_package("jax_rocm10_plugin", "__init__.py", "")
+
+    @staticmethod
+    def _is_faked(module_name: str) -> bool:
+        return module_name.split(".")[0] in (
+            "jaxlib",
+            "jax_plugins",
+            "jax_rocm10_plugin",
+        )
+
+    def _restore_import_state(self) -> None:
+        sys.path[:] = self._saved_path
+        for name in [name for name in sys.modules if self._is_faked(name)]:
+            del sys.modules[name]
+        sys.modules.update(self._saved_modules)
+        importlib.invalidate_caches()
+
+    def _write_package(self, package: str, file_name: str, text: str) -> Path:
+        directory = self.site_packages / package
+        directory.mkdir(parents=True, exist_ok=True)
+        init = directory / "__init__.py"
+        if not init.exists():
+            init.write_text("")
+        path = directory / file_name
+        path.write_text(text)
+        return path
+
+    def test_patches_both_files(self) -> None:
+        patcher.main(["--plugin-package", "jax_rocm10_plugin"])
+
+        self.assertIn("jax_rocm10_plugin", self.jaxlib_path.read_text())
+        self.assertIn(
+            "for pkg_name in ['jax_rocm10_plugin',", self.shim_path.read_text()
+        )
+
+    def test_second_run_changes_nothing(self) -> None:
+        patcher.main(["--plugin-package", "jax_rocm10_plugin"])
+        after_first = (self.jaxlib_path.read_text(), self.shim_path.read_text())
+
+        patcher.main(["--plugin-package", "jax_rocm10_plugin"])
+
+        self.assertEqual(
+            after_first, (self.jaxlib_path.read_text(), self.shim_path.read_text())
+        )
+
+    def test_skip_pjrt_shim_leaves_shim_installed(self) -> None:
+        patcher.main(["--plugin-package", "jax_rocm10_plugin", "--skip-pjrt-shim"])
+
+        self.assertIn("jax_rocm10_plugin", self.jaxlib_path.read_text())
+        self.assertEqual(SHIM_RELEASED, self.shim_path.read_text())
+
+    def test_unreadable_shim_leaves_jaxlib_unpatched(self) -> None:
+        self.shim_path.write_text("rocm_plugin_extension = None\n")
+
+        with self.assertRaisesRegex(ValueError, "plugin list"):
+            patcher.main(["--plugin-package", "jax_rocm10_plugin"])
+
+        self.assertEqual(JAXLIB_RELEASED, self.jaxlib_path.read_text())
+
+    def test_unreadable_jaxlib_leaves_shim_unpatched(self) -> None:
+        self.jaxlib_path.write_text("_PLUGIN_MODULE_NAMES = load_plugin_names()\n")
+
+        with self.assertRaisesRegex(ValueError, "plugin list"):
+            patcher.main(["--plugin-package", "jax_rocm10_plugin"])
+
+        self.assertEqual(SHIM_RELEASED, self.shim_path.read_text())
+
+    def test_missing_plugin_package_is_an_error(self) -> None:
+        with self.assertRaises(FileNotFoundError):
+            patcher.main(["--plugin-package", "jax_rocm99_plugin"])
+
+        self.assertEqual(JAXLIB_RELEASED, self.jaxlib_path.read_text())
+
+    def test_invalid_plugin_package_names_are_rejected(self) -> None:
+        for name in ["jax_rocm_plugin", "jax_rocm10", "rocm10_plugin", ""]:
+            with self.subTest(name=name):
+                with self.assertRaises(SystemExit):
+                    patcher.main(["--plugin-package", name])
+
+        self.assertEqual(JAXLIB_RELEASED, self.jaxlib_path.read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/external-builds/jax/README.md
+++ b/external-builds/jax/README.md
@@ -212,6 +212,29 @@ For more detailed build options, see the `ROCm/jax` repository and the
    sh ci/run_pytest_rocm.sh
    ```
 
+### Teaching an installed JAX about a new ROCm major version
+
+The plugin wheels carry the ROCm major version in their package name
+(`jax_rocm7_plugin`, `jax_rocm10_plugin`), and `jaxlib` looks that name up from a
+list of majors that existed when it was released. A newly bumped major is not
+found, so the GPU kernel modules resolve to `None` and `jax.devices()` fails with
+`'NoneType' object has no attribute ...`.
+
+[`patch_installed_jax_rocm_plugin_names.py`](./patch_installed_jax_rocm_plugin_names.py)
+adds the name to the installed `jaxlib`, and to the PJRT shim on wheels that
+predate the fix in ROCm/jax:
+
+```bash
+python external-builds/jax/patch_installed_jax_rocm_plugin_names.py \
+    --plugin-package jax_rocm10_plugin
+```
+
+Run it between installing the wheels and running anything that imports `jax`. It
+edits the installed files in place, is idempotent, and detects the fixes that
+obsolete it, so it becomes a no-op once a `jaxlib` carrying
+[jax-ml/jax#39634](https://github.com/jax-ml/jax/pull/39634) is installed. The
+ROCm 7 wheels need none of this.
+
 ## Nightly releases
 
 ### Gating releases with JAX tests

--- a/external-builds/jax/patch_installed_jax_rocm_plugin_names.py
+++ b/external-builds/jax/patch_installed_jax_rocm_plugin_names.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Teaches an installed JAX stack about a new ROCm major version.
+
+The plugin wheels embed the ROCm major version in their package name
+(jax_rocm7_plugin, jax_rocm10_plugin). Two places look that name up from a
+hardcoded list of majors, so a newly bumped major is not found:
+
+  * jaxlib/plugin_support.py holds _PLUGIN_MODULE_NAMES["rocm"], which gates the
+    GPU kernel modules (_linalg, _solver, _sparse, _rnn, _prng, _triton,
+    _hybrid). When the lookup misses, those modules resolve to None and tests
+    fail with "'NoneType' object has no attribute ...". jaxlib is installed from
+    upstream PyPI, so already released versions cannot be fixed at the source.
+
+  * jax_plugins/xla_rocm<major>/__init__.py looks for its companion plugin
+    package the same way. When that misses, rocm_plugin_extension stays None, no
+    FFI handlers are registered, and tests fail with "No FFI handler registered
+    for hipsolver_*". This one is fixed at the source in ROCm/jax, so the patch
+    here is a no-op on wheels that already carry the fix.
+
+Both patches are idempotent and rewrite the installed files before any test
+imports them, and both detect the upstream fix so they no-op once a wheel
+carrying it is installed. Every file is planned before any file is written, so
+an unrecognized layout fails without leaving the install half patched. The
+script fails loudly rather than silently skipping, so a missing patch cannot be
+mistaken for a passing configuration.
+
+Example usage:
+
+    python patch_installed_jax_rocm_plugin_names.py --plugin-package jax_rocm10_plugin
+"""
+
+import argparse
+import importlib.util
+import pathlib
+import re
+import sys
+from typing import Callable, NamedTuple
+
+_PLUGIN_PACKAGE_RE = re.compile(r"^jax_rocm(\d+)_plugin$")
+
+# _PLUGIN_MODULE_NAMES = {..., "rocm": ["jax_rocm7_plugin", ...], ...}
+_JAXLIB_ROCM_LIST_RE = re.compile(r'("rocm"\s*:\s*\[)([^\]]*?)(\s*\])', re.DOTALL)
+
+# Marker for the upstream fix that enumerates installed plugin packages, which
+# covers every major and not just the one this run installs.
+_JAXLIB_FIXED_MARKER = "_discovered_rocm_plugin_module_names"
+
+# for pkg_name in ['jax_rocm7_plugin', 'jax_rocm60_plugin', 'jaxlib.rocm']:
+_SHIM_LIST_RE = re.compile(r"(for pkg_name in \[)([^\]]*?)(\]\s*:)", re.DOTALL)
+
+# Marker for the ROCm/jax fix that derives the major from the package name.
+_SHIM_FIXED_MARKER = "rpartition('xla_rocm')"
+
+
+class Rewrite(NamedTuple):
+    """The new contents of one installed file, before anything is written."""
+
+    # None when the file already resolves the plugin name correctly.
+    text: str | None
+    # One line describing either the change or the reason there is none.
+    detail: str
+
+
+class _PlannedEdit(NamedTuple):
+    path: pathlib.Path
+    text: str
+
+
+def find_installed_module_file(module_name: str, file_name: str) -> pathlib.Path:
+    """Locates a file inside an installed package without importing it."""
+    spec = importlib.util.find_spec(module_name)
+    if spec is None or not spec.submodule_search_locations:
+        raise FileNotFoundError(f"'{module_name}' is not installed")
+    for location in spec.submodule_search_locations:
+        candidate = pathlib.Path(location) / file_name
+        if candidate.exists():
+            return candidate
+    raise FileNotFoundError(f"'{module_name}' does not contain '{file_name}'")
+
+
+def _insert_into_list(
+    text: str, match: re.Match, list_regex: re.Pattern, entry: str
+) -> Rewrite:
+    """Puts entry first in the matched list literal, preferring it on lookup."""
+    patched = (
+        text[: match.start()]
+        + f"{match.group(1)}{entry}, {match.group(2).strip()}{match.group(3)}"
+        + text[match.end() :]
+    )
+    after = list_regex.search(patched)
+    return Rewrite(patched, f"{match.group(0).strip()} -> {after.group(0).strip()}")
+
+
+def rewrite_jaxlib_plugin_names(text: str, plugin_package: str) -> Rewrite:
+    """Adds plugin_package to jaxlib's ROCm plugin lookup list."""
+    if _JAXLIB_FIXED_MARKER in text:
+        return Rewrite(None, "already discovers installed ROCm plugin packages")
+
+    match = _JAXLIB_ROCM_LIST_RE.search(text)
+    if match is None:
+        raise ValueError(
+            "does not contain a '\"rocm\": [...]' plugin list. The upstream"
+            " layout changed and this patch needs updating."
+        )
+
+    if plugin_package in match.group(2):
+        return Rewrite(None, f"already lists {plugin_package}")
+
+    return _insert_into_list(text, match, _JAXLIB_ROCM_LIST_RE, f'"{plugin_package}"')
+
+
+def rewrite_pjrt_shim_plugin_names(text: str, plugin_package: str) -> Rewrite:
+    """Adds plugin_package to the PJRT shim's plugin lookup list."""
+    if _SHIM_FIXED_MARKER in text:
+        return Rewrite(None, "already derives the plugin name from the ROCm major")
+
+    match = _SHIM_LIST_RE.search(text)
+    if match is None:
+        raise ValueError(
+            "does not contain a 'for pkg_name in [...]' plugin list. The layout"
+            " changed and this patch needs updating."
+        )
+
+    if plugin_package in match.group(2):
+        return Rewrite(None, f"already lists {plugin_package}")
+
+    return _insert_into_list(text, match, _SHIM_LIST_RE, f"'{plugin_package}'")
+
+
+def _plan_edit(
+    path: pathlib.Path,
+    rewrite: Callable[[str, str], Rewrite],
+    plugin_package: str,
+) -> _PlannedEdit | None:
+    """Computes the new contents of path without writing them."""
+    try:
+        result = rewrite(path.read_text(), plugin_package)
+    except ValueError as e:
+        raise ValueError(f"{path} {e}") from e
+
+    print(f"  {path}: {result.detail}")
+    return None if result.text is None else _PlannedEdit(path, result.text)
+
+
+def plan_jaxlib_edit(plugin_package: str) -> _PlannedEdit | None:
+    path = find_installed_module_file("jaxlib", "plugin_support.py")
+    return _plan_edit(path, rewrite_jaxlib_plugin_names, plugin_package)
+
+
+def plan_pjrt_shim_edit(plugin_package: str, rocm_major: str) -> _PlannedEdit | None:
+    module_name = f"jax_plugins.xla_rocm{rocm_major}"
+    path = find_installed_module_file(module_name, "__init__.py")
+    return _plan_edit(path, rewrite_pjrt_shim_plugin_names, plugin_package)
+
+
+def main(argv: list[str]):
+    p = argparse.ArgumentParser(prog="patch_installed_jax_rocm_plugin_names.py")
+    p.add_argument(
+        "--plugin-package",
+        required=True,
+        type=str,
+        help="Installed plugin package name (e.g. jax_rocm10_plugin)",
+    )
+    p.add_argument(
+        "--skip-pjrt-shim",
+        action="store_true",
+        help="Only patch jaxlib, leaving the PJRT shim as installed",
+    )
+
+    args = p.parse_args(argv)
+
+    match = _PLUGIN_PACKAGE_RE.match(args.plugin_package)
+    if match is None:
+        p.error(
+            f"--plugin-package '{args.plugin_package}' is not of the form"
+            " jax_rocm<major>_plugin"
+        )
+    rocm_major = match.group(1)
+
+    if importlib.util.find_spec(args.plugin_package) is None:
+        raise FileNotFoundError(
+            f"'{args.plugin_package}' is not installed, so there is nothing to"
+            " point the installed JAX stack at"
+        )
+
+    print(f"Patching the installed JAX stack for {args.plugin_package}:")
+
+    # Both files are planned before either is written: a layout this patch does
+    # not recognize raises here, while the install is still untouched.
+    planned = [plan_jaxlib_edit(args.plugin_package)]
+    if not args.skip_pjrt_shim:
+        planned.append(plan_pjrt_shim_edit(args.plugin_package, rocm_major))
+
+    edits = [edit for edit in planned if edit is not None]
+    for edit in edits:
+        edit.path.write_text(edit.text)
+
+    print(f"Patched {len(edits)} file(s)." if edits else "Nothing to patch.")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])


### PR DESCRIPTION
## Motivation

Plugin wheels carry the ROCm major in their package name (`jax_rocm7_plugin`, `jax_rocm10_plugin`), and both `jaxlib` and the PJRT shim look that name up from a hardcoded list of majors. On ROCm 10 the lookup misses, so the GPU kernel modules
resolve to `None` and no FFI handlers register: `'NoneType' object has no attribute ...` and `No FFI handler registered for hipsolver_*`, which is what #7067 reports.

Both sides are fixed at the source, the shim in ROCm/jax #822-#825 and `jaxlib` upstream in jax-ml/jax#39634. The gap is that `jaxlib` comes from upstream PyPI and the pinned 0.10.0-0.11.0 predate that fix, so CI and end users still need the installed copy patched.

This is the first half of the #6558 split: the ROCm 10 fixes that stand on their own. The full-suite enablement, the flake deselects and the fresh-process retry stay in #6558, since they only exist once the job runs the whole suite.

## Technical Details

- `patch_installed_jax_rocm_plugin_names.py` rewrites both lookups in the installed files between wheel install and test. It is idempotent, a no-op on ROCm 7, and detects the upstream fix so it disappears on its own once a fixed wheel ships.
- Wire the step into `test_linux_jax_wheels.yml` and `test_linux_jax_wheels_partial.yml`.
- RELEASES.md documents the same workaround where the JAX install section verifies `jax.devices()`, which is where the failure surfaces for users.

## Test Plan

Validated on the branch that also carries #6558, where the same code paths run against ~28k tests per job:

- Before the patch step, run 30561401221: all 15 jobs failed, 1468 failures each, essentially all plugin-name lookups.
- With the patch step, run 30701879601: those failures are gone.
- Full matrix green on the combined tree, runs 30781739300 and 30831999820.


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
