### PR TITLE
hip-tests: Disable two hip-tests UTs blocked by Compiler ww28 SMP 2.5

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_hiptests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiptests.py
@@ -71,9 +71,6 @@ TEST_TO_IGNORE = {
             "Unit_NonHost_Printf_loop",
             "Unit_NonHost_Printf_multiple_Threads",
             "Unit_NonHost_Printf_BufferAvailability",
-            # TODO(#7139): Compiler ww28 SMP 2.5 (TheRock#7052) — re-enable after fix.
-            "Unit_hip_linker_spirv_input",
-            "Unit_hipExtModuleLaunchKernel_CheckCodeObjAttr",
         ]
     },
     "gfx94X-dcgpu": {
@@ -82,17 +79,12 @@ TEST_TO_IGNORE = {
             "Unit_NonHost_Printf_loop",
             "Unit_NonHost_Printf_multiple_Threads",
             "Unit_NonHost_Printf_BufferAvailability",
-            # TODO(#7139): Compiler ww28 SMP 2.5 (TheRock#7052) — re-enable after fix.
-            "Unit_hip_linker_spirv_input",
-            "Unit_hipExtModuleLaunchKernel_CheckCodeObjAttr",
         ]
     },
     "gfx110X-all": {
         "windows": [
             "Unit_hipStreamValue_Wait_Blocking - uint64_t",
             "Unit_hipStreamValue_Wait_Blocking - uint32_t",
-            # TODO(#7139): Compiler ww28 SMP 2.5 (TheRock#7052) — re-enable after fix.
-            "Unit_hipExtModuleLaunchKernel_CheckCodeObjAttr",
         ]
     },
     "gfx125X-dcgpu": {
@@ -101,6 +93,15 @@ TEST_TO_IGNORE = {
         ]
     },
 }
+
+# Tests excluded on every family and platform, merged into the per-family lists
+# above. Use this for failures that are not architecture specific, since nightly
+# runs many more families than presubmit does.
+GENERIC_TEST_TO_IGNORE = [
+    # TODO(#7139): Compiler ww28 SMP 2.5 (TheRock#7052) — re-enable after fix.
+    "Unit_hip_linker_spirv_input",
+    "Unit_hipExtModuleLaunchKernel_CheckCodeObjAttr",
+]
 
 
 def get_asan_lib_path():
@@ -192,8 +193,10 @@ def execute_tests(env):
     if TEST_TYPE == "quick":
         cmd.extend(["-L", "smoke"])
 
+    ignored_tests = list(GENERIC_TEST_TO_IGNORE)
     if AMDGPU_FAMILIES in TEST_TO_IGNORE and os_type in TEST_TO_IGNORE[AMDGPU_FAMILIES]:
-        ignored_tests = TEST_TO_IGNORE[AMDGPU_FAMILIES][os_type]
+        ignored_tests += TEST_TO_IGNORE[AMDGPU_FAMILIES][os_type]
+    if ignored_tests:
         cmd.extend(["--exclude-regex", "|".join(ignored_tests)])
 
     logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")

--- a/build_tools/github_actions/test_executable_scripts/test_hiptests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiptests.py
@@ -71,6 +71,9 @@ TEST_TO_IGNORE = {
             "Unit_NonHost_Printf_loop",
             "Unit_NonHost_Printf_multiple_Threads",
             "Unit_NonHost_Printf_BufferAvailability",
+            # TODO(#7139): Compiler ww28 SMP 2.5 (TheRock#7052) — re-enable after fix.
+            "Unit_hip_linker_spirv_input",
+            "Unit_hipExtModuleLaunchKernel_CheckCodeObjAttr",
         ]
     },
     "gfx94X-dcgpu": {
@@ -79,12 +82,17 @@ TEST_TO_IGNORE = {
             "Unit_NonHost_Printf_loop",
             "Unit_NonHost_Printf_multiple_Threads",
             "Unit_NonHost_Printf_BufferAvailability",
+            # TODO(#7139): Compiler ww28 SMP 2.5 (TheRock#7052) — re-enable after fix.
+            "Unit_hip_linker_spirv_input",
+            "Unit_hipExtModuleLaunchKernel_CheckCodeObjAttr",
         ]
     },
     "gfx110X-all": {
         "windows": [
             "Unit_hipStreamValue_Wait_Blocking - uint64_t",
             "Unit_hipStreamValue_Wait_Blocking - uint32_t",
+            # TODO(#7139): Compiler ww28 SMP 2.5 (TheRock#7052) — re-enable after fix.
+            "Unit_hipExtModuleLaunchKernel_CheckCodeObjAttr",
         ]
     },
     "gfx125X-dcgpu": {


### PR DESCRIPTION
## Summary

Temporarily exclude `Unit_hip_linker_spirv_input` and `Unit_hipExtModuleLaunchKernel_CheckCodeObjAttr` from TheRock hip-tests CI so [TheRock#7052](https://github.com/ROCm/TheRock/pull/7052) (Compiler ww28 SMP 2.5) promotion is not blocked.

## Motivation

Multi-Arch CI hip-tests fail with amd-llvm `7287e2062fa6` from #7052. These issues will be fixed in rocm-systems, which is exposed by the compiler promotion PR. CI exclusion is a short-term unblock until runtime/compiler owners deliver a fix.

## Test plan

- Multi-Arch CI hip-tests pass on gfx94X / gfx950 (Linux) and gfx110X (Windows) with #7052 compiler artifacts
- Confirm excluded tests are skipped in CI logs (`ctest --exclude-regex` in `test_hiptests.py`)
- After #7139 is resolved, remove `TEST_TO_IGNORE` entries and re-run hip-tests on main

## Related

- Unblocks: [TheRock#7052](https://github.com/ROCm/TheRock/pull/7052)
- Tracking issue: #7139