### PR TITLE
Introduce codeowners for python/tarball promotion scripts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,6 +17,11 @@
 /build_tools/build_python_packages.py   @ScottTodd @marbre
 /external-builds/pytorch                @ScottTodd
 
+# Release promotion scripts.
+/build_tools/packaging/download_python_packages.py  @HereThereBeDragons @araravik-psd @jeniferc99
+/build_tools/packaging/promote_packages.py          @HereThereBeDragons @araravik-psd @jeniferc99
+/build_tools/packaging/upload_release_packages.py   @HereThereBeDragons @araravik-psd @jeniferc99
+
 # A few central CI system components that must align with
 # https://github.com/ROCm/TheRock/blob/main/docs/development/ci_overview.md
 /.github/workflows/setup_multi_arch.yml                   @ScottTodd

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,9 +18,9 @@
 /external-builds/pytorch                @ScottTodd
 
 # Release promotion scripts.
-/build_tools/packaging/download_python_packages.py  @HereThereBeDragons @araravik-psd @jeniferc99
-/build_tools/packaging/promote_packages.py          @HereThereBeDragons @araravik-psd @jeniferc99
-/build_tools/packaging/upload_release_packages.py   @HereThereBeDragons @araravik-psd @jeniferc99
+/build_tools/packaging/download_python_packages.py  @HereThereBeDragons @araravik-psd @JeniferC99
+/build_tools/packaging/promote_packages.py          @HereThereBeDragons @araravik-psd @JeniferC99
+/build_tools/packaging/upload_release_packages.py   @HereThereBeDragons @araravik-psd @JeniferC99
 
 # A few central CI system components that must align with
 # https://github.com/ROCm/TheRock/blob/main/docs/development/ci_overview.md


### PR DESCRIPTION
## Summary

Promotion scripts are critical to work correctly, as such members of the release devops team should have a gating decision if changes to those files should be merged or not.

The following scripts are part of the promotion process to promote prerelease python packages/tarballs to release version,
```
/build_tools/packaging/download_python_packages.py 
/build_tools/packaging/promote_packages.py 
/build_tools/packaging/upload_release_packages.py 
```

Best owners currently are: HereThereBeDragons (me), araravik-psd (Aravind) and JeniferC99 (Jenifer)

## Motivation

PRs like https://github.com/ROCm/TheRock/pull/6968 changed the promotion script without having been reviewed by someone of the release devops team familiar with the code. Changes in that PR do not fully align with the preexisting patterns in the script and side-effects might be missed.