### PR TITLE
feat: add disable_processors support to feature system

### DIFF
--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -66,6 +66,8 @@
 #   platform = "windows"                    # Optional: platform-specific artifact
 #   disable_platforms = ["windows"]         # Optional: platforms where disabled
 #   disable_platforms_if_flags_not_set = { windows = "FOO" }  # Optional: conditional platform disables
+#   disable_processors = ["aarch64"]     # Optional: CPU processors where disabled
+#                                           #   Canonical names: x86_64, aarch64, ppc64le
 #   python_requires = ["-r path/to/req.txt", "pkg"]  # Optional: pip install args
 #   split_databases = ["rocblas", "hipblaslt"]  # Optional: database handlers for kpack split
 #
@@ -765,6 +767,7 @@ artifact_deps = ["amd-llvm", "core-hip", "rocprofiler-sdk", "core-amdsmi", "spdl
 feature_name = "ROCPROFSYS"
 feature_group = "PROFILER"
 disable_platforms = ["windows"]
+disable_processors = ["ppc64le"]
 
 [artifacts.rocprofiler-systems-examples]
 artifact_group = "profiler-apps"
@@ -772,6 +775,7 @@ type = "target-neutral"
 artifact_deps = ["rocprofiler-systems"]
 feature_group = "PROFILER"
 disable_platforms = ["windows"]
+disable_processors = ["ppc64le"]
 
 # --- Data Center Tools ---
 

--- a/build_tools/_therock_utils/build_topology.py
+++ b/build_tools/_therock_utils/build_topology.py
@@ -118,6 +118,9 @@ class Artifact:
     disable_platforms_if_flags_not_set: Dict[str, str] = field(
         default_factory=dict
     )  # Platforms disabled unless the named build flag is set
+    disable_processors: List[str] = field(
+        default_factory=list
+    )  # CPU processors where disabled (canonical: x86_64, aarch64, ppc64le)
     python_requires: List[str] = field(
         default_factory=list
     )  # pip install args (e.g., ["-r path/to/req.txt"])
@@ -234,6 +237,9 @@ class BuildTopology:
                 feature_group=artifact_data.get("feature_group"),
                 disable_platforms=artifact_data.get("disable_platforms", []),
                 disable_platforms_if_flags_not_set=disable_platforms_if_flags_not_set,
+                disable_processors=artifact_data.get(
+                    "disable_processors", []
+                ),
                 python_requires=python_requires,
                 split_databases=artifact_data.get("split_databases", []),
                 test_artifacts=artifact_data.get("test_artifacts", []),
@@ -267,6 +273,16 @@ class BuildTopology:
             return False
         enabled_flags = enabled_flags or set()
         return required_flag not in enabled_flags
+
+    def is_artifact_disabled_on_processor(
+        self,
+        artifact: Artifact,
+        processor_name: str,
+    ) -> bool:
+        """Return whether an artifact is disabled for a CPU processor."""
+        if not processor_name:
+            return False
+        return processor_name in artifact.disable_processors
 
     def get_artifact_feature_name(self, artifact: Artifact) -> str:
         """Get the effective feature name for an artifact."""
@@ -411,6 +427,7 @@ class BuildTopology:
         valid_stage_types = {"generic", "per-arch"}
         valid_artifact_types = {"target-neutral", "target-specific"}
         valid_platforms = {"windows", "linux"}
+        valid_processors = {"x86_64", "aarch64", "ppc64le"}
 
         # Validate build stage names and types
         for stage_name, stage in self.build_stages.items():
@@ -482,6 +499,12 @@ class BuildTopology:
                     errors.append(
                         f"Artifact '{artifact_name}' disable_platforms_if_flags_not_set "
                         f"entry for '{platform}' should be UPPERCASE_WITH_UNDERSCORES"
+                    )
+            for proc in artifact.disable_processors:
+                if proc not in valid_processors:
+                    errors.append(
+                        f"Artifact '{artifact_name}' has invalid disable_processor "
+                        f"'{proc}' (expected: {valid_processors})"
                     )
 
         # Validate source set disable_platforms
@@ -1231,6 +1254,7 @@ class BuildTopology:
         project_names: List[str],
         platform_name: str = "",
         build_dir: Optional[Path] = None,
+        processor_name: str = "",
     ) -> Set[str]:
         """Resolve project names to CMake feature names."""
         features: Set[str] = set()
