### PR TITLE
fix: support fetching xnack-suffixed artifacts

### DIFF
--- a/build_tools/artifact_manager.py
+++ b/build_tools/artifact_manager.py
@@ -77,7 +77,11 @@ ARTIFACT_COMPONENTS = ["lib", "run", "dev", "dbg", "doc", "test"]
 
 
 def _get_base_arch(target: str) -> str:
-    """Strip xnack/other suffixes: 'gfx942:xnack+' -> 'gfx942'."""
+    """Strip xnack/other suffixes: 'gfx942:xnack+' -> 'gfx942'.
+
+    Note: This strips everything after the first colon. Any suffix (not just
+    xnack) will be removed, e.g., 'gfx942:foo' -> 'gfx942'.
+    """
     if not target:
         return ""
     base = target.split(":")[0]
@@ -85,7 +89,17 @@ def _get_base_arch(target: str) -> str:
 
 
 def _matches_target(artifact_target: str, requested_targets: set[str]) -> bool:
-    """Match if the artifact's base arch equals any requested target's base arch."""
+    """Match if the artifact's base arch equals any requested target's base arch.
+
+    Uses base-arch matching: both the artifact target and requested targets are
+    stripped to their base arch before comparison. This means requesting 'gfx942'
+    will match 'gfx942', 'gfx942:xnack+', 'gfx942:xnack-', or any 'gfx942:*' variant.
+
+    Known limitation: All colon-suffixed variants of the same base arch will match.
+    For example, requesting 'gfx942' matches 'gfx942:xnack+', 'gfx942:xnack-',
+    'gfx942:abc', etc. This is intentional to ensure all relevant artifacts are
+    fetched for a given GPU architecture.
+    """
     if not artifact_target:
         return False
     requested_bases = {_get_base_arch(t) for t in requested_targets}
