### PR TITLE
fix: Add xnack variant support across artifact fetching and packaging

### DIFF
--- a/build_tools/artifact_manager.py
+++ b/build_tools/artifact_manager.py
@@ -76,6 +76,36 @@ from _therock_utils.workflow_outputs import WorkflowOutputRoot
 ARTIFACT_COMPONENTS = ["lib", "run", "dev", "dbg", "doc", "test"]
 
 
+def _get_base_arch(target: str) -> str:
+    """Strip xnack/other suffixes: 'gfx942:xnack+' -> 'gfx942'.
+
+    Note: This strips everything after the first colon. Any suffix (not just
+    xnack) will be removed, e.g., 'gfx942:foo' -> 'gfx942'.
+    """
+    if not target:
+        return ""
+    base = target.split(":")[0]
+    return base if base else target
+
+
+def _matches_target(artifact_target: str, requested_targets: set[str]) -> bool:
+    """Match if the artifact's base arch equals any requested target's base arch.
+
+    Uses base-arch matching: both the artifact target and requested targets are
+    stripped to their base arch before comparison. This means requesting 'gfx942'
+    will match 'gfx942', 'gfx942:xnack+', 'gfx942:xnack-', or any 'gfx942:*' variant.
+
+    Known limitation: All colon-suffixed variants of the same base arch will match.
+    For example, requesting 'gfx942' matches 'gfx942:xnack+', 'gfx942:xnack-',
+    'gfx942:abc', etc. This is intentional to ensure all relevant artifacts are
+    fetched for a given GPU architecture.
+    """
+    if not artifact_target:
+        return False
+    requested_bases = {_get_base_arch(t) for t in requested_targets}
+    return _get_base_arch(artifact_target) in requested_bases
+
+
 def log(msg: str):
     """Print message and flush."""
     print(msg, flush=True)
@@ -144,22 +174,44 @@ def find_available_artifacts(
 ) -> list[str]:
     """Find which artifacts exist in the available set.
 
-    Iterates artifact_names × target_families × components × extensions,
-    returning filenames that are present in `available`. Prefers .tar.zst
-    over .tar.xz when both exist.
+    Iterates available artifacts and filters by artifact_names, target_families,
+    and components. Uses base-arch matching: requesting a base arch (e.g., "gfx942")
+    will also match variants with suffixes (e.g., "gfx942:xnack+", "gfx942:xnack-").
+
+    Prefers .tar.zst over .tar.xz when both exist, because zstd offers faster
+    decompression and better compression ratios for our artifact workloads.
     """
     excluded_components = excluded_components or set()
+    targets_to_match = set(target_families)
+
+    # Use structured ArtifactName parsing for reliable matching (like fetch_artifacts.py)
     matched = []
-    for artifact_name in sorted(artifact_names):
-        for tf in target_families:
-            for comp in ARTIFACT_COMPONENTS:
-                if comp in excluded_components:
-                    continue
-                for ext in ARTIFACT_EXTENSIONS:
-                    filename = f"{artifact_name}_{comp}_{tf}{ext}"
-                    if filename in available:
-                        matched.append(filename)
-                        break  # Found this artifact, don't check other extensions
+    seen = set()
+
+    # Sort .tar.zst before .tar.xz so dedup prefers zstd (faster decompression)
+    def _sort_key(f: str) -> tuple:
+        base = f.rsplit(".tar", 1)[0]
+        priority = 0 if f.endswith(".tar.zst") else 1
+        return (base, priority)
+
+    for filename in sorted(available, key=_sort_key):
+        an = ArtifactName.from_filename(filename)
+        if not an:
+            continue
+        if an.name not in artifact_names:
+            continue
+        if an.component in excluded_components:
+            continue
+        if not _matches_target(an.target_family, targets_to_match):
+            continue
+
+        # Dedupe: prefer .tar.zst over .tar.xz for same artifact
+        key = (an.name, an.component, an.target_family)
+        if key in seen:
+            continue
+        seen.add(key)
+        matched.append(filename)
+
     return matched
 
 

