### PR TITLE
[hipthreads] Add hipThreads lit and example-app test jobs to TheRock CI (#6770)

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -676,6 +676,32 @@ test_matrix = {
             "windows": 1,
         },
     },
+    # hipthreads lit tests
+    "hipthreads": {
+        "job_name": "hipthreads",
+        "fetch_artifact_args": "--hipthreads --tests",
+        "timeout_minutes": 30,
+        "test_script": f"python {_get_script_path('test_hipthreads.py')}",
+        "platform": ["linux", "windows"],
+        "total_shards_dict": {
+            "linux": 1,
+            "windows": 1,
+        },
+    },
+    # hipthreads example apps (build + run consumer samples against the artifact).
+    "hipthreads_examples": {
+        "job_name": "hipthreads_examples",
+        # --prim pulls rocThrust/rocPrim (roc::rocthrust); --rand pulls hipRAND
+        # (the InOneWeekend example includes <hiprand/hiprand.hpp>).
+        "fetch_artifact_args": "--hipthreads --prim --rand --tests",
+        "timeout_minutes": 30,
+        "test_script": f"python {_get_script_path('test_hipthreads_examples.py')}",
+        "platform": ["linux", "windows"],
+        "total_shards_dict": {
+            "linux": 1,
+            "windows": 1,
+        },
+    },
     "rocdecode": {
         "job_name": "rocdecode",
         "fetch_artifact_args": "--rocdecode --tests",

--- a/build_tools/github_actions/test_executable_scripts/test_hipthreads.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipthreads.py
@@ -1,0 +1,197 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Runs the hipThreads lit test suite against pre-built TheRock artifacts.
+
+Unlike libhipcxx (which re-runs CMake + a ci/ shell script), hipThreads ships a
+self-contained lit suite driven entirely by environment variables (see the
+hipThreads test/lit.cfg). This script:
+
+  1. Points lit at the test sources packaged in the `test` artifact
+     (OUTPUT_ARTIFACTS_DIR/hipthreads, produced by HIPTHREADS_COPY_TO_BUILD).
+  2. Makes the pre-built static library (libhipthreads.a / hipthreads.lib)
+     discoverable at the
+     `<HIPTHREADS_BUILD_DIR>/lib` path that lit.cfg's link flags expect.
+  3. Invokes lit directly.
+"""
+
+import json
+import logging
+import os
+import platform
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+
+from libhipcxx_utils import get_gpu_architecture_portable, prepend_env_path
+
+THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
+OUTPUT_ARTIFACTS_DIR = os.getenv("OUTPUT_ARTIFACTS_DIR")
+SCRIPT_DIR = Path(__file__).resolve().parent
+THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
+
+IS_WINDOWS = platform.system() == "Windows"
+# The static library is libhipthreads.a on Linux but hipthreads.lib on Windows.
+STATIC_LIB_NAME = "hipthreads.lib" if IS_WINDOWS else "libhipthreads.a"
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+
+def load_rocm_version() -> str:
+    """Loads the rocm-version from the repository's version.json file."""
+    version_file = THEROCK_DIR / "version.json"
+    logging.info(f"Loading ROCm version from: {version_file}")
+    with open(version_file, "rt") as f:
+        loaded_file = json.load(f)
+        return loaded_file["rocm-version"]
+
+
+ROCM_VERSION = load_rocm_version()
+logging.info(f"ROCm version: {ROCM_VERSION}")
+
+environ_vars = os.environ.copy()
+
+# Resolve absolute paths
+OUTPUT_ARTIFACTS_PATH = Path(OUTPUT_ARTIFACTS_DIR).resolve()
+THEROCK_BIN_PATH = Path(THEROCK_BIN_DIR).resolve()
+
+# Set up ROCm/HIP environment
+environ_vars["ROCM_PATH"] = str(OUTPUT_ARTIFACTS_PATH)
+environ_vars["HIP_DEVICE_LIB_PATH"] = str(
+    OUTPUT_ARTIFACTS_PATH / "lib" / "llvm" / "amdgcn" / "bitcode"
+)
+environ_vars["HIP_PATH"] = str(OUTPUT_ARTIFACTS_PATH)
+environ_vars["HIP_PLATFORM"] = "amd"
+environ_vars["ROCM_VERSION"] = str(ROCM_VERSION)
+# Kill any individual test that hangs (e.g. a hip::thread scheduler deadlock)
+# after this many seconds, so one stuck test can't burn the whole job timeout.
+# Honored by the vendored test executor (test/utils/run.py).
+environ_vars["HIPTHREADS_TEST_TIMEOUT"] = "20"
+# hipThreads' persistent scheduler kernel spawns numVcores = CU_count *
+# HIPTHREADS_VCORES_PER_WGP workgroups; the default (16) occupies the whole GPU
+# and can deadlock the suite under shared/over-subscribed CI runners. This is a
+# RUNTIME setting (read via getenv in thread.cxx), so we dial it to 1 here for the
+# test run only — the shipped library keeps its default. lit.cfg forwards this var
+# to each spawned test via run.py's --env.
+environ_vars["HIPTHREADS_VCORES_PER_WGP"] = "1"
+
+# Add ROCm binaries to PATH (also the hipcc location).
+prepend_env_path(environ_vars, "PATH", str(THEROCK_BIN_PATH))
+
+# Set library / loader paths. On Windows the ROCm DLLs live in bin/ and PATH is
+# the DLL search path; on Linux the shared libs are under lib/ on LD_LIBRARY_PATH.
+if IS_WINDOWS:
+    prepend_env_path(environ_vars, "PATH", str(OUTPUT_ARTIFACTS_PATH / "bin"))
+else:
+    prepend_env_path(
+        environ_vars, "LD_LIBRARY_PATH", str(OUTPUT_ARTIFACTS_PATH / "lib")
+    )
+
+# Windows ONLY: hipcc has no GPU auto-detection there, so without --offload-arch
+# it defaults to gfx906 and links against the wrong arch. lit.cfg turns the
+# HIP_ARCHITECTURES env var into --offload-arch, so resolve a CONCRETE arch (e.g.
+# gfx1100) here and pass it through. We probe offload-arch (like libhipcxx) rather
+# than parsing AMDGPU_FAMILIES, whose gfx110X testers report the wildcard family
+# "gfx110X-all" that is not a compilable target. offload-arch.exe loads ROCm DLLs
+# from PATH, so prime os.environ's PATH first (the helper runs it with os.environ);
+# see TheRock #2019 / test_sanity.py.
+#
+# On Linux we deliberately do NOT set this: hipcc auto-detects the GPU and the lit
+# suite has always run green without --offload-arch, so leave that path untouched.
+if IS_WINDOWS:
+    os.environ["PATH"] = (
+        str(OUTPUT_ARTIFACTS_PATH / "bin") + os.pathsep + os.environ.get("PATH", "")
+    )
+    gpu_arch = get_gpu_architecture_portable(OUTPUT_ARTIFACTS_DIR)
+    logging.info(f"++ Detected GPU architecture: {gpu_arch}")
+    if gpu_arch:
+        environ_vars["HIP_ARCHITECTURES"] = gpu_arch
+    else:
+        # A miss means hipcc's gfx906 default kicks in and the link fails loudly
+        # on its own; surface why here.
+        logging.warning(
+            "Could not detect GPU architecture; lit will fall back to hipcc's "
+            "gfx906 default and likely fail to link."
+        )
+
+# The hipThreads lit suite is self-contained and resolves all of its paths from
+# these three environment variables (see hipThreads test/lit.cfg):
+#   HIPTHREADS_SOURCE_DIR  -> the source tree (test/) packaged in the test artifact
+#   HIPTHREADS_BUILD_DIR   -> where the pre-built libhipthreads.a is found (links -L <dir>/lib)
+#   ROCM_PATH              -> hipcc + ROCm/libhipcxx headers
+HIPTHREADS_SOURCE_DIR = OUTPUT_ARTIFACTS_PATH / "hipthreads"
+environ_vars["HIPTHREADS_SOURCE_DIR"] = str(HIPTHREADS_SOURCE_DIR)
+
+# lit.cfg compiles with `-I <HIPTHREADS_SOURCE_DIR>/inc`. The headers are not
+# bundled in the test artifact (they ship in the dev artifact, as
+# <artifacts>/include/hipthreads/hip, to avoid duplicating files across artifacts),
+# so stage them into <SOURCE_DIR>/inc/hip where lit expects them.
+# TODO (future release): repoint lit.cfg's include at <ROCM_PATH>/include/hipthreads
+# so it consumes the dev headers directly and this staging step can be removed.
+staged_include_dir = OUTPUT_ARTIFACTS_PATH / "include" / "hipthreads" / "hip"
+lit_include_dir = HIPTHREADS_SOURCE_DIR / "inc" / "hip"
+if not staged_include_dir.exists():
+    logging.error(f"Dev headers not found at: {staged_include_dir}")
+    raise FileNotFoundError(staged_include_dir)
+shutil.copytree(staged_include_dir, lit_include_dir, dirs_exist_ok=True)
+
+# lit.cfg links against `-L <HIPTHREADS_BUILD_DIR>/lib -lhipthreads`. The dev artifact
+# stages the static library at <artifacts>/lib/hipthreads/<lib> (libhipthreads.a on
+# Linux, hipthreads.lib on Windows), so we point HIPTHREADS_BUILD_DIR at a location
+# whose `lib/` contains that archive.
+HIPTHREADS_BUILD_DIR = OUTPUT_ARTIFACTS_PATH / "hipthreads"
+hipthreads_lib_dir = HIPTHREADS_BUILD_DIR / "lib"
+hipthreads_lib_dir.mkdir(parents=True, exist_ok=True)
+
+staged_lib_dir = OUTPUT_ARTIFACTS_PATH / "lib" / "hipthreads"
+staged_lib = staged_lib_dir / STATIC_LIB_NAME
+if not staged_lib.exists():
+    # Fall back to globbing in case the staged name/path differs from expectation,
+    # so a naming surprise surfaces a clear log instead of a silent link failure.
+    candidates = sorted(staged_lib_dir.glob("*hipthreads*"))
+    logging.error(
+        f"Pre-built library not found at {staged_lib}. "
+        f"Candidates in {staged_lib_dir}: {[p.name for p in candidates]}"
+    )
+    if not candidates:
+        raise FileNotFoundError(staged_lib)
+    staged_lib = candidates[0]
+    logging.warning(f"Falling back to staged library: {staged_lib}")
+
+linked_lib = hipthreads_lib_dir / staged_lib.name
+if not linked_lib.exists():
+    # Hard link (fall back to copy) so lit's -L <build>/lib finds the archive.
+    try:
+        os.link(staged_lib, linked_lib)
+    except OSError:
+        shutil.copy2(staged_lib, linked_lib)
+environ_vars["HIPTHREADS_BUILD_DIR"] = str(HIPTHREADS_BUILD_DIR)
+
+logging.info(f"ROCM_PATH: {environ_vars['ROCM_PATH']}")
+logging.info(f"HIPTHREADS_SOURCE_DIR: {environ_vars['HIPTHREADS_SOURCE_DIR']}")
+logging.info(f"HIPTHREADS_BUILD_DIR: {environ_vars['HIPTHREADS_BUILD_DIR']}")
+logging.info(f"PATH: {environ_vars['PATH']}")
+
+# Report the size of the (now target-neutral) static archive so each CI run
+# records how large the all-architecture library is.
+_lib_size_bytes = staged_lib.stat().st_size
+logging.info(
+    f"{staged_lib.name} size: {_lib_size_bytes} bytes "
+    f"({_lib_size_bytes / (1024 * 1024):.2f} MiB) at {staged_lib}"
+)
+
+if not HIPTHREADS_SOURCE_DIR.exists():
+    logging.error(f"Test sources not found at: {HIPTHREADS_SOURCE_DIR}")
+    raise FileNotFoundError(HIPTHREADS_SOURCE_DIR)
+
+# Run the lit suite.
+cmd = [
+    "lit",
+    "-v",
+    "-j",
+    "1",
+    str(HIPTHREADS_SOURCE_DIR / "test"),
+]
+logging.info(f"++ Exec [{os.getcwd()}]$ {shlex.join(cmd)}")
+subprocess.run(cmd, check=True, env=environ_vars)

--- a/build_tools/github_actions/test_executable_scripts/test_hipthreads_examples.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipthreads_examples.py
@@ -1,0 +1,282 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Builds and runs hipThreads example apps against pre-built TheRock artifacts.
+
+Unlike test_hipthreads.py (which runs the lit unit-test suite), this script
+exercises the public consumer path: it configures each example with
+find_package(hipthreads) / find_package(rocthrust) against the packaged ROCm
+artifact, builds it, runs it, and checks for a clean exit plus an expected
+output marker. This catches breakage in the installed CMake package and headers
+that the unit tests do not.
+
+The example sources are packaged in the `test` artifact (HIPTHREADS_COPY_TO_BUILD
+copies the source tree, including examples/, into the build dir which the test
+artifact globs as hipthreads/**/*).
+"""
+
+import json
+import logging
+import os
+import platform
+import shlex
+import subprocess
+from pathlib import Path
+
+from libhipcxx_utils import (
+    get_gpu_architecture_portable,
+    prepend_env_path,
+)
+
+THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
+OUTPUT_ARTIFACTS_DIR = os.getenv("OUTPUT_ARTIFACTS_DIR")
+SCRIPT_DIR = Path(__file__).resolve().parent
+THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+# Each example: where it lives under <artifacts>/hipthreads/examples, the binary
+# name produced, the argv to run it with, and a substring expected on stdout.
+# stdout is captured to a file (the raytracer emits a multi-million-line PPM) and
+# scanned for the marker.
+EXAMPLES = [
+    {
+        "name": "saxpy",
+        "subdir": "saxpy/step3-simdize",
+        "binary": "saxpy",
+        "args": [],
+        "marker": "Time to run saxpy(",
+    },
+    {
+        "name": "inOneWeekend",
+        "subdir": "InOneWeekendRaytracer/step4-simdize",
+        "binary": "inOneWeekend",
+        "args": [],
+        "marker": "P3",
+    },
+    {
+        # Pass an explicit matrix path so spmm runs ONE tiny matrix instead of its
+        # default pair (the other default matrices are LFS files that CI does not
+        # `git lfs pull`). test_general.mtx is committed as plain text (exempted
+        # from the *.mtx LFS rule in .gitattributes); the path is relative to the
+        # example dir, which is run_example's cwd.
+        "name": "spmm",
+        "subdir": "sparse-mat-mul/step3-hipthread-port",
+        "binary": "spmm",
+        "args": ["../data/test_general.mtx"],
+        "marker": "Time(",
+    },
+]
+
+# Per-example wall-clock cap. The examples run at full benchmark sizes and the CI
+# run sets HIPTHREADS_VCORES_PER_WGP=1 (see build_environment), so they can be
+# slow; keep this comfortably under the job timeout in fetch_test_configurations.py.
+RUN_TIMEOUT_SECONDS = 1800
+
+IS_WINDOWS = platform.system() == "Windows"
+EXE_SUFFIX = ".exe" if IS_WINDOWS else ""
+
+
+def load_rocm_version() -> str:
+    """Loads the rocm-version from the repository's version.json file."""
+    version_file = THEROCK_DIR / "version.json"
+    logging.info(f"Loading ROCm version from: {version_file}")
+    with open(version_file, "rt") as f:
+        loaded_file = json.load(f)
+        return loaded_file["rocm-version"]
+
+
+def build_environment() -> dict:
+    """Returns an environment dict configured for hipcc + ROCm from the artifact."""
+    environ_vars = os.environ.copy()
+
+    environ_vars["ROCM_PATH"] = str(OUTPUT_ARTIFACTS_PATH)
+    environ_vars["HIP_DEVICE_LIB_PATH"] = str(
+        OUTPUT_ARTIFACTS_PATH / "lib/llvm/amdgcn/bitcode/"
+    )
+    environ_vars["HIP_PATH"] = str(OUTPUT_ARTIFACTS_PATH)
+    environ_vars["CMAKE_PREFIX_PATH"] = str(OUTPUT_ARTIFACTS_PATH)
+    environ_vars["HIP_PLATFORM"] = "amd"
+    environ_vars["ROCM_VERSION"] = str(ROCM_VERSION)
+    environ_vars["CMAKE_GENERATOR"] = "Ninja"
+    # RUNTIME setting (read via getenv in thread.cxx): dial the scheduler's
+    # per-WGP vcore count down to 1 so the example binaries don't over-subscribe a
+    # shared CI GPU and deadlock. The shipped library keeps its default (16).
+    environ_vars["HIPTHREADS_VCORES_PER_WGP"] = "1"
+
+    prepend_env_path(environ_vars, "PATH", str(THEROCK_BIN_PATH))
+    if IS_WINDOWS:
+        # ROCm DLLs live in bin/ on Windows; PATH is also the DLL search path.
+        prepend_env_path(environ_vars, "PATH", str(OUTPUT_ARTIFACTS_PATH / "bin"))
+    else:
+        prepend_env_path(
+            environ_vars, "LD_LIBRARY_PATH", str(OUTPUT_ARTIFACTS_PATH / "lib")
+        )
+    return environ_vars
+
+
+def configure_and_build(example: dict, gpu_arch: str, environ_vars: dict) -> Path:
+    """Configures + builds one example; returns the built binary path.
+
+    NOTE: This compiles on the (GPU) test runner rather than in the build stage.
+    Normally these wrappers should only run pre-built binaries, but the hipThreads
+    artifact is TARGET_NEUTRAL: libhipthreads.a is arch-independent, whereas an
+    example executable embeds device code for a specific gfx arch. Pre-building the
+    examples would therefore make the artifact target-specific (per-arch binaries).
+    Tracked for future releases: once hipThreads ships a shared library, move example
+    compilation into the build stage as a target-specific test artifact.
+    """
+    source_dir = EXAMPLES_ROOT / example["subdir"]
+    if not source_dir.exists():
+        raise FileNotFoundError(f"Example source dir not found: {source_dir}")
+
+    build_dir = source_dir / "build"
+    llvm_bin = OUTPUT_ARTIFACTS_PATH / "lib" / "llvm" / "bin"
+    clang = llvm_bin / f"clang{EXE_SUFFIX}"
+    clangxx = llvm_bin / f"clang++{EXE_SUFFIX}"
+
+    configure_cmd = [
+        "cmake",
+        "-B",
+        str(build_dir),
+        "-S",
+        str(source_dir),
+        "-GNinja",
+        f"-DCMAKE_PREFIX_PATH={OUTPUT_ARTIFACTS_PATH}",
+        # The examples are project(... LANGUAGES CXX HIP). Pin BOTH the CXX and
+        # HIP compilers to the ROCm clang from the artifact. Otherwise CMake
+        # picks the system C++ compiler for CXX (e.g. clang-18 at /usr/bin/c++)
+        # while HIP uses ROCm clang, and the final link fails looking for the
+        # system toolchain's compiler-rt (libclang_rt.builtins) which isn't
+        # installed in the CI container.
+        f"-DCMAKE_C_COMPILER={clang.as_posix()}",
+        f"-DCMAKE_CXX_COMPILER={clangxx.as_posix()}",
+        f"-DCMAKE_HIP_COMPILER={clangxx.as_posix()}",
+        f"-DCMAKE_HIP_ARCHITECTURES={gpu_arch}",
+        # The packaged hipthreads.lib is built Release (dynamic CRT, msvcrt,
+        # _ITERATOR_DEBUG_LEVEL=0). Pin the examples to Release too: without an
+        # explicit build type the Windows/Ninja default links the debug CRT
+        # (msvcrtd, _ITERATOR_DEBUG_LEVEL=2) and lld-link /failifmismatch aborts.
+        # Matches the documented per-example Windows build command.
+        "-DCMAKE_BUILD_TYPE=Release",
+    ]
+    if IS_WINDOWS:
+        # clang needs the MSVC resource compiler for the CXX language on Windows.
+        configure_cmd.append("-DCMAKE_RC_COMPILER=rc.exe")
+    logging.info(f"++ Configure [{example['name']}]$ {shlex.join(configure_cmd)}")
+    subprocess.run(configure_cmd, check=True, env=environ_vars)
+
+    build_cmd = ["cmake", "--build", str(build_dir)]
+    logging.info(f"++ Build [{example['name']}]$ {shlex.join(build_cmd)}")
+    subprocess.run(build_cmd, check=True, env=environ_vars)
+
+    binary = build_dir / "bin" / f"{example['binary']}{EXE_SUFFIX}"
+    if not binary.exists():
+        raise FileNotFoundError(f"Built binary not found: {binary}")
+    return binary
+
+
+def run_example(example: dict, binary: Path, environ_vars: dict) -> None:
+    """Runs one example; requires exit 0 and the expected output marker."""
+    build_dir = binary.parent.parent
+    stdout_path = build_dir / f"{example['name']}.stdout.log"
+
+    cmd = [str(binary), *example["args"]]
+    logging.info(f"++ Run [{example['name']}]$ {shlex.join(cmd)}")
+    with open(stdout_path, "wt") as stdout_file:
+        # cwd = source dir so any relative paths in the example resolve as it
+        # expects when run from its own directory.
+        result = subprocess.run(
+            cmd,
+            cwd=EXAMPLES_ROOT / example["subdir"],
+            stdout=stdout_file,
+            stderr=subprocess.STDOUT,
+            env=environ_vars,
+            timeout=RUN_TIMEOUT_SECONDS,
+        )
+
+    if result.returncode != 0:
+        logging.error(f"{example['name']} exited with code {result.returncode}")
+        _dump_tail(stdout_path)
+        raise subprocess.CalledProcessError(result.returncode, cmd)
+
+    marker = example["marker"]
+    if not _file_contains(stdout_path, marker):
+        logging.error(f"{example['name']} output missing marker {marker!r}")
+        _dump_tail(stdout_path)
+        raise RuntimeError(f"{example['name']}: expected marker {marker!r} not found")
+
+    logging.info(f"PASS: {example['name']} (exit 0, found marker {marker!r})")
+
+
+def _file_contains(path: Path, needle: str) -> bool:
+    with open(path, "rt", errors="replace") as f:
+        for line in f:
+            if needle in line:
+                return True
+    return False
+
+
+def _dump_tail(path: Path, lines: int = 40) -> None:
+    try:
+        with open(path, "rt", errors="replace") as f:
+            tail = f.readlines()[-lines:]
+        logging.error("---- last output ----\n%s", "".join(tail))
+    except OSError:
+        pass
+
+
+if OUTPUT_ARTIFACTS_DIR is None or THEROCK_BIN_DIR is None:
+    raise EnvironmentError("OUTPUT_ARTIFACTS_DIR and THEROCK_BIN_DIR must both be set.")
+
+OUTPUT_ARTIFACTS_PATH = Path(OUTPUT_ARTIFACTS_DIR).resolve()
+THEROCK_BIN_PATH = Path(THEROCK_BIN_DIR).resolve()
+EXAMPLES_ROOT = OUTPUT_ARTIFACTS_PATH / "hipthreads" / "examples"
+
+ROCM_VERSION = load_rocm_version()
+logging.info(f"ROCm version: {ROCM_VERSION}")
+
+# offload-arch must resolve a CONCRETE arch (e.g. gfx1100) for
+# -DCMAKE_HIP_ARCHITECTURES. The AMDGPU_FAMILIES env var is unsuitable here: for
+# the gfx110X testers it holds the wildcard family "gfx110X-all", which is not a
+# compilable target. So we probe offload-arch like libhipcxx does. On Windows
+# offload-arch.exe loads ROCm DLLs from PATH, which is also the DLL search path,
+# so prepend the artifact bin/ dir before probing (see TheRock #2019, mirrored in
+# test_sanity.py) or detection returns None.
+if IS_WINDOWS:
+    os.environ["PATH"] = (
+        str(OUTPUT_ARTIFACTS_PATH / "bin") + os.pathsep + os.environ.get("PATH", "")
+    )
+
+gpu_arch = get_gpu_architecture_portable(OUTPUT_ARTIFACTS_DIR)
+if not gpu_arch:
+    # offload-arch can transiently fail (e.g. "no ROCm-capable device detected");
+    # fall back to the first concrete target from AMDGPU_TARGETS, which CI sets to
+    # a comma-separated list of compilable arches (e.g. gfx1100,gfx1101,...).
+    amdgpu_targets = os.getenv("AMDGPU_TARGETS", "")
+    gpu_arch = amdgpu_targets.split(",")[0].strip()
+    if gpu_arch:
+        logging.warning(
+            f"offload-arch probe failed; using AMDGPU_TARGETS[0]={gpu_arch}"
+        )
+logging.info(f"++ Detected GPU architecture: {gpu_arch}")
+if not gpu_arch:
+    raise RuntimeError(
+        "Could not detect GPU architecture (offload-arch and AMDGPU_TARGETS both empty)."
+    )
+
+if not EXAMPLES_ROOT.exists():
+    raise FileNotFoundError(
+        f"Examples not found at {EXAMPLES_ROOT}. The hipthreads test artifact "
+        "must be fetched (HIPTHREADS_COPY_TO_BUILD packages examples/)."
+    )
+
+environ_vars = build_environment()
+logging.info(f"ROCM_PATH: {environ_vars['ROCM_PATH']}")
+logging.info(f"EXAMPLES_ROOT: {EXAMPLES_ROOT}")
+
+for example in EXAMPLES:
+    binary = configure_and_build(example, gpu_arch, environ_vars)
+    run_example(example, binary, environ_vars)
+
+logging.info("All hipThreads example apps built and ran successfully.")

--- a/build_tools/install_rocm_from_artifacts.py
+++ b/build_tools/install_rocm_from_artifacts.py
@@ -48,6 +48,7 @@ python build_tools/install_rocm_from_artifacts.py
     [--rocwmma | --no-rocwmma]
     [--hiptensor | --no-hiptensor]
     [--libhipcxx | --no-libhipcxx]
+    [--hipthreads | --no-hipthreads]
     [--tests | --no-tests]
     [--base-only]
 
@@ -425,6 +426,7 @@ def retrieve_artifacts_by_run_id(args):
             args.rocalution,
             args.rocwmma,
             args.libhipcxx,
+            args.hipthreads,
         ]
     ):
         argv.extend(base_artifact_patterns)