@@ -1250,6 +1274,10 @@ class BuildTopology:
             if artifact_name and artifact_name in self.artifacts:
                 artifact = self.artifacts[artifact_name]
                 if platform_name and platform_name in artifact.disable_platforms:
+                    continue
+                if self.is_artifact_disabled_on_processor(
+                    artifact, processor_name
+                ):
                     continue
                 features.add(self.get_artifact_feature_name(artifact))
 

--- a/build_tools/_therock_utils/build_topology.py
+++ b/build_tools/_therock_utils/build_topology.py
@@ -237,9 +237,7 @@ class BuildTopology:
                 feature_group=artifact_data.get("feature_group"),
                 disable_platforms=artifact_data.get("disable_platforms", []),
                 disable_platforms_if_flags_not_set=disable_platforms_if_flags_not_set,
-                disable_processors=artifact_data.get(
-                    "disable_processors", []
-                ),
+                disable_processors=artifact_data.get("disable_processors", []),
                 python_requires=python_requires,
                 split_databases=artifact_data.get("split_databases", []),
                 test_artifacts=artifact_data.get("test_artifacts", []),
@@ -1275,9 +1273,7 @@ class BuildTopology:
                 artifact = self.artifacts[artifact_name]
                 if platform_name and platform_name in artifact.disable_platforms:
                     continue
-                if self.is_artifact_disabled_on_processor(
-                    artifact, processor_name
-                ):
+                if self.is_artifact_disabled_on_processor(artifact, processor_name):
                     continue
                 features.add(self.get_artifact_feature_name(artifact))
 

