### PR TITLE
feat(ci): use host-asan for presubmit ASAN builds

### DIFF
--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -1236,8 +1236,8 @@ def expand_build_configs(
     all_families = _apply_external_family_overrides(all_families)
     build_variant = ci_inputs.build_variant
     # for ASAN CI runs, workflow_dispatch and scheduled events are "asan".
-    # Otherwise, push events run "host-asan"
-    if build_variant == "asan" and ci_inputs.is_push:
+    # Otherwise, push and pull_request events run "host-asan"
+    if build_variant == "asan" and (ci_inputs.is_push or ci_inputs.is_pull_request):
         build_variant = "host-asan"
 
     linux_config: BuildConfig | None = None


### PR DESCRIPTION
Remap asan -> host-asan for pull_request events, not just push. This makes presubmit ASAN builds faster and more focused on host-side sanitizer checks rather than full device ASAN.

ISSUE ID: https://github.com/ROCm/TheRock/issues/6627