### PR TITLE
build(ml-libs): add rocRAND runtime dep to hipDNN integration tests

### DIFF
--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -694,7 +694,7 @@ artifact_deps = ["core-runtime", "core-hip", "spdlog"]
 [artifacts.hipdnn-integration-tests]
 artifact_group = "ml-libs"
 type = "target-neutral"
-artifact_deps = ["core-runtime", "core-hip", "hipdnn"]
+artifact_deps = ["core-runtime", "core-hip", "hipdnn", "rand"]
 
 [artifacts.miopenprovider]
 artifact_group = "ml-libs"

--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -679,7 +679,7 @@ artifact_deps = ["core-runtime", "core-hip", "spdlog"]
 [artifacts.hipdnn-integration-tests]
 artifact_group = "ml-libs"
 type = "target-neutral"
-artifact_deps = ["core-runtime", "core-hip", "hipdnn"]
+artifact_deps = ["core-runtime", "core-hip", "hipdnn", "rand"]
 
 [artifacts.miopenprovider]
 artifact_group = "ml-libs"

--- a/build_tools/install_rocm_from_artifacts.py
+++ b/build_tools/install_rocm_from_artifacts.py
@@ -467,6 +467,8 @@ def retrieve_artifacts_by_run_id(args):
             # --test-engine; without _run, ctest finds the entry but errors with
             # "Unable to find executable: ../hipdnn_integration_tests".
             argv.append("hipdnn-integration-tests_run")
+            # The test binaries link librocrand.
+            argv.append("rand_lib")
         if args.hipdnn_samples:
             extra_artifacts.append("hipdnn-samples")
         if args.hipfile:

--- a/build_tools/install_rocm_from_artifacts.py
+++ b/build_tools/install_rocm_from_artifacts.py
@@ -469,6 +469,8 @@ def retrieve_artifacts_by_run_id(args):
             # --test-engine; without _run, ctest finds the entry but errors with
             # "Unable to find executable: ../hipdnn_integration_tests".
             argv.append("hipdnn-integration-tests_run")
+            # The test binaries link librocrand.
+            argv.append("rand_lib")
         if args.hipdnn_samples:
             extra_artifacts.append("hipdnn-samples")
         if args.hipfile:

--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -2724,12 +2724,14 @@
       "amdrocm-dnn-devel",
       "amdrocm-runtime",
       "amdrocm-blas",
+      "amdrocm-rand",
       "amdrocm-sysdeps"
     ],
     "RPMRequires": [
       "amdrocm-dnn-devel",
       "amdrocm-runtime",
       "amdrocm-blas",
+      "amdrocm-rand",
       "amdrocm-sysdeps"
     ],
     "Maintainer": "MIOpen Maintainer <miopen-lib.support@amd.com>",

--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -2644,12 +2644,14 @@
       "amdrocm-dnn-devel",
       "amdrocm-runtime",
       "amdrocm-blas",
+      "amdrocm-rand",
       "amdrocm-sysdeps"
     ],
     "RPMRequires": [
       "amdrocm-dnn-devel",
       "amdrocm-runtime",
       "amdrocm-blas",
+      "amdrocm-rand",
       "amdrocm-sysdeps"
     ],
     "Maintainer": "MIOpen Maintainer <miopen-lib.support@amd.com>",

--- a/build_tools/tests/install_rocm_from_artifacts_test.py
+++ b/build_tools/tests/install_rocm_from_artifacts_test.py
@@ -74,6 +74,14 @@ class TestRetrieveArtifactsByRunId(unittest.TestCase):
         argv = self._run_main(["--base-only"])
         self.assertIn("rocjitsu-hotswap_lib", argv)
 
+    def test_hipdnn_integration_tests_includes_rocrand(self):
+        # The hipdnn_gpu_ref_tests binary links librocrand for GPU tensor data
+        # generation, so the test runners must fetch the rand artifact even
+        # though --rand was not requested.
+        argv = self._run_main(["--hipdnn-integration-tests"])
+        self.assertIn("hipdnn-integration-tests_run", argv)
+        self.assertIn("rand_lib", argv)
+
 
 def _tarball_name(platform: str, artifact_group: str, version: str) -> str:
     """Return a tarball name matching the platform under test."""

--- a/ml-libs/CMakeLists.txt
+++ b/ml-libs/CMakeLists.txt
@@ -177,6 +177,7 @@ if(THEROCK_ENABLE_HIPDNN_INTEGRATION_TESTS)
     RUNTIME_DEPS
       hip-clr
       hipDNN
+      rocRAND
     TEST_SUBPROJECTS
       miopenprovider
   )

--- a/ml-libs/CMakeLists.txt
+++ b/ml-libs/CMakeLists.txt
@@ -170,6 +170,7 @@ if(THEROCK_ENABLE_HIPDNN_INTEGRATION_TESTS)
     RUNTIME_DEPS
       hip-clr
       hipDNN