--- a/build_tools/configure_stage.py
+++ b/build_tools/configure_stage.py
@@ -87,6 +87,7 @@ def get_stage_features(
     stage_name: str,
     platform_name: str = "",
     enabled_flags: Optional[Set[str]] = None,
+    processor_name: str = "",
 ) -> Set[str]:
     """Get the set of feature names that should be enabled for a stage.
 
@@ -94,7 +95,7 @@ def get_stage_features(
     1. Features for artifacts produced by this stage
     2. Features for artifacts that are inbound dependencies (needed but prebuilt)
 
-    Artifacts disabled for platform_name are excluded.
+    Artifacts disabled for platform_name or processor_name are excluded.
 
     Note: The inbound dependencies will be marked as prebuilt via buildctl.py bootstrap,
     but CMake still needs their features enabled for dependency resolution.
@@ -121,6 +122,8 @@ def get_stage_features(
                 platform_name,
                 enabled_flags=enabled_flags,
             ):
+                continue
+            if topology.is_artifact_disabled_on_processor(artifact, processor_name):
                 continue
             feature_name = topology.get_artifact_feature_name(artifact)
             features.add(feature_name)

--- a/build_tools/tests/build_topology_test.py
+++ b/build_tools/tests/build_topology_test.py
@@ -1004,7 +1004,6 @@ class BuildTopologyTest(unittest.TestCase):
         foundation_inbound = topology.get_inbound_artifacts("foundation")
         self.assertEqual(len(foundation_inbound), 0)
 
-
     def test_parse_disable_processors(self):
         """Test parsing disable_processors from TOML."""
         self.write_topology(

--- a/build_tools/tests/build_topology_test.py
+++ b/build_tools/tests/build_topology_test.py
@@ -1005,6 +1005,125 @@ class BuildTopologyTest(unittest.TestCase):
         self.assertEqual(len(foundation_inbound), 0)
 
 
+    def test_parse_disable_processors(self):
+        """Test parsing disable_processors from TOML."""
+        self.write_topology(
+            """
+            [artifacts.profiler]
+            artifact_group = "profiler"
+            type = "target-neutral"
+            disable_processors = ["aarch64"]
+        """
+        )
+
+        topology = BuildTopology(self.topology_path)
+        artifact = topology.artifacts["profiler"]
+
+        self.assertEqual(artifact.disable_processors, ["aarch64"])
+
+    def test_is_artifact_disabled_on_processor(self):
+        """Test is_artifact_disabled_on_processor method."""
+        self.write_topology(
+            """
+            [artifacts.profiler]
+            artifact_group = "profiler"
+            type = "target-neutral"
+            disable_processors = ["aarch64"]
+        """
+        )
+
+        topology = BuildTopology(self.topology_path)
+        artifact = topology.artifacts["profiler"]
+
+        self.assertTrue(topology.is_artifact_disabled_on_processor(artifact, "aarch64"))
+        self.assertFalse(topology.is_artifact_disabled_on_processor(artifact, "x86_64"))
+        self.assertFalse(topology.is_artifact_disabled_on_processor(artifact, ""))
+
+    def test_validate_invalid_disable_processor(self):
+        """Test validation catches invalid processor names."""
+        self.write_topology(
+            """
+            [artifacts.profiler]
+            artifact_group = "profiler"
+            type = "target-neutral"
+            disable_processors = ["invalid_arch"]
+        """
+        )
+
+        topology = BuildTopology(self.topology_path)
+        errors = topology.validate_topology()
+
+        self.assertTrue(
+            any("invalid disable_processor" in e for e in errors),
+            f"Expected processor validation error, got: {errors}",
+        )
+
+    def test_stage_features_skip_processor_disabled_artifacts(self):
+        """Test get_stage_features excludes artifacts disabled on a processor."""
+        self.write_topology(
+            """
+            [build_stages.profiler]
+            description = "Profiler"
+            artifact_groups = ["profiler"]
+
+            [artifact_groups.profiler]
+            description = "Profiler"
+            type = "generic"
+
+            [artifacts.profiler-sdk]
+            artifact_group = "profiler"
+            type = "target-neutral"
+            feature_name = "PROFILER_SDK"
+            feature_group = "PROFILER"
+
+            [artifacts.rocprofiler-systems]
+            artifact_group = "profiler"
+            type = "target-neutral"
+            feature_name = "ROCPROFSYS"
+            feature_group = "PROFILER"
+            disable_processors = ["aarch64"]
+        """
+        )
+
+        topology = BuildTopology(self.topology_path)
+
+        features = get_stage_features(topology, "profiler", processor_name="aarch64")
+        self.assertNotIn("ROCPROFSYS", features)
+        self.assertIn("PROFILER_SDK", features)
+
+        features = get_stage_features(topology, "profiler", processor_name="x86_64")
+        self.assertIn("ROCPROFSYS", features)
+        self.assertIn("PROFILER_SDK", features)
+
+    def test_generates_disable_processors_feature(self):
+        """Test generated CMake includes DISABLE_PROCESSORS."""
+        self.write_topology(
+            """
+            [build_stages.profiler]
+            description = "Profiler"
+            artifact_groups = ["profiler"]
+
+            [artifact_groups.profiler]
+            description = "Profiler"
+            type = "generic"
+
+            [artifacts.rocprofiler-systems]
+            artifact_group = "profiler"
+            type = "target-neutral"
+            feature_name = "ROCPROFSYS"
+            feature_group = "PROFILER"
+            disable_processors = ["aarch64"]
+        """
+        )
+
+        topology = BuildTopology(self.topology_path)
+        output = StringIO()
+        generate_feature_declarations(topology, output)
+        cmake = output.getvalue()
+
+        self.assertIn("DISABLE_PROCESSORS aarch64", cmake)
+
+
 class RealTopologyTest(unittest.TestCase):
     """Assertions against the repo's actual BUILD_TOPOLOGY.toml."""
 

--- a/build_tools/topology_to_cmake.py
+++ b/build_tools/topology_to_cmake.py
@@ -217,6 +217,7 @@ def generate_feature_declarations(topology: BuildTopology, f: TextIO):
         requires: list[str],
         *,
         disable_platforms: list[str],
