### PR TITLE
ROCM-29174: disabling libhipcxx build

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -703,30 +703,33 @@ test_matrix = {
             "linux": 1,
         },
     },
-    # libhipcxx amdclang++ tests (formerly libhipcxx_hipcc)
-    "libhipcxx_amdclang": {
-        "job_name": "libhipcxx_amdclang",
-        "fetch_artifact_args": "--libhipcxx --tests",
-        "timeout_minutes": 30,
-        "test_script": f"python {_get_script_path('test_libhipcxx_amdclang.py')}",
-        "platform": ["linux", "windows"],
-        "total_shards_dict": {
-            "linux": 1,
-            "windows": 1,
-        },
-    },
-    # libhipcxx hiprtc tests
-    "libhipcxx_hiprtc": {
-        "job_name": "libhipcxx_hiprtc",
-        "fetch_artifact_args": "--libhipcxx --tests",
-        "timeout_minutes": 20,
-        "test_script": f"python {_get_script_path('test_libhipcxx_hiprtc.py')}",
-        "platform": ["linux"],
-        "total_shards_dict": {
-            "linux": 1,
-            "windows": 1,
-        },
-    },
+    # Disabled while the libhipcxx build is disabled in math-libs/CMakeLists.txt
+    # (ROCM-29174): the artifacts are never produced, so both scripts fail hard.
+    #
+    # # libhipcxx amdclang++ tests (formerly libhipcxx_hipcc)
+    # "libhipcxx_amdclang": {
+    #     "job_name": "libhipcxx_amdclang",
+    #     "fetch_artifact_args": "--libhipcxx --tests",
+    #     "timeout_minutes": 30,
+    #     "test_script": f"python {_get_script_path('test_libhipcxx_amdclang.py')}",
+    #     "platform": ["linux", "windows"],
+    #     "total_shards_dict": {
+    #         "linux": 1,
+    #         "windows": 1,
+    #     },
+    # },
+    # # libhipcxx hiprtc tests
+    # "libhipcxx_hiprtc": {
+    #     "job_name": "libhipcxx_hiprtc",
+    #     "fetch_artifact_args": "--libhipcxx --tests",
+    #     "timeout_minutes": 20,
+    #     "test_script": f"python {_get_script_path('test_libhipcxx_hiprtc.py')}",
+    #     "platform": ["linux"],
+    #     "total_shards_dict": {
+    #         "linux": 1,
+    #         "windows": 1,
+    #     },
+    # },
     # hipthreads lit tests
     "hipthreads": {
         "job_name": "hipthreads",

--- a/math-libs/CMakeLists.txt
+++ b/math-libs/CMakeLists.txt
@@ -510,7 +510,9 @@ if(THEROCK_ENABLE_ROCALUTION)
   )
 endif(THEROCK_ENABLE_ROCALUTION)
 
-if(THEROCK_ENABLE_LIBHIPCXX)
+#if(THEROCK_ENABLE_LIBHIPCXX)
+# disable libhipcxx temporarily for ROCm builds
+if(FALSE)
   ##############################################################################
   # libhipcxx
   ##############################################################################

--- a/math-libs/CMakeLists.txt
+++ b/math-libs/CMakeLists.txt
@@ -510,8 +510,11 @@ if(THEROCK_ENABLE_ROCALUTION)
   )
 endif(THEROCK_ENABLE_ROCALUTION)
 
+# libhipcxx is temporarily disabled for ROCm builds (ROCM-29174). Hard-disabled
+# rather than defaulting the flag off, since hipthreads REQUIRES libhipcxx and
+# therock_finalize_features() force-enables it back on. Matching CI test jobs are
+# commented out in build_tools/github_actions/fetch_test_configurations.py.
 #if(THEROCK_ENABLE_LIBHIPCXX)
-# disable libhipcxx temporarily for ROCm builds
 if(FALSE)
   ##############################################################################
   # libhipcxx


### PR DESCRIPTION
## Motivation

Temporarily disable libhipcxx from ROCm builds.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

JIRA ID: ROCM-29174

<!-- Most pull requests should be associated with at least one GitHub issue -->

<!-- GitHub issue: https://github.com/ROCm/TheRock/issues/1234 -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