+      rocRAND
   )
   therock_cmake_subproject_glob_c_sources(hipdnn_integration_tests
   SUBDIRS

--- a/test_tools/therock_consumer_graph.json
+++ b/test_tools/therock_consumer_graph.json
@@ -467,6 +467,7 @@
   "rocrand": {
     "consumers": [
       "composable_kernel",
+      "hipdnn_integration_tests",
       "hiprand",
       "miopen",
       "rocalution",


### PR DESCRIPTION
## Summary

The hipDNN integration test suite is adding rocRAND-based GPU tensor data generation in [rocm-libraries#10305](https://github.com/ROCm/rocm-libraries/pull/10305). That change calls `find_package(rocrand)` unconditionally, so TheRock must declare the dependency before it lands. This PR wires rocRAND into the `hipdnn_integration_tests` subproject, artifact topology, artifact fetch, and Linux packaging.

Stacked on #7297, which regenerates the consumer graph for unrelated kfdtest edges missing from `main` (#7298). It must merge first.

ISSUE ID : https://github.com/ROCm/rocm-libraries/issues/8991

## Risk Assessment

Low risk. Build wiring only, scoped to the `hipdnn_integration_tests` subproject and its artifact. No product code, no public API, no change to any other subproject. The main consequence is that enabling `THEROCK_ENABLE_HIPDNN_INTEGRATION_TESTS` now force-enables `THEROCK_ENABLE_RAND`, which adds rocRAND to the build graph for configurations that previously excluded it.

## ASIC Coverage

Passing PR CI is sufficient. The change is ASIC-independent: it adds a link dependency on rocRAND's host API only. The integration test suite compiles no device code at build time, since all of its kernels are HipRTC-compiled at runtime from embedded sources, so the `hipdnn-integration-tests` artifact remains `TARGET_NEUTRAL`. rocRAND's per-arch device code lives in `librocrand`'s fatbin and is delivered by the existing target-specific `rand` artifact, which is already resolved per-architecture by the artifact fetch.

## Testing Summary

- Topology validation confirming the new artifact dependency resolves and stays acyclic.
- Feature-resolution check confirming `THEROCK_ENABLE_RAND` is force-enabled and declared before its dependent.
- Generator and schema checks on the modified topology and packaging manifest.
- End-to-end CI validation on a dry-run branch that points the `rocm-libraries` submodule at the consuming PR.

## Testing Checklist

- [x] Topology validation - `BuildTopology.validate_topology()` - Status: Passed
- [x] Topology unit tests - `python3 -m unittest tests.build_topology_test` - Status: Passed
- [x] Feature resolution - `therock_finalize_features()` with `-DTHEROCK_ENABLE_RAND=OFF -DTHEROCK_ENABLE_HIPDNN_INTEGRATION_TESTS=ON` resolves to `RAND=ON` - Status: Passed
- [x] Feature ordering - `topology_to_cmake.py` emits `RAND` before `HIPDNN_INTEGRATION_TESTS` - Status: Passed
- [x] Packaging manifest - `json.load` on `build_tools/packaging/linux/package.json` - Status: Passed
- [x] Commit hooks - `pre-commit run --files` - Status: Passed
- [x] Unit test - `pytest build_tools/tests/install_rocm_from_artifacts_test.py` - 18 passed; verified failing when the `rand_lib` line is reverted - Status: Passed
- [ ] Dry-run CI with [rocm-libraries#10305](https://github.com/ROCm/rocm-libraries/pull/10305) - `users/bharriso/hipdnn-integration-tests-rocrand-dryrun`, gfx94X - Status: Re-running after the restack - Link: [run](https://github.com/ROCm/TheRock/actions/runs/31607249037) (prior run on the old base passed: [31126893581](https://github.com/ROCm/TheRock/actions/runs/31126893581))
- [ ] PR CI - GitHub PR checks - Status: Pending

## Technical Changes

- `ml-libs/CMakeLists.txt`: adds `rocRAND` to `hipdnn_integration_tests` `RUNTIME_DEPS`. This satisfies the super-project dependency provider, which raises a fatal error when a subproject calls `find_package` on a provided package without a declared edge, and places `librocrand` in the dist tree for link and RPATH. `RUNTIME_DEPS` rather than `BUILD_DEPS` because the library is linked, matching the existing `miopenprovider` to `MIOpen` and `hipblasltprovider` to `hipBLASLt` edges, which are likewise `TARGET_NEUTRAL` consumers of target-specific libraries.
- `BUILD_TOPOLOGY.toml`: adds `rand` to the `hipdnn-integration-tests` artifact dependencies, which force-enables `THEROCK_ENABLE_RAND` and makes sharded CI fetch the `rand` artifact before building and testing `ml-libs`.
- `build_tools/install_rocm_from_artifacts.py`: fetches `rand_lib` alongside `--hipdnn-integration-tests`. Artifact expansion is explicit rather than transitive, so without this the test runners have no `librocrand` to load.
- `build_tools/packaging/linux/package.json`: `amdrocm-dnn-test` now depends on `amdrocm-rand`.
- `test_tools/therock_consumer_graph.json`: adds `hipdnn_integration_tests` as a consumer of `rocrand`. One line.
- `build_tools/tests/install_rocm_from_artifacts_test.py`: asserts `--hipdnn-integration-tests` pulls `rand_lib`, so the dependency cannot be dropped silently in a future merge conflict.

## Merge Order

This PR must merge after #7297 and before [rocm-libraries#10305](https://github.com/ROCm/rocm-libraries/pull/10305). That PR calls `find_package(rocrand)` unconditionally, and TheRock's dependency provider fails configuration for an undeclared provided package regardless of the `QUIET` argument.