+        disable_processors: list[str],
     ):
         f.write(f"therock_add_feature({feature_name}\n")
         f.write(f"  GROUP {feature_group}\n")
@@ -227,6 +228,11 @@ def generate_feature_declarations(topology: BuildTopology, f: TextIO):
 
         if disable_platforms:
             f.write(f"  DISABLE_PLATFORMS {' '.join(disable_platforms)}\n")
+
+        if disable_processors:
+            f.write(
+                f"  DISABLE_PROCESSORS {' '.join(disable_processors)}\n"
+            )
 
         f.write(")\n")
 
@@ -262,6 +268,7 @@ def generate_feature_declarations(topology: BuildTopology, f: TextIO):
             feature_group,
             requires,
             disable_platforms=[f"${{{disable_platforms_var}}}"],
+            disable_processors=artifact.disable_processors,
         )
         f.write("else()\n")
         write_feature_declaration(
@@ -270,6 +277,7 @@ def generate_feature_declarations(topology: BuildTopology, f: TextIO):
             feature_group,
             requires,
             disable_platforms=[],
+            disable_processors=artifact.disable_processors,
         )
         f.write("endif()\n")
         f.write(f"unset({disable_platforms_var})\n")
@@ -301,6 +309,7 @@ def generate_feature_declarations(topology: BuildTopology, f: TextIO):
                 feature_group,
                 requires,
                 disable_platforms=artifact.disable_platforms,
+                disable_processors=artifact.disable_processors,
             )
         f.write("\n")
 

--- a/build_tools/topology_to_cmake.py
+++ b/build_tools/topology_to_cmake.py
@@ -230,9 +230,7 @@ def generate_feature_declarations(topology: BuildTopology, f: TextIO):
             f.write(f"  DISABLE_PLATFORMS {' '.join(disable_platforms)}\n")
 
         if disable_processors:
-            f.write(
-                f"  DISABLE_PROCESSORS {' '.join(disable_processors)}\n"
-            )
+            f.write(f"  DISABLE_PROCESSORS {' '.join(disable_processors)}\n")
 
         f.write(")\n")
 

--- a/cmake/therock_features.cmake
+++ b/cmake/therock_features.cmake
@@ -14,6 +14,8 @@
 #     be enabled for this feature
 #   THEROCK_PLATFORM_DISABLED_${feature_name}: List of platforms where this
 #     feature is disabled (only set if DISABLE_PLATFORMS is specified)
+#   THEROCK_PROCESSOR_DISABLED_${feature_name}: List of CPU processors where
+#     this feature is disabled (only set if DISABLE_PROCESSORS is specified)
 #   THEROCK_ALL_FEATURES: Added to this global list of features.
 #
 # A feature is enabled by default unless if the GROUP keyword is specified.
@@ -23,8 +25,20 @@ function(therock_add_feature feature_name)
   cmake_parse_arguments(PARSE_ARGV 1 ARG
     ""
     "DEFAULT;GROUP;DESCRIPTION"
-    "REQUIRES;DISABLE_PLATFORMS"
+    "REQUIRES;DISABLE_PLATFORMS;DISABLE_PROCESSORS"
   )
+
+  # Normalize CMAKE_SYSTEM_PROCESSOR to a canonical processor name.
+  string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" _proc_lower)
+  if(_proc_lower MATCHES "^(x86_64|amd64)$")
+    set(_therock_host_arch "x86_64")
+  elseif(_proc_lower MATCHES "^(aarch64|arm64|arm64e|arm64ec)$")
+    set(_therock_host_arch "aarch64")
+  elseif(_proc_lower STREQUAL "ppc64le")
+    set(_therock_host_arch "ppc64le")
+  else()
+    set(_therock_host_arch "${_proc_lower}")
+  endif()
 
   set(_default_enabled ON)
   if(ARG_GROUP)
@@ -43,7 +57,16 @@ function(therock_add_feature feature_name)
     string(TOLOWER "${CMAKE_SYSTEM_NAME}" _system_lower)
     if(_system_lower IN_LIST ARG_DISABLE_PLATFORMS)
       set(_default_enabled OFF)
