### PR TITLE
Simplify install-tree file-security check to os.walk only

### DIFF
--- a/build_tools/packaging/linux/native_linux_package_install_test.py
+++ b/build_tools/packaging/linux/native_linux_package_install_test.py
@@ -139,7 +139,7 @@ import subprocess
 import sys
 import traceback
 from argparse import ArgumentParser, Namespace
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 
 _SCRIPT_DIR = Path(__file__).resolve().parent
 if str(_SCRIPT_DIR) not in sys.path:
@@ -1013,35 +1013,10 @@ gpgcheck=0
         why = ",".join(reasons) if reasons else "?"
         return f"uid={st.st_uid} gid={st.st_gid} mode={stat.S_IMODE(mode):04o} -> {why}"
 
-    @classmethod
-    def _describe_flagged_path(cls, path: str) -> str:
-        """Best-effort ``(owner/group/mode -> why)`` annotation for a ``find`` hit.
-
-        ``find`` prints only names, so re-``lstat`` the path to explain why it
-        was flagged. The prefix itself is often a symlink that ``find -H``
-        follows and flags via its *target*; ``lstat`` would only see the link's
-        meaningless ``0777`` bits, so for a symlink we additionally ``stat`` the
-        target and report that. Never raises: on any error it returns an
-        annotation noting the failure so reporting is unaffected.
-        """
-        try:
-            st = os.lstat(path)
-        except OSError as e:
-            return f"(stat failed: {e.strerror or e})"
-        if stat.S_ISLNK(st.st_mode):
-            try:
-                target = os.stat(path)
-            except OSError as e:
-                return f"(symlink; target stat failed: {e.strerror or e})"
-            return f"(symlink target: {cls._format_flagged_reason(target)})"
-        return f"({cls._format_flagged_reason(st)})"
-
     def verify_installed_file_security(self) -> bool:
         """Verify installed files are owned by root:root with safe permissions.
 
-        Combines two related install-tree security checks into a single
-        traversal. A path under the prefix is flagged when any of the following
-        holds:
+        Scans the install tree and flags a path when any of the following holds:
 
         - Ownership: its owner uid or group gid is not 0 (not ``root:root``);
           a non-root-owned path can be tampered with by that owner.
@@ -1057,123 +1032,29 @@ gpgcheck=0
 
         Symbolic links are exempt from the permission rules: on Linux a
         symlink's own mode bits are always ``lrwxrwxrwx`` and are ignored by
-        the kernel (the target's permissions govern access), so checking them
-        would produce false positives. The install prefix itself is commonly a
-        symlink (e.g. ``/opt/rocm/core`` -> ``/opt/rocm/core-X.Y``), so
-        ``find -H`` follows that top-level link to scan the real tree while not
-        following links found *inside* the tree. ``-xdev`` keeps the scan on the
-        prefix's own filesystem so bind mounts inside the tree are not crossed.
-
-        Uses ``find`` (C-level traversal) for speed on large install trees and
-        falls back to a pure-Python ``os.walk`` scan if ``find`` is unavailable
-        so the check is not silently skipped.
-
-        Returns:
-        True if no offending path is found (or the check could not be run),
-        False if any offending path is found.
-        """
-        print("\nVerifying installed files are owned by root with safe permissions...")
-        # PurePosixPath, not Path: this is a path on the target Linux filesystem
-        # handed to find(1). Path follows the local flavour, so on Windows it
-        # renders "\opt\rocm\core" and the scan silently targets the wrong path.
-        install_prefix = str(PurePosixPath(self.install_prefix))
-        try:
-            result = subprocess.run(
-                [
-                    "find",
-                    # follow the prefix if it is a symlink, but not links inside
-                    "-H",
-                    install_prefix,
-                    # do not cross into other filesystems mounted under prefix
-                    "-xdev",
-                    "(",
-                    # not owned by root:root
-                    "(",
-                    "!",
-                    "-uid",
-                    "0",
-                    "-o",
-                    "!",
-                    "-gid",
-                    "0",
-                    ")",
-                    "-o",
-                    # insecure permissions
-                    "(",
-                    # group/other-writable on any non-symlink (a symlink's own
-                    # mode bits are meaningless; the target is checked on its own)
-                    "(",
-                    "!",
-                    "-type",
-                    "l",
-                    "-perm",
-                    "/022",
-                    ")",
-                    "-o",
-                    # setuid/setgid on a regular file only; setgid on a
-                    # directory (drwxr-sr-x) is a benign group-inheritance
-                    # pattern and must not be flagged.
-                    "(",
-                    "-type",
-                    "f",
-                    "-perm",
-                    "/6000",
-                    ")",
-                    ")",
-                    ")",
-                    "-print",
-                ],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
-            )
-        except OSError as e:
-            # find not available on this host; fall back to a Python walk so the
-            # check still runs rather than being silently skipped.
-            print(f" [WARN] 'find' unavailable ({e}); falling back to Python scan")
-            return self._verify_installed_file_security_python(Path(install_prefix))
-
-        # find can exit non-zero (e.g. permission denied on a subtree) while
-        # still printing partial results; surface that rather than passing
-        # silently on an incomplete scan.
-        if result.returncode != 0:
-            print(f" [WARN] find exited {result.returncode}: {result.stderr[:200]}")
-        elif result.stderr.strip():
-            print(f" [WARN] find reported: {result.stderr[:200]}")
-
-        bad = [line for line in result.stdout.splitlines() if line]
-        if bad:
-            print(
-                f" [FAIL] {len(bad)} path(s) not owned by root "
-                "or with insecure permissions:"
-            )
-            for line in bad[:10]:
-                print(f"   {line} {self._describe_flagged_path(line)}")
-            if len(bad) > 10:
-                print(f"   ... and {len(bad) - 10} more")
-            return False
-        print(" [PASS] All installed files owned by root with safe permissions")
-        return True
-
-    def _verify_installed_file_security_python(self, install_path: Path) -> bool:
-        """Pure-Python fallback for the install-tree security check.
-
-        Walks the install tree with ``os.walk`` (does not follow symlinked
-        directories found inside the tree) and ``os.lstat`` each entry, applying
-        the same rules as :meth:`verify_installed_file_security`: flag entries
-        not owned by ``root:root``, group/other-writable entries, and
-        setuid/setgid *regular files*. Symlinks are exempt from the permission
-        rules since their mode bits are meaningless on Linux, and setgid
-        directories are not flagged (a benign group-inheritance pattern).
-        Slower than ``find`` on large trees but portable.
+        the kernel (the target's permissions govern access), so only ownership
+        is meaningful for links. The scan uses ``os.walk`` + ``os.lstat``: it
+        follows the (commonly symlinked) prefix itself -- e.g. ``/opt/rocm/core``
+        -> ``/opt/rocm/core-X.Y`` -- but does not descend into symlinked
+        directories found *inside* the tree.
 
         Returns:
         True if no offending path is found, False if any offending path is found.
         """