@@ -559,6 +561,29 @@ def retrieve_artifacts_by_run_id(args):
             argv.append("amd-llvm_dev")
             argv.append("amd-llvm_lib")
             argv.append("base_dev_generic")
+        if args.hipthreads:
+            extra_artifacts.append("hipthreads")
+            # hipthreads ships a static library (libhipthreads.a) and headers in
+            # its _dev component, and its lit suite includes the libhipcxx
+            # headers, so both _dev artifacts are required at test time.
+            argv.append("hipthreads_dev")
+            argv.append("core-hip_run")
+            extra_artifacts.append("libhipcxx")
+            argv.append("libhipcxx_dev")
+            argv.append("amd-llvm_dev")
+            argv.append("amd-llvm_lib")
+            argv.append("base_dev_generic")
+            if args.prim:
+                # The hipthreads example apps link roc::rocthrust and call
+                # find_package(rocthrust/rocprim CONFIG); those headers and
+                # CMake package configs live in prim's _dev component (the
+                # extra_artifacts expansion below only pulls _lib/_test).
+                argv.append("prim_dev")
+            if args.rand:
+                # The InOneWeekend example includes <hiprand/hiprand.hpp>; the
+                # hipRAND/rocRAND headers live in rand's _dev component (the
+                # extra_artifacts expansion below only pulls _lib/_test).
+                argv.append("rand_dev")
 
         # Fetch _lib (always) and _test (when --tests) for each artifact.
         # Some projects have self-contained _test archives (just test
