### PR TITLE
[sysdeps][linux][amd-mesa] - auto-detect libva subproject version in patch_source.sh

### DIFF
--- a/third-party/sysdeps/linux/amd-mesa/patch_source.sh
+++ b/third-party/sysdeps/linux/amd-mesa/patch_source.sh
@@ -6,14 +6,23 @@ set -e
 
 SOURCE_DIR="${1:?Source directory must be given}"
 VA_MESON_BUILD="$SOURCE_DIR/src/gallium/targets/va/meson.build"
-LIBVA_MESON_BUILD="$SOURCE_DIR/subprojects/libva-2.22.0/va/meson.build"
-LIBVA_MAIN_MESON_BUILD="$SOURCE_DIR/subprojects/libva-2.22.0/meson.build"
-LIBVA_PKGCONFIG_MESON_BUILD="$SOURCE_DIR/subprojects/libva-2.22.0/pkgconfig/meson.build"
-LIBVA_SOURCE="$SOURCE_DIR/subprojects/libva-2.22.0/va/va.c"
+
+# Detect the libva subproject directory without hardcoding the version number.
+LIBVA_SUBPROJECT_DIR="$(echo "$SOURCE_DIR"/subprojects/libva-[0-9]*/)"
+if [[ ! -d "$LIBVA_SUBPROJECT_DIR" ]]; then
+  echo "ERROR: Could not find libva subproject directory under $SOURCE_DIR/subprojects/" >&2
+  exit 1
+fi
+# Strip trailing slash so paths below are clean.
+LIBVA_SUBPROJECT_DIR="${LIBVA_SUBPROJECT_DIR%/}"
+
+LIBVA_MESON_BUILD="$LIBVA_SUBPROJECT_DIR/va/meson.build"
+LIBVA_MAIN_MESON_BUILD="$LIBVA_SUBPROJECT_DIR/meson.build"
+LIBVA_PKGCONFIG_MESON_BUILD="$LIBVA_SUBPROJECT_DIR/pkgconfig/meson.build"
+LIBVA_SOURCE="$LIBVA_SUBPROJECT_DIR/va/va.c"
 echo "Patching sources..."
 
 # Replace 'gallium_drv_video' in shared_library() calls with 'rocm_sysdeps_gallium_drv_video'
-# This handles both the with_amd_decode_only branch and the standard branch
 sed -i -E "/shared_library\(/,/\)/ s/'gallium_drv_video'/'rocm_sysdeps_gallium_drv_video'/" "$VA_MESON_BUILD"
 
 # Replace 'va' library name with 'rocm_sysdeps_va' in libva meson.build


### PR DESCRIPTION
## Motivation

Previously, patch_source.sh hardcoded the libva version (2.22.0) in four path variables pointing into Mesa's subprojects/ directory. If Mesa were to bundle a newer libva (e.g. 2.23.0 or later), the script would silently reference non-existent paths and all downstream sed patches would either no-op or fail.


## Technical Details

Changes:
- Replace the four hardcoded `subprojects/libva-2.22.0/...` paths with a single `LIBVA_SUBPROJECT_DIR` variable that is resolved at runtime via a shell glob (`libva-[0-9]*/`), making the script version-agnostic.
- Add an explicit existence check that aborts with a clear error message if no matching libva subproject directory is found, preventing silent failures.
- Remove a now-redundant inline comment on the gallium_drv_video sed line.


## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