+        print("\nVerifying installed files are owned by root with safe permissions...")
+        install_path = Path(self.install_prefix)
+
+        # os.walk swallows traversal errors by default; surface them so an
+        # incomplete scan (e.g. permission denied on a subtree) is not silently
+        # treated as a pass.
+        def _on_walk_error(err: OSError) -> None:
+            where = getattr(err, "filename", None) or install_path
+            print(f" [WARN] scan error under {where}: {err}")
+
         # Store (path, stat) so printing can annotate why each path was flagged
         # without re-stat'ing (the stat result here is authoritative).
         bad: list[tuple[Path, os.stat_result]] = []
-        for root, dirs, files in os.walk(install_path):
+        for root, dirs, files in os.walk(install_path, onerror=_on_walk_error):
             for name in dirs + files:
                 entry = Path(root) / name
                 try:

--- a/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
+++ b/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
@@ -1090,111 +1090,10 @@ class VerifyInstalledFileSecurityTest(unittest.TestCase):
             install_prefix=install_prefix,
         )
 
-    @patch("native_linux_package_install_test.subprocess.run")
-    def test_returns_true_when_find_reports_no_offending_paths(self, mock_run):
-        # Empty find output means every path is root-owned with safe permissions.
-        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
-        with _suppress_script_output():
-            self.assertTrue(self._make().verify_installed_file_security())
-
-    @patch("native_linux_package_install_test.subprocess.run")
-    def test_returns_false_when_find_reports_offending_paths(self, mock_run):
-        # Non-empty find output lists non-root-owned or insecure paths -> failure.
-        mock_run.return_value = MagicMock(
-            returncode=0,
-            stdout="/opt/rocm/core/bin/foo\n/opt/rocm/core/bin/setuid-tool\n",
-            stderr="",
-        )
-        with _suppress_script_output():
-            self.assertFalse(self._make().verify_installed_file_security())
-
-    @patch("native_linux_package_install_test.subprocess.run")
-    def test_ignores_blank_lines_in_find_output(self, mock_run):
-        # Trailing/blank lines alone should not be treated as offending paths.
-        mock_run.return_value = MagicMock(returncode=0, stdout="\n\n", stderr="")
-        with _suppress_script_output():
-            self.assertTrue(self._make().verify_installed_file_security())
-
-    @patch("native_linux_package_install_test.subprocess.run")
-    def test_nonzero_find_returncode_warns_but_still_evaluates_output(self, mock_run):
-        # find can exit non-zero (e.g. permission denied on a subtree) while
-        # still printing partial output; that output is still evaluated.
-        mock_run.return_value = MagicMock(
-            returncode=1,
-            stdout="/opt/rocm/core/bin/foo\n",
-            stderr="find: '/opt/rocm/core/x': Permission denied\n",
-        )
-        with _suppress_script_output():
-            self.assertFalse(self._make().verify_installed_file_security())
-
-    @patch("native_linux_package_install_test.subprocess.run")
-    def test_builds_expected_find_command(self, mock_run):
-        # Verify the single find invocation follows the prefix symlink (-H),
-        # stays on one filesystem (-xdev), checks ownership (uid/gid), writable
-        # (0o022) on non-symlinks (! -type l) and setid (0o6000) on regular
-        # files only (-type f).
-        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
-        with _suppress_script_output():
-            self._make("/opt/rocm/core").verify_installed_file_security()
-        cmd = mock_run.call_args[0][0]
-        self.assertEqual(cmd[0], "find")
-        self.assertEqual(cmd[1], "-H")
-        self.assertEqual(cmd[2], "/opt/rocm/core")
-        self.assertIn("-xdev", cmd)
-        self.assertIn("-uid", cmd)
-        self.assertIn("-gid", cmd)
-        self.assertIn("/022", cmd)
-        self.assertIn("/6000", cmd)
-        self.assertIn("!", cmd)
-        # symlinks are excluded from the writable portion (! -type l)
-        self.assertIn("-type", cmd)
-        self.assertIn("l", cmd)
-        # setuid/setgid is scoped to regular files (-type f) so benign setgid
-        # directories (drwxr-sr-x) are not flagged.
-        self.assertIn("f", cmd)
-        setid_idx = cmd.index("/6000")
-        self.assertEqual(cmd[setid_idx - 3 : setid_idx], ["-type", "f", "-perm"])
-        # no sticky-bit special-casing anymore
-        self.assertNotIn("-1000", cmd)
-        # no in-process timeout (style guide: no timeouts on basic binutils)
-        self.assertNotIn("timeout", mock_run.call_args[1])
-
-    @patch.object(
-        native_linux_package_install_test.NativeLinuxPackageInstallTest,
-        "_verify_installed_file_security_python",
-        return_value=True,
-    )
-    @patch("native_linux_package_install_test.subprocess.run")
-    def test_falls_back_to_python_when_find_not_available(
-        self, mock_run, mock_fallback
-    ):
-        # If find cannot be executed (OSError), fall back to the Python scan
-        # rather than silently skipping; the fallback result is returned.
-        mock_run.side_effect = OSError("find not found")
-        with _suppress_script_output():
-            self.assertTrue(self._make().verify_installed_file_security())
-        mock_fallback.assert_called_once()
-
-    @patch.object(
-        native_linux_package_install_test.NativeLinuxPackageInstallTest,
-        "_verify_installed_file_security_python",
-        return_value=False,
-    )
-    @patch("native_linux_package_install_test.subprocess.run")
-    def test_find_missing_fallback_can_fail(self, mock_run, mock_fallback):
-        # When find is missing and the Python fallback finds offenders, the
-        # overall check fails.
-        mock_run.side_effect = OSError("find not found")
-        with _suppress_script_output():
-            self.assertFalse(self._make().verify_installed_file_security())
-        mock_fallback.assert_called_once()
-
     @patch("native_linux_package_install_test.os.lstat")
     @patch("native_linux_package_install_test.os.walk")
