### PR TITLE
Use a fixed "Tarballs" page title instead of bucket-name pattern matching

### DIFF
--- a/build_tools/index_generation_s3_tar.py
+++ b/build_tools/index_generation_s3_tar.py
@@ -99,7 +99,7 @@ def generate_index_s3(
         raise FileNotFoundError(f"No .tar.gz files found in bucket {bucket_name}.")
 
     # Page title
-    page_title = "Tarballs"
+    page_title = "Tarball index"
 
     # Prepare filter options and files array for JS
     gpu_families = extract_gpu_details(files)

--- a/build_tools/index_generation_s3_tar.py
+++ b/build_tools/index_generation_s3_tar.py
@@ -100,14 +100,7 @@ def generate_index_s3(
 
     # Page title
     bucket_lower = bucket_name.lower()
-    if "dev" in bucket_lower:
-        page_title = "ROCm SDK dev tarballs"
-    elif "nightly" in bucket_lower or "nightlies" in bucket_lower:
-        page_title = "ROCm SDK nightly tarballs"
-    elif "prerelease" in bucket_lower:
-        page_title = "ROCm SDK prerelease tarballs"
-    else:
-        page_title = "ROCm SDK tarballs"
+    page_title = "Tarballs"
 
     # Prepare filter options and files array for JS
     gpu_families = extract_gpu_details(files)

--- a/build_tools/index_generation_s3_tar.py
+++ b/build_tools/index_generation_s3_tar.py
@@ -99,7 +99,6 @@ def generate_index_s3(
         raise FileNotFoundError(f"No .tar.gz files found in bucket {bucket_name}.")
 
     # Page title
-    bucket_lower = bucket_name.lower()
     page_title = "Tarballs"
 
     # Prepare filter options and files array for JS


### PR DESCRIPTION
## Summary
  - Replaces the bucket-name pattern matching in `generate_index_s3()` (`index_generation_s3_tar.py`) that guessed a page title from substrings
  like "dev", "nightly"/"nightlies", and "prerelease" in the bucket name with a fixed `"Tarballs"` title.
  - Addresses the immediate fix requested in #7189: per RFC0012, this indexer will be repurposed for per-product local indexes that aren't ROCm
  SDK-specific, so bucket-name-based title guessing no longer applies and was silently falling back to a misleading "ROCm SDK tarballs"
  default.

ISSUE ID: #7189 

  ## Why
  The old logic hard-coded assumptions about bucket naming conventions ("ROCm SDK dev/nightly/prerelease tarballs") that don't hold once this
  indexer is used for arbitrary per-product roots. Rather than keep producing an incorrect/misleading title, this uses a neutral,
  always-correct default.

  ## Follow-up
  Per #7189, a follow-up change will make the title reflect the actual file path or product name being indexed. This PR only covers the
  immediate fix so it can be deployed without waiting on that larger change. Leaving #7189 open for the follow-up.

  Fixes the immediate part of #7189.