-      # If user tries to force enable, we'll check later and error
+    endif()
+  endif()
+
+  # Check if current CPU processor is in DISABLE_PROCESSORS list
+  if(ARG_DISABLE_PROCESSORS)
+    set(THEROCK_PROCESSOR_DISABLED_${feature_name} "${ARG_DISABLE_PROCESSORS}")
+    set(THEROCK_PROCESSOR_DISABLED_${feature_name} "${ARG_DISABLE_PROCESSORS}" PARENT_SCOPE)
+
+    if(_therock_host_arch IN_LIST ARG_DISABLE_PROCESSORS)
+      set(_default_enabled OFF)
     endif()
   endif()
 
@@ -56,23 +79,21 @@ function(therock_add_feature feature_name)
     message(FATAL_ERROR "CMake feature already defined: ${feature_name}")
   endif()
 
-  # Filter out requirements that are disabled on the current platform
+  # Filter out requirements that are disabled on the current platform.
+  # Note: processor-disabled requirements are NOT filtered because
+  # DISABLE_PROCESSORS is a soft default that the user can override.
   set(_filtered_requires)
   foreach(require ${ARG_REQUIRES})
     if(NOT DEFINED THEROCK_ENABLE_${require})
       message(FATAL_ERROR "CMake feature order error: ${feature_name} requires ${require} which was not defined first")
     endif()
-    # Check if this requirement is disabled on the current platform
-    # by checking if it's in the list of platform-disabled features
     if(DEFINED THEROCK_PLATFORM_DISABLED_${require})
-      # Skip this requirement on platforms where it's disabled
       string(TOLOWER "${CMAKE_SYSTEM_NAME}" _system_lower)
-      if(NOT _system_lower IN_LIST THEROCK_PLATFORM_DISABLED_${require})
-        list(APPEND _filtered_requires ${require})
+      if(_system_lower IN_LIST THEROCK_PLATFORM_DISABLED_${require})
+        continue()
       endif()
-    else()
-      list(APPEND _filtered_requires ${require})
     endif()
+    list(APPEND _filtered_requires ${require})
   endforeach()
   # Use filtered requirements
   set(ARG_REQUIRES ${_filtered_requires})
@@ -89,6 +110,10 @@ function(therock_add_feature feature_name)
       message(FATAL_ERROR "${feature_name} is not supported on ${CMAKE_SYSTEM_NAME}")
     endif()
   endif()
+
+  # Note: unlike DISABLE_PLATFORMS, DISABLE_PROCESSORS is a soft default.
+  # The feature is OFF by default on matching processors but the user can
+  # override it with -DTHEROCK_ENABLE_<feature>=ON.
 
   set(THEROCK_ENABLE_${feature_name} "${_actual}" PARENT_SCOPE)
   set(THEROCK_REQUIRES_${feature_name} ${ARG_REQUIRES} PARENT_SCOPE)

--- a/docs/development/build_system.md
+++ b/docs/development/build_system.md
@@ -228,6 +228,24 @@ The topology has a three-level hierarchy:
 - `build_tools/_therock_utils/build_topology.py` - Python parser and utilities
 - `build_tools/topology_to_cmake.py` - Generates CMake includes from topology
 
+### Conditional Availability
+
+Artifacts can be conditionally disabled based on the build environment using the
+following fields in `BUILD_TOPOLOGY.toml`:
+
+| Field                | Scope            | Behavior                                                                                                                                                                 | Example                            |
+| -------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------- |
+| `disable_platforms`  | OS platform      | **Hard disable.** The feature is OFF on matching platforms and cannot be overridden. Attempting `-DTHEROCK_ENABLE_<feature>=ON` on a disabled platform is a fatal error. | `disable_platforms = ["windows"]`  |
+| `disable_processors` | CPU architecture | **Soft default.** The feature defaults to OFF on matching processors but can be overridden with `-DTHEROCK_ENABLE_<feature>=ON`.                                         | `disable_processors = ["ppc64le"]` |
+
+The distinction reflects intent: platform disables typically indicate fundamental
+incompatibility (e.g., Linux-only kernel interfaces), while processor disables
+indicate practical issues (e.g., broken dependencies) that an advanced user may
+want to work around.
+
+Canonical processor names: `x86_64`, `aarch64`, `ppc64le`. Platform-specific
+values (e.g., `AMD64`, `ARM64`) are normalized automatically in CMake.
+
 ### Naming Conventions
 
 | Field             | Convention                 | Example           |

