### PR TITLE
fix(py_packaging): strip xnack suffix from wheel package names

### DIFF
--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -341,8 +341,10 @@ def _run_kpack_split(
     # Per-ISA device wheels. Device artifacts overlay into
     # _rocm_sdk_libraries/lib/ and may include ELF .so files (per-arch
     # MIOpen CK kernels) with dynamic deps on core.
-    all_targets = sorted(params.all_target_families)
-    for target in all_targets:
+    # Group by base target (strip xnack suffix) to merge variants like
+    # 'gfx950' and 'gfx950:xnack+' into a single device package.
+    all_base_targets = sorted(set(t.split(":")[0] for t in params.all_target_families))
+    for target in all_base_targets:
         dev = PopulatedDistPackage(params, logical_name="device", target_family=target)
         dev.rpath_dep(core, "lib")
         dev.rpath_dep(core, "lib/rocm_sysdeps/lib")
@@ -594,7 +596,13 @@ def device_artifact_filter(target: str, an: ArtifactName) -> bool:
 
     Unlike libraries_artifact_filter, this only matches the specific ISA target
     (no generic). Used in kpack-split mode for device wheel population.
+
+    Matches both the base target and any xnack variants (e.g., target='gfx950'
+    matches artifacts for both 'gfx950' and 'gfx950:xnack+'), merging them into
+    a single device package.
     """
+    # Strip xnack suffix from artifact's target_family for comparison
+    artifact_base_target = an.target_family.split(":")[0]
     return (
         an.name
         in [
@@ -609,7 +617,7 @@ def device_artifact_filter(target: str, an: ArtifactName) -> bool:
             "rccl",
         ]
         and an.component == "lib"
-        and an.target_family == target
+        and artifact_base_target == target
     )
 
 

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
@@ -331,8 +331,13 @@ def get_target_family_platform_marker(target_family: str) -> str:
     """
     if not LINUX_TARGET_FAMILIES or not WINDOWS_TARGET_FAMILIES:
         return ""
-    in_linux = target_family in LINUX_TARGET_FAMILIES
-    in_windows = target_family in WINDOWS_TARGET_FAMILIES
+    # Compare base targets (strip xnack suffix) since platform lists may contain
+    # xnack-suffixed entries like 'gfx942:xnack+' while we receive base targets.
+    base_target = target_family.split(":")[0]
+    linux_base_targets = {t.split(":")[0] for t in LINUX_TARGET_FAMILIES}
+    windows_base_targets = {t.split(":")[0] for t in WINDOWS_TARGET_FAMILIES}
+    in_linux = base_target in linux_base_targets
+    in_windows = base_target in windows_base_targets
     if in_linux and not in_windows:
         return 'sys_platform == "linux"'
     if in_windows and not in_linux:
@@ -353,13 +358,16 @@ def build_per_target_extras() -> "dict[str, list[str]]":
     the generic extras already in setup.py's EXTRAS_REQUIRE suffice).
     """
     result: dict[str, list[str]] = {}
-    if len(AVAILABLE_TARGET_FAMILIES) <= 1:
+    # Deduplicate by base target (strip xnack suffix) to avoid redundant iterations
+    # when both 'gfx942' and 'gfx942:xnack+' exist in AVAILABLE_TARGET_FAMILIES.
+    base_targets = sorted(set(tf.split(":")[0] for tf in AVAILABLE_TARGET_FAMILIES))
+    if len(base_targets) <= 1:
         return result
     for pkg in ALL_PACKAGES.values():
         if not pkg.is_target_specific or pkg.required:
             continue
         all_requires: list[str] = []
-        for tf in sorted(AVAILABLE_TARGET_FAMILIES):
+        for tf in base_targets:
             extra_name = f"{pkg.logical_name}-{tf}"
             req = pkg.get_dist_package_require(target_family=tf)
             marker = get_target_family_platform_marker(tf)

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
@@ -96,7 +96,8 @@ class PackageEntry:
             )
         kwargs = {}
         if target_family is not None:
-            kwargs["target_family"] = target_family
+            # Strip xnack suffix (e.g., 'gfx942:xnack+' -> 'gfx942') for valid package names
+            kwargs["target_family"] = target_family.split(":")[0]
         return self.dist_package_template.format(**kwargs)
 
     def get_dist_package_require(self, target_family: str | None = None) -> str:

--- a/build_tools/tests/py_packaging_test.py
+++ b/build_tools/tests/py_packaging_test.py
@@ -540,8 +540,19 @@ class DevicePackagingTest(TmpDirTestCase):
         # Verify xnack-suffixed targets produce valid package names by stripping
         # the suffix (e.g., 'gfx942:xnack+' -> 'rocm-sdk-device-gfx942')
         device_entry = params.dist_info.ALL_PACKAGES["device"]
+        # Test xnack+ suffix
         self.assertEqual(
             device_entry.get_dist_package_name("gfx942:xnack+"),
+            "rocm-sdk-device-gfx942",
+        )
+        # Test xnack- suffix
+        self.assertEqual(
+            device_entry.get_dist_package_name("gfx942:xnack-"),
+            "rocm-sdk-device-gfx942",
+        )
+        # Test base target without suffix
+        self.assertEqual(
+            device_entry.get_dist_package_name("gfx942"),
             "rocm-sdk-device-gfx942",
         )
         # Verify get_dist_package_require also strips xnack suffix

--- a/build_tools/tests/py_packaging_test.py
+++ b/build_tools/tests/py_packaging_test.py
@@ -537,6 +537,14 @@ class DevicePackagingTest(TmpDirTestCase):
         artifact_dir = self._setup_kpack_split_artifacts()
         params = self._make_params(artifact_dir, kpack_split=True)
 
+        # Verify xnack-suffixed targets produce valid package names by stripping
+        # the suffix (e.g., 'gfx942:xnack+' -> 'rocm-sdk-device-gfx942')
+        device_entry = params.dist_info.ALL_PACKAGES["device"]
+        self.assertEqual(
+            device_entry.get_dist_package_name("gfx942:xnack+"),
+            "rocm-sdk-device-gfx942",
+        )
+
         dev = PopulatedDistPackage(
             params, logical_name="device", target_family="gfx942"
         )

--- a/build_tools/tests/py_packaging_test.py
+++ b/build_tools/tests/py_packaging_test.py
@@ -544,6 +544,18 @@ class DevicePackagingTest(TmpDirTestCase):
             device_entry.get_dist_package_name("gfx942:xnack+"),
             "rocm-sdk-device-gfx942",
         )
+        # Verify get_dist_package_require also strips xnack suffix
+        self.assertTrue(
+            device_entry.get_dist_package_require("gfx942:xnack+").startswith(
+                "rocm-sdk-device-gfx942=="
+            ),
+        )
+        # Verify get_py_package_name also strips xnack suffix
+        self.assertTrue(
+            device_entry.get_py_package_name("gfx942:xnack+").startswith(
+                "_rocm_sdk_device_gfx942"
+            ),
+        )
 
         dev = PopulatedDistPackage(
             params, logical_name="device", target_family="gfx942"
@@ -665,6 +677,14 @@ class DevicePackagingTest(TmpDirTestCase):
         # Should NOT match non-library artifact name.
         an_core = ArtifactName("core-hip", "lib", "gfx942")
         self.assertFalse(device_artifact_filter("gfx942", an_core))
+
+        # Should match xnack variant of the same base target (merges into one package).
+        an_xnack = ArtifactName("blas", "lib", "gfx942:xnack+")
+        self.assertTrue(device_artifact_filter("gfx942", an_xnack))
+
+        # Should NOT match xnack variant of a different base target.
+        an_xnack_other = ArtifactName("blas", "lib", "gfx950:xnack+")
+        self.assertFalse(device_artifact_filter("gfx942", an_xnack_other))
 
     def test_core_artifact_filter_includes_only_rocjitsu_hotswap(self):
         """The core wheel ships the HSA hotswap hook without the rocjitsu library."""
@@ -1495,6 +1515,16 @@ class PlatformMarkerTest(TmpDirTestCase):
         # Cross-platform target has no marker.
         self.assertEqual(dist_info.get_target_family_platform_marker("gfx1100"), "")
 
+        # Verify xnack-suffixed targets in platform lists are matched by base target.
+        xnack_dist_info = self._make_dist_info(
+            linux_target_families=["gfx942:xnack+", "gfx1100"],
+            windows_target_families=["gfx1100"],
+        )
+        self.assertEqual(
+            xnack_dist_info.get_target_family_platform_marker("gfx942"),
+            'sys_platform == "linux"',
+        )
+
     def test_no_marker_when_per_platform_lists_unknown(self):
         """Single-platform builds don't pass the new kwargs; no markers
         are added, so existing (non-multi-arch) sdists are unchanged.
@@ -1626,6 +1656,21 @@ class PerTargetExtrasTest(TmpDirTestCase):
                 + extras["device-gfx1100"]
                 + extras["device-gfx1102"]
             ),
