### PR TITLE
fix(ml-libs): correct bundle artifact glob for hipdnn integration tests

### DIFF
--- a/ml-libs/artifact-hipdnn-integration-tests.toml
+++ b/ml-libs/artifact-hipdnn-integration-tests.toml
@@ -3,7 +3,7 @@
 include = [
   "bin/*hipdnn_*_test*",
   "bin/hipdnn_integration_tests_ctest/CTestTestfile.cmake",
-  "lib/integration_test_bundles/**",
+  "lib/integration-test-bundles/**",
 ]
 [components.run."ml-libs/hipdnn_integration_tests/stage"]
 include = [


### PR DESCRIPTION
## Summary

- The `artifact-hipdnn-integration-tests.toml` include glob used underscores (`lib/integration_test_bundles/**`) but `rocm-libraries` installs the bundle directory with hyphens (`lib/integration-test-bundles/`).
- This mismatch caused the test tarball to ship without any bundle data, silently skipping all bundle tests in TheRock CI.
- One-character fix: `_` → `-` in the glob pattern.

Closes #7219
JIRA ID : ALMIOPEN-2390

## Test plan

- [ ] Verify TheRock CI test tarball now includes bundle data under `lib/integration-test-bundles/`
- [ ] Confirm bundle tests run (not skip) in the `hipdnn-integration-tests` test component

🤖 Generated with [Claude Code](https://claude.com/claude-code)