--- a/docs/development/development_guide.md
+++ b/docs/development/development_guide.md
@@ -162,6 +162,17 @@ The following CMake flags are mirrored to component projects (see `THEROCK_DEFAU
 - `THEROCK_BINARY_DIR`
 - `ROCM_SYMLINK_LIBS`
 
+#### Feature availability by platform and processor
+
+Some features are not available on all platforms or CPU architectures. Features
+may be hard-disabled on certain OS platforms (cannot be overridden) or
+soft-disabled on certain CPU processors (defaults to OFF but can be overridden
+with `-DTHEROCK_ENABLE_<feature>=ON`).
+
+See [Build Topology — Conditional Availability](./build_system.md#conditional-availability)
+for details on how `disable_platforms` and `disable_processors` work in
+`BUILD_TOPOLOGY.toml`.
+
 In addition, if a component is using the host toolchain, the following are mirrored:
 
 - `CMAKE_C_COMPILER`


### PR DESCRIPTION
## Motivation

Part of work for https://github.com/ROCm/TheRock/issues/5518

ROCm's build system currently supports disabling features by OS platform (`disable_platforms`), but has no mechanism to disable features by CPU architecture.

This PR extends the build feature system to support `disable_processors`, allowing features to be disabled by CPU processor type, and uses it to disable `rocprofiler-systems` on ppc64le as there are several bugs that make it unusable.

## Technical Details

Adds a new `disable_processors` field to the artifact definition in `BUILD_TOPOLOGY.toml`, mirroring the existing `disable_platforms` mechanism. Canonical processor names (`x86_64`, `aarch64`, `ppc64le`) are normalized from platform-specific values (e.g. `AMD64`, `ARM64`) in CMake.

Key design decisions:
- **Soft default, not hard disable:** Unlike `DISABLE_PLATFORMS`, `DISABLE_PROCESSORS` only sets the default to OFF. Users can still override with `-DTHEROCK_ENABLE_<feature>=ON`. This reflects that processor disables are typically due to practical issues (broken dependencies) rather than fundamental incompatibility.
- **Processor-disabled requirements are not filtered from dependency lists**, keeping the override path clean — if a user force-enables a feature, its dependency chain remains intact.

Changes span the full feature stack:
- `BUILD_TOPOLOGY.toml` — adds `disable_processors = ["ppc64le"]` to `rocprofiler-systems` and `rocprofiler-systems-examples`
- `build_tools/_therock_utils/build_topology.py` — parses the new field, adds `is_artifact_disabled_on_processor()`, validates against canonical names, threads `processor_name` through `resolve_project_names_to_features()`
- `build_tools/configure_stage.py` — threads `processor_name` into `get_stage_features()`
- `build_tools/topology_to_cmake.py` — generates `DISABLE_PROCESSORS` in CMake feature declarations
- `cmake/therock_features.cmake` — normalizes `CMAKE_SYSTEM_PROCESSOR` and checks against `DISABLE_PROCESSORS`

## Test Plan

- Built on x86_64 and verified `rocprofiler-systems` and `rocprofiler-systems-examples` are included in the build as expected.
- Built on ppc64le and verified `rocprofiler-systems` and `rocprofiler-systems-examples` are excluded from the build.
- New unit tests (119 lines) added covering: TOML parsing, processor disable checks, invalid processor name validation, stage feature exclusion by processor, and CMake generation of `DISABLE_PROCESSORS`.

## Test Result

All builds succeed. On ppc64le, `rocprofiler-systems` is correctly excluded. On x86_64, behavior is unchanged. Unit tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.