### PR TITLE
ci(pytorch): set CC and CXX for dependency installation

### DIFF
--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -203,22 +203,24 @@ jobs:
 
       - name: Install test requirements
         run: |
-          # Some pinned test requirements have no cp314 wheel and build from source.
-          # The test container ships clang but not gcc, and setuptools/distutils
-          # defaults to sysconfig's baked CC=gcc. Point it at the clang that is
-          # already installed. Scoped to this step so it does not affect the tests.
-          if [[ "${RUNNER_OS}" == "Linux" ]]; then
+          # Some pinned test requirements have no cp314 wheel and build from
+          # source. Scoped to this step so it does not affect the tests.
+          if [[ "${RUNNER_OS}" == "Windows" ]]; then
+            # cl.exe is not on PATH. Activate MSVC so meson picks cl over the
+            # MinGW gcc that chocolatey puts on PATH; meson tries cl first.
+            vswhere="/c/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe"
+            vcvars=$("${vswhere}" -latest -products '*' \
+              -find 'VC\Auxiliary\Build\vcvars64.bat' | tr -d '\r')
+            pip_install() { cmd //c "call \"${vcvars}\" >NUL && python -m pip install $*"; }
+          else
+            # The container ships clang but not gcc; setuptools defaults to gcc.
             export CC=clang
             export CXX=clang++
-          elif [[ "${RUNNER_OS}" == "Windows" ]]; then
-            export CC=cl
-            export CXX=cl
+            pip_install() { python -m pip install "$@"; }
           fi
-          python -m pip install -r external-builds/pytorch/requirements-test.txt
-          python -m pip install -r external-builds/pytorch/pytorch/.ci/docker/requirements-ci.txt
+          pip_install -r external-builds/pytorch/requirements-test.txt
+          pip_install -r external-builds/pytorch/pytorch/.ci/docker/requirements-ci.txt
           pip freeze
-          unset CC
-          unset CXX
 
       - name: Driver / GPU sanity check
         timeout-minutes: 3

--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -202,17 +202,23 @@ jobs:
             --activate-in-future-github-actions-steps
 
       - name: Install test requirements
-        # Some pinned test requirements have no cp314 wheel and build from source.
-        # The test container ships clang but not gcc, and setuptools/distutils
-        # defaults to sysconfig's baked CC=gcc. Point it at the clang that is
-        # already installed. Scoped to this step so it does not affect the tests.
-        env:
-          CC: clang
-          CXX: clang++
         run: |
+          # Some pinned test requirements have no cp314 wheel and build from source.
+          # The test container ships clang but not gcc, and setuptools/distutils
+          # defaults to sysconfig's baked CC=gcc. Point it at the clang that is
+          # already installed. Scoped to this step so it does not affect the tests.
+          if [[ "${RUNNER_OS}" == "Linux" ]]; then
+            export CC=clang
+            export CXX=clang++
+          elif [[ "${RUNNER_OS}" == "Windows" ]]; then
+            export CC=cl
+            export CXX=cl
+          fi
           python -m pip install -r external-builds/pytorch/requirements-test.txt
           python -m pip install -r external-builds/pytorch/pytorch/.ci/docker/requirements-ci.txt
           pip freeze
+          unset CC
+          unset CXX
 
       - name: Driver / GPU sanity check
         timeout-minutes: 3

--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -204,28 +204,15 @@ jobs:
       - name: Install test requirements
         run: |
           # Some pinned test requirements have no cp314 wheel and build from
-          # source. Scoped to this step so it does not affect the tests.
-          if [[ "${RUNNER_OS}" == "Windows" ]]; then
-            # cl.exe is not on PATH. Activate MSVC so meson picks cl over the
-            # MinGW gcc that chocolatey puts on PATH; meson tries cl first.
-            # The vcvars path has spaces, and MSYS escapes embedded quotes in a
-            # way cmd does not understand, so drive it from a batch file.
-            vswhere="/c/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe"
-            vcvars=$("${vswhere}" -latest -products '*' \
-              -find 'VC\Auxiliary\Build\vcvars64.bat' | tr -d '\r')
-            pip_install() {
-              printf '@echo off\r\ncall "%s" || exit /b 1\r\npython -m pip install %s\r\n' \
-                "${vcvars}" "$*" > pip_install_msvc.bat
-              cmd //c pip_install_msvc.bat
-            }
-          else
-            # The container ships clang but not gcc; setuptools defaults to gcc.
+          # source. The container ships clang but not gcc, and setuptools
+          # defaults to the CC=gcc baked into sysconfig. Scoped to this step so
+          # it does not affect the tests.
+          if [[ "${RUNNER_OS}" == "Linux" ]]; then
             export CC=clang
             export CXX=clang++
-            pip_install() { python -m pip install "$@"; }
           fi
-          pip_install -r external-builds/pytorch/requirements-test.txt
-          pip_install -r external-builds/pytorch/pytorch/.ci/docker/requirements-ci.txt
+          python -m pip install -r external-builds/pytorch/requirements-test.txt
+          python -m pip install -r external-builds/pytorch/pytorch/.ci/docker/requirements-ci.txt
           pip freeze
 
       - name: Driver / GPU sanity check

--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -202,6 +202,13 @@ jobs:
             --activate-in-future-github-actions-steps
 
       - name: Install test requirements
+        # Some pinned test requirements have no cp314 wheel and build from source.
+        # The test container ships clang but not gcc, and setuptools/distutils
+        # defaults to sysconfig's baked CC=gcc. Point it at the clang that is
+        # already installed. Scoped to this step so it does not affect the tests.
+        env:
+          CC: clang
+          CXX: clang++
         run: |
           python -m pip install -r external-builds/pytorch/requirements-test.txt
           python -m pip install -r external-builds/pytorch/pytorch/.ci/docker/requirements-ci.txt

--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -208,10 +208,16 @@ jobs:
           if [[ "${RUNNER_OS}" == "Windows" ]]; then
             # cl.exe is not on PATH. Activate MSVC so meson picks cl over the
             # MinGW gcc that chocolatey puts on PATH; meson tries cl first.
+            # The vcvars path has spaces, and MSYS escapes embedded quotes in a
+            # way cmd does not understand, so drive it from a batch file.
             vswhere="/c/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe"
             vcvars=$("${vswhere}" -latest -products '*' \
               -find 'VC\Auxiliary\Build\vcvars64.bat' | tr -d '\r')
-            pip_install() { cmd //c "call \"${vcvars}\" >NUL && python -m pip install $*"; }
+            pip_install() {
+              printf '@echo off\r\ncall "%s" || exit /b 1\r\npython -m pip install %s\r\n' \
+                "${vcvars}" "$*" > pip_install_msvc.bat
+              cmd //c pip_install_msvc.bat
+            }
           else
             # The container ships clang but not gcc; setuptools defaults to gcc.
             export CC=clang


### PR DESCRIPTION
Fixes https://github.com/ROCm/TheRock/issues/6723#issuecomment-5129810744

Temporarily set env vars `CC` and `CXX` for dependency installation when pip needs to build some dependencies from source. This it to avoid installing extra dependencies in the environment and hiding real usability issues.

Example run: https://github.com/ROCm/TheRock/actions/runs/30931473991/job/92100146314, dependency installation succeeded