### PR TITLE
hipthreads: Disable hipthreads failures blocked by Compiler ww28 SMP 2.5

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -688,6 +688,11 @@ test_matrix = {
             "linux": 1,
             "windows": 1,
         },
+        # TODO(#7157): Compiler ww28 SMP 2.5 (TheRock#7052) — remove after fix.
+        # On Windows, lit fails to build its compiler-check program at link time,
+        # so lit.cfg cannot load and no test runs. There is nothing to skip, so
+        # the whole job is marked expected-to-fail.
+        "expect_failure_platform": ["windows"],
     },
     # hipthreads example apps (build + run consumer samples against the artifact).
     "hipthreads_examples": {
@@ -924,6 +929,13 @@ def run():
 
             job_config_data = {**_common_settings, **selected_matrix[key]}
             job_config_data["test_type"] = test_type
+
+            # If the test is known-broken on this platform, run it but do not gate
+            # CI on the result (continue-on-error + "(xfail)" in the job name).
+            if platform in selected_matrix[key].get("expect_failure_platform", []):
+                logging.info(f"Marking job {job_name} as xfail on platform {platform}")
+                job_config_data["expect_failure"] = True
+
             # For CI testing, we construct a shard array based on "total_shards" from "fetch_test_configurations.py"
             # This way, the test jobs will be split up into X shards. (ex: [1, 2, 3, 4] = 4 test shards)
             # For display purposes, we add "i + 1" for the job name (ex: 1 of 4). During the actual test sharding in the test executable, this array will become 0th index

--- a/build_tools/github_actions/test_executable_scripts/test_hipthreads.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipthreads.py
@@ -26,6 +26,27 @@ from pathlib import Path
 
 from libhipcxx_utils import get_gpu_architecture_portable, prepend_env_path
 
+AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
+os_type = platform.system().lower()
+
+# TODO(#7157): Compiler ww28 SMP 2.5 (TheRock#7052) — re-enable after fix.
+# create_late.pass.cpp is marked XFAIL upstream, but the new compiler makes it
+# pass, and lit fails the run on that unexpected pass. Skip it rather than using
+# --xfail-not: the old compiler on main still fails it, and there --xfail-not would
+# report a real failure.
+LIT_FILTER_OUT = {
+    "gfx94X-dcgpu": {
+        "linux": [
+            r"create_late\.pass\.cpp",
+        ],
+    },
+    "gfx950-dcgpu": {
+        "linux": [
+            r"create_late\.pass\.cpp",
+        ],
+    },
+}
+
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 OUTPUT_ARTIFACTS_DIR = os.getenv("OUTPUT_ARTIFACTS_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -191,7 +212,12 @@ cmd = [
     "-v",
     "-j",
     "1",
-    str(HIPTHREADS_SOURCE_DIR / "test"),
 ]
+filter_patterns = LIT_FILTER_OUT.get(AMDGPU_FAMILIES, {}).get(os_type, [])
+if filter_patterns:
+    combined = "|".join(f"({pattern})" for pattern in filter_patterns)
+    cmd.extend(["--filter-out", combined])
+    logging.info(f"++ Excluding hipthreads lit tests matching: {combined}")
+cmd.append(str(HIPTHREADS_SOURCE_DIR / "test"))
 logging.info(f"++ Exec [{os.getcwd()}]$ {shlex.join(cmd)}")
 subprocess.run(cmd, check=True, env=environ_vars)

--- a/build_tools/github_actions/tests/fetch_test_configurations_test.py
+++ b/build_tools/github_actions/tests/fetch_test_configurations_test.py
@@ -178,6 +178,29 @@ class FetchTestConfigurationsTest(unittest.TestCase):
         self.assertNotIn("rocroller", names)
 
     # -----------------------
+    # Expect-failure (xfail) logic
+    # -----------------------
+
+    def test_expect_failure_platform_marks_only_that_platform(self):
+        """A component runs on both platforms but is only xfail on one of them."""
+        os.environ["RUN_EXTENDED_TESTS"] = "true"
+        os.environ["PROJECTS_TO_TEST"] = "xfail1"
+        fetch_test_configurations.functional_matrix = {
+            "xfail1": {
+                "job_name": "xfail1",
+                "platform": ["linux", "windows"],
+                "expect_failure_platform": ["windows"],
+            }
+        }
+
+        fetch_test_configurations.run()
+        self.assertNotIn("expect_failure", self._get_components()[0])
+
+        sys.argv = ["fetch_test_configurations.py", "--platform=windows"]
+        fetch_test_configurations.run()
+        self.assertTrue(self._get_components()[0]["expect_failure"])
+
+    # -----------------------
     # Functional test merging via run_extended_tests
     # -----------------------
 


### PR DESCRIPTION
## Summary

Temporarily excludes `hipthreads` failures that block the Compiler ww28 SMP 2.5 promotion in [TheRock#7052](https://github.com/ROCm/TheRock/pull/7052) (amd-llvm `7287e2062fa6`). Linux and Windows jobs fail for unrelated reasons, so each uses the mechanism that matches its failure mode.
Tracked by [#7157](https://github.com/ROCm/TheRock/issues/7157).

## Changes

`test_hipthreads.py` excludes `create_late.pass.cpp` on Linux, `fetch_test_configurations.py` marks the Windows hipthreads job as expected-failure, and `tests/fetch_test_configurations_test.py` covers the new matrix field.

## Linux

`create_late.pass.cpp` is marked upstream as "expected to fail", but it passes with the new compiler, and lit fails the run on that unexpected pass. It is the only test that changed out of 384.

It is skipped with lit `--filter-out`. The alternative, `--xfail-not`, would break `main`, where the old compiler still makes the test fail as expected.

## Windows

lit builds a small compiler-check program before running anything, and that build now fails at link time (`lld-link: error: relocation against symbol in discarded section: __start_llvm_offload_entries`). No tests run at all, so there is nothing to skip and the whole job is marked as expected to fail.

The xfail comes from a new `expect_failure_platform` field on the hipthreads matrix entry rather than a hardcoded check in the job loop, following the existing `exclude_family` style.

## Related

- Blocks: [TheRock#7052](https://github.com/ROCm/TheRock/pull/7052)
- Tracking: [TheRock#7157](https://github.com/ROCm/TheRock/issues/7157)