### PR TITLE
fix(packaging): include elfio dev artifact in rocm-sdk-devel wheel

### DIFF
--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -377,6 +377,8 @@ def _run_kpack_split(
             "prim",
             "rocwmma",
             "libhipcxx",
+            # Header-only ELF reader.
+            "elfio",
             # Third party dependencies needed by hipDNN consumers.
             "flatbuffers",
             "nlohmann-json",


### PR DESCRIPTION
## Motivation

Addresses #6156.

`elfio` ships in the deb/rpm packages (via `amdrocm-sysdeps`) but is absent
from every Python wheel.

## Technical Details

`elfio` is header-only (`add_library(elfio INTERFACE)`), so its only
non-empty component is `dev`. The wheel selectors never claimed it:
`core_artifact_filter` gates on `lib`/`run` components, and it was missing
from the `devel` `addl_artifact_names` list. Adding it there routes
`include/elfio/**` and `lib/cmake/elfio/**` into `rocm-sdk-devel`.

## Test Plan

Install nightly `rocm[devel]` built from this branch and check for the
headers under `_rocm_sdk_devel/include/elfio`.

## Test Result

Drove the real `populate_devel_files` path (as `_run_kpack_split` does)
over an artifact catalog of the real `nlohmann-json`/`flatbuffers` dev
artifacts plus a structure-faithful `elfio_dev_generic` fixture:

- With `elfio` in `addl_artifact_names`: `_devel` tarball gains
  `_rocm_sdk_devel/include/elfio/*.hpp` and `lib/cmake/elfio/*.cmake`.
- Control (elfio removed): those entries are absent; nothing else changes.

Full wheel build via nightly CI still pending.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