@@ -954,6 +979,13 @@ def main(argv):
         "--libhipcxx",
         default=False,
         help="Include 'libhipcxx' artifacts",
+        action=argparse.BooleanOptionalAction,
+    )
+
+    artifacts_group.add_argument(
+        "--hipthreads",
+        default=False,
+        help="Include 'hipthreads' artifacts",
         action=argparse.BooleanOptionalAction,
     )
 

--- a/build_tools/tests/install_rocm_from_artifacts_test.py
+++ b/build_tools/tests/install_rocm_from_artifacts_test.py
@@ -394,6 +394,7 @@ def _make_run_id_args(**overrides) -> argparse.Namespace:
         rocalution=False,
         rocwmma=False,
         libhipcxx=False,
+        hipthreads=False,
         tests=False,
     )
     defaults.update(overrides)

--- a/math-libs/CMakeLists.txt
+++ b/math-libs/CMakeLists.txt
@@ -723,8 +723,8 @@ if(THEROCK_ENABLE_HIPTHREADS)
       rocm-cmake
       libhipcxx
     RUNTIME_DEPS
+      amd-llvm
       hip-clr
-      hipcc
   )
   therock_cmake_subproject_glob_c_sources(hipthreads
     SUBDIRS


### PR DESCRIPTION
Cherry-picks commit a4dc044 into the ROCm 10.0 release branch.

JIRA ID: AIRDEL-16

---

## Motivation

JIRA ID : ROCM-23943

Run hipThreads' lit unit tests and example apps in TheRock CI on Linux and Windows. Depends on the hipThreads build PR #6769 .

## Technical Details

- Add `test_hipthreads.py` (runs the lit suite) and `test_hipthreads_examples.py` (builds + runs saxpy, InOneWeekend, and spmm against the packaged artifact via find_package).
- Register the `hipthreads` and `hipthreads_examples` jobs in `fetch_test_configurations.py` (linux + windows) and add the `--hipthreads` fetch flag to `install_rocm_from_artifacts.py`.
- Set `HIPTHREADS_VCORES_PER_WGP=1` at test runtime so the scheduler doesn't over-subscribe shared CI GPUs (runtime setting; the shipped library keeps its default).

## Test Plan

Run both scripts against a built artifact with `OUTPUT_ARTIFACTS_DIR` / `THEROCK_BIN_DIR` set, on Linux and Windows.

## Test Result

lit suite and all three example apps pass on Linux and Windows.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.


[ROCM-23943]:
https://amd-hub.atlassian.net/browse/ROCM-23943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ROCM-23943]: https://amd-hub.atlassian.net/browse/ROCM-23943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