### PR TITLE
fix(packaging) fall back to rocm-sdk-core for --root/--bin when devel is absent

### DIFF
--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/__main__.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/__main__.py
@@ -15,20 +15,32 @@ from . import _dist_info as di
 def _do_path(args: argparse.Namespace):
     from . import _devel
 
+    if args.cmake:
+        try:
+            root_path = _devel.get_devel_root()
+        except ModuleNotFoundError as e:
+            print(
+                "ERROR: `rocm-sdk path --cmake` requires the `rocm[devel]` "
+                "package, which provides the cmake config files. Please install "
+                "it with your package manager (pip, uv, etc)",
+                file=sys.stderr,
+            )
+            print(f"ERROR: {e}", file=sys.stderr)
+            sys.exit(1)
+        print(root_path / "lib" / "cmake")
+        return
+
     try:
         root_path = _devel.get_devel_root()
-    except ModuleNotFoundError as e:
-        print(
-            "ERROR: Could not load the `rocm[devel]` package, which is required "
-            "to access runtime tools and development files. Please install it with "
-            "your package manager (pip, uv, etc)",
-            file=sys.stderr,
-        )
-        print(f"ERROR: {e}", file=sys.stderr)
-        sys.exit(1)
-    if args.cmake:
-        print(root_path / "lib" / "cmake")
-    elif args.bin:
+    except ModuleNotFoundError:
+        # Devel not installed: serve runtime paths from rocm-sdk-core.
+        try:
+            root_path = _devel.get_core_root()
+        except ModuleNotFoundError as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    if args.bin:
         print(root_path / "bin")
     elif args.root:
         print(root_path)

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
@@ -47,6 +47,18 @@ def _is_windows():
     return platform.system() == "Windows"
 
 
+def get_core_root() -> Path:
+    """Returns the rocm-sdk-core install root, which needs no rocm[devel]."""
+    core_spec = di.ALL_PACKAGES["core"].get_py_package()
+    if core_spec is None or core_spec.origin is None:
+        raise ModuleNotFoundError(
+            "rocm-sdk-core package is not installed. This can typically be "
+            "obtained by installing `rocm` or `rocm[libraries]` from your "
+            "package manager"
+        )
+    return Path(core_spec.origin).parent
+
+
 def get_devel_root() -> Path:
     try:
         import rocm_sdk_devel


### PR DESCRIPTION
## Motivation

Resolves https://github.com/ROCm/ROCm/issues/6534.

## Technical Details

