### PR TITLE
feat(ci); `test_component.yml` runner priority update for workflow_dispatch triggers

### DIFF
--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -216,19 +216,25 @@ jobs:
       artifact_group: ${{ inputs.artifact_group }}
       amdgpu_families: ${{ inputs.amdgpu_families }}
       amdgpu_targets: ${{ inputs.amdgpu_targets }}
-      # Route to the appropriate runner:
-      #   1. Multi-GPU components use the multi-GPU runner (required for correct execution)
-      #   2. For workflow_dispatch, honor the explicit test_runs_on input if provided
-      #   3. Benchmark components use the dedicated benchmark runner
-      #   4. CPU-only components use standard GitHub runners (azure-linux-scale-rocm)
-      #   5. Per-component runner (set by fetch_test_configurations.py)
+      # Runner selection priority rules:
+      #
+      # 1. USER-TRIGGERED runs (workflow_dispatch or workflow_call): Honor test_runs_on
+      #    input to allow users to test specific runners. This is detected by checking
+      #    that github.actor does NOT contain 'github-actions' (bots like 'github-actions[bot]').
+      #
+      # 2. BOT-TRIGGERED runs (e.g., nightly runs from rockrel) and other events:
+      #    Follow component-based priority:
+      #    a. Multi-GPU components (rccl, rocshmem) use multi_gpu_runner
+      #    b. Benchmark components use benchmark_runs_on
+      #    c. CPU-only components use azure-linux-scale-rocm
+      #    d. All others use per-component test_runner from fetch_test_configurations.py
       test_runs_on: >-
         ${{
-          (matrix.components.multi_gpu_runner != '' &&
-            matrix.components.multi_gpu_runner) ||
-          (github.event_name == 'workflow_dispatch' &&
+          (!contains(github.actor, 'github-actions') &&
             inputs.test_runs_on != '' &&
             inputs.test_runs_on) ||
+          (matrix.components.multi_gpu_runner != '' &&
+            matrix.components.multi_gpu_runner) ||
           (matrix.components.is_benchmark == true &&
             inputs.benchmark_runs_on != '' &&
             inputs.benchmark_runs_on) ||

--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -216,18 +216,14 @@ jobs:
       artifact_group: ${{ inputs.artifact_group }}
       amdgpu_families: ${{ inputs.amdgpu_families }}
       amdgpu_targets: ${{ inputs.amdgpu_targets }}
-      # Runner selection priority rules:
-      #
-      # 1. USER-TRIGGERED runs (workflow_dispatch or workflow_call): Honor test_runs_on
-      #    input to allow users to test specific runners. This is detected by checking
-      #    that github.actor does NOT contain 'github-actions' (bots like 'github-actions[bot]').
-      #
-      # 2. BOT-TRIGGERED runs (e.g., nightly runs from rockrel) and other events:
-      #    Follow component-based priority:
-      #    a. Multi-GPU components (rccl, rocshmem) use multi_gpu_runner
-      #    b. Benchmark components use benchmark_runs_on
-      #    c. CPU-only components use azure-linux-scale-rocm
-      #    d. All others use per-component test_runner from fetch_test_configurations.py
+      # Route to the appropriate runner:
+      #   1. For user-triggered workflow_dispatch, honor test_runs_on input if provided.
+      #      User-triggered means github.actor does NOT contain 'github-actions'.
+      #      Bot-triggered runs (e.g., nightly from rockrel) skip this and use rules below.
+      #   2. Multi-GPU components use the multi-GPU runner (required for correct execution)
+      #   3. Benchmark components use the dedicated benchmark runner
+      #   4. CPU-only components use standard GitHub runners (azure-linux-scale-rocm)
+      #   5. Per-component runner (set by fetch_test_configurations.py)
       test_runs_on: >-
         ${{
           (!contains(github.actor, 'github-actions') &&


### PR DESCRIPTION
Previously, we were running into errors where the test_component ruleset was not obeyed due to workflow dispatch triggers in rockrel

Now, we only support workflow_dispatch inputs (if user-triggered) - working here: https://github.com/ROCm/TheRock/actions/runs/31195115985/job/92922362899#step:1:2

Otherwise, we obey the ruleset (if a bot triggered like here: https://github.com/ROCm/rockrel/actions/runs/31157157060), working here: https://github.com/ROCm/rockrel/actions/runs/31197168830/job/92942923530 with triggered  https://github.com/ROCm/rockrel/actions/runs/31216565619/job/92993606398#logs

the correct runners are used
<img width="1873" height="620" alt="Screenshot 2026-08-07 135047" src="https://github.com/user-attachments/assets/71743e01-d10d-48d6-afaf-b88334a6e6d5" />
https://github.com/ROCm/rockrel/actions/runs/31216565619/job/92993606746#step:1:2

Adding onto ISSUE ID: #7120