### PR TITLE
fix(ci): Add -Xarch_host flags to HOST_ASAN builds

### DIFF
--- a/cmake/therock_sanitizers.cmake
+++ b/cmake/therock_sanitizers.cmake
@@ -47,10 +47,8 @@ function(therock_sanitizer_configure
       # Avoids: (1) -Woption-ignored on gfx942 without :xnack+ (MIOpen failure due to -Werror)
       #         (2) handleSanitizeOption dropping all device -I/-D with -fno-gpu-sanitize (Bug in Driver)
       # TODO: If this is indeed a Driver bug, then this can be replaced with -fno-gpu-sanitize when that is fixed.
-      string(APPEND _stanza "string(APPEND CMAKE_CXX_FLAGS_INIT \" -Xarch_host -fsanitize=${_sanitizer_string} -Xarch_host -fno-omit-frame-pointer -Xarch_host -g\")\n")
-      string(APPEND _stanza "string(APPEND CMAKE_C_FLAGS_INIT \" -Xarch_host -fsanitize=${_sanitizer_string} -Xarch_host -fno-omit-frame-pointer -Xarch_host -g\")\n")
-      string(APPEND _stanza "add_link_options($<$<LINK_LANGUAGE:C,CXX>:-Xarch_host -fsanitize=${_sanitizer_string}>\n")
-      string(APPEND _stanza "  $<$<AND:$<LINK_LANGUAGE:C,CXX>,$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>>:-Xarch_host -shared-libsan>)\n")
+      string(APPEND _stanza "string(APPEND CMAKE_CXX_FLAGS_INIT \" -Xarch_host -fsanitize=address -Xarch_host -fno-omit-frame-pointer -Xarch_host -g\")\n")
+      string(APPEND _stanza "string(APPEND CMAKE_C_FLAGS_INIT \" -Xarch_host -fsanitize=address -Xarch_host -fno-omit-frame-pointer -Xarch_host -g\")\n")
     else()
       # TODO: Support ASAN_STATIC/TSAN_STATIC to use static sanitizer linkage. Shared is almost always the right thing,
       # so make the sanitizer imply shared linkage.

--- a/cmake/therock_sanitizers.cmake
+++ b/cmake/therock_sanitizers.cmake
@@ -42,10 +42,21 @@ function(therock_sanitizer_configure
       set(_sanitizer_string "thread")
     endif()
 
-    # TODO: Support ASAN_STATIC/TSAN_STATIC to use static sanitizer linkage. Shared is almost always the right thing,
-    # so make the sanitizer imply shared linkage.
-    string(APPEND _stanza "string(APPEND CMAKE_CXX_FLAGS_INIT \" -fsanitize=${_sanitizer_string} -fno-omit-frame-pointer -g\")\n")
-    string(APPEND _stanza "string(APPEND CMAKE_C_FLAGS_INIT \" -fsanitize=${_sanitizer_string} -fno-omit-frame-pointer -g\")\n")
+    if(_sanitizer STREQUAL "HOST_ASAN")
+      # Scope to host arch only so HIP device -cc1 never sees -fsanitize=*.
+      # Avoids: (1) -Woption-ignored on gfx942 without :xnack+ (MIOpen failure due to -Werror)
+      #         (2) handleSanitizeOption dropping all device -I/-D with -fno-gpu-sanitize (Bug in Driver)
+      # TODO: If this is indeed a Driver bug, then this can be replaced with -fno-gpu-sanitize when that is fixed.
+      string(APPEND _stanza "string(APPEND CMAKE_CXX_FLAGS_INIT \" -Xarch_host -fsanitize=${_sanitizer_string} -Xarch_host -fno-omit-frame-pointer -Xarch_host -g\")\n")
+      string(APPEND _stanza "string(APPEND CMAKE_C_FLAGS_INIT \" -Xarch_host -fsanitize=${_sanitizer_string} -Xarch_host -fno-omit-frame-pointer -Xarch_host -g\")\n")
+      string(APPEND _stanza "add_link_options($<$<LINK_LANGUAGE:C,CXX>:-Xarch_host -fsanitize=${_sanitizer_string}>\n")
+      string(APPEND _stanza "  $<$<AND:$<LINK_LANGUAGE:C,CXX>,$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>>:-Xarch_host -shared-libsan>)\n")
+    else()
+      # TODO: Support ASAN_STATIC/TSAN_STATIC to use static sanitizer linkage. Shared is almost always the right thing,
+      # so make the sanitizer imply shared linkage.
+      string(APPEND _stanza "string(APPEND CMAKE_CXX_FLAGS_INIT \" -fsanitize=${_sanitizer_string} -fno-omit-frame-pointer -g\")\n")
+      string(APPEND _stanza "string(APPEND CMAKE_C_FLAGS_INIT \" -fsanitize=${_sanitizer_string} -fno-omit-frame-pointer -g\")\n")
+    endif()
 
     # Sharp edge: The -shared-libsan flag is compiler frontend specific:
     #   gcc (and gfortran): defaults to shared sanitizer linkage

--- a/cmake/therock_sanitizers.cmake
+++ b/cmake/therock_sanitizers.cmake
@@ -46,6 +46,12 @@ function(therock_sanitizer_configure
     # so make the sanitizer imply shared linkage.
     string(APPEND _stanza "string(APPEND CMAKE_CXX_FLAGS_INIT \" -fsanitize=${_sanitizer_string} -fno-omit-frame-pointer -g\")\n")
     string(APPEND _stanza "string(APPEND CMAKE_C_FLAGS_INIT \" -fsanitize=${_sanitizer_string} -fno-omit-frame-pointer -g\")\n")
+    # MIOpen uses -Werror and the HOST_ASAN path with non +xnack gfx target will throw a warning that -fsanitize=address
+    # is not supported. This will fail the math-libs step during HOST_ASAN Multi-Arch CI. Passing -fno-gpu-sanitize supresses this warning.
+    if(_sanitizer STREQUAL "HOST_ASAN")
+      string(APPEND _stanza "string(APPEND CMAKE_CXX_FLAGS_INIT \" -fno-gpu-sanitize\")\n")
+      string(APPEND _stanza "string(APPEND CMAKE_C_FLAGS_INIT \" -fno-gpu-sanitize\")\n")
+    endif()
 
     # Sharp edge: The -shared-libsan flag is compiler frontend specific:
     #   gcc (and gfortran): defaults to shared sanitizer linkage


### PR DESCRIPTION
Recently HOST_ASAN is default for Multi-Arch CI to improve efficiency: (https://github.com/ROCm/TheRock/pull/7110)

There is an issue with HOST_ASAN Multi-Arch CI. MIOpen uses -Werror and during HOST_ASAN
this reports a warning that -fsanitize=address is not supported unless xnack+ is
appended to the gfx target. Regular ASAN builds override the gfx942 target with
gfx942:xnack+ and do not see this issue.

-fno-gpu-sanitize is used to explicitly disable sanitizer checks for GPU device target
compilations, but allows host sanitization to remain. This option currently removes
driver arguments, which I believe to be a bug. Instead -Xarch_host is used to separate
host only sanitizer flags. The clang driver bug will be fixed in the next SMP update for amd-llvm.

ISSUE ID: 6207

## Motivation
Unblock sanitizer build.
