### PR TITLE
fix(rocprofiler-systems): Set SYS_PTRACE and PERFMON capabilities when running tests

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -702,6 +702,7 @@ test_matrix = {
         "total_shards_dict": {
             "linux": 1,
         },
+        "container_options": ["--cap-add=SYS_PTRACE", "--cap-add=PERFMON"],
     },
     # libhipcxx amdclang++ tests (formerly libhipcxx_hipcc)
     "libhipcxx_amdclang": {


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

<!-- Most pull requests should be associated with at least one GitHub issue -->

<!-- GitHub issue: https://github.com/ROCm/TheRock/issues/1234 -->

JIRA ID: AIPROFSYST-720

Some tests in our test suite require certain capabilities for them to be run. Of particular concern are the attach tests, which require `SYS_PTRACE` to run (matches `rocprofiler-SDK`).

I will also add `PERFMON` as some of our other tests (`annotate`, `overflow`...) require this as well.

None of these tests will run yet, a fix on `rocprofiler-systems` side is needed as well.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Added:
```
"container_options": ["--cap-add=SYS_PTRACE", "--cap-add=PERFMON"],
```
To `rocprofiler-systems`'s `fetch_test_configurations.py` code.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Local testing.

Workflows

## Test Result

<!-- Briefly summarize test outcomes. -->

Local testing, with fixes on `rocprofiler-systems` side, shows that attach can run whilst in the docker container (i.e. it won't get skipped due to missing permissions).

Passing systems Workflow (`test_type=QUICK`): https://github.com/ROCm/TheRock/actions/runs/31206896207/job/93073202273?pr=7163

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