- `rocm-sdk path --root/--bin` require devel packages so library only installs (what we recommend for[ ROCm 7.14](https://rocm.docs.amd.com/en/latest/install/rocm.html?fam=ryzen&w=compute&os=ubuntu&ubuntu-ver=26.04&i=pip&gpu=max-plus-pro-495&gfx=gfx1151#install-rocm-wheel-packages-i-pkgman-os-ubuntu-os-wsl-ubuntu-ver-26-04-fam-all-fam-instinct-fam-radeon-fam-ryzen-ubuntu-ver-24-04-fam-all-fam-instinct-fam-radeon-fam-ryzen-ubuntu-ver-22-04-fam-all-fam-instinct-fam-radeon-fam-ryzen-os-debian-debian-ver-13-fam-all-fam-instinct-fam-radeon-fam-ryzen-debian-ver-12-fam-all-fam-instinct-fam-radeon-fam-ryzen-os-rhel-rhel-ver-10-2-rhel-ver-10-0-fam-all-fam-instinct-fam-radeon-fam-ryzen-rhel-ver-9-8-rhel-ver-9-6-rhel-ver-9-4-fam-all-fam-instinct-fam-radeon-fam-ryzen-rhel-ver-8-10-fam-all-fam-instinct-fam-radeon-fam-ryzen-os-oracle-linux-oracle-linux-ver-10-fam-all-fam-instinct-fam-radeon-fam-ryzen-oracle-linux-ver-9-fam-all-fam-instinct-fam-radeon-fam-ryzen-oracle-linux-ver-8-fam-all-fam-instinct-fam-radeon-fam-ryzen-os-rocky-linux-fam-all-fam-instinct-fam-radeon-fam-ryzen-os-sles-sles-ver-16-0-fam-all-fam-instinct-fam-radeon-fam-ryzen-sles-ver-15-7-fam-all-fam-instinct-fam-radeon-fam-ryzen-i-pkgman-os-ubuntu-os-debian-os-wsl-fam-all-gfx-gfx950-gfx-gfx942-gfx-gfx90a-gfx-gfx908-gfx-gfx1201-gfx-gfx1200-gfx-gfx1100-gfx-gfx1101-gfx-gfx1102-gfx-gfx1103-gfx-gfx1030-gfx-gfx1151-gfx-gfx1150-gfx-gfx1152-gfx-gfx1153-os-rhel-os-oracle-linux-os-rocky-linux-fam-all-gfx-gfx950-gfx-gfx942-gfx-gfx90a-gfx-gfx908-gfx-gfx1201-gfx-gfx1200-gfx-gfx1100-gfx-gfx1101-gfx-gfx1102-gfx-gfx1103-gfx-gfx1030-gfx-gfx1151-gfx-gfx1150-gfx-gfx1152-gfx-gfx1153-os-sles-fam-all-gfx-gfx950-gfx-gfx942-gfx-gfx90a-gfx-gfx908-i-pkgman-gfx-gfx950-gfx-gfx942-gfx-gfx90a-gfx-gfx908-gfx-gfx1201-gfx-gfx1200-gfx-gfx1100-gfx-gfx1101-gfx-gfx1102-gfx-gfx1103-gfx-gfx1030-gfx-gfx1151-gfx-gfx1150-gfx-gfx1152-gfx-gfx1153-fam-all-gfx-gfx950-gfx-gfx942-gfx-gfx90a-gfx-gfx908-gfx-gfx1201-gfx-gfx1200-gfx-gfx1100-gfx-gfx1101-gfx-gfx1102-gfx-gfx1103-gfx-gfx1030-gfx-gfx1151-gfx-gfx1150-gfx-gfx1152-gfx-gfx1153-fam-all-w-graphics-os-ubuntu-os-rhel-fam-radeon-fam-ryzen-fam-all-i-pip-os-ubuntu-ubuntu-ver-26-04-ubuntu-ver-24-04-ubuntu-ver-22-04-os-debian-debian-ver-13-debian-ver-12-os-rhel-rhel-ver-10-2-rhel-ver-10-0-rhel-ver-9-8-rhel-ver-9-6-rhel-ver-9-4-rhel-ver-8-10-os-oracle-linux-oracle-linux-ver-10-oracle-linux-ver-9-oracle-linux-ver-8-os-rocky-linux-os-sles-sles-ver-16-0-sles-ver-15-7-os-windows-i-pip)) run into `ERROR: Could not load the rocm[devel] package` when trying to run these commands.

- Add a fallback to use the core package specific paths in case devel package is not present
```
  ┌─────────┬─────────────────────────────────────┬──────────────────────────────────────────────┐
  │  Flag   │    Without devel (library-only)     │             With devel installed             │
  ├─────────┼─────────────────────────────────────┼──────────────────────────────────────────────┤
  │ --root  │ …/site-packages/_rocm_sdk_core (OK) │ …/site-packages/_rocm_sdk_devel (OK)         │
  ├─────────┼─────────────────────────────────────┼──────────────────────────────────────────────┤
  │ --bin   │ …/_rocm_sdk_core/bin (OK)           │ …/_rocm_sdk_devel/bin (OK)                   │
  ├─────────┼─────────────────────────────────────┼──────────────────────────────────────────────┤
  │ --cmake │ FAIL — error: requires rocm[devel]  │ …/_rocm_sdk_devel/lib/cmake (OK, 54 configs) │
  └─────────┴─────────────────────────────────────┴──────────────────────────────────────────────┘
  ```


## Test Plan

1. Install library-only (rocm[libraries,device-gfx1151]) with no devel
2. run `rocm-sdk path --root/--bin/--cmake`
3. Install rocm[devel] and re-run all three to confirm no regression. 

Validate on both ROCm 7.14.0 and nightlies

## Test Result

- Without devel: --root/--bin return real _rocm_sdk_core paths (contain hipcc, lib/, include/), --cmake gives a clean "requires rocm[devel]" error
- with devel: all three return _rocm_sdk_devel paths as before. rocm-sdk test passes (19 tests)

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