--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -339,8 +339,10 @@ def _run_kpack_split(
     # Per-ISA device wheels. Device artifacts overlay into
     # _rocm_sdk_libraries/lib/ and may include ELF .so files (per-arch
     # MIOpen CK kernels) with dynamic deps on core.
-    all_targets = sorted(params.all_target_families)
-    for target in all_targets:
+    # Group by base target (strip xnack suffix) to merge variants like
+    # 'gfx950' and 'gfx950:xnack+' into a single device package.
+    all_base_targets = sorted(set(t.split(":")[0] for t in params.all_target_families))
+    for target in all_base_targets:
         dev = PopulatedDistPackage(params, logical_name="device", target_family=target)
         dev.rpath_dep(core, "lib")
         dev.rpath_dep(core, "lib/rocm_sysdeps/lib")
@@ -589,7 +591,13 @@ def device_artifact_filter(target: str, an: ArtifactName) -> bool:
 
     Unlike libraries_artifact_filter, this only matches the specific ISA target
     (no generic). Used in kpack-split mode for device wheel population.
+
+    Matches both the base target and any xnack variants (e.g., target='gfx950'
+    matches artifacts for both 'gfx950' and 'gfx950:xnack+'), merging them into
+    a single device package.
     """
+    # Strip xnack suffix from artifact's target_family for comparison
+    artifact_base_target = an.target_family.split(":")[0]
     return (
         an.name
         in [
@@ -604,7 +612,7 @@ def device_artifact_filter(target: str, an: ArtifactName) -> bool:
             "rccl",
         ]
         and an.component == "lib"
-        and an.target_family == target
+        and artifact_base_target == target
     )
 
 

--- a/build_tools/packaging/linux/build_package.py
+++ b/build_tools/packaging/linux/build_package.py
@@ -95,7 +95,9 @@ def get_all_target_families(artifact_dir):
 
     # Use ArtifactCatalog from _therock_utils to get all target families
     catalog = ArtifactCatalog(artifact_dir)
-    return sorted(catalog.all_target_families)
+    # Strip xnack suffixes (e.g., gfx942:xnack+ -> gfx942)
+    targets = {t.split(":", 1)[0] for t in catalog.all_target_families}
+    return sorted(targets)
 
 
 ################### Package Variant Builders #######################

--- a/build_tools/packaging/linux/packaging_utils.py
+++ b/build_tools/packaging/linux/packaging_utils.py
@@ -51,7 +51,7 @@ def normalize_target_list(
         raw = [str(a) for a in value]
 
     tokens = [
-        tok.lower() if lowercase else tok
+        (tok.split(":", 1)[0].lower() if lowercase else tok.split(":", 1)[0])
         for item in raw
         for tok in _GFX_ARCH_SPLIT_RE.split(item)
         if tok
@@ -927,30 +927,32 @@ def filter_components_fromartifactory(
             component_list = subdir["Components"]
 
             for component in component_list:
-                source_dir = (
-                    Path(artifacts_dir)
-                    / f"{artifact_prefix}_{component}_{artifact_suffix}"
-                )
-                filename = source_dir / "artifact_manifest.txt"
-                if not filename.exists():
-                    print(f"{pkg_name} : Missing {filename}")
-                    continue
-                try:
-                    with filename.open("r", encoding="utf-8") as file:
-                        for line in file:
+                # Find base artifact and all xnack variants (e.g., :xnack+, :xnack-)
+                base_pattern = f"{artifact_prefix}_{component}_{artifact_suffix}"
+                artifact_dirs = [Path(artifacts_dir) / base_pattern]
+                artifact_dirs.extend(Path(artifacts_dir).glob(f"{base_pattern}:*"))
 
-                            match_found = (
-                                isinstance(artifact_subdir, str)
-                                and (artifact_subdir.lower() + "/") in line.lower()
-                            )
+                for source_dir in artifact_dirs:
+                    filename = source_dir / "artifact_manifest.txt"
+                    if not filename.exists():
+                        print(f"{pkg_name} : Missing {filename}")
+                        continue
+                    try:
+                        with filename.open("r", encoding="utf-8") as file:
+                            for line in file:
 
-                            if match_found and line.strip():
-                                print("Matching line:", line.strip())
-                                source_path = source_dir / line.strip()
-                                sourcedir_list.append(source_path)
-                except OSError as e:
-                    print(f"Could not read manifest {filename}: {e}")
-                    continue
+                                match_found = (
+                                    isinstance(artifact_subdir, str)
+                                    and (artifact_subdir.lower() + "/") in line.lower()
+                                )
+
+                                if match_found and line.strip():
+                                    print("Matching line:", line.strip())
+                                    source_path = source_dir / line.strip()
+                                    sourcedir_list.append(source_path)
+                    except OSError as e:
+                        print(f"Could not read manifest {filename}: {e}")
+                        continue
 
     return sourcedir_list
 

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
@@ -96,7 +96,8 @@ class PackageEntry:
             )
         kwargs = {}
         if target_family is not None:
-            kwargs["target_family"] = target_family
+            # Strip xnack suffix (e.g., 'gfx942:xnack+' -> 'gfx942') for valid package names
+            kwargs["target_family"] = target_family.split(":")[0]
         return self.dist_package_template.format(**kwargs)
 
     def get_dist_package_require(self, target_family: str | None = None) -> str:
@@ -329,8 +330,13 @@ def get_target_family_platform_marker(target_family: str) -> str:
     """
     if not LINUX_TARGET_FAMILIES or not WINDOWS_TARGET_FAMILIES:
         return ""
-    in_linux = target_family in LINUX_TARGET_FAMILIES
-    in_windows = target_family in WINDOWS_TARGET_FAMILIES
+    # Compare base targets (strip xnack suffix) since platform lists may contain
+    # xnack-suffixed entries like 'gfx942:xnack+' while we receive base targets.
+    base_target = target_family.split(":")[0]
+    linux_base_targets = {t.split(":")[0] for t in LINUX_TARGET_FAMILIES}
+    windows_base_targets = {t.split(":")[0] for t in WINDOWS_TARGET_FAMILIES}
+    in_linux = base_target in linux_base_targets
+    in_windows = base_target in windows_base_targets
     if in_linux and not in_windows:
         return 'sys_platform == "linux"'
     if in_windows and not in_linux:
@@ -351,13 +357,16 @@ def build_per_target_extras() -> "dict[str, list[str]]":
     the generic extras already in setup.py's EXTRAS_REQUIRE suffice).
     """
     result: dict[str, list[str]] = {}
-    if len(AVAILABLE_TARGET_FAMILIES) <= 1:
+    # Deduplicate by base target (strip xnack suffix) to avoid redundant iterations
+    # when both 'gfx942' and 'gfx942:xnack+' exist in AVAILABLE_TARGET_FAMILIES.
+    base_targets = sorted(set(tf.split(":")[0] for tf in AVAILABLE_TARGET_FAMILIES))
+    if len(base_targets) <= 1:
         return result
     for pkg in ALL_PACKAGES.values():
         if not pkg.is_target_specific or pkg.required:
             continue
         all_requires: list[str] = []
-        for tf in sorted(AVAILABLE_TARGET_FAMILIES):
+        for tf in base_targets:
             extra_name = f"{pkg.logical_name}-{tf}"
             req = pkg.get_dist_package_require(target_family=tf)
             marker = get_target_family_platform_marker(tf)

--- a/build_tools/tests/artifact_manager_tool_test.py
+++ b/build_tools/tests/artifact_manager_tool_test.py
@@ -10,6 +10,7 @@ particularly error handling and exit codes.
 
 import hashlib
 import os
+import platform
 import shutil
 import sys
 import tempfile
@@ -17,6 +18,11 @@ import unittest
 from pathlib import Path
 from typing import Optional
 from unittest import mock
+
+
+def is_windows():
+    return platform.system() == "Windows"
+
 
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 
@@ -593,12 +599,15 @@ class TestFetchStageAll(ArtifactManagerTestBase):
             )
 
     def test_fetch_exclude_components_skips_test_artifacts(self) -> None:
-        """Test that --exclude-components filters artifact components."""
+        """Test that --exclude-components filters artifact components including xnack variants."""
         import artifact_manager
 
         self._create_staged_artifact("test-artifact", "lib", "generic")
         self._create_staged_artifact("test-artifact", "test", "generic")
         self._create_staged_artifact("test-artifact", "test", "gfx942")
+        # xnack artifacts use ':' which is invalid in Windows filenames
+        if not is_windows():
+            self._create_staged_artifact("test-artifact", "test", "gfx942:xnack+")
         self._create_staged_artifact("second-artifact", "run", "generic")
         self._create_staged_artifact("second-artifact", "test", "generic")
 
@@ -734,12 +743,15 @@ class TestFetchAmdgpuTargets(ArtifactManagerTestBase):
     """Tests that fetch command correctly handles --amdgpu-targets for split artifacts."""
 
     def test_fetch_with_amdgpu_targets_finds_individual_target_archives(self):
-        """Test that --amdgpu-targets matches individual-target split archives."""
+        """Test that --amdgpu-targets matches individual-target and xnack-suffixed archives."""
         import artifact_manager
 
-        # Stage a generic artifact and a per-target artifact
+        # Stage generic, per-target, and xnack-suffixed artifacts
         self._create_staged_artifact("test-artifact", "lib", "generic")
         self._create_staged_artifact("test-artifact", "lib", "gfx942")
+        # xnack artifacts use ':' which is invalid in Windows filenames
+        if not is_windows():
+            self._create_staged_artifact("test-artifact", "lib", "gfx942:xnack+")
 
         extract_calls = []
 
@@ -768,16 +780,21 @@ class TestFetchAmdgpuTargets(ArtifactManagerTestBase):
 
             artifact_manager.main(argv)
 
-        # Should have fetched both generic and gfx942
+        # Should have fetched generic, gfx942, and gfx942:xnack+ (non-Windows only)
         fetched_keys = [c.archive_path.name for c in extract_calls]
         self.assertTrue(
             any("generic" in k for k in fetched_keys),
             f"Should fetch generic artifact, got: {fetched_keys}",
         )
         self.assertTrue(
-            any("gfx942" in k for k in fetched_keys),
+            any("gfx942.tar.zst" in k for k in fetched_keys),
             f"Should fetch gfx942 artifact, got: {fetched_keys}",
         )
+        if not is_windows():
+            self.assertTrue(
+                any("gfx942:xnack+" in k for k in fetched_keys),
+                f"Should fetch gfx942:xnack+ artifact, got: {fetched_keys}",
+            )
 
     def test_fetch_with_amdgpu_targets_skips_other_targets(self):
         """Test that --amdgpu-targets doesn't fetch archives for other targets."""

--- a/build_tools/tests/py_packaging_test.py
+++ b/build_tools/tests/py_packaging_test.py
@@ -536,6 +536,37 @@ class DevicePackagingTest(TmpDirTestCase):
         artifact_dir = self._setup_kpack_split_artifacts()
         params = self._make_params(artifact_dir, kpack_split=True)
 
+        # Verify xnack-suffixed targets produce valid package names by stripping
+        # the suffix (e.g., 'gfx942:xnack+' -> 'rocm-sdk-device-gfx942')
+        device_entry = params.dist_info.ALL_PACKAGES["device"]
+        # Test xnack+ suffix
+        self.assertEqual(
+            device_entry.get_dist_package_name("gfx942:xnack+"),
+            "rocm-sdk-device-gfx942",
+        )
+        # Test xnack- suffix
+        self.assertEqual(
+            device_entry.get_dist_package_name("gfx942:xnack-"),
+            "rocm-sdk-device-gfx942",
+        )
+        # Test base target without suffix
+        self.assertEqual(
+            device_entry.get_dist_package_name("gfx942"),
+            "rocm-sdk-device-gfx942",
+        )
+        # Verify get_dist_package_require also strips xnack suffix
+        self.assertTrue(
+            device_entry.get_dist_package_require("gfx942:xnack+").startswith(
+                "rocm-sdk-device-gfx942=="
+            ),
+        )
+        # Verify get_py_package_name also strips xnack suffix
+        self.assertTrue(
+            device_entry.get_py_package_name("gfx942:xnack+").startswith(
+                "_rocm_sdk_device_gfx942"
+            ),
+        )
+
         dev = PopulatedDistPackage(
             params, logical_name="device", target_family="gfx942"
         )
@@ -656,6 +687,14 @@ class DevicePackagingTest(TmpDirTestCase):
         # Should NOT match non-library artifact name.
         an_core = ArtifactName("core-hip", "lib", "gfx942")
         self.assertFalse(device_artifact_filter("gfx942", an_core))
+
+        # Should match xnack variant of the same base target (merges into one package).
+        an_xnack = ArtifactName("blas", "lib", "gfx942:xnack+")
+        self.assertTrue(device_artifact_filter("gfx942", an_xnack))
+
+        # Should NOT match xnack variant of a different base target.
+        an_xnack_other = ArtifactName("blas", "lib", "gfx950:xnack+")
+        self.assertFalse(device_artifact_filter("gfx942", an_xnack_other))
 
     def test_core_artifact_filter_includes_only_rocjitsu_hotswap(self):
         """The core wheel ships the HSA hotswap hook without the rocjitsu library."""
@@ -1399,6 +1438,16 @@ class PlatformMarkerTest(TmpDirTestCase):
         # Cross-platform target has no marker.
         self.assertEqual(dist_info.get_target_family_platform_marker("gfx1100"), "")
 
+        # Verify xnack-suffixed targets in platform lists are matched by base target.
+        xnack_dist_info = self._make_dist_info(
+            linux_target_families=["gfx942:xnack+", "gfx1100"],
+            windows_target_families=["gfx1100"],
+        )
+        self.assertEqual(
+            xnack_dist_info.get_target_family_platform_marker("gfx942"),
+            'sys_platform == "linux"',
+        )
+
     def test_no_marker_when_per_platform_lists_unknown(self):
         """Single-platform builds don't pass the new kwargs; no markers
         are added, so existing (non-multi-arch) sdists are unchanged.
@@ -1530,6 +1579,21 @@ class PerTargetExtrasTest(TmpDirTestCase):
                 + extras["device-gfx1100"]
                 + extras["device-gfx1102"]
             ),
+        )
+
+        # Verify xnack-suffixed targets produce valid extra names by stripping
+        # the suffix (e.g., 'device-gfx942' not 'device-gfx942:xnack+')
+        xnack_dist_info = self._make_dist_info(
+            linux_target_families=["gfx942:xnack+", "gfx1100"],
+            windows_target_families=["gfx1100"],
+        )
+        xnack_extras = xnack_dist_info.build_per_target_extras()
+        self.assertIn("device-gfx942", xnack_extras)
+        self.assertNotIn("device-gfx942:xnack+", xnack_extras)
+        xnack_req = xnack_extras["device-gfx942"][0]
+        self.assertTrue(
+            xnack_req.startswith("rocm-sdk-device-gfx942=="),
+            f"Expected stripped package name in requirement, got: {xnack_req}",
         )
 
     def test_no_markers_when_per_platform_lists_unknown(self):


### PR DESCRIPTION
Cherry-pick xnack support fixes for ASAN builds and native packaging:
  
  - fix: Add xnack variant support to Linux native packaging (#6098)
    Unify xnack variants (:xnack+, :xnack-) into single packages per GPU
    target by stripping suffixes and globbing variant directories.
    
  - fix(py_packaging): strip xnack suffix from wheel package names (#7113)
    Strip xnack suffix from target names to produce PEP 508 compliant
    wheel names, combining xnack and non-xnack variants into a single
    package per GPU target.
    
  - fix: support fetching xnack-suffixed artifacts (#7090)
    Add base-arch matching so requesting gfx942 also fetches gfx942:xnack+
    and gfx942:xnack- variants.
    
  Together these enable --expand-family-to-targets to correctly build,
  package, and fetch artifacts for ASAN builds using xnack-suffixed targets.
  
  JIRA ID: https://amd-hub.atlassian.net/browse/ROCM-28314

Original PR: 
https://github.com/ROCm/TheRock/pull/6098
https://github.com/ROCm/TheRock/pull/7113 
https://github.com/ROCm/TheRock/pull/7090