### PR TITLE
fix(ci): exclude multi-GPU components when no multi-GPU runner configured

### DIFF
--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -217,21 +217,21 @@ jobs:
       amdgpu_families: ${{ inputs.amdgpu_families }}
       amdgpu_targets: ${{ inputs.amdgpu_targets }}
       # Route to the appropriate runner:
-      #   0. For workflow_dispatch, honor the explicit test_runs_on input if provided
-      #   1. Benchmark components use the dedicated benchmark runner
-      #   2. Multi-GPU components use the multi-GPU runner
-      #   3. CPU-only components use standard GitHub runners (azure-linux-scale-rocm)
-      #   4. Per-component runner (set by fetch_test_configurations.py)
+      #   1. Multi-GPU components use the multi-GPU runner (required for correct execution)
+      #   2. For workflow_dispatch, honor the explicit test_runs_on input if provided
+      #   3. Benchmark components use the dedicated benchmark runner
+      #   4. CPU-only components use standard GitHub runners (azure-linux-scale-rocm)
+      #   5. Per-component runner (set by fetch_test_configurations.py)
       test_runs_on: >-
         ${{
+          (matrix.components.multi_gpu_runner != '' &&
+            matrix.components.multi_gpu_runner) ||
           (github.event_name == 'workflow_dispatch' &&
             inputs.test_runs_on != '' &&
             inputs.test_runs_on) ||
           (matrix.components.is_benchmark == true &&
             inputs.benchmark_runs_on != '' &&
             inputs.benchmark_runs_on) ||
-          (matrix.components.multi_gpu_runner != '' &&
-            matrix.components.multi_gpu_runner) ||
           (matrix.components.linux_cpu_runner == true &&
             'azure-linux-scale-rocm') ||
           matrix.components.test_runner

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -965,6 +965,7 @@ def run():
     # Each component gets its own independent random draw based on configured weights
     # For ASAN builds, use the sandbox runner to isolate potentially failing tests
     is_asan_build = build_variant in ("asan", "host-asan")
+    components_with_runners = []
     for component in all_components:
         job_name = component.get("job_name", "unknown")
         if "multi_gpu_runner" in component:
@@ -975,6 +976,12 @@ def run():
                 )
             elif test_runs_on_multi_gpu_default:
                 component["multi_gpu_runner"] = test_runs_on_multi_gpu_default
+            else:
+                # No multi-GPU runner configured for this family; skip the component
+                logging.info(
+                    f"Excluding job {job_name}: multi-GPU required but no multi-GPU runner configured"
+                )
+                continue
         else:
             # For ASAN builds, use the sandbox runner if available
             if is_asan_build and test_runs_on_sandbox:
@@ -988,9 +995,12 @@ def run():
                 )
             elif test_runs_on_default:
                 component["test_runner"] = test_runs_on_default
+        components_with_runners.append(component)
 
     # Build container options for all components (concatenates base, GPU, and job-specific options)
-    all_components = [_build_container_options(c, platform) for c in all_components]
+    all_components = [
+        _build_container_options(c, platform) for c in components_with_runners
+    ]
 
     # Separate sanity (always a prerequisite) from the regular component matrix.
     sanity_component = next(


### PR DESCRIPTION
When a component requires multi-GPU testing (e.g., rocshmem, rccl) but no multi-GPU runner is configured for the target family, the component is now excluded from the test matrix instead of being assigned an invalid runner.

Previously, if neither test_runs_on_multi_gpu_labels nor test_runs_on_multi_gpu_default was set, multi_gpu_runner would remain as True (boolean) instead of a valid runner label string, causing test failures on single-GPU runners.

Closes #7120

ISSUE ID:  #7120

Working here: https://github.com/ROCm/TheRock/actions/runs/31110212412/job/92667417769#step:1:2 and https://github.com/ROCm/TheRock/actions/runs/31110212412/job/92667417318#step:1:2