### PR TITLE
fix(jax): stamp JAX wheels with the real source commit hash

### DIFF
--- a/.github/workflows/multi_arch_build_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_build_linux_jax_wheels.yml
@@ -148,6 +148,7 @@ jobs:
           ref: ${{ inputs.jax_ref }}
 
       - name: Checkout JAX
+        id: checkout_jax
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: jax-source
@@ -219,7 +220,7 @@ jobs:
                 --bazel_options=--repo_env=ROCM_PATH=$(rocm-sdk path --root) \
                 --bazel_options=--repo_env=ML_WHEEL_TYPE=release \
                 --bazel_options=--repo_env=ML_WHEEL_VERSION_SUFFIX="${ML_WHEEL_VERSION_SUFFIX}" \
-                --bazel_options=--//jaxlib/tools:jaxlib_git_hash=$(git rev-parse HEAD) \
+                --bazel_options=--//jaxlib/tools:jaxlib_git_hash="${{ steps.checkout_jax.outputs.commit }}" \
                 --verbose \
                 --detailed_timestamped_log \
                 --output_path=$(pwd)/dist

--- a/.github/workflows/multi_arch_build_linux_jax_wheels_ci.yml
+++ b/.github/workflows/multi_arch_build_linux_jax_wheels_ci.yml
@@ -137,6 +137,7 @@ jobs:
           ref: ${{ inputs.jax_ref }}
 
       - name: Checkout JAX
+        id: checkout_jax
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: jax-source
@@ -208,7 +209,7 @@ jobs:
                 --bazel_options=--repo_env=ROCM_PATH=$(rocm-sdk path --root) \
                 --bazel_options=--repo_env=ML_WHEEL_TYPE=release \
                 --bazel_options=--repo_env=ML_WHEEL_VERSION_SUFFIX="${ML_WHEEL_VERSION_SUFFIX}" \
-                --bazel_options=--//jaxlib/tools:jaxlib_git_hash=$(git rev-parse HEAD) \
+                --bazel_options=--//jaxlib/tools:jaxlib_git_hash="${{ steps.checkout_jax.outputs.commit }}" \
                 --verbose \
                 --detailed_timestamped_log \
                 --output_path=$(pwd)/dist


### PR DESCRIPTION
Cherry-pick [1352d39](https://github.com/ROCm/TheRock/commit/1352d397da640467e9854cff38e5bf4a53664d70) into the 10.0 release branch.

Jira Ticket: ROCM-29084

### Summary
This PR is required for QA to test the JAX Docker image before release.