-    def test_python_fallback_passes_for_safe_root_owned_tree(
-        self, mock_walk, mock_lstat
-    ):
-        # Python fallback returns True for root-owned 0755 dir / 0644 file modes.
+    def test_passes_for_safe_root_owned_tree(self, mock_walk, mock_lstat):
+        # Returns True for root-owned 0755 dir / 0644 file modes.
         mock_walk.return_value = [
             ("/opt/rocm/core", ["bin"], ["a.txt"]),
             ("/opt/rocm/core/bin", [], ["rocminfo"]),
@@ -1205,48 +1104,34 @@ class VerifyInstalledFileSecurityTest(unittest.TestCase):
             MagicMock(st_uid=0, st_gid=0, st_mode=stat.S_IFREG | 0o755),  # rocminfo
         ]
         with _suppress_script_output():
-            self.assertTrue(
-                self._make()._verify_installed_file_security_python(
-                    Path("/opt/rocm/core")
-                )
-            )
+            self.assertTrue(self._make().verify_installed_file_security())
 
     @patch("native_linux_package_install_test.os.lstat")
     @patch("native_linux_package_install_test.os.walk")
-    def test_python_fallback_fails_on_non_root_entry(self, mock_walk, mock_lstat):
-        # Python fallback returns False when any entry is not owned by root.
+    def test_fails_on_non_root_entry(self, mock_walk, mock_lstat):
+        # Returns False when any entry is not owned by root.
         mock_walk.return_value = [("/opt/rocm/core", [], ["a.txt", "b.txt"])]
         mock_lstat.side_effect = [
             MagicMock(st_uid=0, st_gid=0, st_mode=stat.S_IFREG | 0o644),
             MagicMock(st_uid=1000, st_gid=1000, st_mode=stat.S_IFREG | 0o644),
         ]
         with _suppress_script_output():
