### PR TITLE
feat(flags): add HIPDNN_ENABLE_KERNEL_INGESTOR build flag

### DIFF
--- a/FLAGS.cmake
+++ b/FLAGS.cmake
@@ -52,6 +52,17 @@ therock_declare_flag(
 )
 
 therock_declare_flag(
+  NAME HIPDNN_ENABLE_KERNEL_INGESTOR
+  DEFAULT_VALUE OFF
+  DESCRIPTION "Enable the generic kernel ingestor build-time logic in hipDNN (dynamic engine loading, kpack bundling/packaging) and its providers"
+  CMAKE_VARS
+    HIPDNN_ENABLE_KERNEL_INGESTOR=ON
+  SUB_PROJECTS
+    hipDNN
+    hipkernelprovider
+)
+
+therock_declare_flag(
   NAME MIOPEN_ENABLE_HIPDNN_WRAPPER
   DEFAULT_VALUE OFF
   DESCRIPTION "Build MIOpen as a public wrapper (libMIOpen.so) over a private implementation library (libMIOpen_private.so), with optional runtime forwarding to hipDNN. See rocm-libraries MIOpen RFC 0001."

--- a/FLAGS.cmake
+++ b/FLAGS.cmake
@@ -51,6 +51,8 @@ therock_declare_flag(
     hipkernelprovider
 )
 
+# Gates the generic kernel ingestor platform described in RFC 0017:
+# rocm-libraries/projects/hipdnn/docs/rfcs/0017_UniversalKernelDescriptor.md
 therock_declare_flag(
   NAME HIPDNN_ENABLE_KERNEL_INGESTOR
   DEFAULT_VALUE OFF


### PR DESCRIPTION
## Summary

Adds a single opt-in build flag that gates the generic kernel ingestor build-time logic (dynamic engine loading, kpack bundling/packaging, dynamic engine registration) so that work tracked under the hipDNN generic kernel ingestor epic can land incrementally without affecting default builds. See [RFC 0017: Universal Kernel Descriptors](https://github.com/ROCm/rocm-libraries/blob/develop/projects/hipdnn/docs/rfcs/0017_UniversalKernelDescriptor.md) ([rocm-libraries#9533](https://github.com/ROCm/rocm-libraries/pull/9533)) for the platform this flag gates.

JIRA ID : ALMIOPEN-2399

## Risk Assessment

Minimal risk. This declares an inert, default-OFF build flag in `FLAGS.cmake` with no accompanying source changes; no consuming code currently reads the propagated variable, so default builds and installed artifacts are byte-for-byte unaffected.

## ASIC Coverage

No ASIC impact. The flag is plumbing only (default OFF, no gated logic exists yet in `hipDNN`/`hipkernelprovider` to exercise); standard PR CI is sufficient.

## Testing Summary

- CMake configure smoke test confirming the flag registers and reports correctly with its default value.
- CMake configure smoke test confirming the flag can be toggled on via the command line and propagates through `therock_finalize_flags()`/`therock_report_flags()` without error.

## Testing Checklist

- [x] CMake configure (flag default) - `cmake -S . -B build -DTHEROCK_ENABLE_ALL=OFF -DTHEROCK_ENABLE_HIPDNN=OFF` - Status: Passed (reports `HIPDNN_ENABLE_KERNEL_INGESTOR = OFF`)
- [x] CMake configure (flag enabled) - `cmake -S . -B build -DTHEROCK_ENABLE_ALL=OFF -DTHEROCK_ENABLE_HIPDNN=OFF -DTHEROCK_FLAG_HIPDNN_ENABLE_KERNEL_INGESTOR=ON` - Status: Passed (reports `HIPDNN_ENABLE_KERNEL_INGESTOR = ON`)
- [x] PR CI - GitHub PR checks - Status: Pending

## Technical Changes

- Declares `THEROCK_FLAG_HIPDNN_ENABLE_KERNEL_INGESTOR` (default `OFF`) in `FLAGS.cmake`.
- Scopes `CMAKE_VARS HIPDNN_ENABLE_KERNEL_INGESTOR=ON` to the `hipDNN` and `hipkernelprovider` subprojects, matching the epic's plan to gate plugin-sdk and hip-kernel-provider dynamic-engine logic behind one flag.