### PR TITLE
Add guidance to CONTRIBUTING.md for external contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,6 +131,73 @@ for maintainers).
 
 ## Development workflows and contributing guide
 
+### Finding an issue to work on
+
+If you want to contribute but don't have a specific problem in mind, the
+[issue tracker](https://github.com/ROCm/TheRock/issues) is the best place to
+start. Issues that several people have confirmed, or that a maintainer has
+already investigated, are usually the most productive ones to pick up.
+
+Two labels mark work that we are actively hoping someone from the community
+will take:
+
+| Label                                                                                                                 | What it means                                                                                                                                   |
+| --------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`help wanted`](https://github.com/ROCm/TheRock/issues?q=is%3Aissue+state%3Aopen+label%3A%22help+wanted%22)           | The problem is understood well enough for someone outside the core team to pick it up, and no maintainer is actively working on it. Start here. |
+| [`good first issue`](https://github.com/ROCm/TheRock/issues?q=is%3Aissue+state%3Aopen+label%3A%22good+first+issue%22) | Approachable for a newcomer: small in scope and unlikely to need wide-ranging changes across the build. These usually also carry `help wanted`. |
+
+Triaged issues carry additional labels that describe the problem, which you can
+combine with the two above to find something in an area you already know:
+
+- `status: triage`, `status: assessed`, and `status: fix submitted` show how far
+  along an issue is. `status: assessed` means the root cause is already known,
+  which usually makes an issue much easier to pick up.
+- `project: *` (for example `project: clr`, `project: rocblas`) identify the
+  affected component.
+- `gfx*` (for example `gfx110X-dgpu`, `gfx1151`) identify the affected GPU
+  family, which matters because many issues can only be reproduced on specific
+  hardware.
+- `platform: Linux`, `platform: Windows`, and `platform: WSL` identify the
+  affected host platform.
+- `ecosystem: *` (for example `ecosystem: PyTorch`, `ecosystem: vLLM`) identify
+  the downstream project a user hit the problem through.
+- `build issue`, `CICD`, `documentation`, and `test-debt` are good places to
+  look for contributions that don't require specific GPU hardware.
+
+If an issue looks like a good fit but is missing information you need, ask for
+it in the issue thread. If you think an issue deserves the `help wanted` or
+`good first issue` label, or that the label no longer applies, say so on the
+issue and a maintainer will take another look.
+
+#### Do I need to ask before working on an issue?
+
+No, but please leave a comment on the issue saying that you are picking it up so
+other contributors and maintainers don't duplicate your effort. We don't lock
+issues to a single person, and an existing assignee doesn't stop you from
+opening a pull request. If multiple pull requests address the same issue, we
+take the highest quality one (or the first one, if they are comparable).
+
+A few things worth knowing before you start:
+
+- For anything larger than a small fix, describe your intended approach on the
+  issue before writing much code. That is the cheapest point at which a
+  maintainer can redirect you away from an approach we can't accept. See also
+  [Using GitHub Issues for feature development](#using-github-issues-for-feature-development).
+- Issues without `help wanted` are still fair game, but they may already be in
+  progress internally, blocked on an upstream component, or not something we are
+  ready to take a fix for yet. Ask on the issue first.
+- Many issues filed here are ultimately bugs in a component that TheRock builds
+  from a submodule (LLVM, the ROCm math libraries, and so on), so the fix may
+  need to land in that upstream repository rather than in this one. Maintainers
+  can point you at the right place.
+- Reproducing an issue often requires specific AMD hardware. If you don't have
+  the matching GPU, adding a precise reproduction, narrowing down a regression
+  range, or improving the diagnostics is still valuable work on its own.
+
+When your change is ready, follow
+[Creating pull requests](#creating-pull-requests) and link the issue from the
+pull request description.
+
 ### Using GitHub Issues for bug reporting
 
 Before filing a new issue, please search through

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,68 +135,48 @@ for maintainers).
 
 If you want to contribute but don't have a specific problem in mind, the
 [issue tracker](https://github.com/ROCm/TheRock/issues) is the best place to
-start. Issues that several people have confirmed, or that a maintainer has
-already investigated, are usually the most productive ones to pick up.
+start. These two labels mark work we hope someone outside the core team will
+pick up:
 
-Two labels mark work that we are actively hoping someone from the community
-will take:
+| Label                                                                                                                 | What it means                                                                                                        |
+| --------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| [`help wanted`](https://github.com/ROCm/TheRock/issues?q=is%3Aissue+state%3Aopen+label%3A%22help+wanted%22)           | Understood well enough for someone outside the core team to pick up, and no maintainer is working on it. Start here. |
+| [`good first issue`](https://github.com/ROCm/TheRock/issues?q=is%3Aissue+state%3Aopen+label%3A%22good+first+issue%22) | Small in scope and unlikely to need wide-ranging changes across the build. Usually also carries `help wanted`.       |
 
-| Label                                                                                                                 | What it means                                                                                                                                   |
-| --------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`help wanted`](https://github.com/ROCm/TheRock/issues?q=is%3Aissue+state%3Aopen+label%3A%22help+wanted%22)           | The problem is understood well enough for someone outside the core team to pick it up, and no maintainer is actively working on it. Start here. |
-| [`good first issue`](https://github.com/ROCm/TheRock/issues?q=is%3Aissue+state%3Aopen+label%3A%22good+first+issue%22) | Approachable for a newcomer: small in scope and unlikely to need wide-ranging changes across the build. These usually also carry `help wanted`. |
+Triaged issues carry other labels you can combine with those two to find
+something in an area you already know:
 
-Triaged issues carry additional labels that describe the problem, which you can
-combine with the two above to find something in an area you already know:
+- `status: *` shows how far along an issue is. `status: assessed` means the root
+  cause is already known.
+- `project: *`, `gfx*`, `platform: *`, and `ecosystem: *` identify the affected
+  component, GPU family, host platform, and downstream project.
+- `build issue`, `CICD`, `documentation`, and `test-debt` are good places to look
+  for contributions that don't need specific GPU hardware.
 
-- `status: triage`, `status: assessed`, and `status: fix submitted` show how far
-  along an issue is. `status: assessed` means the root cause is already known,
-  which usually makes an issue much easier to pick up.
-- `project: *` (for example `project: clr`, `project: rocblas`) identify the
-  affected component.
-- `gfx*` (for example `gfx110X-dgpu`, `gfx1151`) identify the affected GPU
-  family, which matters because many issues can only be reproduced on specific
-  hardware.
-- `platform: Linux`, `platform: Windows`, and `platform: WSL` identify the
-  affected host platform.
-- `ecosystem: *` (for example `ecosystem: PyTorch`, `ecosystem: vLLM`) identify
-  the downstream project a user hit the problem through.
-- `build issue`, `CICD`, `documentation`, and `test-debt` are good places to
-  look for contributions that don't require specific GPU hardware.
+> [!TIP]
+> Don't have the hardware to reproduce an issue? A precise reproduction, a
+> narrowed-down regression range, or better diagnostics are valuable
+> contributions on their own.
 
-If an issue looks like a good fit but is missing information you need, ask for
-it in the issue thread. If you think an issue deserves the `help wanted` or
-`good first issue` label, or that the label no longer applies, say so on the
-issue and a maintainer will take another look.
+If an issue is missing information you need, or you think it deserves one of the
+labels above, say so in the thread and a maintainer will take another look.
 
 #### Do I need to ask before working on an issue?
 
-No, but please leave a comment on the issue saying that you are picking it up so
-other contributors and maintainers don't duplicate your effort. We don't lock
-issues to a single person, and an existing assignee doesn't stop you from
-opening a pull request. If multiple pull requests address the same issue, we
-take the highest quality one (or the first one, if they are comparable).
+No, but please comment on the issue to say you are picking it up so others don't
+duplicate your effort. We don't lock issues to one person, and an existing
+assignee doesn't stop you from opening a pull request. If multiple pull requests
+address the same issue, we take the highest quality one (or the first one, if
+they are comparable).
 
-A few things worth knowing before you start:
-
-- For anything larger than a small fix, describe your intended approach on the
-  issue before writing much code. That is the cheapest point at which a
-  maintainer can redirect you away from an approach we can't accept. See also
-  [Using GitHub Issues for feature development](#using-github-issues-for-feature-development).
-- Issues without `help wanted` are still fair game, but they may already be in
-  progress internally, blocked on an upstream component, or not something we are
-  ready to take a fix for yet. Ask on the issue first.
-- Many issues filed here are ultimately bugs in a component that TheRock builds
-  from a submodule (LLVM, the ROCm math libraries, and so on), so the fix may
-  need to land in that upstream repository rather than in this one. Maintainers
-  can point you at the right place.
-- Reproducing an issue often requires specific AMD hardware. If you don't have
-  the matching GPU, adding a precise reproduction, narrowing down a regression
-  range, or improving the diagnostics is still valuable work on its own.
+> [!NOTE]
+> Issues without `help wanted` are still fair game, but they may already be in
+> progress internally or blocked on an upstream change, so ask first. Some
+> issues filed here are ultimately bugs in a component that TheRock builds from
+> a submodule, in which case the fix belongs in that repository instead.
 
 When your change is ready, follow
-[Creating pull requests](#creating-pull-requests) and link the issue from the
-pull request description.
+[Creating pull requests](#creating-pull-requests).
 
 ### Using GitHub Issues for bug reporting
 


### PR DESCRIPTION
## Motivation

`CONTRIBUTING.md` covers our policies and how to open a good pull request, but it never explains how a prospective contributor finds something to work on. The guide goes straight from the branch naming policy into "Using GitHub Issues for bug reporting", which addresses people reporting a problem rather than people offering to help.

We now have a `help wanted` label for issues that are ready for someone outside the core team to pick up, and nothing in the repository documents what it means or how it relates to `good first issue`. This PR adds that guidance.

## Technical Details

Adds a single "Finding an issue to work on" section to `CONTRIBUTING.md`, placed as the first subsection under "Development workflows and contributing guide" so the reading order becomes find work, then report bugs, then propose features, then open a pull request. No existing text is modified or removed; the change is 67 added lines in one file.

The section contains:

- A table describing `help wanted` and `good first issue`, each linking to a pre-filtered issue search.
- A list of the triage labels that scope an issue (`status: *`, `project: *`, `gfx*`, `platform: *`, `ecosystem: *`), plus a pointer to `build issue`, `CICD`, `documentation`, and `test-debt` as areas that do not require specific GPU hardware.
- A "Do I need to ask before working on an issue?" subsection: no, but comment on the issue, since we do not lock issues to one person and an existing assignee does not block a pull request.
- Caveats specific to this repository: discuss non-trivial approaches on the issue first, issues without `help wanted` may already be in progress internally or blocked upstream, many issues are ultimately bugs in a submodule component rather than in this repository, and reproducing an issue often needs particular AMD hardware, so repros and bisects are valuable contributions on their own.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