-            self.assertFalse(
-                self._make()._verify_installed_file_security_python(
-                    Path("/opt/rocm/core")
-                )
-            )
+            self.assertFalse(self._make().verify_installed_file_security())
 
     @patch("native_linux_package_install_test.os.lstat")
     @patch("native_linux_package_install_test.os.walk")
-    def test_python_fallback_fails_on_world_writable(self, mock_walk, mock_lstat):
+    def test_fails_on_world_writable(self, mock_walk, mock_lstat):
         # A root-owned but world-writable directory (PATH-hijack case) is flagged.
         mock_walk.return_value = [("/opt/rocm/core", ["bin"], [])]
         mock_lstat.return_value = MagicMock(
             st_uid=0, st_gid=0, st_mode=stat.S_IFDIR | 0o777
         )
         with _suppress_script_output():
-            self.assertFalse(
-                self._make()._verify_installed_file_security_python(
-                    Path("/opt/rocm/core")
-                )
-            )
+            self.assertFalse(self._make().verify_installed_file_security())
 
     @patch("native_linux_package_install_test.os.lstat")
     @patch("native_linux_package_install_test.os.walk")
-    def test_python_fallback_flags_sticky_world_writable_dir(
-        self, mock_walk, mock_lstat
-    ):
+    def test_flags_sticky_world_writable_dir(self, mock_walk, mock_lstat):
         # ROCm ships no world-writable dirs, so even a sticky one (mode 1777)
         # is flagged rather than exempted.
         mock_walk.return_value = [("/opt/rocm/core", ["tmp"], [])]
