### PR TITLE
hip-tests: Exclude compiler-blocked UTs on all families

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_hiptests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiptests.py
@@ -71,9 +71,6 @@ TEST_TO_IGNORE = {
             "Unit_NonHost_Printf_loop",
             "Unit_NonHost_Printf_multiple_Threads",
             "Unit_NonHost_Printf_BufferAvailability",
-            # TODO(#7139): Compiler ww28 SMP 2.5 (TheRock#7052) — re-enable after fix.
-            "Unit_hip_linker_spirv_input",
-            "Unit_hipExtModuleLaunchKernel_CheckCodeObjAttr",
         ]
     },
     "gfx94X-dcgpu": {
@@ -82,17 +79,12 @@ TEST_TO_IGNORE = {
             "Unit_NonHost_Printf_loop",
             "Unit_NonHost_Printf_multiple_Threads",
             "Unit_NonHost_Printf_BufferAvailability",
-            # TODO(#7139): Compiler ww28 SMP 2.5 (TheRock#7052) — re-enable after fix.
-            "Unit_hip_linker_spirv_input",
-            "Unit_hipExtModuleLaunchKernel_CheckCodeObjAttr",
         ]
     },
     "gfx110X-all": {
         "windows": [
             "Unit_hipStreamValue_Wait_Blocking - uint64_t",
             "Unit_hipStreamValue_Wait_Blocking - uint32_t",
-            # TODO(#7139): Compiler ww28 SMP 2.5 (TheRock#7052) — re-enable after fix.
-            "Unit_hipExtModuleLaunchKernel_CheckCodeObjAttr",
         ]
     },
     "gfx125X-dcgpu": {
@@ -101,6 +93,15 @@ TEST_TO_IGNORE = {
         ]
     },
 }
+
+# Tests excluded on every family and platform, merged into the per-family lists
+# above. Use this for failures that are not architecture specific, since nightly
+# runs many more families than presubmit does.
+GENERIC_TEST_TO_IGNORE = [
+    # TODO(#7139): Compiler ww28 SMP 2.5 (TheRock#7052) — re-enable after fix.
+    "Unit_hip_linker_spirv_input",
+    "Unit_hipExtModuleLaunchKernel_CheckCodeObjAttr",
+]
 
 
 def get_asan_lib_path():
@@ -192,8 +193,10 @@ def execute_tests(env):
     if TEST_TYPE == "quick":
         cmd.extend(["-L", "smoke"])
 
+    ignored_tests = list(GENERIC_TEST_TO_IGNORE)
     if AMDGPU_FAMILIES in TEST_TO_IGNORE and os_type in TEST_TO_IGNORE[AMDGPU_FAMILIES]:
-        ignored_tests = TEST_TO_IGNORE[AMDGPU_FAMILIES][os_type]
+        ignored_tests += TEST_TO_IGNORE[AMDGPU_FAMILIES][os_type]
+    if ignored_tests:
         cmd.extend(["--exclude-regex", "|".join(ignored_tests)])
 
     logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")

--- a/build_tools/github_actions/test_executable_scripts/test_hiptests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiptests.py
@@ -71,6 +71,9 @@ TEST_TO_IGNORE = {
             "Unit_NonHost_Printf_loop",
             "Unit_NonHost_Printf_multiple_Threads",
             "Unit_NonHost_Printf_BufferAvailability",
+            # TODO(#7139): Compiler ww28 SMP 2.5 (TheRock#7052) — re-enable after fix.
+            "Unit_hip_linker_spirv_input",
+            "Unit_hipExtModuleLaunchKernel_CheckCodeObjAttr",
         ]
     },
     "gfx94X-dcgpu": {
@@ -79,12 +82,17 @@ TEST_TO_IGNORE = {
             "Unit_NonHost_Printf_loop",
             "Unit_NonHost_Printf_multiple_Threads",
             "Unit_NonHost_Printf_BufferAvailability",
+            # TODO(#7139): Compiler ww28 SMP 2.5 (TheRock#7052) — re-enable after fix.
+            "Unit_hip_linker_spirv_input",
+            "Unit_hipExtModuleLaunchKernel_CheckCodeObjAttr",
         ]
     },
     "gfx110X-all": {
         "windows": [
             "Unit_hipStreamValue_Wait_Blocking - uint64_t",
             "Unit_hipStreamValue_Wait_Blocking - uint32_t",
+            # TODO(#7139): Compiler ww28 SMP 2.5 (TheRock#7052) — re-enable after fix.
+            "Unit_hipExtModuleLaunchKernel_CheckCodeObjAttr",
         ]
     },
     "gfx125X-dcgpu": {


### PR DESCRIPTION
## Summary

Follow-up to #7144, addressing review comment that the list of skipped targets there may not be exhaustive.

#7144 excludes `Unit_hip_linker_spirv_input` and `Unit_hipExtModuleLaunchKernel_CheckCodeObjAttr` per family, covering only the three combinations that ran in the #7052 presubmit. Nightly runs many more families through rockrel's [test_artifacts.yml](https://github.com/ROCm/rockrel/actions/workflows/test_artifacts.yml), so those two tests would still fail there once the compiler promotion lands.

Neither failure is architecture specific — one exercises SPIR-V input linking, the other checks `uniform_work_group_size` code-object metadata — so enumerating families is the wrong shape for them. This moves both into a `GENERIC_TEST_TO_IGNORE` list that is merged into the per-family lists and applies everywhere.

## Revert plan

When #7139 is fixed, empty `GENERIC_TEST_TO_IGNORE` and drop the TODO. The `if ignored_tests:` guard keeps the script correct with an empty list, so nothing else needs changing.

## Related

- Follow-up to: #7144
- Unblocks: #7052
- Tracking: #7139