### PR TITLE
ci(Pytorch): Fixes Windows Pytorch test process_hangs after test completion

### DIFF
--- a/.github/workflows/test_pytorch_wheels_full.yml
+++ b/.github/workflows/test_pytorch_wheels_full.yml
@@ -349,23 +349,11 @@ jobs:
       # See https://github.com/ROCm/TheRock/issues/999.
       - name: (Windows) Run PyTorch tests
         if: ${{ runner.os == 'Windows'}}
-        continue-on-error: true
         run: |
           python ./external-builds/pytorch/run_pytorch_tests.py -- \
             --continue-on-collection-errors \
             -v
 
-      - name: (Windows) Read and propagate exit code
-        if: ${{ runner.os == 'Windows'}}
-        run: |
-          if [ -f run_pytorch_tests_exit_code.txt ]; then
-            EXIT_CODE=$(cat run_pytorch_tests_exit_code.txt)
-            echo "Exit code from file: ${EXIT_CODE}"
-            exit ${EXIT_CODE}
-          else
-            echo "No run_pytorch_tests_exit_code.txt found"
-            exit 1
-          fi
 
   # Aggregate every shard's JUnit XML test reports into a single failure table
   # on the run's summary page, so all failures across configs/shards are visible

--- a/external-builds/pytorch/run_pytorch_tests.py
+++ b/external-builds/pytorch/run_pytorch_tests.py
@@ -311,7 +311,12 @@ def main() -> int:
 
         retcode = pytest.main(pytest_args)
         print(f"Pytest finished with return code: {retcode}")
-        return retcode
+        # Force-exit immediately. PyTorch's pytest is known to hang after
+        # all test files complete due to leaked daemon threads or orphan child
+        # processes (https://github.com/ROCm/TheRock/issues/999). os._exit()
+        # terminates without waiting for threads or running atexit handlers.
+        os._exit(retcode if retcode >= 0 else 1)
+
     except (ValueError, IndexError) as e:
         print(f"[ERROR] Exception in PyTorch unit-tests runner: {e}")
         sys.exit(1)


### PR DESCRIPTION

## Motivation

Fixes issue : Windows PyTorch test process hangs after test completion due to
leaked daemon threads from torch's HIP runtime initialization.

`run_pytorch_tests_full.py` already applies this fix via `os._exit()`, but
`run_pytorch_tests.py` (used for Windows testing in the full test suite workflow)
uses `sys.exit()` which blocks indefinitely on Windows.

The existing workflow workaround (`continue-on-error: true` + reading from
a nonexistent `run_pytorch_tests_exit_code.txt`) silently discards all Windows
test results (always exits 1).

## Changes

1. **`run_pytorch_tests.py`**: Replace `return retcode` with
   `os._exit(retcode if retcode >= 0 else 1)`, matching the fix in
   `run_pytorch_tests_full.py`.

2. **`test_pytorch_wheels_full.yml`**: Remove the Windows exit-code hack
   (`continue-on-error: true` + the file-read workaround). Normal error
   propagation is restored.

## Test Plan

- [ ] Verify `run_pytorch_tests.py` exits cleanly on Windows (no hang)
- [ ] Confirm Windows test results are correctly reflected in CI (pass/fail)
- [ ] Verify Linux behavior is unaffected (no regression)