@@ -164,7 +178,8 @@ def find_available_artifacts(
     and components. Uses base-arch matching: requesting a base arch (e.g., "gfx942")
     will also match variants with suffixes (e.g., "gfx942:xnack+", "gfx942:xnack-").
 
-    Prefers .tar.zst over .tar.xz when both exist.
+    Prefers .tar.zst over .tar.xz when both exist, because zstd offers faster
+    decompression and better compression ratios for our artifact workloads.
     """
     excluded_components = excluded_components or set()
     targets_to_match = set(target_families)
@@ -173,7 +188,7 @@ def find_available_artifacts(
     matched = []
     seen = set()
 
-    # Sort with .tar.zst before .tar.xz so dedup prefers zstd
+    # Sort .tar.zst before .tar.xz so dedup prefers zstd (faster decompression)
     def _sort_key(f: str) -> tuple:
         base = f.rsplit(".tar", 1)[0]
         priority = 0 if f.endswith(".tar.zst") else 1

--- a/build_tools/artifact_manager.py
+++ b/build_tools/artifact_manager.py
@@ -76,6 +76,22 @@ from _therock_utils.workflow_outputs import WorkflowOutputRoot
 ARTIFACT_COMPONENTS = ["lib", "run", "dev", "dbg", "doc", "test"]
 
 
+def _get_base_arch(target: str) -> str:
+    """Strip xnack/other suffixes: 'gfx942:xnack+' -> 'gfx942'."""
+    if not target:
+        return ""
+    base = target.split(":")[0]
+    return base if base else target
+
+
+def _matches_target(artifact_target: str, requested_targets: set[str]) -> bool:
+    """Match if the artifact's base arch equals any requested target's base arch."""
+    if not artifact_target:
+        return False
+    requested_bases = {_get_base_arch(t) for t in requested_targets}
+    return _get_base_arch(artifact_target) in requested_bases
+
+
 def log(msg: str):
     """Print message and flush."""
     print(msg, flush=True)
@@ -144,22 +160,43 @@ def find_available_artifacts(
 ) -> list[str]:
     """Find which artifacts exist in the available set.
 
-    Iterates artifact_names × target_families × components × extensions,
-    returning filenames that are present in `available`. Prefers .tar.zst
-    over .tar.xz when both exist.
+    Iterates available artifacts and filters by artifact_names, target_families,
+    and components. Uses base-arch matching: requesting a base arch (e.g., "gfx942")
+    will also match variants with suffixes (e.g., "gfx942:xnack+", "gfx942:xnack-").
+
+    Prefers .tar.zst over .tar.xz when both exist.
     """
     excluded_components = excluded_components or set()
+    targets_to_match = set(target_families)
+
+    # Use structured ArtifactName parsing for reliable matching (like fetch_artifacts.py)
     matched = []
-    for artifact_name in sorted(artifact_names):
-        for tf in target_families:
-            for comp in ARTIFACT_COMPONENTS:
-                if comp in excluded_components:
-                    continue
-                for ext in ARTIFACT_EXTENSIONS:
-                    filename = f"{artifact_name}_{comp}_{tf}{ext}"
-                    if filename in available:
-                        matched.append(filename)
-                        break  # Found this artifact, don't check other extensions
+    seen = set()
+
+    # Sort with .tar.zst before .tar.xz so dedup prefers zstd
+    def _sort_key(f: str) -> tuple:
+        base = f.rsplit(".tar", 1)[0]
+        priority = 0 if f.endswith(".tar.zst") else 1
+        return (base, priority)
+
+    for filename in sorted(available, key=_sort_key):
+        an = ArtifactName.from_filename(filename)
+        if not an:
+            continue
+        if an.name not in artifact_names:
+            continue
+        if an.component in excluded_components:
+            continue
+        if not _matches_target(an.target_family, targets_to_match):
+            continue
+
+        # Dedupe: prefer .tar.zst over .tar.xz for same artifact
+        key = (an.name, an.component, an.target_family)
+        if key in seen:
+            continue
+        seen.add(key)
+        matched.append(filename)
+
     return matched
 
 

--- a/build_tools/tests/artifact_manager_tool_test.py
+++ b/build_tools/tests/artifact_manager_tool_test.py
@@ -593,12 +593,13 @@ class TestFetchStageAll(ArtifactManagerTestBase):
             )
 
     def test_fetch_exclude_components_skips_test_artifacts(self) -> None:
-        """Test that --exclude-components filters artifact components."""
+        """Test that --exclude-components filters artifact components including xnack variants."""
         import artifact_manager
 
         self._create_staged_artifact("test-artifact", "lib", "generic")
         self._create_staged_artifact("test-artifact", "test", "generic")
         self._create_staged_artifact("test-artifact", "test", "gfx942")
+        self._create_staged_artifact("test-artifact", "test", "gfx942:xnack+")
         self._create_staged_artifact("second-artifact", "run", "generic")
         self._create_staged_artifact("second-artifact", "test", "generic")
 
@@ -734,12 +735,13 @@ class TestFetchAmdgpuTargets(ArtifactManagerTestBase):
     """Tests that fetch command correctly handles --amdgpu-targets for split artifacts."""
 
     def test_fetch_with_amdgpu_targets_finds_individual_target_archives(self):
-        """Test that --amdgpu-targets matches individual-target split archives."""
+        """Test that --amdgpu-targets matches individual-target and xnack-suffixed archives."""
         import artifact_manager
 
-        # Stage a generic artifact and a per-target artifact
+        # Stage generic, per-target, and xnack-suffixed artifacts
         self._create_staged_artifact("test-artifact", "lib", "generic")
         self._create_staged_artifact("test-artifact", "lib", "gfx942")
+        self._create_staged_artifact("test-artifact", "lib", "gfx942:xnack+")
 
         extract_calls = []
 
@@ -768,15 +770,19 @@ class TestFetchAmdgpuTargets(ArtifactManagerTestBase):
 
             artifact_manager.main(argv)
 
-        # Should have fetched both generic and gfx942
+        # Should have fetched generic, gfx942, and gfx942:xnack+
         fetched_keys = [c.archive_path.name for c in extract_calls]
         self.assertTrue(
             any("generic" in k for k in fetched_keys),
             f"Should fetch generic artifact, got: {fetched_keys}",
         )
         self.assertTrue(
-            any("gfx942" in k for k in fetched_keys),
+            any("gfx942.tar.zst" in k for k in fetched_keys),
             f"Should fetch gfx942 artifact, got: {fetched_keys}",
+        )
+        self.assertTrue(
+            any("gfx942:xnack+" in k for k in fetched_keys),
+            f"Should fetch gfx942:xnack+ artifact, got: {fetched_keys}",
         )
 
     def test_fetch_with_amdgpu_targets_skips_other_targets(self):
@@ -1488,100 +1494,6 @@ class ParseTargetFamiliesTest(unittest.TestCase):
         self.assertIn("gfx110X-all", result)
         self.assertIn("gfx1100", result)
         self.assertIn("gfx1101", result)
-
-
-class XnackArtifactMatchingTest(unittest.TestCase):
-    """Unit tests for xnack-suffixed artifact matching in artifact_manager.
-
-    These tests mirror the tests in fetch_artifacts_test.py since the
-    _get_base_arch and _matches_target functions are duplicated.
-    """
-
-    def setUp(self):
-        import artifact_manager as am
-
-        self.am = am
-
-    def testGetBaseArch_HandlesEdgeCases(self):
-        """Test _get_base_arch with empty and various inputs."""
-        self.assertEqual(self.am._get_base_arch(""), "")
-        self.assertEqual(self.am._get_base_arch(":xnack+"), ":xnack+")
-        self.assertEqual(self.am._get_base_arch("gfx942"), "gfx942")
-        self.assertEqual(self.am._get_base_arch("gfx942:xnack+"), "gfx942")
-        self.assertEqual(self.am._get_base_arch("gfx950:xnack-"), "gfx950")
-
-    def testMatchesTarget_HandlesEdgeCases(self):
-        """Test _matches_target with empty and various inputs."""
-        requested = {"generic", "gfx942"}
-        self.assertFalse(self.am._matches_target("", requested))
-        self.assertTrue(self.am._matches_target("gfx942", requested))
-        self.assertTrue(self.am._matches_target("gfx942:xnack+", requested))
-
-    def testFindAvailableArtifacts_MatchesXnackVariants(self):
-        """Test that requesting base arch also matches xnack-suffixed variants."""
-        available = {
-            "blas_lib_generic.tar.zst",
-            "blas_lib_gfx942.tar.zst",
-            "blas_test_gfx942.tar.zst",
-            "rccl_test_gfx942:xnack+.tar.zst",
-            "rccl_lib_gfx942:xnack-.tar.zst",
-            "blas_lib_gfx950.tar.zst",
-        }
-        result = self.am.find_available_artifacts(
-            artifact_names={"blas", "rccl"},
-            target_families=["generic", "gfx942"],
-            available=available,
-        )
-        self.assertIn("blas_lib_generic.tar.zst", result)
-        self.assertIn("blas_lib_gfx942.tar.zst", result)
-        self.assertIn("blas_test_gfx942.tar.zst", result)
-        self.assertIn("rccl_test_gfx942:xnack+.tar.zst", result)
-        self.assertIn("rccl_lib_gfx942:xnack-.tar.zst", result)
-        self.assertNotIn("blas_lib_gfx950.tar.zst", result)
-
-    def testFindAvailableArtifacts_ExplicitXnackTargetMatchesBase(self):
-        """Test that requesting xnack variant explicitly also matches base arch."""
-        available = {
-            "blas_lib_generic.tar.zst",
-            "blas_lib_gfx950.tar.zst",
-            "rccl_test_gfx950:xnack+.tar.zst",
-        }
-        result = self.am.find_available_artifacts(
-            artifact_names={"blas", "rccl"},
-            target_families=["generic", "gfx950:xnack+"],
-            available=available,
-        )
-        self.assertIn("blas_lib_generic.tar.zst", result)
-        self.assertIn("blas_lib_gfx950.tar.zst", result)
-        self.assertIn("rccl_test_gfx950:xnack+.tar.zst", result)
-
-    def testFindAvailableArtifacts_PrefersZstOverXz(self):
-        """Test that .tar.zst is preferred over .tar.xz."""
-        available = {
-            "fft_lib_gfx942.tar.zst",
-            "fft_lib_gfx942.tar.xz",
-        }
-        result = self.am.find_available_artifacts(
-            artifact_names={"fft"},
-            target_families=["gfx942"],
-            available=available,
-        )
-        self.assertEqual(result, ["fft_lib_gfx942.tar.zst"])
-
-    def testFindAvailableArtifacts_ExcludesComponents(self):
-        """Test that excluded_components filters out matching artifacts."""
-        available = {
-            "fft_lib_gfx942.tar.zst",
-            "fft_test_gfx942.tar.zst",
-            "fft_test_gfx942:xnack+.tar.zst",
-        }
-        result = self.am.find_available_artifacts(
-            artifact_names={"fft"},
-            target_families=["gfx942"],
-            available=available,
-            excluded_components={"test"},
-        )
-        self.assertEqual(result, ["fft_lib_gfx942.tar.zst"])
 
 
 if __name__ == "__main__":

--- a/build_tools/tests/artifact_manager_tool_test.py
+++ b/build_tools/tests/artifact_manager_tool_test.py
@@ -10,6 +10,7 @@ particularly error handling and exit codes.
 
 import hashlib
 import os
+import platform
 import shutil
 import sys
 import tempfile
@@ -17,6 +18,11 @@ import unittest
 from pathlib import Path
 from typing import Optional
 from unittest import mock
+
+
+def is_windows():
+    return platform.system() == "Windows"
+
 
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 
@@ -599,7 +605,9 @@ class TestFetchStageAll(ArtifactManagerTestBase):
         self._create_staged_artifact("test-artifact", "lib", "generic")
         self._create_staged_artifact("test-artifact", "test", "generic")
         self._create_staged_artifact("test-artifact", "test", "gfx942")
-        self._create_staged_artifact("test-artifact", "test", "gfx942:xnack+")
+        # xnack artifacts use ':' which is invalid in Windows filenames
+        if not is_windows():
+            self._create_staged_artifact("test-artifact", "test", "gfx942:xnack+")
         self._create_staged_artifact("second-artifact", "run", "generic")
         self._create_staged_artifact("second-artifact", "test", "generic")
 
@@ -741,7 +749,9 @@ class TestFetchAmdgpuTargets(ArtifactManagerTestBase):
         # Stage generic, per-target, and xnack-suffixed artifacts
         self._create_staged_artifact("test-artifact", "lib", "generic")
         self._create_staged_artifact("test-artifact", "lib", "gfx942")
-        self._create_staged_artifact("test-artifact", "lib", "gfx942:xnack+")
+        # xnack artifacts use ':' which is invalid in Windows filenames
+        if not is_windows():
+            self._create_staged_artifact("test-artifact", "lib", "gfx942:xnack+")
 
         extract_calls = []
 
@@ -770,7 +780,7 @@ class TestFetchAmdgpuTargets(ArtifactManagerTestBase):
 
             artifact_manager.main(argv)
 
-        # Should have fetched generic, gfx942, and gfx942:xnack+
+        # Should have fetched generic, gfx942, and gfx942:xnack+ (non-Windows only)
         fetched_keys = [c.archive_path.name for c in extract_calls]
         self.assertTrue(
             any("generic" in k for k in fetched_keys),
@@ -780,10 +790,11 @@ class TestFetchAmdgpuTargets(ArtifactManagerTestBase):
             any("gfx942.tar.zst" in k for k in fetched_keys),
             f"Should fetch gfx942 artifact, got: {fetched_keys}",
         )
-        self.assertTrue(
-            any("gfx942:xnack+" in k for k in fetched_keys),
-            f"Should fetch gfx942:xnack+ artifact, got: {fetched_keys}",
-        )
+        if not is_windows():
+            self.assertTrue(
+                any("gfx942:xnack+" in k for k in fetched_keys),
+                f"Should fetch gfx942:xnack+ artifact, got: {fetched_keys}",
+            )
 
     def test_fetch_with_amdgpu_targets_skips_other_targets(self):
         """Test that --amdgpu-targets doesn't fetch archives for other targets."""

--- a/build_tools/tests/artifact_manager_tool_test.py
+++ b/build_tools/tests/artifact_manager_tool_test.py
@@ -1490,5 +1490,99 @@ class ParseTargetFamiliesTest(unittest.TestCase):
         self.assertIn("gfx1101", result)
 
 
+class XnackArtifactMatchingTest(unittest.TestCase):
+    """Unit tests for xnack-suffixed artifact matching in artifact_manager.
+
+    These tests mirror the tests in fetch_artifacts_test.py since the
+    _get_base_arch and _matches_target functions are duplicated.
+    """
+
+    def setUp(self):
+        import artifact_manager as am
+
+        self.am = am
+
+    def testGetBaseArch_HandlesEdgeCases(self):
+        """Test _get_base_arch with empty and various inputs."""
+        self.assertEqual(self.am._get_base_arch(""), "")
+        self.assertEqual(self.am._get_base_arch(":xnack+"), ":xnack+")
+        self.assertEqual(self.am._get_base_arch("gfx942"), "gfx942")
+        self.assertEqual(self.am._get_base_arch("gfx942:xnack+"), "gfx942")
+        self.assertEqual(self.am._get_base_arch("gfx950:xnack-"), "gfx950")
+
+    def testMatchesTarget_HandlesEdgeCases(self):
+        """Test _matches_target with empty and various inputs."""
+        requested = {"generic", "gfx942"}
+        self.assertFalse(self.am._matches_target("", requested))
+        self.assertTrue(self.am._matches_target("gfx942", requested))
+        self.assertTrue(self.am._matches_target("gfx942:xnack+", requested))
+
+    def testFindAvailableArtifacts_MatchesXnackVariants(self):
+        """Test that requesting base arch also matches xnack-suffixed variants."""
+        available = {
+            "blas_lib_generic.tar.zst",
+            "blas_lib_gfx942.tar.zst",
+            "blas_test_gfx942.tar.zst",
+            "rccl_test_gfx942:xnack+.tar.zst",
+            "rccl_lib_gfx942:xnack-.tar.zst",
+            "blas_lib_gfx950.tar.zst",
+        }
+        result = self.am.find_available_artifacts(
+            artifact_names={"blas", "rccl"},
+            target_families=["generic", "gfx942"],
+            available=available,
+        )
+        self.assertIn("blas_lib_generic.tar.zst", result)
+        self.assertIn("blas_lib_gfx942.tar.zst", result)
+        self.assertIn("blas_test_gfx942.tar.zst", result)
+        self.assertIn("rccl_test_gfx942:xnack+.tar.zst", result)
+        self.assertIn("rccl_lib_gfx942:xnack-.tar.zst", result)
+        self.assertNotIn("blas_lib_gfx950.tar.zst", result)
+
+    def testFindAvailableArtifacts_ExplicitXnackTargetMatchesBase(self):
+        """Test that requesting xnack variant explicitly also matches base arch."""
+        available = {
+            "blas_lib_generic.tar.zst",
+            "blas_lib_gfx950.tar.zst",
+            "rccl_test_gfx950:xnack+.tar.zst",
+        }
+        result = self.am.find_available_artifacts(
+            artifact_names={"blas", "rccl"},
+            target_families=["generic", "gfx950:xnack+"],
+            available=available,
+        )
+        self.assertIn("blas_lib_generic.tar.zst", result)
+        self.assertIn("blas_lib_gfx950.tar.zst", result)
+        self.assertIn("rccl_test_gfx950:xnack+.tar.zst", result)
+
+    def testFindAvailableArtifacts_PrefersZstOverXz(self):
+        """Test that .tar.zst is preferred over .tar.xz."""
+        available = {
+            "fft_lib_gfx942.tar.zst",
+            "fft_lib_gfx942.tar.xz",
+        }
+        result = self.am.find_available_artifacts(
+            artifact_names={"fft"},
+            target_families=["gfx942"],
+            available=available,
+        )
+        self.assertEqual(result, ["fft_lib_gfx942.tar.zst"])
+
+    def testFindAvailableArtifacts_ExcludesComponents(self):
+        """Test that excluded_components filters out matching artifacts."""
+        available = {
+            "fft_lib_gfx942.tar.zst",
+            "fft_test_gfx942.tar.zst",
+            "fft_test_gfx942:xnack+.tar.zst",
+        }
+        result = self.am.find_available_artifacts(
+            artifact_names={"fft"},
+            target_families=["gfx942"],
+            available=available,
+            excluded_components={"test"},
+        )
+        self.assertEqual(result, ["fft_lib_gfx942.tar.zst"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
  Add base-arch matching to find_available_artifacts() so requesting a
  base architecture (e.g., gfx942) also matches xnack variants
  (gfx942:xnack+, gfx942:xnack-).

  Changes:
  - Add _get_base_arch() to strip xnack suffixes from targets
  - Add _matches_target() for base-arch comparison
  - Refactor find_available_artifacts() to iterate available artifacts and filter using ArtifactName parsing (like fetch_artifacts.py)
  - Add _sort_key to preserve .tar.zst preference over .tar.xz

  This enables --expand-family-to-targets to correctly fetch artifacts
  for ASAN builds which use xnack-suffixed targets.

JIRA ID: https://amd-hub.atlassian.net/browse/ROCM-28314