### PR TITLE
fix(ci): Fix ASAN builds to build native Linux packages, skip Python packages

### DIFF
--- a/.github/workflows/multi_arch_ci_asan.yml
+++ b/.github/workflows/multi_arch_ci_asan.yml
@@ -56,6 +56,7 @@ jobs:
       linux_test_labels: ${{ inputs.linux_test_labels || '' }}
       prebuilt_stages: ${{ inputs.prebuilt_stages || '' }}
       baseline_run_id: ${{ inputs.baseline_run_id || '' }}
+      build_python_packages: false
       build_pytorch: false
       build_jax: false
 

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -251,7 +251,7 @@ jobs:
   build_python_packages:
     needs: [build_multi_arch_stages]
     name: Build Python Packages
-    if: ${{ !failure() && !cancelled() }}
+    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).build_python_packages == true }}
     uses: ./.github/workflows/build_portable_linux_python_packages.yml
     with:
       artifact_group: ${{ fromJSON(inputs.build_config).artifact_group }}

--- a/.github/workflows/multi_arch_ci_windows.yml
+++ b/.github/workflows/multi_arch_ci_windows.yml
@@ -153,7 +153,7 @@ jobs:
   build_python_packages:
     needs: [build_multi_arch_stages]
     name: Build Python Packages
-    if: ${{ !failure() && !cancelled() }}
+    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).build_python_packages == true }}
     uses: ./.github/workflows/build_windows_python_packages.yml
     with:
       artifact_group: ${{ fromJSON(inputs.build_config).artifact_group }}

--- a/.github/workflows/setup_multi_arch.yml
+++ b/.github/workflows/setup_multi_arch.yml
@@ -60,6 +60,10 @@ on:
           Automatic stage reuse: number of recent branch commits to fetch for ancestry. default: "50"
         type: string
         default: "50"
+      build_python_packages:
+        description: "Build ROCm Python packages (rocm-sdk, rocm-profiler, etc.)."
+        type: boolean
+        default: true
       build_pytorch:
         description: "Build PyTorch wheels."
         type: boolean
@@ -167,6 +171,7 @@ jobs:
         env:
           BUILD_VARIANT: ${{ inputs.build_variant }}
           RELEASE_TYPE: ${{ inputs.release_type }}
+          BUILD_PYTHON_PACKAGES: ${{ inputs.build_python_packages }}
           BUILD_PYTORCH: ${{ inputs.build_pytorch }}
           BUILD_JAX: ${{ inputs.build_jax }}
           PYTHON_VERSION: ${{ inputs.python_version }}

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -494,6 +494,7 @@ class BuildConfig:
     build_variant_suffix: str
     build_variant_cmake_preset: str
     build_native_linux: bool
+    build_python_packages: bool
     build_pytorch: bool
     build_jax: bool
     test_python_packages_matrix: list[dict[str, str]] = field(default_factory=list)