@@ -1254,45 +1139,33 @@ class VerifyInstalledFileSecurityTest(unittest.TestCase):
             st_uid=0, st_gid=0, st_mode=stat.S_IFDIR | stat.S_ISVTX | 0o777
         )
         with _suppress_script_output():
-            self.assertFalse(
-                self._make()._verify_installed_file_security_python(
-                    Path("/opt/rocm/core")
-                )
-            )
+            self.assertFalse(self._make().verify_installed_file_security())
 
     @patch("native_linux_package_install_test.os.lstat")
     @patch("native_linux_package_install_test.os.walk")
-    def test_python_fallback_fails_on_setuid(self, mock_walk, mock_lstat):
+    def test_fails_on_setuid(self, mock_walk, mock_lstat):
         # A root-owned setuid binary is flagged as a privilege-escalation surface.
         mock_walk.return_value = [("/opt/rocm/core", [], ["setuid-tool"])]
         mock_lstat.return_value = MagicMock(
             st_uid=0, st_gid=0, st_mode=stat.S_IFREG | stat.S_ISUID | 0o755
         )
         with _suppress_script_output():
-            self.assertFalse(
-                self._make()._verify_installed_file_security_python(
-                    Path("/opt/rocm/core")
-                )
-            )
+            self.assertFalse(self._make().verify_installed_file_security())
 
     @patch("native_linux_package_install_test.os.lstat")
     @patch("native_linux_package_install_test.os.walk")
-    def test_python_fallback_fails_on_setgid_file(self, mock_walk, mock_lstat):
+    def test_fails_on_setgid_file(self, mock_walk, mock_lstat):
         # A root-owned setgid *regular file* is still flagged.
         mock_walk.return_value = [("/opt/rocm/core", [], ["setgid-tool"])]
         mock_lstat.return_value = MagicMock(
             st_uid=0, st_gid=0, st_mode=stat.S_IFREG | stat.S_ISGID | 0o755
         )
         with _suppress_script_output():
-            self.assertFalse(
-                self._make()._verify_installed_file_security_python(
-                    Path("/opt/rocm/core")
-                )
-            )
+            self.assertFalse(self._make().verify_installed_file_security())
 
     @patch("native_linux_package_install_test.os.lstat")
     @patch("native_linux_package_install_test.os.walk")
-    def test_python_fallback_allows_setgid_directory(self, mock_walk, mock_lstat):
+    def test_allows_setgid_directory(self, mock_walk, mock_lstat):
         # A root-owned setgid *directory* (drwxr-sr-x, mode 2755) is a benign
         # group-inheritance pattern and must NOT be flagged. This is the common
         # ROCm install-tree case (2287 such dirs surfaced in CI).
@@ -1301,15 +1174,11 @@ class VerifyInstalledFileSecurityTest(unittest.TestCase):
             st_uid=0, st_gid=0, st_mode=stat.S_IFDIR | stat.S_ISGID | 0o755
         )
         with _suppress_script_output():
-            self.assertTrue(
-                self._make()._verify_installed_file_security_python(
-                    Path("/opt/rocm/core")
-                )
-            )
+            self.assertTrue(self._make().verify_installed_file_security())
 
     @patch("native_linux_package_install_test.os.lstat")
     @patch("native_linux_package_install_test.os.walk")
