### PR TITLE
ci(jax): group the JAX release jobs by release instead of calling them all builds

### DIFF
--- a/.github/workflows/multi_arch_build_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_build_linux_jax_wheels.yml
@@ -276,7 +276,7 @@ jobs:
   test_jax_wheels:
     if: ${{ inputs.test_amdgpu_family != '' }}
     needs: [build_jax_wheels, generate_target_to_run]
-    name: Test JAX wheels | py ${{ inputs.python_version }} | jax ${{ inputs.jax_ref }}
+    name: Test | ${{ inputs.test_amdgpu_family }} | ${{ needs.generate_target_to_run.outputs.test_runs_on }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/multi_arch_release_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_jax_wheels.yml
@@ -96,7 +96,8 @@ jobs:
 
   build_jax_wheels:
     needs: setup_matrix
-    name: Build | py ${{ matrix.python_version }} | jax ${{ matrix.jax_ref }}
+    # The build and the tests for this cell are both shown under this name.
+    name: Release | py ${{ matrix.python_version }} | JAX ${{ matrix.jax_label }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test_linux_jax_wheels_partial.yml
+++ b/.github/workflows/test_linux_jax_wheels_partial.yml
@@ -128,7 +128,7 @@ permissions:
 
 jobs:
   test_jax_wheels:
-    name: Test JAX | ${{ inputs.jax_ref }} | Python ${{ inputs.python_version }} | ${{ inputs.test_amdgpu_family }}
+    name: Test JAX | ${{ inputs.test_amdgpu_family }}
     runs-on: ${{ inputs.test_runs_on }}
     timeout-minutes: 120
 

--- a/build_tools/github_actions/configure_jax_release_matrix.py
+++ b/build_tools/github_actions/configure_jax_release_matrix.py
@@ -113,6 +113,8 @@ def generate_jax_matrix(
                 {
                     "python_version": py,
                     "jax_ref": ref_cfg["jax_ref"],
+                    # The ref without its prefix, for job names.
+                    "jax_label": ref_cfg["jax_ref"].removeprefix("rocm-jaxlib-v"),
                     "jax_repository": ref_cfg["jax_repository"],
                     # gfx_arch selects the ROCm device package for the manylinux
                     # build (e.g. device-all). This direct lookup raises

--- a/build_tools/github_actions/tests/configure_jax_release_matrix_test.py
+++ b/build_tools/github_actions/tests/configure_jax_release_matrix_test.py
@@ -32,7 +32,7 @@ class ConfigureJaxReleaseMatrixTest(unittest.TestCase):
         self.assertGreater(len(jax_refs), 1)
         self.assertEqual(
             set(matrix[0]),
-            {"python_version", "jax_ref", "jax_repository", "gfx_arch"},
+            {"python_version", "jax_ref", "jax_label", "jax_repository", "gfx_arch"},
         )
 
     def test_explicit_python_version_narrows_matrix(self):
@@ -57,6 +57,7 @@ class ConfigureJaxReleaseMatrixTest(unittest.TestCase):
         self.assertEqual(len(matrix), 1)
         self.assertEqual(matrix[0]["python_version"], "3.12")
         self.assertEqual(matrix[0]["jax_ref"], "rocm-jaxlib-v0.10.0")
+        self.assertEqual(matrix[0]["jax_label"], "0.10.0")
         self.assertEqual(matrix[0]["jax_repository"], "ROCm/jax")
         self.assertEqual(matrix[0]["gfx_arch"], "device-all")
 


### PR DESCRIPTION
## Motivation

Every job of a called workflow is displayed under the name of the job that called it, so a JAX release matrix cell said "Build" over its own tests, and the Python version and the jax ref were repeated at all three levels. Name the cell for the release it covers and let the jobs inside say what they are, matching how the PyTorch jobs read.

Cosmetic only; peeled out of #6558 so that PR stays about test behavior.

## Technical Details

- Matrix cell becomes `Release | py 3.12 | JAX 0.10.0`, covering both the build and the tests underneath it.
- The called jobs drop the version and ref they inherit from the cell heading and say what they are: `Test | gfx94X-dcgpu | <runner>` and `Test JAX | gfx94X-dcgpu`.
- `configure_jax_release_matrix.py` adds a `jax_label` field, the ref without its `rocm-jaxlib-v` prefix, because a workflow expression cannot strip it.

## Test Plan

- `configure_jax_release_matrix_test.py` covers the new field.
- Job naming as rendered in run 30781739300.

JIRA ID: AIJAX-313

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