@@ -1154,6 +1155,9 @@ def _expand_build_config_for_platform(
     # Python package build is disabled. Then multi_arch_ci_* can also condition
     # build_python_packages on that decision.
 
+    # ASAN builds native Linux packages (deb/rpm) but not Python packages.
+    is_asan = suffix == "asan"
+
     return BuildConfig(
         per_family_info=per_family_info,
         dist_amdgpu_families=dist_amdgpu_families,
@@ -1161,7 +1165,8 @@ def _expand_build_config_for_platform(
         build_variant_label=variant_config["build_variant_label"],
         build_variant_suffix=suffix,
         build_variant_cmake_preset=variant_config["build_variant_cmake_preset"],
-        build_native_linux=(suffix != "asan"),
+        build_native_linux=True,
+        build_python_packages=(not is_asan),
         build_pytorch=build_pytorch,
         build_jax=build_jax,
         pytorch_build_matrix=pytorch_build_matrix,

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -142,6 +142,7 @@ class CIInputs:
     base_ref: str | None  # Git ref used for diffing, or None to skip path filters
     build_variant: str  # Build variant label, e.g. "release", "asan", "tsan"
     release_type: str = "ci"  # "ci", or "dev", "nightly", "prerelease" for releases
+    build_python_packages: bool = True
     build_pytorch: bool = True
     build_jax: bool = False
     python_versions: list[str] = field(default_factory=list)
@@ -198,6 +199,9 @@ class CIInputs:
         # push before-commit) comes from the event payload.
         build_variant = os.environ.get("BUILD_VARIANT", "release")
         release_type = os.environ.get("RELEASE_TYPE", "ci")
+        build_python_packages = (
+            os.environ.get("BUILD_PYTHON_PACKAGES", "true").lower() != "false"
+        )
         build_pytorch = os.environ.get("BUILD_PYTORCH", "true").lower() != "false"
         build_jax = os.environ.get("BUILD_JAX", "false").lower() != "false"
         python_version = os.environ.get("PYTHON_VERSION", "").strip()
@@ -245,6 +249,7 @@ class CIInputs:
             base_ref=base_ref,
             build_variant=build_variant,
             release_type=release_type,
+            build_python_packages=build_python_packages,
             build_pytorch=build_pytorch,
             build_jax=build_jax,
             python_versions=[python_version] if python_version else [],
@@ -1151,12 +1156,10 @@ def _expand_build_config_for_platform(
         per_family_info=per_family_info,
         platform=platform,
     )
-    # TODO: Use jobs.build_rocm_python so this matrix is empty when the ROCm
-    # Python package build is disabled. Then multi_arch_ci_* can also condition
-    # build_python_packages on that decision.
-
     # ASAN builds native Linux packages (deb/rpm) but not Python packages.
+    # The build_python_packages input allows callers to disable Python packages.
     is_asan = suffix == "asan"
+    build_python_packages = ci_inputs.build_python_packages and not is_asan
 
     return BuildConfig(
         per_family_info=per_family_info,
@@ -1166,7 +1169,7 @@ def _expand_build_config_for_platform(
         build_variant_suffix=suffix,
         build_variant_cmake_preset=variant_config["build_variant_cmake_preset"],
         build_native_linux=True,
-        build_python_packages=(not is_asan),
+        build_python_packages=build_python_packages,
         build_pytorch=build_pytorch,
         build_jax=build_jax,
         pytorch_build_matrix=pytorch_build_matrix,

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -938,6 +938,7 @@ class TestExpandBuildConfigs(unittest.TestCase):
             build_pytorch=True,
             build_jax=False,
             build_native_linux=True,
+            build_python_packages=True,
         )
         d = config.to_dict()
         # to_dict keys should match dataclass fields.
@@ -969,6 +970,7 @@ class TestExpandBuildConfigs(unittest.TestCase):
             build_pytorch=True,
             build_jax=False,
             build_native_linux=True,
+            build_python_packages=True,
         )
         # Present config → valid JSON
         serialized = json.dumps(config.to_dict())
@@ -1658,9 +1660,15 @@ class TestBuildConfigWorkflowContract(unittest.TestCase):
         workflow_path = WORKFLOWS_DIR / "multi_arch_ci_windows.yml"
         yaml_fields = self._extract_build_config_fields(workflow_path)
         python_fields = {f.name for f in fields(cm.BuildConfig)}
-        # build_native_linux is Linux-only. JAX builds are release-only and
-        # Linux-only for now, so Windows CI workflows do not consume them.
-        unused_fields = {"build_native_linux", "build_jax", "jax_build_matrix"}
+        # build_native_linux and build_python_packages are Linux-only. JAX builds
+        # are release-only and Linux-only for now, so Windows CI workflows do not
+        # consume them.
+        unused_fields = {
+            "build_native_linux",
+            "build_python_packages",
+            "build_jax",
+            "jax_build_matrix",
+        }
         self.assertEqual(
             yaml_fields,
             python_fields - unused_fields,

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -1660,15 +1660,9 @@ class TestBuildConfigWorkflowContract(unittest.TestCase):
         workflow_path = WORKFLOWS_DIR / "multi_arch_ci_windows.yml"
         yaml_fields = self._extract_build_config_fields(workflow_path)
         python_fields = {f.name for f in fields(cm.BuildConfig)}
-        # build_native_linux and build_python_packages are Linux-only. JAX builds
-        # are release-only and Linux-only for now, so Windows CI workflows do not
-        # consume them.
-        unused_fields = {
-            "build_native_linux",
-            "build_python_packages",
-            "build_jax",
-            "jax_build_matrix",
-        }
+        # build_native_linux is Linux-only. JAX builds are release-only and
+        # Linux-only for now, so Windows CI workflows do not consume them.
+        unused_fields = {"build_native_linux", "build_jax", "jax_build_matrix"}
         self.assertEqual(
             yaml_fields,
             python_fields - unused_fields,


### PR DESCRIPTION
ASAN builds should:
- Build native Linux packages (deb/rpm) - set build_native_linux=True
- Skip Python packages - add new build_python_packages field, set to False for ASAN

This fixes the issue where ASAN builds were incorrectly building Python packages instead of native Linux packages during submodule bumps.