-    def test_python_fallback_allows_root_owned_symlink(self, mock_walk, mock_lstat):
+    def test_allows_root_owned_symlink(self, mock_walk, mock_lstat):
         # A root-owned symlink (mode 0o777, but bits are meaningless) is allowed.
         # This is the /opt/rocm/core -> /opt/rocm/core-X.Y case from CI.
         mock_walk.return_value = [("/opt/rocm/core", [], ["link"])]
@@ -1317,39 +1186,27 @@ class VerifyInstalledFileSecurityTest(unittest.TestCase):
             st_uid=0, st_gid=0, st_mode=stat.S_IFLNK | 0o777
         )
         with _suppress_script_output():
-            self.assertTrue(
-                self._make()._verify_installed_file_security_python(
-                    Path("/opt/rocm/core")
-                )
-            )
+            self.assertTrue(self._make().verify_installed_file_security())
 
     @patch("native_linux_package_install_test.os.lstat")
     @patch("native_linux_package_install_test.os.walk")
-    def test_python_fallback_fails_on_non_root_symlink(self, mock_walk, mock_lstat):
+    def test_fails_on_non_root_symlink(self, mock_walk, mock_lstat):
         # A non-root-owned symlink is still flagged (ownership is meaningful).
         mock_walk.return_value = [("/opt/rocm/core", [], ["link"])]
         mock_lstat.return_value = MagicMock(
             st_uid=1000, st_gid=1000, st_mode=stat.S_IFLNK | 0o777
         )
         with _suppress_script_output():
-            self.assertFalse(
-                self._make()._verify_installed_file_security_python(
-                    Path("/opt/rocm/core")
-                )
-            )
+            self.assertFalse(self._make().verify_installed_file_security())
 
     @patch("native_linux_package_install_test.os.lstat")
     @patch("native_linux_package_install_test.os.walk")
-    def test_python_fallback_skips_unstatable_entries(self, mock_walk, mock_lstat):
+    def test_skips_unstatable_entries(self, mock_walk, mock_lstat):
         # Entries that cannot be lstat'd (e.g. race/permission) are skipped, not fatal.
         mock_walk.return_value = [("/opt/rocm/core", [], ["gone.txt"])]
         mock_lstat.side_effect = OSError("no such file")
         with _suppress_script_output():
-            self.assertTrue(
-                self._make()._verify_installed_file_security_python(
-                    Path("/opt/rocm/core")
-                )
-            )
+            self.assertTrue(self._make().verify_installed_file_security())
 
     @patch.object(
         native_linux_package_install_test.NativeLinuxPackageInstallTest,


### PR DESCRIPTION
## Summary

Follow-up to #6974. Removes the `find(1)`-based install-tree security scan (and its pure-Python fallback) from `verify_installed_file_security()`, leaving a single `os.walk` + `os.lstat` traversal.

- The performance gap between `find` and `os.walk` is negligible for a one-shot install verification, so a single implementation is simpler to reason about, maintain, and test.
- **Behavior is unchanged.** A path is flagged when it is not owned by `root:root`, is group/other-writable (`0o022`) and not a symlink, or is a setuid/setgid **regular file**. Benign setgid *directories* (`drwxr-sr-x`) remain exempt, and symlink mode bits are ignored (only ownership is meaningful for links).
- An `os.walk(onerror=...)` handler surfaces traversal errors (e.g. permission denied on a subtree) as `[WARN]` so an incomplete scan is not silently treated as a pass.
- Drops the now-unused, `find`-only `_describe_flagged_path()` helper and the `PurePosixPath` import.

## Tests

- Removed the five `find`-specific unit tests (command shape, blank-line parsing, non-zero returncode, and the two fallback tests).
- Repointed the remaining behavioral tests (ownership, group/other-writable, sticky world-writable, setuid, setgid file, setgid dir, symlink cases, unstatable-entry skip) at the public `verify_installed_file_security()`.

## Test plan

- [x] `pytest build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py` — 111 passed
- [x] `pre-commit run --files <changed files>` — all hooks pass (black, etc.)
- [ ] CI install-test job passes on a real RPM/DEB install tree

Made with [Cursor](https://cursor.com)