### PR TITLE
ci: stop falling back to wheel version for native deb/rpm builds

### DIFF
--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -157,7 +157,7 @@ jobs:
     uses: ./.github/workflows/multi_arch_build_native_linux_packages.yml
     with:
       dist_amdgpu_families: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
-      rocm_version: ${{ inputs.rocm_deb_package_version || inputs.rocm_package_version }}
+      rocm_version: ${{ inputs.rocm_deb_package_version }}
       native_package_type: deb
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
@@ -172,7 +172,7 @@ jobs:
     uses: ./.github/workflows/multi_arch_build_native_linux_packages.yml
     with:
       dist_amdgpu_families: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
-      rocm_version: ${{ inputs.rocm_rpm_package_version || inputs.rocm_package_version }}
+      rocm_version: ${{ inputs.rocm_rpm_package_version }}
       native_package_type: rpm
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}


### PR DESCRIPTION
## Motivation

Fix for [ROCm/TheRock#7161]: The `||` fallback added in #5799 masked missing version wiring in external-repo CI (rocm-libraries).  Dependent PR to rocm-libraries PR that passes `rocm_deb_package_version` and `rocm_rpm_package_version` from `therock-multi-arch-ci.yml`.

Merge order: land rocm-libraries version-wiring first  (https://github.com/ROCm/rocm-libraries/pull/10507), then this TheRock PR

ISSUE ID: https://github.com/ROCm/TheRock/issues/7161

## Technical Details

- Remove `|| inputs.rocm_package_version` fallback from native DEB and RPM build jobs in `multi_arch_ci_linux.yml`
- DEB builds use `rocm_deb_package_version` only; RPM builds use `rocm_rpm_package_version` only
- Prevents the Python wheel version (`10.1.0.dev0+<sha>`) from being substituted into native package filenames when callers omit the native version inputs

## Test Plan

- [ ] TheRock native multi-arch CI Passes all four install lanes (ubuntu2404, rhel8, rhel10, sles16)
- [ ] rocm-libraries multi-arch CI Passes after rocm-libraries version-wiring PR merges
- [ ] Native RPM names use `~` form (e.g. `10.1.0~20260806g<sha>`), not `dev0+<sha>`
- [ ] Native DEB names use deb form (e.g. `10.1.0~dev20260806`), not wheel form

## Test Result


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
