### PR TITLE
ci(hipkernelprovider): restore rocKE wheel setup around test_runner.py

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -590,12 +590,13 @@ test_matrix = {
             "windows": 1,
         },
     },
-    # hip-kernel-provider tests
+    # hip-kernel-provider tests. test_hipkernelprovider.py installs the staged
+    # rocKE wheels, then delegates to test_runner.py.
     "hipkernelprovider": {
         "job_name": "hipkernelprovider",
         "fetch_artifact_args": "--hipdnn --hipkernelprovider --hipdnn-integration-tests --tests",
         "timeout_minutes": 30,
-        "test_script": f"python {_get_script_path('test_runner.py')}",
+        "test_script": f"python {_get_script_path('test_hipkernelprovider.py')}",
         "platform": ["linux", "windows"],
         "total_shards_dict": {
             "linux": 1,

--- a/build_tools/github_actions/test_executable_scripts/test_hipkernelprovider.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipkernelprovider.py
@@ -1,59 +1,106 @@
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""Environment-setup wrapper around test_runner.py for hipkernelprovider.
 
-import glob
+Makes the `rocke` Python package importable, then delegates to test_runner.py
+so test selection stays on the standard CTest category labels. Two independent
+sources are staged into the test artifact: the wheels, which this installs, and
+the co-located rocke package, which this puts on PYTHONPATH. Without at least
+one, the rocKE CTest entries fail with ModuleNotFoundError.
+"""
+
 import logging
 import os
 import shlex
 import subprocess
 import sys
 from pathlib import Path
+from typing import NoReturn
 
-THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
+TEST_RUNNER = SCRIPT_DIR / "test_runner.py"
 
-environ_vars = os.environ.copy()
-# Some of our runtime kernel compilations have been relying on either ROCM_PATH being set, or ROCm being installed at
-# /opt/rocm. Neither of these is true in TheRock so we need to supply ROCM_PATH to our tests.
-ROCM_PATH = Path(THEROCK_BIN_DIR).resolve().parent
-environ_vars["ROCM_PATH"] = str(ROCM_PATH)
+
+def fail(message) -> NoReturn:
+    """Report a setup failure as one line rather than a traceback.
+
+    Exit 1 overlaps with ctest's error code and test_runner.py's own setup
+    failures, but all of them mean the job failed; the ERROR line identifies
+    the wrapper as the source.
+    """
+    print(f"ERROR: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def run_forwarding_exit_code(cmd) -> NoReturn:
+    """Run cmd and exit with a status describing how it ended.
+
+    A child killed by signal N gives a returncode of -N, which sys.exit() would
+    mangle into 256-N; report the shell's 128+N instead.
+    """
+    try:
+        returncode = subprocess.run(cmd).returncode
+    except OSError as e:
+        fail(f"could not execute {shlex.join(cmd)}: {e}")
+    if returncode < 0:
+        signal_number = -returncode
+        print(
+            f"ERROR: {Path(cmd[-1]).name} was terminated by signal {signal_number}.",
+            file=sys.stderr,
+        )
+        sys.exit(128 + signal_number)
+    sys.exit(returncode)
+
 
 logging.basicConfig(level=logging.INFO)
 
-# Install rocke Python wheels into the test venv so `import rocke` and
-# `import kernels` resolve from site-packages when ctest runs the pytest
-# entries. The wheels are built by the rocke CMake build and staged into
-# the test artifact.
-wheel_dir = Path(THEROCK_BIN_DIR) / "hip_kernel_provider" / "wheels"
-wheels = sorted(glob.glob(str(wheel_dir / "*.whl")))
+THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
+if not THEROCK_BIN_DIR:
+    fail("THEROCK_BIN_DIR environment variable is required but not set.")
+
+test_dir = Path(THEROCK_BIN_DIR) / "hip_kernel_provider"
+wheel_dir = test_dir / "wheels"
+# Path.glob, not glob.glob: the latter would treat a glob metacharacter in
+# THEROCK_BIN_DIR as part of the pattern and silently match nothing.
+wheels = sorted(str(p) for p in wheel_dir.glob("*.whl"))
 if wheels:
     logging.info(f"Installing rocke wheels: {wheels}")
-    subprocess.run(
-        [sys.executable, "-m", "pip", "install", "--no-deps"] + wheels,
-        check=True,
-        env=environ_vars,
+    # uv, not `python -m pip`: setup_venv.py builds the CI venv with `uv venv`,
+    # which does not seed pip. --reinstall because ROCKE_WHEEL_VERSION is not
+    # bumped per build, so a reused venv would otherwise keep the old wheel.
+    install_cmd = [
+        "uv",
+        "pip",
+        "install",
+        "--no-deps",
+        "--reinstall",
+        "--python",
+        sys.executable,
+    ] + wheels
+    logging.info(f"++ Exec $ {shlex.join(install_cmd)}")
+    try:
+        subprocess.run(install_cmd, check=True)
+    except OSError as e:
+        fail(f"could not run uv ({e}); it installs the rocKE wheels (venv has no pip).")
+    except subprocess.CalledProcessError as e:
+        fail(f"installing the rocKE wheels failed with exit code {e.returncode}.")
+else:
+    logging.info(f"No rocKE wheels staged in {wheel_dir}, skipping install")
+
+# Fallback to the co-located rocke package for any rocKE CTest entry that does
+# not pin its own PYTHONPATH. The wheels and the package are staged under
+# separate CMake options, so either can be absent independently; the entries
+# themselves are gated separately again and may run with neither.
+if (test_dir / "rocke").is_dir():
+    existing = os.environ.get("PYTHONPATH", "")
+    os.environ["PYTHONPATH"] = os.pathsep.join(filter(None, [str(test_dir), existing]))
+    logging.info(f"PYTHONPATH += {test_dir}")
+elif not wheels:
+    logging.warning(
+        f"Neither rocKE wheels nor a rocke package found under {test_dir}. "
+        "Any rocKE CTest entry that runs will fail to import rocke."
     )
 
-cmd = [
-    "ctest",
-    "--test-dir",
-    f"{THEROCK_BIN_DIR}/hip_kernel_provider",
-    "--output-on-failure",
-]
-
-# Determine test filter based on TEST_TYPE environment variable
-test_type = os.getenv("TEST_TYPE", "standard")
-
-if test_type == "quick":
-    # Exclude tests that start with "Full" during quick tests
-    environ_vars["GTEST_FILTER"] = "-Full*"
-
-logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")
-
-subprocess.run(
-    cmd,
-    cwd=THEROCK_DIR,
-    check=True,
-    env=environ_vars,
-)
+# Subprocess rather than import: test_runner.py validates the environment and
+# calls sys.exit() at module scope.
+run_forwarding_exit_code([sys.executable, str(TEST_RUNNER)])

--- a/ml-libs/artifact-hipkernelprovider.toml
+++ b/ml-libs/artifact-hipkernelprovider.toml
@@ -21,11 +21,14 @@ include = [
   # Test config TOMLs (e.g. HIP_KERNEL_ENGINE.toml) consumed by the cross-provider
   # integration suite (hipdnn_integration_tests --test-config).
   "bin/hip_kernel_provider/*.toml",
-  # rocKE IR parity gate: Python test scripts, harness, and golden data.
+  # rocKE IR parity gate: Python test scripts, harness, golden data, and the
+  # rocke Python package they import. The package is the fallback import source
+  # (via PYTHONPATH) when the wheels below are absent, e.g. ROCKE_BUILD_PYENV=OFF.
   "bin/hip_kernel_provider/*.py",
   "bin/hip_kernel_provider/golden/**",
-  # rocKE Python wheels (rocke + rocke-library), pip-installed by
-  # test_hipkernelprovider.py before running ctest.
+  "bin/hip_kernel_provider/rocke/**",
+  # rocKE Python wheels (rocke + rocke-library), installed by
+  # test_hipkernelprovider.py before running ctest when present.
   "bin/hip_kernel_provider/wheels/*.whl",
   # rocKE pytest suite
   "bin/hip_kernel_provider/tests/**",


### PR DESCRIPTION
## Summary

Un-breaks the `hipkernelprovider` test job, which fails every rocKE CTest entry with `ModuleNotFoundError: No module named 'rocke'` when rocKE is enabled. Two merged PRs each removed one of the two ways the `rocke` package reached the test venv: [#6849](https://github.com/ROCm/TheRock/pull/6849) dropped the artifact include, assuming the staged wheels replaced it, then [#7042](https://github.com/ROCm/TheRock/pull/7042) dropped the wheel install. This restores both and keeps #7042's standardized CTest label selection.

JIRA ID : ALMIOPEN-2398

## Risk Assessment

Low risk. CI-only, scoped to one test job, and failing loudly rather than silently. One item deserves reviewer attention: re-adding the artifact include widens the test artifact by the `rocke` Python package (roughly 5.5 MiB, per [#6412](https://github.com/ROCm/TheRock/pull/6412)), and only when rocKE is enabled. That restores a previously shipped state but is a packaging change rather than a script change. No product code, public API, build wiring, or submodule movement.

## ASIC Coverage

No per-ASIC exposure. The change makes a pure-Python package importable and forwards to the existing runner, altering neither kernel selection, support surface, nor default behavior, and the CTest label selection is arch-agnostic.

The dimension that does matter is per-platform, because the wrapper resolves an interpreter inside a `uv`-created venv and Linux and Windows use different venv layouts (`bin/python` versus `Scripts\python.exe`). Both are covered by the dry-run gates below, on gfx942 and gfx1151 respectively. Those arches are incidental to the platform, not a support-surface claim.

## Testing Summary

- Import sources validated across all four staging combinations against a real `uv` virtual environment, reproducing the CI failure and confirming each repaired state.
- Exit-status fidelity checked for normal exit, non-zero ctest exit, and termination by signal.
- Setup failures checked for one-line errors rather than tracebacks.
- CI configuration generator unit tests confirm the `hipkernelprovider` entry stays valid.
- rocKE runs only when `HIPKERNELPROVIDER_ENABLE_ROCKE` is on, which is not the default, so end-to-end signal comes from branch `users/bharriso/hipkernelprovider-rocke-ci-signal`, a DO NOT MERGE commit that flips the flag. Run [31105542775](https://github.com/ROCm/TheRock/actions/runs/31105542775) on that branch is what surfaced this bug.
- The wheel-install path needs its own signal. With the currently pinned `rocm-libraries`, the rocKE wheel `install()` rules never register, so no `.whl` reaches the artifact and that branch of the wrapper is unreachable. The flag-on run above therefore proves only the artifact-include path.
- Branch `users/bharriso/hipkernelprovider-rocke-wheel-signal` closes that gap. It stacks a `rocm-libraries` gitlink bump onto the flag-on branch, pointing at [rocm-libraries#10496](https://github.com/ROCm/rocm-libraries/pull/10496) cherry-picked onto the currently pinned commit, so the only delta CI sees is that fix. Both dry-run branches are DO NOT MERGE.
- That pairing reflects a real failure. #10496 is the first change to make the wheels stage, and its own CI failed on both [Linux gfx942](https://github.com/ROCm/rocm-libraries/actions/runs/31130221962/job/92748513293) and [Windows gfx1151](https://github.com/ROCm/rocm-libraries/actions/runs/31130221962/job/92737775295) with `No module named pip`: the wheels enumerated, then `python -m pip install` failed because `setup_venv.py --use-uv` seeds no pip. Those jobs pinned `therock_ref` 54d14392, which predates this PR, so they ran the old wrapper. The `uv pip install` in this PR is the corresponding fix.

## Testing Checklist

- [x] Unit tests - `pytest build_tools/github_actions/tests/fetch_test_configurations_test.py build_tools/tests/build_topology_test.py` (54 passed) - Status: Passed
- [x] Import sources, all four staging combinations - neither present reproduces the failure (rc 8, `ModuleNotFoundError`); package-only, wheels-only, and both each pass - Status: Passed
- [x] PYTHONPATH prepend preserves an inherited value and does not clobber a CTest entry's own `ENVIRONMENT` - Status: Passed
- [x] Exit status forwarding - failing ctest returns 8, runner exiting 7 returns 7, runner killed by SIGTERM returns 143 - Status: Passed
- [x] Setup failures produce one-line errors - `uv` missing, `uv` not executable, corrupt wheel, missing `THEROCK_BIN_DIR`, missing `TEST_COMPONENT` - Status: Passed
- [x] pre-commit - `pre-commit run --files <changed>` - Status: Passed
- [x] Artifact-include import path, rocKE enabled - [Multi-Arch CI 31124210625](https://github.com/ROCm/TheRock/actions/runs/31124210625) - ASICs: gfx942 - Status: Passed
- [x] PR CI - GitHub PR checks - Status: Pending
- [x] Wheel-install import path, Windows - covers the `Scripts\python.exe` venv layout that failed in #10496. The wrapper installed both staged wheels via `uv pip install --no-deps --reinstall --python`, then all rocKE CTest entries passed, including `rocke_python_import_smoke`, `rocke_golden_static`, and `rocke_pytest` (8/8) - [Multi-Arch CI 31327442962](https://github.com/ROCm/TheRock/actions/runs/31327442962) - ASICs: gfx1151 - Status: Passed
- [x] Wheel-install import path, Linux - same pairing on the `bin/python` venv layout. Build [31325354360](https://github.com/ROCm/TheRock/actions/runs/31325354360) completed, but its GPU test jobs did not receive a runner, so the signal is being replayed against those artifacts via [test_artifacts 31337238290](https://github.com/ROCm/TheRock/actions/runs/31337238290). Blocked on Linux gfx942 runner availability, which is currently affecting `main` and other branches as well - ASICs: gfx942 - Status: Pending

## Technical Changes

- `ml-libs/artifact-hipkernelprovider.toml`: restores the `bin/hip_kernel_provider/rocke/**` include removed by #6849. The rocKE CMake installs that package whenever rocKE is built and its own comment expects a matching include, so without it the artifact drops the package the CTest entries import. This is what un-breaks the job today.
- `test_hipkernelprovider.py`: rewritten as an environment-setup wrapper. It installs any staged wheels, prepends the test directory to `PYTHONPATH` when the co-located `rocke` package is present, then execs `test_runner.py` and exits with its status. The legacy `ctest` invocation, `ROCM_PATH` setup, and `GTEST_FILTER=-Full*` filter are gone, since `test_runner.py` supplies the first two and the label categories replace the third.
- Both import sources are covered because they are independently gated: wheels on `ROCKE_BUILD_PYENV`, the package on `ROCKE_INSTALL_PYTHON_PACKAGE`, and the CTest entries on `ROCKE_INSTALL_TESTS`. Any one can be absent without the others, which is what produced this bug. When neither is found, the wrapper warns rather than failing silently.
- Wheel installation uses `uv pip install --no-deps --reinstall --python sys.executable`. `setup_venv.py --use-uv` creates the CI venv with `uv venv`, which does not seed pip, so `python -m pip` is unavailable; this matches `install_additional_requirements.py`. `--reinstall` guards a reused venv, since `ROCKE_WHEEL_VERSION` defaults to 0.1.0 and is not bumped per build.
- Exit status is forwarded, not approximated. A child killed by signal N returns `-N`, which `sys.exit()` would mangle into `256-N`; the wrapper reports the shell's `128+N` so a timeout kill reads as terminated. Setup failures exit 1 with an `ERROR:` line.
- `fetch_test_configurations.py`: `test_script` points back at `test_hipkernelprovider.py`, with a comment recording what the wrapper does. `test_runner.py` is unchanged and its `hipkernelprovider` mapping still resolves the test directory.
- Not fixed here: `rocm-libraries` `rocke/CMakeLists.txt` calls `add_subdirectory(platform)` before declaring `ROCKE_BUILD_PYENV` and `ROCKE_WHEEL_DIR`, so the wheel `install(FILES ...)` guarded on them in `platform/CMakeLists.txt` never registers and the wheels are built but never staged. That upstream fix is [#10496](https://github.com/ROCm/rocm-libraries/pull/10496). The two are complementary and independently landable: this PR is correct with or without it, and the artifact include keeps the job green in the meantime, while #10496 needs this PR's wrapper to get past `python -m pip` once the wheels do stage.