+        )
+
+        # Verify xnack-suffixed targets produce valid extra names by stripping
+        # the suffix (e.g., 'device-gfx942' not 'device-gfx942:xnack+')
+        xnack_dist_info = self._make_dist_info(
+            linux_target_families=["gfx942:xnack+", "gfx1100"],
+            windows_target_families=["gfx1100"],
+        )
+        xnack_extras = xnack_dist_info.build_per_target_extras()
+        self.assertIn("device-gfx942", xnack_extras)
+        self.assertNotIn("device-gfx942:xnack+", xnack_extras)
+        xnack_req = xnack_extras["device-gfx942"][0]
+        self.assertTrue(
+            xnack_req.startswith("rocm-sdk-device-gfx942=="),
+            f"Expected stripped package name in requirement, got: {xnack_req}",
         )
 
     def test_no_markers_when_per_platform_lists_unknown(self):


### PR DESCRIPTION
  Target families like 'gfx942:xnack+' contain characters (':' and '+')
  that are invalid in Python package names (PEP 508). This caused wheel
  builds to fail with:

    error: Invalid distribution name or version syntax:
    rocm-sdk-device-gfx942-xnack--10.1.0.dev0+...

  Fix by stripping the xnack suffix in get_dist_package_name() so that
  'gfx942:xnack+' produces 'rocm-sdk-device-gfx942' instead of the
  invalid 'rocm-sdk-device-gfx942:xnack+'.

  Fixes multi-arch ASAN builds for gfx94x targets.

JIRA ID : https://amd-hub.atlassian.net/browse/ROCM-28314