### PR TITLE
Make bucket layout and public/CDN URLs data-driven, including the repo.amd.com product buckets

### DIFF
--- a/build_tools/_therock_utils/s3_buckets.py
+++ b/build_tools/_therock_utils/s3_buckets.py
@@ -4,9 +4,16 @@
 """Inventory of S3 buckets used by CI/CD systems and related functions.
 
 See docs/development/s3_buckets.md.
+
+Repositories outside TheRock that reuse these build tools against their own
+buckets can extend the in-tree inventory with a JSON registry file, pointed at
+by the ``THEROCK_S3_BUCKETS_FILE`` environment variable or by an explicit
+``--bucket-config-file`` argument. See ``load_bucket_registry_file`` for the
+schema and merge rules.
 """
 
 from dataclasses import dataclass, field, replace
+import json
 import os
 import sys
 
@@ -257,26 +264,341 @@ _RELEASE_STREAM_BY_TYPE = {
 }
 
 
-_bucket_registry_cache: dict[str, S3BucketConfig] | None = None
+# ---------------------------------------------------------------------------
+# Bucket registry
+#
+# The in-tree inventory above, optionally extended by a downstream JSON file.
+# ---------------------------------------------------------------------------
+
+BUCKET_REGISTRY_ENV_VAR = "THEROCK_S3_BUCKETS_FILE"
+
+_SUPPORTED_REGISTRY_VERSIONS = (1,)
+
+_REGISTRY_TOP_LEVEL_KEYS = {
+    "version",
+    "buckets",
+    "artifacts_buckets",
+    "release_buckets",
+}
+_REGISTRY_BUCKET_KEYS = {
+    "name",
+    "region",
+    "iam_account",
+    "iam_role",
+    "key_prefix",
+    "cdn_rules",
+    "namespace_external_repos",
+    "override",
+}
+_REGISTRY_CDN_RULE_KEYS = {"key_prefix", "url_prefix"}
+
+# Selection slots for get_artifacts_bucket_config. "ci" and "ci-external" are
+# separate slots because the shared external bucket is chosen by fork state
+# rather than by release type, and a downstream overriding one should have to
+# say what it wants for the other rather than inherit it silently.
+_ARTIFACTS_SELECTION_SLOTS = _ALLOWED_ARTIFACT_RELEASE_TYPES | {"ci-external"}
 
 
-def _bucket_registry() -> dict[str, S3BucketConfig]:
-    """Bucket configs by name, built on first use.
+class BucketRegistryError(Exception):
+    """A bucket registry file is missing, malformed, or internally inconsistent."""
+
+
+@dataclass(frozen=True)
+class _BucketRegistry:
+    """Resolved bucket inventory plus any downstream selection overrides."""
+
+    buckets: dict[str, S3BucketConfig]
+    artifacts_buckets: dict[str, str]
+    release_buckets: dict[str, dict[str, str]]
+
+
+_registry_cache: _BucketRegistry | None = None
+_bucket_config_file_override: str | None = None
+
+
+def set_bucket_config_file(path: str | os.PathLike | None) -> None:
+    """Point the registry at an explicit file, overriding the environment variable.
+
+    Backs the ``--bucket-config-file`` argument. Like ``THEROCK_S3_BUCKETS_FILE``
+    this sets process-wide state - it writes a module global that every later
+    lookup reads - but the value is stated by the invocation rather than
+    inherited from the environment, so it cannot be picked up unnoticed from a
+    parent process. Prefer it wherever a single invocation should be
+    self-describing; the environment variable exists for wrapper scripts that
+    shell out to many entry points and cannot pass a flag to each.
+
+    Passing None clears the override and falls back to the environment variable.
+    """
+    global _bucket_config_file_override
+    _bucket_config_file_override = os.fspath(path) if path is not None else None
+    reset_bucket_registry()
+
+
+def _registry_file_path() -> str | None:
+    """The registry file to load, if any. The explicit override wins."""
+    env_value = os.environ.get(BUCKET_REGISTRY_ENV_VAR) or None
+    if _bucket_config_file_override is not None:
+        if env_value and env_value != _bucket_config_file_override:
+            _log(
+                f"[INFO] Bucket registry: using --bucket-config-file "
+                f"{_bucket_config_file_override!r}, ignoring "
+                f"{BUCKET_REGISTRY_ENV_VAR}={env_value!r}"
+            )
+        return _bucket_config_file_override
+    return env_value
+
+
+def _reject_unknown_keys(obj: dict, allowed: set[str], what: str, path: str) -> None:
+    """Fail on keys we do not recognize.
+
+    A typo'd ``cdn_rule`` would otherwise mean "this bucket has no CDN", which is
+    exactly the silently-wrong-URL failure this whole mechanism exists to prevent.
+    """
+    unknown = sorted(set(obj) - allowed)
+    if unknown:
+        raise BucketRegistryError(
+            f"{path}: unknown {what} key(s): {', '.join(unknown)}. "
+            f"Allowed: {', '.join(sorted(allowed))}"
+        )
+
+
+def _parse_cdn_rules(entries, bucket_name: str, path: str) -> tuple[CdnRule, ...]:
+    if not isinstance(entries, list):
+        raise BucketRegistryError(
+            f"{path}: bucket {bucket_name!r} 'cdn_rules' must be a list"
+        )
+    rules = []
+    for index, entry in enumerate(entries):
+        where = f"bucket {bucket_name!r} cdn_rules[{index}]"
+        if not isinstance(entry, dict):
+            raise BucketRegistryError(f"{path}: {where} must be an object")
+        _reject_unknown_keys(entry, _REGISTRY_CDN_RULE_KEYS, where, path)
+        for key in sorted(_REGISTRY_CDN_RULE_KEYS):
+            if key not in entry:
+                raise BucketRegistryError(f"{path}: {where} is missing {key!r}")
+        try:
+            rules.append(CdnRule(entry["key_prefix"], entry["url_prefix"]))
+        except (ValueError, AttributeError) as e:
+            raise BucketRegistryError(f"{path}: {where}: {e}") from e
+    return tuple(rules)
+
+
+def _parse_bucket(entry, path: str) -> tuple[S3BucketConfig, bool]:
+    """Parse one bucket entry. Returns (config, override_requested)."""
+    if not isinstance(entry, dict):
+        raise BucketRegistryError(f"{path}: each entry in 'buckets' must be an object")
+    name = entry.get("name")
+    if not isinstance(name, str) or not name:
+        raise BucketRegistryError(
+            f"{path}: each entry in 'buckets' needs a non-empty string 'name'"
+        )
+    _reject_unknown_keys(entry, _REGISTRY_BUCKET_KEYS, f"bucket {name!r}", path)
+
+    key_prefix = entry.get("key_prefix", "")
+    if not isinstance(key_prefix, str):
+        raise BucketRegistryError(
+            f"{path}: bucket {name!r} 'key_prefix' must be a string"
+        )
+
+    namespace_external_repos = entry.get("namespace_external_repos", False)
+    if not isinstance(namespace_external_repos, bool):
+        raise BucketRegistryError(
+            f"{path}: bucket {name!r} 'namespace_external_repos' must be a boolean"
+        )
+
+    # S3BucketConfig.__post_init__ validates and normalizes key_prefix; wrap its
+    # ValueError with the file path, the same way _parse_cdn_rules does for CdnRule.
+    try:
+        config = S3BucketConfig(
+            name=name,
+            region=entry.get("region", "us-east-2"),
+            iam_account=entry.get("iam_account", "692859939525"),
+            iam_role=entry.get("iam_role"),
+            key_prefix=key_prefix,
+            cdn_rules=_parse_cdn_rules(entry.get("cdn_rules", []), name, path),
+            namespace_external_repos=namespace_external_repos,
+        )
+    except ValueError as e:
+        raise BucketRegistryError(f"{path}: bucket {name!r}: {e}") from e
+    return config, bool(entry.get("override", False))
+
+
+def _parse_selection_map(
+    raw,
+    allowed_keys: set[str],
+    buckets: dict[str, S3BucketConfig],
+    what: str,
+    path: str,
+) -> dict[str, str]:
+    if not isinstance(raw, dict):
+        raise BucketRegistryError(f"{path}: {what!r} must be an object")
+    _reject_unknown_keys(raw, allowed_keys, what, path)
+    result = {}
+    for key, value in raw.items():
+        if not isinstance(value, str):
+            raise BucketRegistryError(
+                f"{path}: {what}[{key!r}] must be a bucket name string"
+            )
+        if value not in buckets:
+            raise BucketRegistryError(
+                f"{path}: {what}[{key!r}] names unregistered bucket {value!r}. "
+                f"Add it to 'buckets' in the same file."
+            )
+        result[key] = value
+    return result
+
+
+def load_bucket_registry_file(path: str) -> _BucketRegistry:
+    """Load a registry file and merge it over the in-tree inventory.
+
+    Schema::
+
+        {
+          "version": 1,
+          "buckets": [
+            {
+              "name": "therock-npi-artifacts",
+              "key_prefix": "v3/artifacts/",
+              "iam_role": "therock-npi",
+              "cdn_rules": [
+                {"key_prefix": "v3/artifacts/",
+                 "url_prefix": "https://genesis.example.com/artifacts/"}
+              ]
+            }
+          ],
+          "artifacts_buckets": {
+            "ci": "therock-npi-artifacts",
+            "ci-external": "therock-npi-artifacts"
+          },
+          "release_buckets": {"nightly": {"python": "therock-npi-python"}}
+        }
+
+    ``buckets`` registers bucket metadata. ``artifacts_buckets`` and
+    ``release_buckets`` override *selection*: which bucket the lookup functions
+    choose, which registration alone cannot express because those functions
+    compute a name from a formula.
+
+    Note the two CI slots. ``get_artifacts_bucket_config`` picks ``ci-external``
+    for fork PRs *and* for any repository other than ROCm/TheRock, so a
+    downstream repo lands there for all of its own CI. Set both slots (to the
+    same bucket, if fork PRs need no separate destination). They are separate
+    keys on purpose: overriding only ``ci`` must not silently redirect
+    untrusted fork uploads into a trusted bucket.
+
+    Merge rules:
+
+    * Additive. A name already in the in-tree inventory is rejected unless the
+      entry sets ``"override": true``, in which case it fully replaces the
+      in-tree entry (no field-wise merge) and the replacement is logged.
+      Silently retargeting a production bucket from an inherited environment
+      variable is the worst failure this mechanism could have, so it is opt-in
+      and loud.
+    * Unknown keys at any level are an error, not ignored.
+    * Selection overrides must name a bucket registered in the same file or
+      in-tree.
+    """
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except FileNotFoundError as e:
+        raise BucketRegistryError(f"Bucket registry file not found: {path}") from e
+    except json.JSONDecodeError as e:
+        raise BucketRegistryError(f"{path}: invalid JSON: {e}") from e
+    except OSError as e:
+        raise BucketRegistryError(f"{path}: could not be read: {e}") from e
+
+    if not isinstance(data, dict):
+        raise BucketRegistryError(f"{path}: top level must be a JSON object")
+    _reject_unknown_keys(data, _REGISTRY_TOP_LEVEL_KEYS, "top-level", path)
+
+    version = data.get("version")
+    if version not in _SUPPORTED_REGISTRY_VERSIONS:
+        raise BucketRegistryError(
+            f"{path}: unsupported 'version' {version!r}; "
+            f"this build supports {list(_SUPPORTED_REGISTRY_VERSIONS)}"
+        )
+
+    buckets = {c.name: c for c in s3_bucket_configs}
+    in_tree_names = set(buckets)
+    seen_in_file: set[str] = set()
+
+    raw_buckets = data.get("buckets", [])
+    if not isinstance(raw_buckets, list):
+        raise BucketRegistryError(f"{path}: 'buckets' must be a list")
+    for entry in raw_buckets:
+        config, override_requested = _parse_bucket(entry, path)
+        if config.name in seen_in_file:
+            raise BucketRegistryError(
+                f"{path}: bucket {config.name!r} is defined more than once"
+            )
+        seen_in_file.add(config.name)
+        if config.name in in_tree_names:
+            if not override_requested:
+                raise BucketRegistryError(
+                    f"{path}: bucket {config.name!r} already exists in TheRock's "
+                    f'inventory. Set "override": true on this entry to replace it.'
+                )
+            _log(
+                f"[WARNING] Bucket registry: {path} replaces TheRock's built-in "
+                f"config for bucket {config.name!r}"
+            )
+        buckets[config.name] = config
+
+    artifacts_buckets = _parse_selection_map(
+        data.get("artifacts_buckets", {}),
+        _ARTIFACTS_SELECTION_SLOTS,
+        buckets,
+        "artifacts_buckets",
+        path,
+    )
+
+    raw_release = data.get("release_buckets", {})
+    if not isinstance(raw_release, dict):
+        raise BucketRegistryError(f"{path}: 'release_buckets' must be an object")
+    _reject_unknown_keys(raw_release, _ALLOWED_RELEASE_TYPES, "release_buckets", path)
+    release_buckets = {
+        release_type: _parse_selection_map(
+            inner,
+            _ALLOWED_RELEASE_BUCKET_TYPES,
+            buckets,
+            f"release_buckets[{release_type!r}]",
+            path,
+        )
+        for release_type, inner in raw_release.items()
+    }
+
+    _log(f"[INFO] Bucket registry: loaded {len(seen_in_file)} bucket(s) from {path}")
+    return _BucketRegistry(buckets, artifacts_buckets, release_buckets)
+
+
+def _registry() -> _BucketRegistry:
+    """The resolved registry, built on first use.
 
     Built lazily rather than at import time so that a malformed downstream
     registry file raises where a caller can report it, instead of breaking the
     import of every module that reaches for a bucket config at module scope.
     """
-    global _bucket_registry_cache
-    if _bucket_registry_cache is None:
-        _bucket_registry_cache = {c.name: c for c in s3_bucket_configs}
-    return _bucket_registry_cache
+    global _registry_cache
+    if _registry_cache is None:
+        path = _registry_file_path()
+        if path:
+            _registry_cache = load_bucket_registry_file(path)
+        else:
+            _registry_cache = _BucketRegistry(
+                {c.name: c for c in s3_bucket_configs}, {}, {}
+            )
+    return _registry_cache
+
+
+def _bucket_registry() -> dict[str, S3BucketConfig]:
+    """Bucket configs by name."""
+    return _registry().buckets
 
 
 def reset_bucket_registry() -> None:
     """Discard the cached registry so it is rebuilt on next use (for tests)."""
-    global _bucket_registry_cache
-    _bucket_registry_cache = None
+    global _registry_cache
+    _registry_cache = None
 
 
 def lookup_bucket_config(name: str) -> S3BucketConfig | None:
@@ -295,7 +617,8 @@ def require_bucket_config(name: str) -> S3BucketConfig:
         known = ", ".join(sorted(_bucket_registry()))
         raise KeyError(
             f"Unknown S3 bucket {name!r}. Known buckets: {known}. "
-            f"Buckets outside TheRock can be registered via a JSON registry file."
+            f"Buckets outside TheRock can be registered via a JSON registry file "
+            f"named by {BUCKET_REGISTRY_ENV_VAR} or --bucket-config-file."
         )
     return config
 
@@ -348,18 +671,25 @@ def get_artifacts_bucket_config(
             f"expected one of {_ALLOWED_ARTIFACT_RELEASE_TYPES}"
         )
 
-    if release_type == "ci":
-        if is_pr_from_fork or repository != "ROCm/TheRock":
-            bucket_name = "therock-ci-artifacts-external"
-        else:
-            bucket_name = "therock-ci-artifacts"
+    if release_type == "ci" and (is_pr_from_fork or repository != "ROCm/TheRock"):
+        slot = "ci-external"
+        bucket_name = "therock-ci-artifacts-external"
     else:
+        # BKC builds share the dev/nightly artifact buckets, but keep their own
+        # selection slot so a downstream registry can redirect a BKC channel
+        # without also redirecting the channel it shares a bucket with.
+        slot = release_type
         if release_type == "dev-bkc":
             bucket_name = "therock-dev-artifacts"
         elif release_type == "nightly-bkc":
             bucket_name = "therock-nightly-artifacts"
         else:
             bucket_name = f"therock-{release_type}-artifacts"
+
+    # A downstream registry file can override which bucket a slot selects;
+    # registering a bucket by name is not enough, because the name is computed
+    # here from a formula the downstream repo does not follow.
+    bucket_name = _registry().artifacts_buckets.get(slot, bucket_name)
     return require_bucket_config(bucket_name)
 
 
@@ -376,7 +706,8 @@ def get_release_bucket_config(
 
     Returns:
         S3BucketConfig for the selected release bucket. BKC release types use
-        the corresponding dev or nightly bucket.
+        the corresponding dev or nightly bucket. A registry file can redirect
+        the slot via ``release_buckets``.
 
     Raises:
         ValueError: If release_type or bucket_type is invalid.
@@ -397,6 +728,12 @@ def get_release_bucket_config(
         bucket_name = f"therock-nightly-{bucket_type}"
     else:
         bucket_name = f"therock-{release_type}-{bucket_type}"
+    # See the note in get_artifacts_bucket_config: selection, not registration.
+    # Keyed by the release_type as given, so a BKC channel can be redirected
+    # independently of the dev/nightly bucket it otherwise shares.
+    bucket_name = (
+        _registry().release_buckets.get(release_type, {}).get(bucket_type, bucket_name)
+    )
     return require_bucket_config(bucket_name)
 
 

--- a/build_tools/_therock_utils/s3_buckets.py
+++ b/build_tools/_therock_utils/s3_buckets.py
@@ -6,7 +6,7 @@
 See docs/development/s3_buckets.md.
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 import os
 import sys
 
@@ -15,6 +15,47 @@ def _log(*args, **kwargs):
     """Log to stdout with flush for CI visibility."""
     print(*args, **kwargs)
     sys.stdout.flush()
+
+
+@dataclass(frozen=True)
+class CdnRule:
+    """Maps an S3 key prefix to the public CDN URL prefix that fronts it.
+
+    A bucket may have several rules when different key prefixes are fronted by
+    different CDN paths (e.g. ``v4/deb/`` and ``v4/rpm/``). Resolution picks the
+    longest matching ``key_prefix``, so a bucket-wide rule (``key_prefix=""``)
+    can coexist with more specific ones.
+    """
+
+    key_prefix: str
+    """S3 key prefix this rule applies to (e.g. 'v4/whl/'). Empty matches the whole bucket."""
+
+    url_prefix: str
+    """Public URL replacing key_prefix (e.g. 'https://rocm.nightlies.amd.com/whl-multi-arch/')."""
+
+    def __post_init__(self):
+        key_prefix = self.key_prefix
+        url_prefix = self.url_prefix
+        # Validate rather than coerce: these values can come from a downstream
+        # registry file (see THEROCK_S3_BUCKETS_FILE) and a malformed entry
+        # would otherwise put a broken link in a CI job summary.
+        if key_prefix.startswith("/"):
+            raise ValueError(
+                f"CdnRule key_prefix must not start with '/' (S3 keys have no "
+                f"leading slash), got {key_prefix!r}"
+            )
+        if not url_prefix.startswith("https://"):
+            raise ValueError(
+                f"CdnRule url_prefix must start with 'https://', got {url_prefix!r}"
+            )
+        # Normalize to trailing slashes so prefix swapping never joins or splits
+        # a path component.
+        if key_prefix and not key_prefix.endswith("/"):
+            key_prefix += "/"
+        if not url_prefix.endswith("/"):
+            url_prefix += "/"
+        object.__setattr__(self, "key_prefix", key_prefix)
+        object.__setattr__(self, "url_prefix", url_prefix)
 
 
 @dataclass(frozen=True)
@@ -33,6 +74,37 @@ class S3BucketConfig:
     iam_role: str | None = field(default=None)
     """IAM role name that grants write access to this bucket (e.g. 'therock-ci'), if any"""
 
+    key_prefix: str = field(default="")
+    """Key prefix prepended to every object this bucket stores (e.g. 'v3/artifacts/').
+
+    Normalized to a trailing '/' when non-empty. Empty for all of TheRock's own
+    buckets, which store at the bucket root. Downstream repositories that share a
+    bucket layout under a versioned prefix set this via a registry file.
+    Independent of ``cdn_rules``: TheRock's release buckets have no ``key_prefix``
+    but do have prefix-specific CDN rules.
+    """
+
+    cdn_rules: tuple[CdnRule, ...] = field(default=())
+    """CDN mappings for this bucket, if any. A tuple so the dataclass stays hashable."""
+
+    namespace_external_repos: bool = field(default=False)
+    """Whether uploads are namespaced by '{owner}-{repo}/' (shared external bucket)."""
+
+    def __post_init__(self):
+        # Same contract as CdnRule.key_prefix, enforced in the same place: the
+        # trailing slash is what keeps prefix concatenation from joining two path
+        # components (key_prefix='v3' would yield 'v34242-linux'). Enforced on the
+        # dataclass rather than only where configs are parsed, so a config built
+        # directly in Python cannot violate an invariant the docstrings promise.
+        key_prefix = self.key_prefix
+        if key_prefix.startswith("/"):
+            raise ValueError(
+                f"S3BucketConfig key_prefix must not start with '/' (S3 keys have "
+                f"no leading slash), got {key_prefix!r}"
+            )
+        if key_prefix and not key_prefix.endswith("/"):
+            object.__setattr__(self, "key_prefix", key_prefix + "/")
+
     @property
     def write_access_iam_role(self) -> str | None:
         """IAM role granting write access to the bucket"""
@@ -45,34 +117,117 @@ class S3BucketConfig:
         return f"arn:aws:iam::{self.iam_account}:role/{self.iam_role}"
 
 
+# CloudFront distribution roots fronting the release buckets. These same URLs are
+# already user-facing elsewhere in the tree (e.g. setup_venv.py's package index map).
+_DEV_CDN = "https://rocm.devreleases.amd.com/"
+_NIGHTLY_CDN = "https://rocm.nightlies.amd.com/"
+_PRERELEASE_CDN = "https://rocm.prereleases.amd.com/"
+_RELEASE_CDN = "https://repo.amd.com/rocm/"
+
+
+# The key prefixes below come from publish_rocm_to_release_buckets.py, which writes
+# python packages to "v4/whl" and tarballs to "v4/tarball" for every release type,
+# and native packages to "v4/{deb,rpm}/{date}-{run_id}" for dev and nightly.
+#
+# Deliberately NOT mapped, because the CDN layout is not a prefix rewrite of the
+# bucket and a wrong rule would silently produce a link to the wrong file:
+#   * prerelease/release native packages - those CDNs serve a distro-partitioned
+#     apt/dnf repo (debian12/, ubuntu2204/, rhel8/, gpg/, ...), not v4/packages/{deb,rpm}/.
+#   * ASAN prefixes (v4/tarball-asan/, v4/packages-asan/) - no CDN is published.
+#   * The artifacts buckets - no CDN, matching the '-' column in s3_buckets.md.
+# A bucket with no matching rule falls back to its raw S3 URL, which is the
+# behavior every caller had before CDN rules existed.
+#
+# All 12 rules below were checked against the live CloudFront distributions on
+# 2026-08-03; see the pull request for what was and was not proven.
+def _whl_cdn_rules(cdn: str) -> tuple[CdnRule, ...]:
+    return (CdnRule("v4/whl/", cdn + "whl-multi-arch/"),)
+
+
+def _tarball_cdn_rules(cdn: str) -> tuple[CdnRule, ...]:
+    return (CdnRule("v4/tarball/", cdn + "tarball-multi-arch/"),)
+
+
+def _package_cdn_rules(cdn: str) -> tuple[CdnRule, ...]:
+    return (
+        CdnRule("v4/deb/", cdn + "packages-multi-arch/deb/"),
+        CdnRule("v4/rpm/", cdn + "packages-multi-arch/rpm/"),
+    )
+
+
 s3_bucket_configs = [
     # CI (external repos use OIDC with therock-ci-external; fork PRs use runner base credentials)
     S3BucketConfig("therock-ci-artifacts", iam_role="therock-ci"),
-    S3BucketConfig("therock-ci-artifacts-external", iam_role="therock-ci-external"),
+    S3BucketConfig(
+        "therock-ci-artifacts-external",
+        iam_role="therock-ci-external",
+        namespace_external_repos=True,
+    ),
     # Release type "dev"
     S3BucketConfig("therock-dev-artifacts", iam_role="therock-dev"),
-    S3BucketConfig("therock-dev-packages", iam_role="therock-dev"),
-    S3BucketConfig("therock-dev-python", iam_role="therock-dev"),
-    S3BucketConfig("therock-dev-tarball", iam_role="therock-dev"),
+    S3BucketConfig(
+        "therock-dev-packages",
+        iam_role="therock-dev",
+        cdn_rules=_package_cdn_rules(_DEV_CDN),
+    ),
+    S3BucketConfig(
+        "therock-dev-python",
+        iam_role="therock-dev",
+        cdn_rules=_whl_cdn_rules(_DEV_CDN),
+    ),
+    S3BucketConfig(
+        "therock-dev-tarball",
+        iam_role="therock-dev",
+        cdn_rules=_tarball_cdn_rules(_DEV_CDN),
+    ),
     # Release type "nightly"
     S3BucketConfig("therock-nightly-artifacts", iam_role="therock-nightly"),
-    S3BucketConfig("therock-nightly-packages", iam_role="therock-nightly"),
-    S3BucketConfig("therock-nightly-python", iam_role="therock-nightly"),
-    S3BucketConfig("therock-nightly-tarball", iam_role="therock-nightly"),
+    S3BucketConfig(
+        "therock-nightly-packages",
+        iam_role="therock-nightly",
+        cdn_rules=_package_cdn_rules(_NIGHTLY_CDN),
+    ),
+    S3BucketConfig(
+        "therock-nightly-python",
+        iam_role="therock-nightly",
+        cdn_rules=_whl_cdn_rules(_NIGHTLY_CDN),
+    ),
+    S3BucketConfig(
+        "therock-nightly-tarball",
+        iam_role="therock-nightly",
+        cdn_rules=_tarball_cdn_rules(_NIGHTLY_CDN),
+    ),
     # Release type "prerelease"
     S3BucketConfig("therock-prerelease-artifacts", iam_role="therock-prerelease"),
+    # TODO: therock-prerelease-packages has a CDN, but it serves a distro-partitioned
+    # repo rather than a rewrite of this bucket's v4/packages/{deb,rpm}/ layout.
     S3BucketConfig("therock-prerelease-packages", iam_role="therock-prerelease"),
-    S3BucketConfig("therock-prerelease-python", iam_role="therock-prerelease"),
-    S3BucketConfig("therock-prerelease-tarball", iam_role="therock-prerelease"),
+    S3BucketConfig(
+        "therock-prerelease-python",
+        iam_role="therock-prerelease",
+        cdn_rules=_whl_cdn_rules(_PRERELEASE_CDN),
+    ),
+    S3BucketConfig(
+        "therock-prerelease-tarball",
+        iam_role="therock-prerelease",
+        cdn_rules=_tarball_cdn_rules(_PRERELEASE_CDN),
+    ),
     # Release type "release" (no automated credentials for uploading)
     S3BucketConfig("therock-release-artifacts", iam_role=None),
+    # TODO: see the therock-prerelease-packages note above.
     S3BucketConfig("therock-release-packages", iam_role=None),
-    S3BucketConfig("therock-release-python", iam_role=None),
-    S3BucketConfig("therock-release-tarball", iam_role=None),
+    S3BucketConfig(
+        "therock-release-python",
+        iam_role=None,
+        cdn_rules=_whl_cdn_rules(_RELEASE_CDN),
+    ),
+    S3BucketConfig(
+        "therock-release-tarball",
+        iam_role=None,
+        cdn_rules=_tarball_cdn_rules(_RELEASE_CDN),
+    ),
 ]
 
-
-_BUCKET_CONFIGS_BY_NAME = {c.name: c for c in s3_bucket_configs}
 
 _ALLOWED_ARTIFACT_RELEASE_TYPES = {
     "ci",
@@ -100,6 +255,75 @@ _RELEASE_STREAM_BY_TYPE = {
     "nightly-bkc": "bkc",
     "prerelease": "rc",
 }
+
+
+_bucket_registry_cache: dict[str, S3BucketConfig] | None = None
+
+
+def _bucket_registry() -> dict[str, S3BucketConfig]:
+    """Bucket configs by name, built on first use.
+
+    Built lazily rather than at import time so that a malformed downstream
+    registry file raises where a caller can report it, instead of breaking the
+    import of every module that reaches for a bucket config at module scope.
+    """
+    global _bucket_registry_cache
+    if _bucket_registry_cache is None:
+        _bucket_registry_cache = {c.name: c for c in s3_bucket_configs}
+    return _bucket_registry_cache
+
+
+def reset_bucket_registry() -> None:
+    """Discard the cached registry so it is rebuilt on next use (for tests)."""
+    global _bucket_registry_cache
+    _bucket_registry_cache = None
+
+
+def lookup_bucket_config(name: str) -> S3BucketConfig | None:
+    """Look up a bucket config by name, or None if the bucket is unknown."""
+    return _bucket_registry().get(name)
+
+
+def require_bucket_config(name: str) -> S3BucketConfig:
+    """Look up a bucket config by name.
+
+    Raises:
+        KeyError: If no bucket with that name is registered.
+    """
+    config = lookup_bucket_config(name)
+    if config is None:
+        known = ", ".join(sorted(_bucket_registry()))
+        raise KeyError(
+            f"Unknown S3 bucket {name!r}. Known buckets: {known}. "
+            f"Buckets outside TheRock can be registered via a JSON registry file."
+        )
+    return config
+
+
+def all_bucket_configs() -> tuple[S3BucketConfig, ...]:
+    """Every registered bucket config, in registration order."""
+    return tuple(_bucket_registry().values())
+
+
+def resolve_public_url(bucket: str, relative_path: str, *, default: str) -> str:
+    """Resolve the public (CDN) URL for an object, falling back to ``default``.
+
+    The longest matching ``CdnRule.key_prefix`` wins, so a bucket-wide rule can
+    coexist with prefix-specific ones. Buckets that are unknown or have no
+    matching rule resolve to ``default`` (normally the raw S3 URL).
+
+    Args:
+        bucket: S3 bucket name.
+        relative_path: Full S3 key, including any bucket ``key_prefix``.
+        default: URL to return when no CDN rule applies.
+    """
+    config = lookup_bucket_config(bucket)
+    if config is None:
+        return default
+    for rule in sorted(config.cdn_rules, key=lambda r: len(r.key_prefix), reverse=True):
+        if relative_path.startswith(rule.key_prefix):
+            return rule.url_prefix + relative_path[len(rule.key_prefix) :]
+    return default
 
 
 def get_artifacts_bucket_config(
@@ -136,7 +360,7 @@ def get_artifacts_bucket_config(
             bucket_name = "therock-nightly-artifacts"
         else:
             bucket_name = f"therock-{release_type}-artifacts"
-    return _BUCKET_CONFIGS_BY_NAME[bucket_name]
+    return require_bucket_config(bucket_name)
 
 
 def get_release_bucket_config(
@@ -173,7 +397,7 @@ def get_release_bucket_config(
         bucket_name = f"therock-nightly-{bucket_type}"
     else:
         bucket_name = f"therock-{release_type}-{bucket_type}"
-    return _BUCKET_CONFIGS_BY_NAME[bucket_name]
+    return require_bucket_config(bucket_name)
 
 
 def get_release_stream(release_type: str) -> str:
@@ -313,11 +537,9 @@ def get_artifacts_bucket_config_for_workflow_run(
     # so the configure-aws-credentials step is skipped.
     if is_pr_from_fork and config.iam_role is not None:
         _log("  Fork PR detected, skipping OIDC (using runner base credentials)")
-        config = S3BucketConfig(
-            name=config.name,
-            region=config.region,
-            iam_account=config.iam_account,
-            iam_role=None,
-        )
+        # Use dataclasses.replace rather than rebuilding field-by-field, so that
+        # fields added to S3BucketConfig later are carried over instead of being
+        # silently reset to their defaults on every fork PR.
+        config = replace(config, iam_role=None)
 
     return config

--- a/build_tools/_therock_utils/s3_buckets.py
+++ b/build_tools/_therock_utils/s3_buckets.py
@@ -97,6 +97,22 @@ class S3BucketConfig:
     namespace_external_repos: bool = field(default=False)
     """Whether uploads are namespaced by '{owner}-{repo}/' (shared external bucket)."""
 
+    anonymous_s3_read: bool = field(default=True)
+    """Whether the bucket can be read over raw S3 without credentials.
+
+    Machine-consumed URLs (a pip index, an apt/dnf base URL, a tarball download)
+    prefer the raw S3 URL when this is True, because CI reads there avoid
+    CloudFront data-transfer charges - see docs/development/s3_buckets.md. When
+    it is False the CDN is the only public way in, so those URLs must go through
+    ``cdn_rules`` instead; falling back to raw S3 would hand out a URL that
+    answers 403.
+
+    This is a fact about the bucket rather than a policy about the caller, which
+    is why it lives here. The prerelease buckets grant no anonymous read
+    (ROCm/TheRock#2139), and downstream repositories whose buckets are entirely
+    private set it via a registry file.
+    """
+
     def __post_init__(self):
         # Same contract as CdnRule.key_prefix, enforced in the same place: the
         # trailing slash is what keeps prefix concatenation from joining two path
@@ -124,15 +140,77 @@ class S3BucketConfig:
         return f"arn:aws:iam::{self.iam_account}:role/{self.iam_role}"
 
 
-# CloudFront distribution roots fronting the release buckets. These same URLs are
-# already user-facing elsewhere in the tree (e.g. setup_venv.py's package index map).
+# ---------------------------------------------------------------------------
+# repo.amd.com streams and products (RFC0012)
+#
+# Every stream is served from its own subdomain, and the folder hierarchy under
+# each one is identical. Both facts come straight from
+# docs/rfcs/RFC0012-Repo-Structure.md, so the URL is derived from a formula
+# rather than transcribed per stream: a stream that has not finished cutting
+# over yet needs no follow-up edit here when it does.
+# ---------------------------------------------------------------------------
+_ALLOWED_RELEASE_PRODUCTS = {"core", "pytorch", "jax"}
+
+_RELEASE_STREAM_BY_TYPE = {
+    "dev": "dev",
+    "dev-bkc": "bkc",
+    "nightly": "nightly",
+    "nightly-bkc": "bkc",
+    "prerelease": "rc",
+}
+
+# The key prefix every product bucket stores under, stripped from the public URL:
+# s3://therock-repo-amd-nightly-core/v5/rocm/core/tarball/X is served at
+# https://nightly.repo.amd.com/rocm/core/tarball/X.
+_PRODUCT_KEY_PREFIX = "v5/"
+
+
+def release_stream_url(stream: str) -> str:
+    """Public root for a repo.amd.com stream, e.g. 'https://nightly.repo.amd.com/'."""
+    return f"https://{stream}.repo.amd.com/"
+
+
+def _product_cdn_rules(stream: str) -> tuple[CdnRule, ...]:
+    return (CdnRule(_PRODUCT_KEY_PREFIX, release_stream_url(stream)),)
+
+
+def _product_release_bucket_configs() -> list[S3BucketConfig]:
+    """Final publication buckets, one per (stream, product).
+
+    Cross-account (324352301041) and reachable only through the stream CDN;
+    anonymous S3 reads are refused, verified 2026-08-25.
+    """
+    return [
+        S3BucketConfig(
+            f"therock-repo-amd-{stream}-{product}",
+            iam_account="324352301041",
+            iam_role=f"therock-repo-{stream}-{product}",
+            key_prefix=_PRODUCT_KEY_PREFIX,
+            cdn_rules=_product_cdn_rules(stream),
+            anonymous_s3_read=False,
+        )
+        # Sorted for a stable inventory order; the set is small and fixed.
+        for stream in sorted(set(_RELEASE_STREAM_BY_TYPE.values()))
+        for product in sorted(_ALLOWED_RELEASE_PRODUCTS)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Legacy release CDNs (pre-RFC0012 layout)
+#
+# These distributions front the therock-{release_type}-{python,tarball,packages}
+# buckets. Those buckets are no longer publication targets - since the
+# repo.amd.com rewire, publish_rocm_to_release_buckets.py writes to the product
+# buckets below - but they still serve every release made under the old layout,
+# so the mappings stay. See docs/development/s3_buckets.md.
+# ---------------------------------------------------------------------------
 _DEV_CDN = "https://rocm.devreleases.amd.com/"
 _NIGHTLY_CDN = "https://rocm.nightlies.amd.com/"
 _PRERELEASE_CDN = "https://rocm.prereleases.amd.com/"
 _RELEASE_CDN = "https://repo.amd.com/rocm/"
 
 
-# The key prefixes below come from publish_rocm_to_release_buckets.py, which writes
+# The key prefixes below come from publish_rocm_to_release_buckets.py, which wrote
 # python packages to "v4/whl" and tarballs to "v4/tarball" for every release type,
 # and native packages to "v4/{deb,rpm}/{date}-{run_id}" for dev and nightly.
 #
@@ -144,9 +222,6 @@ _RELEASE_CDN = "https://repo.amd.com/rocm/"
 #   * The artifacts buckets - no CDN, matching the '-' column in s3_buckets.md.
 # A bucket with no matching rule falls back to its raw S3 URL, which is the
 # behavior every caller had before CDN rules existed.
-#
-# All 12 rules below were checked against the live CloudFront distributions on
-# 2026-08-03; see the pull request for what was and was not proven.
 def _whl_cdn_rules(cdn: str) -> tuple[CdnRule, ...]:
     return (CdnRule("v4/whl/", cdn + "whl-multi-arch/"),)
 
@@ -176,6 +251,7 @@ s3_bucket_configs = [
         "therock-dev-packages",
         iam_role="therock-dev",
         cdn_rules=_package_cdn_rules(_DEV_CDN),
+        anonymous_s3_read=False,
     ),
     S3BucketConfig(
         "therock-dev-python",
@@ -193,6 +269,7 @@ s3_bucket_configs = [
         "therock-nightly-packages",
         iam_role="therock-nightly",
         cdn_rules=_package_cdn_rules(_NIGHTLY_CDN),
+        anonymous_s3_read=False,
     ),
     S3BucketConfig(
         "therock-nightly-python",
@@ -208,31 +285,41 @@ s3_bucket_configs = [
     S3BucketConfig("therock-prerelease-artifacts", iam_role="therock-prerelease"),
     # TODO: therock-prerelease-packages has a CDN, but it serves a distro-partitioned
     # repo rather than a rewrite of this bucket's v4/packages/{deb,rpm}/ layout.
-    S3BucketConfig("therock-prerelease-packages", iam_role="therock-prerelease"),
+    S3BucketConfig(
+        "therock-prerelease-packages",
+        iam_role="therock-prerelease",
+        anonymous_s3_read=False,
+    ),
     S3BucketConfig(
         "therock-prerelease-python",
         iam_role="therock-prerelease",
         cdn_rules=_whl_cdn_rules(_PRERELEASE_CDN),
+        anonymous_s3_read=False,
     ),
     S3BucketConfig(
         "therock-prerelease-tarball",
         iam_role="therock-prerelease",
         cdn_rules=_tarball_cdn_rules(_PRERELEASE_CDN),
+        anonymous_s3_read=False,
     ),
     # Release type "release" (no automated credentials for uploading)
     S3BucketConfig("therock-release-artifacts", iam_role=None),
     # TODO: see the therock-prerelease-packages note above.
-    S3BucketConfig("therock-release-packages", iam_role=None),
+    S3BucketConfig("therock-release-packages", iam_role=None, anonymous_s3_read=False),
     S3BucketConfig(
         "therock-release-python",
         iam_role=None,
         cdn_rules=_whl_cdn_rules(_RELEASE_CDN),
+        anonymous_s3_read=False,
     ),
     S3BucketConfig(
         "therock-release-tarball",
         iam_role=None,
         cdn_rules=_tarball_cdn_rules(_RELEASE_CDN),
+        anonymous_s3_read=False,
     ),
+    # Final publication buckets for the repo.amd.com product layout.
+    *_product_release_bucket_configs(),
 ]
 
 
@@ -254,14 +341,9 @@ _ALLOWED_RELEASE_TYPES = {
 }
 
 _ALLOWED_RELEASE_BUCKET_TYPES = {"tarball", "python", "packages"}
-_ALLOWED_RELEASE_PRODUCTS = {"core", "pytorch", "jax"}
-_RELEASE_STREAM_BY_TYPE = {
-    "dev": "dev",
-    "dev-bkc": "bkc",
-    "nightly": "nightly",
-    "nightly-bkc": "bkc",
-    "prerelease": "rc",
-}
+
+# _ALLOWED_RELEASE_PRODUCTS and _RELEASE_STREAM_BY_TYPE are defined above the
+# bucket inventory, which is generated from them.
 
 
 # ---------------------------------------------------------------------------
@@ -279,6 +361,7 @@ _REGISTRY_TOP_LEVEL_KEYS = {
     "buckets",
     "artifacts_buckets",
     "release_buckets",
+    "product_release_buckets",
 }
 _REGISTRY_BUCKET_KEYS = {
     "name",
@@ -288,6 +371,7 @@ _REGISTRY_BUCKET_KEYS = {
     "key_prefix",
     "cdn_rules",
     "namespace_external_repos",
+    "anonymous_s3_read",
     "override",
 }
 _REGISTRY_CDN_RULE_KEYS = {"key_prefix", "url_prefix"}
@@ -310,6 +394,7 @@ class _BucketRegistry:
     buckets: dict[str, S3BucketConfig]
     artifacts_buckets: dict[str, str]
     release_buckets: dict[str, dict[str, str]]
+    product_release_buckets: dict[str, dict[str, str]]
 
 
 _registry_cache: _BucketRegistry | None = None
@@ -406,6 +491,12 @@ def _parse_bucket(entry, path: str) -> tuple[S3BucketConfig, bool]:
             f"{path}: bucket {name!r} 'namespace_external_repos' must be a boolean"
         )
 
+    anonymous_s3_read = entry.get("anonymous_s3_read", True)
+    if not isinstance(anonymous_s3_read, bool):
+        raise BucketRegistryError(
+            f"{path}: bucket {name!r} 'anonymous_s3_read' must be a boolean"
+        )
+
     # S3BucketConfig.__post_init__ validates and normalizes key_prefix; wrap its
     # ValueError with the file path, the same way _parse_cdn_rules does for CdnRule.
     try:
@@ -417,6 +508,7 @@ def _parse_bucket(entry, path: str) -> tuple[S3BucketConfig, bool]:
             key_prefix=key_prefix,
             cdn_rules=_parse_cdn_rules(entry.get("cdn_rules", []), name, path),
             namespace_external_repos=namespace_external_repos,
+            anonymous_s3_read=anonymous_s3_read,
         )
     except ValueError as e:
         raise BucketRegistryError(f"{path}: bucket {name!r}: {e}") from e
@@ -567,8 +659,29 @@ def load_bucket_registry_file(path: str) -> _BucketRegistry:
         for release_type, inner in raw_release.items()
     }
 
+    raw_products = data.get("product_release_buckets", {})
+    if not isinstance(raw_products, dict):
+        raise BucketRegistryError(
+            f"{path}: 'product_release_buckets' must be an object"
+        )
+    _reject_unknown_keys(
+        raw_products, _ALLOWED_RELEASE_TYPES, "product_release_buckets", path
+    )
+    product_release_buckets = {
+        release_type: _parse_selection_map(
+            inner,
+            _ALLOWED_RELEASE_PRODUCTS,
+            buckets,
+            f"product_release_buckets[{release_type!r}]",
+            path,
+        )
+        for release_type, inner in raw_products.items()
+    }
+
     _log(f"[INFO] Bucket registry: loaded {len(seen_in_file)} bucket(s) from {path}")
-    return _BucketRegistry(buckets, artifacts_buckets, release_buckets)
+    return _BucketRegistry(
+        buckets, artifacts_buckets, release_buckets, product_release_buckets
+    )
 
 
 def _registry() -> _BucketRegistry:
@@ -585,7 +698,7 @@ def _registry() -> _BucketRegistry:
             _registry_cache = load_bucket_registry_file(path)
         else:
             _registry_cache = _BucketRegistry(
-                {c.name: c for c in s3_bucket_configs}, {}, {}
+                {c.name: c for c in s3_bucket_configs}, {}, {}, {}
             )
     return _registry_cache
 
@@ -628,25 +741,43 @@ def all_bucket_configs() -> tuple[S3BucketConfig, ...]:
     return tuple(_bucket_registry().values())
 
 
+def cdn_url_for(bucket: str, relative_path: str) -> str | None:
+    """CDN URL for an object, or None when no rule covers it.
+
+    The longest matching ``CdnRule.key_prefix`` wins, so a bucket-wide rule can
+    coexist with prefix-specific ones.
+
+    This is the ``str | None`` form, for callers that must not fall back to a raw
+    S3 URL: a value handed to pip, or an object in a bucket that refuses
+    anonymous reads. Callers that do have a sensible fallback want
+    ``resolve_public_url``.
+
+    Args:
+        bucket: S3 bucket name.
+        relative_path: Full S3 key, including any bucket ``key_prefix``.
+    """
+    config = lookup_bucket_config(bucket)
+    if config is None:
+        return None
+    for rule in sorted(config.cdn_rules, key=lambda r: len(r.key_prefix), reverse=True):
+        if relative_path.startswith(rule.key_prefix):
+            return rule.url_prefix + relative_path[len(rule.key_prefix) :]
+    return None
+
+
 def resolve_public_url(bucket: str, relative_path: str, *, default: str) -> str:
     """Resolve the public (CDN) URL for an object, falling back to ``default``.
 
-    The longest matching ``CdnRule.key_prefix`` wins, so a bucket-wide rule can
-    coexist with prefix-specific ones. Buckets that are unknown or have no
-    matching rule resolve to ``default`` (normally the raw S3 URL).
+    Buckets that are unknown or have no matching rule resolve to ``default``
+    (normally the raw S3 URL).
 
     Args:
         bucket: S3 bucket name.
         relative_path: Full S3 key, including any bucket ``key_prefix``.
         default: URL to return when no CDN rule applies.
     """
-    config = lookup_bucket_config(bucket)
-    if config is None:
-        return default
-    for rule in sorted(config.cdn_rules, key=lambda r: len(r.key_prefix), reverse=True):
-        if relative_path.startswith(rule.key_prefix):
-            return rule.url_prefix + relative_path[len(rule.key_prefix) :]
-    return default
+    url = cdn_url_for(bucket, relative_path)
+    return default if url is None else url
 
 
 def get_artifacts_bucket_config(
@@ -780,11 +911,18 @@ def get_product_release_bucket_config(
             f"product={product!r} is invalid, "
             f"expected one of {_ALLOWED_RELEASE_PRODUCTS}"
         )
-    return S3BucketConfig(
-        name=f"therock-repo-amd-{stream}-{product}",
-        iam_account="324352301041",
-        iam_role=f"therock-repo-{stream}-{product}",
+    # Looked up rather than constructed here, so these buckets carry the same
+    # key_prefix and cdn_rules as every other entry and StorageLocation can
+    # derive their public URLs. The config is otherwise identical to the one
+    # this function used to build inline.
+    bucket_name = f"therock-repo-amd-{stream}-{product}"
+    # See the note in get_artifacts_bucket_config: selection, not registration.
+    bucket_name = (
+        _registry()
+        .product_release_buckets.get(release_type, {})
+        .get(product, bucket_name)
     )
+    return require_bucket_config(bucket_name)
 
 
 def get_release_package_index_url(release_type: str) -> str:

--- a/build_tools/_therock_utils/storage_location.py
+++ b/build_tools/_therock_utils/storage_location.py
@@ -14,6 +14,8 @@ Usage::
     loc.s3_uri        # "s3://my-bucket/some/path/file.tar.xz"
     loc.https_url     # "https://my-bucket.s3.amazonaws.com/some/path/file.tar.xz"
     loc.public_url    # CDN URL if the bucket has one, else https_url
+    loc.download_url  # what a credential-less tool should fetch: raw S3 for a
+                      # publicly readable bucket, the CDN otherwise
     loc.local_path(Path("/tmp/staging"))  # Path("/tmp/staging/some/path/file.tar.xz")
 """
 
@@ -31,6 +33,8 @@ class StorageLocation:
     - ``.s3_uri`` - For AWS CLI uploads (``s3://bucket/path/file.tar.xz``)
     - ``.https_url`` - Raw S3 URL (``https://bucket.s3.amazonaws.com/...``)
     - ``.public_url`` - CDN URL where one is configured, else ``.https_url``
+    - ``.download_url`` - For pip/apt/curl: raw S3 when the bucket allows
+      anonymous reads, the CDN when it does not
     - ``.local_path(staging_dir)`` - For local testing (``Path("/tmp/staging/...")``)
     - ``.relative_path`` - Backend-agnostic relative path from the bucket/staging root
     """
@@ -72,6 +76,43 @@ class StorageLocation:
         return resolve_public_url(
             self.bucket, self.relative_path, default=self.https_url
         )
+
+    @property
+    def download_url(self) -> str:
+        """URL a tool without AWS credentials should fetch this object from.
+
+        For pip indexes, apt/dnf base URLs and plain downloads - the URLs that
+        end up in a command line rather than in a job summary.
+
+        Prefers the raw S3 URL, because CI reads there avoid CloudFront
+        data-transfer charges, and falls back to the CDN for buckets that refuse
+        anonymous S3 reads. That choice is driven by the bucket's
+        ``anonymous_s3_read`` flag rather than by a rule about the call site: the
+        prerelease and release buckets are private (ROCm/TheRock#2139) and so are
+        downstream repositories' buckets, and handing any of those a raw S3 URL
+        produces a link that answers 403.
+
+        Unlike ``.public_url`` this raises rather than silently returning a URL
+        that cannot be fetched: a private bucket with no CDN rule covering the
+        key has no public download URL at all, and discovering that from a 403
+        in a build log is worse than discovering it here.
+        """
+        # Deferred import, for the same reason as public_url above.
+        from _therock_utils.s3_buckets import cdn_url_for, lookup_bucket_config
+
+        config = lookup_bucket_config(self.bucket)
+        if config is None or config.anonymous_s3_read:
+            return self.https_url
+
+        url = cdn_url_for(self.bucket, self.relative_path)
+        if url is None:
+            raise ValueError(
+                f"Bucket {self.bucket!r} refuses anonymous S3 reads and has no CDN "
+                f"rule covering {self.relative_path!r}, so this object has no "
+                f"public download URL. Add a cdn_rule for it in "
+                f"_therock_utils/s3_buckets.py, or read it with credentials."
+            )
+        return url
 
     def local_path(self, staging_dir: Path) -> Path:
         """Local filesystem path for this location.

--- a/build_tools/_therock_utils/storage_location.py
+++ b/build_tools/_therock_utils/storage_location.py
@@ -13,6 +13,7 @@ Usage::
     loc = StorageLocation("my-bucket", "some/path/file.tar.xz")
     loc.s3_uri        # "s3://my-bucket/some/path/file.tar.xz"
     loc.https_url     # "https://my-bucket.s3.amazonaws.com/some/path/file.tar.xz"
+    loc.public_url    # CDN URL if the bucket has one, else https_url
     loc.local_path(Path("/tmp/staging"))  # Path("/tmp/staging/some/path/file.tar.xz")
 """
 
@@ -28,7 +29,8 @@ class StorageLocation:
     Use the properties/methods to get the representation you need:
 
     - ``.s3_uri`` - For AWS CLI uploads (``s3://bucket/path/file.tar.xz``)
-    - ``.https_url`` - For public links (``https://bucket.s3.amazonaws.com/...``)
+    - ``.https_url`` - Raw S3 URL (``https://bucket.s3.amazonaws.com/...``)
+    - ``.public_url`` - CDN URL where one is configured, else ``.https_url``
     - ``.local_path(staging_dir)`` - For local testing (``Path("/tmp/staging/...")``)
     - ``.relative_path`` - Backend-agnostic relative path from the bucket/staging root
     """
@@ -46,8 +48,30 @@ class StorageLocation:
 
     @property
     def https_url(self) -> str:
-        """Public HTTPS URL for browser access."""
+        """Raw S3 HTTPS URL, bypassing any CDN.
+
+        Prefer ``.public_url`` for links a human will click. This stays the raw
+        S3 URL for machine-consumed URLs (package indexes, apt/dnf base URLs) and
+        for existence probes, where a CDN cache could give a stale answer and
+        where CI reads deliberately avoid CloudFront data-transfer charges. See
+        docs/development/s3_buckets.md.
+        """
         return f"https://{self.bucket}.s3.amazonaws.com/{self.relative_path}"
+
+    @property
+    def public_url(self) -> str:
+        """Public URL for browser access, via the bucket's CDN when it has one.
+
+        Falls back to ``.https_url`` for buckets with no CDN rule covering this
+        key, which is every bucket TheRock's CI writes build outputs to.
+        """
+        # Deferred import: storage_location is bundled into the artifact index
+        # Lambda and must stay free of import-time project dependencies.
+        from _therock_utils.s3_buckets import resolve_public_url
+
+        return resolve_public_url(
+            self.bucket, self.relative_path, default=self.https_url
+        )
 
     def local_path(self, staging_dir: Path) -> Path:
         """Local filesystem path for this location.

--- a/build_tools/_therock_utils/workflow_outputs.py
+++ b/build_tools/_therock_utils/workflow_outputs.py
@@ -51,7 +51,10 @@ import platform as platform_module
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 
 from _therock_utils.storage_location import StorageLocation
-from _therock_utils.s3_buckets import get_artifacts_bucket_config_for_workflow_run
+from _therock_utils.s3_buckets import (
+    S3BucketConfig,
+    get_artifacts_bucket_config_for_workflow_run,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -82,15 +85,32 @@ class WorkflowOutputRoot:
     platform: str
     """Platform name ('linux' or 'windows')."""
 
+    key_prefix: str = ""
+    """Key prefix the bucket stores everything under (e.g. 'v3/artifacts/').
+
+    Materialized from ``S3BucketConfig.key_prefix``, the same way ``bucket`` is
+    materialized from ``S3BucketConfig.name``. Empty for all of TheRock's own
+    buckets. Must end with '/' when non-empty.
+
+    This is distinct from ``external_repo``: ``key_prefix`` is a property of the
+    bucket's layout, while ``external_repo`` namespaces one fork's uploads within
+    that layout. Downstream repositories that share a bucket under a versioned
+    prefix set the former and leave the latter meaning what it says.
+    """
+
     # -- Root -------------------------------------------------------------------
 
     @property
     def prefix(self) -> str:
         """Relative path prefix for this run (no trailing slash).
 
-        This is the common root for all outputs from this run.
+        This is the common root for all outputs from this run. The bucket's
+        ``key_prefix`` is folded in here rather than applied by each backend, so
+        that the ``relative_path`` of every ``StorageLocation`` below *is* the
+        full S3 key and needs no further adjustment by callers that consume raw
+        keys.
         """
-        return f"{self.external_repo}{self.run_id}-{self.platform}"
+        return f"{self.key_prefix}{self.external_repo}{self.run_id}-{self.platform}"
 
     def root(self) -> StorageLocation:
         """Location for the run output root (where build artifacts live)."""
@@ -313,17 +333,18 @@ class WorkflowOutputRoot:
         workflow_run_id = (
             run_id if lookup_workflow_run and workflow_run is None else None
         )
-        external_repo, bucket = _retrieve_bucket_info(
+        external_repo, bucket_config = _retrieve_bucket_info(
             github_repository=github_repository,
             workflow_run_id=workflow_run_id,
             workflow_run=workflow_run,
             release_type=release_type,
         )
         return cls(
-            bucket=bucket,
+            bucket=bucket_config.name,
             external_repo=external_repo,
             run_id=run_id,
             platform=platform,
+            key_prefix=bucket_config.key_prefix,
         )
 
     @classmethod
@@ -355,16 +376,18 @@ def _retrieve_bucket_info(
     workflow_run_id: str | None = None,
     workflow_run: dict | None = None,
     release_type: str | None = None,
-) -> tuple[str, str]:
-    """Determine S3 bucket and external_repo prefix for a workflow run.
+) -> tuple[str, S3BucketConfig]:
+    """Determine S3 bucket config and external_repo prefix for a workflow run.
 
     This is an internal implementation detail — use
     `WorkflowOutputRoot.from_workflow_run` instead.
 
     Returns:
-        Tuple of ``(external_repo, bucket)`` where:
+        Tuple of ``(external_repo, bucket_config)`` where:
         - external_repo: ``''`` for ROCm/TheRock, or ``'{owner}-{repo}/'``
-        - bucket: S3 bucket name
+        - bucket_config: the resolved ``S3BucketConfig``. The whole config is
+          returned rather than just the name so the caller can also pick up
+          ``key_prefix``.
     """
     if not github_repository:
         github_repository = os.environ.get("GITHUB_REPOSITORY", "ROCm/TheRock")
@@ -378,7 +401,7 @@ def _retrieve_bucket_info(
     owner, repo_name = github_repository.split("/")
     external_repo = (
         f"{owner}-{repo_name}/"
-        if artifact_bucket_config.name == "therock-ci-artifacts-external"
+        if artifact_bucket_config.namespace_external_repos
         else ""
     )
-    return (external_repo, artifact_bucket_config.name)
+    return (external_repo, artifact_bucket_config)

--- a/build_tools/artifact_manager.py
+++ b/build_tools/artifact_manager.py
@@ -70,6 +70,7 @@ from _therock_utils.artifact_backend import (
 )
 from _therock_utils.artifacts import ArtifactName, ArtifactPopulator
 from _therock_utils.hash_util import calculate_hash
+from _therock_utils.s3_buckets import set_bucket_config_file
 from _therock_utils.workflow_outputs import WorkflowOutputRoot
 
 # Component types that artifacts are split into
@@ -1205,6 +1206,15 @@ def _add_backend_args(parser: argparse.ArgumentParser):
         default=os.getenv("THEROCK_LOCAL_STAGING_DIR"),
         help="Local staging directory (sets THEROCK_LOCAL_STAGING_DIR)",
     )
+    parser.add_argument(
+        "--bucket-config-file",
+        type=Path,
+        default=None,
+        help="JSON file registering S3 buckets outside TheRock's inventory, and "
+        "optionally overriding which bucket each release type selects. Takes "
+        "precedence over the THEROCK_S3_BUCKETS_FILE environment variable. "
+        "See build_tools/_therock_utils/s3_buckets.py for the schema.",
+    )
 
 
 def main(argv: Optional[List[str]] = None):
@@ -1390,6 +1400,16 @@ def main(argv: Optional[List[str]] = None):
     local_staging_dir = getattr(args, "local_staging_dir", None)
     if local_staging_dir:
         os.environ["THEROCK_LOCAL_STAGING_DIR"] = str(local_staging_dir)
+
+    # Point the bucket registry at an explicit file, if one was given. Note this
+    # IS process-wide: it sets a module global that every backend built below
+    # reads, including both ends of `copy`. That is intended - the registry
+    # answers "which buckets exist and where do they map", which is one fact per
+    # process. What varies per end of a `copy` is the transport, which is why
+    # that is a separate flag (--source-transport) rather than more registry state.
+    bucket_config_file = getattr(args, "bucket_config_file", None)
+    if bucket_config_file:
+        set_bucket_config_file(bucket_config_file)
 
     args.func(args)
 

--- a/build_tools/find_artifacts_for_commit.py
+++ b/build_tools/find_artifacts_for_commit.py
@@ -50,15 +50,12 @@ from _therock_utils.cmake_amdgpu_targets import (
 )
 
 
-# TODO: wrap `ArtifactBackend` (or `S3Backend`) class here? Or use `BucketMetadata`?
-#       (we have a few classes tracking similar metadata and reimplementing URL schemes)
 @dataclass
 class ArtifactRunInfo:
     """Information about a workflow run's artifacts."""
 
     git_commit_sha: str
     github_repository_name: str
-    external_repo: str  # e.g. "ROCm-TheRock" (used for namespacing, may be empty)
 
     platform: str  # "linux" or "windows"
     artifact_group: str  # e.g., "gfx94X-dcgpu", "gfx950-dcgpu-asan"
@@ -69,7 +66,13 @@ class ArtifactRunInfo:
     workflow_run_conclusion: str | None  # "success", "failure", None if in_progress
     workflow_run_html_url: str
 
-    s3_bucket: str  # e.g. "therock-ci-artifacts"
+    output_root: WorkflowOutputRoot
+    """Canonical path computation for this run.
+
+    The S3 properties below delegate here rather than re-deriving the layout, so
+    that a bucket with a non-empty ``key_prefix`` is handled correctly instead of
+    silently producing a path that does not exist.
+    """
 
     # Artifact inspection constraints.
     amdgpu_targets: tuple[str, ...] = ()
@@ -84,16 +87,29 @@ class ArtifactRunInfo:
         return f"https://github.com/{self.github_repository_name}/commit/{self.git_commit_sha}"
 
     @property
+    def external_repo(self) -> str:
+        """e.g. 'ROCm-TheRock/' (used for namespacing, may be empty)."""
+        return self.output_root.external_repo
+
+    @property
+    def s3_bucket(self) -> str:
+        """e.g. 'therock-ci-artifacts'."""
+        return self.output_root.bucket
+
+    @property
     def s3_path(self) -> str:
-        return f"{self.external_repo}{self.workflow_run_id}-{self.platform}/"
+        return f"{self.output_root.prefix}/"
 
     @property
     def s3_uri(self) -> str:
-        return f"s3://{self.s3_bucket}/{self.s3_path}"
+        return self.output_root.root().s3_uri
 
     @property
     def s3_index_url(self) -> str:
-        return f"https://{self.s3_bucket}.s3.amazonaws.com/{self.s3_path}index.html"
+        # Raw S3 URL, not .public_url: this is the target of an existence probe
+        # (see check_if_artifacts_exist), where a CDN cache could report an object
+        # that has since been deleted, or miss one just written.
+        return self.output_root.artifact_index().https_url
 
     def print(self):
         """Prints artifact info in a human-readable format."""
@@ -369,7 +385,6 @@ def _find_artifacts_in_workflow_runs(
             info = ArtifactRunInfo(
                 git_commit_sha=commit,
                 github_repository_name=github_repository_name,
-                external_repo=output_root.external_repo,
                 platform=platform,
                 artifact_group=group,
                 workflow_file_name=workflow_file_name,
@@ -383,7 +398,7 @@ def _find_artifacts_in_workflow_runs(
                     "html_url",
                     "",
                 ),
-                s3_bucket=output_root.bucket,
+                output_root=output_root,
                 amdgpu_targets=tuple(amdgpu_targets),
                 required_artifact_patterns=tuple(required_artifact_patterns),
             )

--- a/build_tools/github_actions/configure_multi_arch_ci_summary.py
+++ b/build_tools/github_actions/configure_multi_arch_ci_summary.py
@@ -202,15 +202,17 @@ def _append_build_rocm(
         )
         if platform_name == "linux":
             linux_output_root = output_root
-        log_url = output_root.log_root_index().https_url
-        artifact_url = output_root.artifact_index().https_url
-        manifest_url = output_root.manifests_index().https_url
+        # These land in the job summary table for a human to click, so they use
+        # .public_url and pick up the bucket's CDN when it has one.
+        log_url = output_root.log_root_index().public_url
+        artifact_url = output_root.artifact_index().public_url
+        manifest_url = output_root.manifests_index().public_url
         lines.append(
             f"{platform_name.capitalize()} | {log_url} | {artifact_url} | {manifest_url}"
         )
     manifest_diff_url = linux_output_root.log_file(
         "manifest-diff", "index.html"
-    ).https_url
+    ).public_url
     lines.append(f"Manifest diff *(if produced)* | {manifest_diff_url} | — | —")
     lines.append("")
     lines.append(

--- a/build_tools/github_actions/post_build_upload.py
+++ b/build_tools/github_actions/post_build_upload.py
@@ -184,22 +184,24 @@ def write_gha_build_summary(
 ):
     log(f"Adding links to job summary for {output_root.prefix}")
 
-    log_index_url = output_root.log_index(artifact_group).https_url
+    # Every URL here is a link a human clicks in the job summary, so it goes
+    # through .public_url to pick up the bucket's CDN when it has one.
+    log_index_url = output_root.log_index(artifact_group).public_url
     gha_append_step_summary(f"[Build Logs]({log_index_url})")
 
     observability_path = build_dir / "logs" / "build_observability.html"
     if observability_path.is_file():
-        analysis_url = output_root.build_observability(artifact_group).https_url
+        analysis_url = output_root.build_observability(artifact_group).public_url
         gha_append_step_summary(f"[Build Observability]({analysis_url})")
     else:
         log("[INFO] Build Observability: Not generated")
 
     # Only add artifact links if the job not failed
     if not job_status or job_status == "success":
-        artifact_url = output_root.artifact_index().https_url
+        artifact_url = output_root.artifact_index().public_url
         gha_append_step_summary(f"[Artifacts]({artifact_url})")
 
-    manifest_url = output_root.manifest(artifact_group).https_url
+    manifest_url = output_root.manifest(artifact_group).public_url
     gha_append_step_summary(f"[TheRock Manifest]({manifest_url})")
 
 

--- a/build_tools/github_actions/tests/conftest.py
+++ b/build_tools/github_actions/tests/conftest.py
@@ -16,7 +16,7 @@ import pytest
 # Add build_tools to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
-from _therock_utils.s3_buckets import reset_bucket_registry
+from _therock_utils.s3_buckets import set_bucket_config_file
 
 
 @pytest.fixture(autouse=True)
@@ -24,10 +24,10 @@ def _reset_bucket_registry():
     """Rebuild the S3 bucket registry around every test.
 
     The registry is cached after first use, so a test that points
-    THEROCK_S3_BUCKETS_FILE at a fixture would otherwise leak its buckets into
-    every test that runs after it in the same process. Reset on both sides so
-    the leak cannot travel in either direction.
+    THEROCK_S3_BUCKETS_FILE (or --bucket-config-file) at a fixture would
+    otherwise leak its buckets into every test that runs after it in the same
+    process. Reset on both sides so the leak cannot travel in either direction.
     """
-    reset_bucket_registry()
+    set_bucket_config_file(None)
     yield
-    reset_bucket_registry()
+    set_bucket_config_file(None)

--- a/build_tools/github_actions/tests/conftest.py
+++ b/build_tools/github_actions/tests/conftest.py
@@ -1,7 +1,12 @@
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-"""Pytest configuration for build_tools tests."""
+"""Pytest configuration for build_tools/github_actions tests.
+
+This is a separate pytest testpath from build_tools/tests (see the ``testpaths``
+list in build_tools/pyproject.toml), so it needs its own copy of the fixtures
+that must apply to every test in the process.
+"""
 
 import sys
 from pathlib import Path
@@ -9,7 +14,7 @@ from pathlib import Path
 import pytest
 
 # Add build_tools to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from _therock_utils.s3_buckets import reset_bucket_registry
 

--- a/build_tools/github_actions/upload_python_packages.py
+++ b/build_tools/github_actions/upload_python_packages.py
@@ -186,9 +186,12 @@ def write_gha_upload_summary(
               all per-target wheels
             - [...] non-empty: legacy per-family mode — per-family install links
     """
+    # These URLs go into the job summary for a human to click, so they use the
+    # CDN where the bucket has one. The machine-consumed find-links URL emitted
+    # by run() deliberately stays on the raw S3 URL.
     if families:
         # Legacy per-family multi-arch
-        base_url = packages_loc.https_url
+        base_url = packages_loc.public_url
         family_links = "\n".join(
             f"- [{family}]({base_url}/{family}/index.html)" for family in families
         )
@@ -206,7 +209,7 @@ Per-family indexes:
 """
     elif families is not None:
         # kpack-split flat build — single index covers all per-target wheels
-        index_url = f"{packages_loc.https_url}/index.html"
+        index_url = f"{packages_loc.public_url}/index.html"
         install_instructions_markdown = f"""[ROCm Python packages (kpack-split)]({index_url})
 Replace `<YOUR_TARGET>` with your GPU target (e.g. `gfx942`, `gfx1201`):
 ```bash
@@ -216,7 +219,7 @@ pip install rocm[libraries,devel,device-<YOUR_TARGET>] --pre {LINE_CONTINUATION_
 """
     else:
         # Single-arch: traditional index URL
-        index_url = f"{packages_loc.https_url}/index.html"
+        index_url = f"{packages_loc.public_url}/index.html"
         install_instructions_markdown = f"""[ROCm Python packages]({index_url})
 ```bash
 pip install rocm[libraries,devel] --pre {LINE_CONTINUATION_CHAR}
@@ -270,6 +273,10 @@ def run(args: argparse.Namespace):
     upload_packages(dist_dir=dist_dir, packages_loc=packages_loc, backend=backend)
 
     if not args.output_dir:
+        # package_find_links_url is consumed by CI pip installs, not clicked by a
+        # human, so it stays on the raw S3 URL rather than .public_url: CI reads
+        # the backing bucket directly to avoid CloudFront data-transfer charges.
+        # See docs/development/s3_buckets.md ("Public URLs and CDN").
         if args.multiarch:
             # Detect flat (kpack-split) vs legacy per-family layout from dist/.
             # Dot-directories (e.g. .kpack_staging) are staging artifacts, not

--- a/build_tools/github_actions/upload_tarballs.py
+++ b/build_tools/github_actions/upload_tarballs.py
@@ -47,6 +47,10 @@ logger = logging.getLogger(__name__)
 
 
 def _tarball_url(output_root: WorkflowOutputRoot, name: str) -> str:
+    # Emitted as a workflow output for downstream jobs to download, not as a link
+    # a human clicks, so it stays on the raw S3 URL rather than .public_url: CI
+    # reads the backing bucket directly to avoid CloudFront data-transfer charges.
+    # See docs/development/s3_buckets.md ("Public URLs and CDN").
     return output_root.tarball(quote(name, safe="")).https_url
 
 

--- a/build_tools/github_actions/upload_test_report_script.py
+++ b/build_tools/github_actions/upload_test_report_script.py
@@ -100,7 +100,7 @@ def run(args: argparse.Namespace):
     # is omitted or empty; otherwise legacy base_uri + log_destination (backward compat).
     log_dest = (args.log_destination or "").strip()
     if log_dest:
-        base_uri = f"s3://{output_root.bucket}/{output_root.prefix}"
+        base_uri = output_root.root().s3_uri
         dest_s3_uri = f"{base_uri.rstrip('/')}/{log_dest.lstrip('/')}"
     else:
         dest_s3_uri = output_root.log_dir(args.subfolder).s3_uri

--- a/build_tools/github_actions/upload_test_report_script.py
+++ b/build_tools/github_actions/upload_test_report_script.py
@@ -108,7 +108,9 @@ def run(args: argparse.Namespace):
     create_index_file(args)
     upload_test_report(args.report_path, dest_s3_uri)
 
-    report_url = output_root.log_file(args.subfolder, args.index_file_name).https_url
+    # Job summary link for a human to click: resolve through the bucket's CDN
+    # when it has one.
+    report_url = output_root.log_file(args.subfolder, args.index_file_name).public_url
     gha_append_step_summary(f"[Report (S3)]({report_url})")
 
 

--- a/build_tools/packaging/linux/upload_package_repo.py
+++ b/build_tools/packaging/linux/upload_package_repo.py
@@ -688,6 +688,11 @@ def _package_install_url(bucket: str, prefix: str, pkg_type: str) -> str:
     For RPM repos, dnf/yum baseurl must point to the x86_64/ subdirectory
     (the directory containing repodata/). For DEB repos, apt points to the
     repo root (it resolves dists/ itself).
+
+    This is an apt/dnf baseurl consumed by a package manager, not a link a human
+    clicks, so it stays on the raw S3 URL rather than .public_url: CI reads the
+    backing bucket directly to avoid CloudFront data-transfer charges. See
+    docs/development/s3_buckets.md ("Public URLs and CDN").
     """
     base = StorageLocation(bucket, prefix).https_url
     if pkg_type == "rpm":

--- a/build_tools/tests/artifact_backend_test.py
+++ b/build_tools/tests/artifact_backend_test.py
@@ -22,6 +22,7 @@ from _therock_utils.artifact_backend import (
     create_backend_from_env,
 )
 from _therock_utils.workflow_outputs import WorkflowOutputRoot
+from _therock_utils.s3_buckets import S3BucketConfig, require_bucket_config
 
 
 def _make_local_root(run_id="test-run-123", platform="linux"):
@@ -680,7 +681,7 @@ class TestCreateBackendFromEnv(unittest.TestCase):
     @mock.patch("_therock_utils.workflow_outputs._retrieve_bucket_info")
     def test_s3_backend_when_no_local_dir(self, mock_retrieve):
         """Test that S3Backend is created when THEROCK_LOCAL_STAGING_DIR is not set."""
-        mock_retrieve.return_value = ("", "test-bucket")
+        mock_retrieve.return_value = ("", S3BucketConfig(name="test-bucket"))
         with mock.patch.dict(
             os.environ,
             {"THEROCK_RUN_ID": "s3-run-id"},
@@ -699,7 +700,7 @@ class TestCreateBackendFromEnv(unittest.TestCase):
         When running on a fork (GITHUB_REPOSITORY=SomeUser/TheRock), passing
         github_repository="ROCm/TheRock" should use the main repo's bucket.
         """
-        mock_retrieve.return_value = ("", "therock-ci-artifacts")
+        mock_retrieve.return_value = ("", require_bucket_config("therock-ci-artifacts"))
         with mock.patch.dict(
             os.environ,
             {

--- a/build_tools/tests/conftest.py
+++ b/build_tools/tests/conftest.py
@@ -11,7 +11,7 @@ import pytest
 # Add build_tools to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from _therock_utils.s3_buckets import reset_bucket_registry
+from _therock_utils.s3_buckets import set_bucket_config_file
 
 
 @pytest.fixture(autouse=True)
@@ -19,10 +19,10 @@ def _reset_bucket_registry():
     """Rebuild the S3 bucket registry around every test.
 
     The registry is cached after first use, so a test that points
-    THEROCK_S3_BUCKETS_FILE at a fixture would otherwise leak its buckets into
-    every test that runs after it in the same process. Reset on both sides so
-    the leak cannot travel in either direction.
+    THEROCK_S3_BUCKETS_FILE (or --bucket-config-file) at a fixture would
+    otherwise leak its buckets into every test that runs after it in the same
+    process. Reset on both sides so the leak cannot travel in either direction.
     """
-    reset_bucket_registry()
+    set_bucket_config_file(None)
     yield
-    reset_bucket_registry()
+    set_bucket_config_file(None)

--- a/build_tools/tests/find_artifacts_for_commit_test.py
+++ b/build_tools/tests/find_artifacts_for_commit_test.py
@@ -529,7 +529,6 @@ class ConcreteArtifactInspectionTest(unittest.TestCase):
         return ArtifactRunInfo(
             git_commit_sha="abc123",
             github_repository_name="ROCm/TheRock",
-            external_repo="",
             platform="linux",
             artifact_group=artifact_group,
             workflow_file_name="multi_arch_ci.yml",
@@ -537,7 +536,12 @@ class ConcreteArtifactInspectionTest(unittest.TestCase):
             workflow_run_status="completed",
             workflow_run_conclusion="success",
             workflow_run_html_url="https://example.invalid/run/123",
-            s3_bucket="therock-ci-artifacts",
+            output_root=WorkflowOutputRoot(
+                bucket="therock-ci-artifacts",
+                external_repo="",
+                run_id="123",
+                platform="linux",
+            ),
             amdgpu_targets=amdgpu_targets,
             required_artifact_patterns=required_patterns,
         )

--- a/build_tools/tests/s3_buckets_test.py
+++ b/build_tools/tests/s3_buckets_test.py
@@ -17,6 +17,7 @@ from _therock_utils.s3_buckets import (
     CdnRule,
     S3BucketConfig,
     all_bucket_configs,
+    cdn_url_for,
     get_artifacts_bucket_config,
     get_artifacts_bucket_config_for_workflow_run,
     get_product_release_bucket_config,
@@ -26,9 +27,11 @@ from _therock_utils.s3_buckets import (
     lookup_bucket_config,
     require_bucket_config,
     reset_bucket_registry,
+    release_stream_url,
     resolve_public_url,
     set_bucket_config_file,
 )
+from _therock_utils.storage_location import StorageLocation
 
 
 # ---------------------------------------------------------------------------
@@ -565,6 +568,162 @@ class TestArtifactsBucketsHaveNoCdn(unittest.TestCase):
                     self.assertEqual(config.cdn_rules, ())
 
 
+class TestProductReleaseBuckets(unittest.TestCase):
+    """The repo.amd.com product buckets, now registered rather than synthesized.
+
+    Registering them is what lets StorageLocation derive their public URLs; the
+    price is that get_product_release_bucket_config must keep returning exactly
+    what it built inline before, which the first test below pins field by field.
+    """
+
+    # What get_product_release_bucket_config constructed before these buckets
+    # joined the inventory. Written out rather than imported so that a change to
+    # the inventory cannot quietly redefine what "unchanged" means.
+    EXPECTED = {
+        "dev": ("therock-repo-amd-dev-core", "therock-repo-dev-core"),
+        "dev-bkc": ("therock-repo-amd-bkc-core", "therock-repo-bkc-core"),
+        "nightly": ("therock-repo-amd-nightly-core", "therock-repo-nightly-core"),
+        "nightly-bkc": ("therock-repo-amd-bkc-core", "therock-repo-bkc-core"),
+        "prerelease": ("therock-repo-amd-rc-core", "therock-repo-rc-core"),
+    }
+
+    def test_identical_to_the_previously_synthesized_config(self):
+        for release_type, (name, role) in self.EXPECTED.items():
+            with self.subTest(release_type=release_type):
+                config = get_product_release_bucket_config(release_type, "core")
+                self.assertEqual(config.name, name)
+                self.assertEqual(config.iam_role, role)
+                self.assertEqual(config.iam_account, "324352301041")
+                self.assertEqual(config.region, "us-east-2")
+                self.assertEqual(
+                    config.write_access_iam_role,
+                    f"arn:aws:iam::324352301041:role/{role}",
+                )
+
+    def test_v5_prefix_is_stripped_in_the_public_url(self):
+        """The whole point of registering them: v5/ in the bucket, gone on the CDN.
+
+        Asserted as literal URLs rather than rebuilt from release_stream_url, so
+        a wrong formula cannot agree with itself.
+        """
+        cases = [
+            (
+                "therock-repo-amd-dev-core",
+                "v5/rocm/core/tarball/therock-dist-linux-gfx94X-dcgpu-7.10.0.tar.gz",
+                "https://dev.repo.amd.com/rocm/core/tarball/"
+                "therock-dist-linux-gfx94X-dcgpu-7.10.0.tar.gz",
+            ),
+            (
+                "therock-repo-amd-nightly-core",
+                "v5/rocm/core/whl-next/rocm-sdk-core/rocm_sdk_core-7.13.0.whl",
+                "https://nightly.repo.amd.com/rocm/core/whl-next/rocm-sdk-core/"
+                "rocm_sdk_core-7.13.0.whl",
+            ),
+            (
+                "therock-repo-amd-rc-core",
+                "v5/rocm/core/packages/deb/",
+                "https://rc.repo.amd.com/rocm/core/packages/deb/",
+            ),
+            (
+                "therock-repo-amd-bkc-core",
+                "v5/rocm/core/tarball/therock-dist-linux-gfx950-dcgpu-7.10.0.tar.gz",
+                "https://bkc.repo.amd.com/rocm/core/tarball/"
+                "therock-dist-linux-gfx950-dcgpu-7.10.0.tar.gz",
+            ),
+            (
+                "therock-repo-amd-nightly-pytorch",
+                "v5/rocm/pytorch/whl-next/torch/torch-2.9.0.whl",
+                "https://nightly.repo.amd.com/rocm/pytorch/whl-next/torch/"
+                "torch-2.9.0.whl",
+            ),
+        ]
+        for bucket, key, expected in cases:
+            with self.subTest(bucket=bucket):
+                self.assertEqual(StorageLocation(bucket, key).public_url, expected)
+
+    def test_bkc_streams_resolve_like_any_other(self):
+        """Both BKC release types share one stream, and it rewrites normally."""
+        for release_type in ("dev-bkc", "nightly-bkc"):
+            with self.subTest(release_type=release_type):
+                config = get_product_release_bucket_config(release_type, "core")
+                self.assertEqual(config.name, "therock-repo-amd-bkc-core")
+                self.assertEqual(
+                    cdn_url_for(config.name, "v5/rocm/core/tarball/x.tar.gz"),
+                    "https://bkc.repo.amd.com/rocm/core/tarball/x.tar.gz",
+                )
+
+    def test_release_stream_url(self):
+        for stream in ("dev", "nightly", "weekly", "rc", "stable", "bkc"):
+            with self.subTest(stream=stream):
+                self.assertEqual(
+                    release_stream_url(stream), f"https://{stream}.repo.amd.com/"
+                )
+
+    def test_every_product_bucket_has_a_rule(self):
+        """No stream is a special case; the formula covers the whole inventory."""
+        for config in all_bucket_configs():
+            if config.name.startswith("therock-repo-amd-"):
+                with self.subTest(bucket=config.name):
+                    self.assertEqual(len(config.cdn_rules), 1)
+                    self.assertEqual(config.key_prefix, "v5/")
+
+    def test_invalid_product_is_rejected(self):
+        with self.assertRaises(ValueError):
+            get_product_release_bucket_config("nightly", "tensorflow")
+
+
+class TestAnonymousS3Read(unittest.TestCase):
+    """download_url picks raw S3 or the CDN from a fact about the bucket.
+
+    Verified against the live buckets on 2026-08-25 by requesting a key that
+    does not exist: a public bucket answers 404 NoSuchKey, a private one answers
+    403 AccessDenied. Every therock-*-packages bucket, both prerelease and
+    release python/tarball buckets, and all repo.amd.com product buckets
+    answered 403.
+    """
+
+    def test_public_buckets_keep_the_raw_s3_url(self):
+        # Every URL TheRock's CI hands to pip or apt today resolves to one of
+        # these, so this is the assertion that says "nothing changed".
+        for bucket in (
+            "therock-ci-artifacts",
+            "therock-ci-artifacts-external",
+            "therock-dev-artifacts",
+            "therock-nightly-artifacts",
+            "therock-prerelease-artifacts",
+        ):
+            with self.subTest(bucket=bucket):
+                location = StorageLocation(bucket, "12345-linux/python/index.html")
+                self.assertTrue(require_bucket_config(bucket).anonymous_s3_read)
+                self.assertEqual(location.download_url, location.https_url)
+
+    def test_private_buckets_fall_back_to_the_cdn(self):
+        location = StorageLocation("therock-prerelease-tarball", "v4/tarball/x.tar.gz")
+        self.assertEqual(
+            location.download_url,
+            "https://rocm.prereleases.amd.com/tarball-multi-arch/x.tar.gz",
+        )
+
+    def test_private_bucket_with_no_rule_raises(self):
+        """A 403 in a build log is a worse way to learn this than an exception.
+
+        therock-prerelease-packages is private and deliberately carries no rule
+        (its CDN serves a distro-partitioned repo, not a prefix rewrite), so it
+        has no public download URL at all.
+        """
+        location = StorageLocation("therock-prerelease-packages", "v4/deb/x.deb")
+        with self.assertRaises(ValueError) as cm:
+            location.download_url
+        message = str(cm.exception)
+        self.assertIn("therock-prerelease-packages", message)
+        self.assertIn("anonymous", message)
+
+    def test_unknown_bucket_keeps_the_raw_s3_url(self):
+        """An unregistered bucket behaves exactly as it did before this field."""
+        location = StorageLocation("some-other-bucket", "path/file.txt")
+        self.assertEqual(location.download_url, location.https_url)
+
+
 class TestForkPrConfigPreservesNewFields(unittest.TestCase):
     """Fork PRs drop the IAM role, and must drop nothing else.
 
@@ -590,6 +749,7 @@ class TestForkPrConfigPreservesNewFields(unittest.TestCase):
         self.assertEqual(
             config.namespace_external_repos, original.namespace_external_repos
         )
+        self.assertEqual(config.anonymous_s3_read, original.anonymous_s3_read)
 
     def test_covers_every_field(self):
         """Guard against a new field being added without extending the test above."""
@@ -605,6 +765,7 @@ class TestForkPrConfigPreservesNewFields(unittest.TestCase):
                 "key_prefix",
                 "cdn_rules",
                 "namespace_external_repos",
+                "anonymous_s3_read",
             },
         )
 
@@ -992,6 +1153,182 @@ class TestSelectionOverrides(RegistryFileTestCase):
         self.use(self.REGISTRY)
         with self.assertRaises(ValueError):
             get_artifacts_bucket_config("bogus", "ROCm/TheRock", False)
+
+    def test_bkc_slots_are_redirectable_independently(self):
+        """A BKC channel shares dev's bucket but not dev's selection slot.
+
+        Redirecting "dev-bkc" must not drag "dev" with it, or a downstream repo
+        could not separate the two.
+        """
+        self.use(
+            {
+                "version": 1,
+                "buckets": [{"name": "downstream-bkc-artifacts"}],
+                "artifacts_buckets": {"dev-bkc": "downstream-bkc-artifacts"},
+            }
+        )
+        self.assertEqual(
+            get_artifacts_bucket_config("dev-bkc", "ROCm/TheRock", False).name,
+            "downstream-bkc-artifacts",
+        )
+        self.assertEqual(
+            get_artifacts_bucket_config("dev", "ROCm/TheRock", False).name,
+            "therock-dev-artifacts",
+        )
+
+    def test_product_release_slot_is_redirected(self):
+        """The v5 product buckets are selected by formula too, so they need a slot.
+
+        ``therock-repo-amd-{stream}-{product}`` is no more guessable by a
+        downstream repo than ``therock-{release_type}-artifacts`` is.
+        """
+        self.use(
+            {
+                "version": 1,
+                "buckets": [{"name": "downstream-core"}],
+                "product_release_buckets": {"nightly": {"core": "downstream-core"}},
+            }
+        )
+        self.assertEqual(
+            get_product_release_bucket_config("nightly", "core").name,
+            "downstream-core",
+        )
+        # An unset (release_type, product) pair keeps the built-in formula.
+        self.assertEqual(
+            get_product_release_bucket_config("nightly", "jax").name,
+            "therock-repo-amd-nightly-jax",
+        )
+
+
+class TestDownstreamRegistryRoundTrip(RegistryFileTestCase):
+    """The shape rocm-npi-dev needs, pinned in TheRock's own suite.
+
+    That repo currently reaches the same result by monkey-patching
+    WorkflowOutputRoot.from_workflow_run and string-replacing S3 hostnames in
+    job summaries, in two scripts each. Both copies are installed by sniffing
+    TheRock's module layout at run time, so an upstream refactor breaks them
+    silently. Encoding the contract here is what makes that detectable.
+
+    Three buckets share one CDN host and each strips a different ``v3/…``
+    prefix - the case a single per-bucket CDN URL cannot express, because it
+    supplies a URL to prepend but no prefix length to strip. It is the same
+    shape as RFC0012's ``v5/`` rewrite.
+    """
+
+    REGISTRY = {
+        "version": 1,
+        "buckets": [
+            {
+                "name": "therock-npi-artifacts",
+                "key_prefix": "v3/artifacts/",
+                "anonymous_s3_read": False,
+                "cdn_rules": [
+                    {
+                        "key_prefix": "v3/artifacts/",
+                        "url_prefix": "https://rocm.genesis.amd.com/artifacts/",
+                    }
+                ],
+            },
+            {
+                "name": "therock-npi-tarball",
+                "key_prefix": "v3/tarball/",
+                "anonymous_s3_read": False,
+                "cdn_rules": [
+                    {
+                        "key_prefix": "v3/tarball/",
+                        "url_prefix": "https://rocm.genesis.amd.com/tarball/",
+                    }
+                ],
+            },
+            {
+                "name": "therock-npi-python",
+                "key_prefix": "v3/whl/",
+                "anonymous_s3_read": False,
+                "cdn_rules": [
+                    {
+                        "key_prefix": "v3/whl/",
+                        "url_prefix": "https://rocm.genesis.amd.com/whl/",
+                    }
+                ],
+            },
+        ],
+        "artifacts_buckets": {
+            "ci": "therock-npi-artifacts",
+            "ci-external": "therock-npi-artifacts",
+        },
+        "release_buckets": {"nightly": {"python": "therock-npi-python"}},
+    }
+
+    def test_each_bucket_rewrites_its_own_prefix(self):
+        """Literal URLs, matching the rewrite table those wrapper scripts hold."""
+        self.use(self.REGISTRY)
+        cases = [
+            (
+                "therock-npi-artifacts",
+                "v3/artifacts/4242-linux/index.html",
+                "https://rocm.genesis.amd.com/artifacts/4242-linux/index.html",
+            ),
+            (
+                "therock-npi-tarball",
+                "v3/tarball/therock-dist-linux-gfx1250-7.0.0.tar.gz",
+                "https://rocm.genesis.amd.com/tarball/"
+                "therock-dist-linux-gfx1250-7.0.0.tar.gz",
+            ),
+            (
+                "therock-npi-python",
+                "v3/whl/gfx1250/rocm-7.0.0.whl",
+                "https://rocm.genesis.amd.com/whl/gfx1250/rocm-7.0.0.whl",
+            ),
+        ]
+        for bucket, key, expected in cases:
+            with self.subTest(bucket=bucket):
+                self.assertEqual(StorageLocation(bucket, key).public_url, expected)
+
+    def test_private_buckets_get_the_cdn_for_machine_urls(self):
+        """The pip index must be the CDN, because raw S3 answers 403 there.
+
+        TheRock's own buckets are readable and keep the raw S3 URL for egress
+        cost. Both answers come from the same field, so neither repo has to
+        override a policy set for the other.
+        """
+        self.use(self.REGISTRY)
+        location = StorageLocation("therock-npi-python", "v3/whl/gfx1250/index.html")
+        self.assertEqual(
+            location.download_url,
+            "https://rocm.genesis.amd.com/whl/gfx1250/index.html",
+        )
+        self.assertEqual(
+            StorageLocation(
+                "therock-ci-artifacts", "4242-linux/python/index.html"
+            ).download_url,
+            "https://therock-ci-artifacts.s3.amazonaws.com/4242-linux/python/index.html",
+        )
+
+    def test_key_prefix_is_folded_into_the_s3_key(self):
+        """The prefix reaches the key without going through ``external_repo``.
+
+        Storing it in external_repo is the abuse this replaces: that field means
+        "fork namespace", and a run in a fork would have overwritten it.
+        """
+        from _therock_utils.workflow_outputs import WorkflowOutputRoot
+
+        self.use(self.REGISTRY)
+        root = WorkflowOutputRoot.from_workflow_run(
+            run_id="4242",
+            platform="linux",
+            github_repository="AMD-ROCm-Internal/rocm-npi-dev",
+            workflow_run={
+                "id": 4242,
+                "head_repository": {"full_name": "AMD-ROCm-Internal/rocm-npi-dev"},
+            },
+        )
+        location = root.artifact_index()
+        self.assertTrue(location.relative_path.startswith("v3/artifacts/"))
+        self.assertTrue(
+            location.public_url.startswith("https://rocm.genesis.amd.com/artifacts/")
+        )
+        # The prefix is stripped on the way out, not carried into the CDN path.
+        self.assertNotIn("v3/artifacts", location.public_url)
 
 
 class TestRequireBucketConfigError(unittest.TestCase):

--- a/build_tools/tests/s3_buckets_test.py
+++ b/build_tools/tests/s3_buckets_test.py
@@ -12,12 +12,22 @@ from unittest import mock
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 
 from _therock_utils.s3_buckets import (
+    BUCKET_REGISTRY_ENV_VAR,
+    BucketRegistryError,
+    CdnRule,
+    S3BucketConfig,
+    all_bucket_configs,
     get_artifacts_bucket_config,
     get_artifacts_bucket_config_for_workflow_run,
     get_product_release_bucket_config,
     get_release_package_index_url,
     get_release_stream,
     get_release_bucket_config,
+    lookup_bucket_config,
+    require_bucket_config,
+    reset_bucket_registry,
+    resolve_public_url,
+    set_bucket_config_file,
 )
 
 
@@ -394,6 +404,604 @@ class TestGetArtifactsBucketConfigForWorkflowRun(unittest.TestCase):
         )
         self.mock_api.assert_not_called()
         self.assertEqual(config.name, "therock-ci-artifacts")
+
+
+# ---------------------------------------------------------------------------
+# CdnRule / resolve_public_url
+# ---------------------------------------------------------------------------
+
+
+class TestCdnRule(unittest.TestCase):
+    def test_appends_trailing_slashes(self):
+        rule = CdnRule("v4/whl", "https://cdn.example.com/whl")
+        self.assertEqual(rule.key_prefix, "v4/whl/")
+        self.assertEqual(rule.url_prefix, "https://cdn.example.com/whl/")
+
+    def test_keeps_existing_trailing_slashes(self):
+        rule = CdnRule("v4/whl/", "https://cdn.example.com/whl/")
+        self.assertEqual(rule.key_prefix, "v4/whl/")
+        self.assertEqual(rule.url_prefix, "https://cdn.example.com/whl/")
+
+    def test_empty_key_prefix_matches_whole_bucket(self):
+        rule = CdnRule("", "https://cdn.example.com/")
+        self.assertEqual(rule.key_prefix, "")
+
+    def test_leading_slash_key_prefix_raises(self):
+        with self.assertRaises(ValueError):
+            CdnRule("/v4/whl/", "https://cdn.example.com/")
+
+    def test_non_https_url_prefix_raises(self):
+        with self.assertRaises(ValueError):
+            CdnRule("v4/whl/", "http://cdn.example.com/")
+
+    def test_frozen(self):
+        rule = CdnRule("v4/whl/", "https://cdn.example.com/")
+        with self.assertRaises(Exception):
+            rule.key_prefix = "other/"
+
+
+class TestS3BucketConfigKeyPrefix(unittest.TestCase):
+    """The trailing-slash invariant documented on WorkflowOutputRoot.key_prefix.
+
+    Enforced on the dataclass, not only in the registry parser, so a config built
+    directly in Python cannot produce 'v34242-linux' out of key_prefix='v3'.
+    """
+
+    def test_appends_trailing_slash(self):
+        self.assertEqual(S3BucketConfig(name="b", key_prefix="v3").key_prefix, "v3/")
+
+    def test_keeps_existing_trailing_slash(self):
+        self.assertEqual(S3BucketConfig(name="b", key_prefix="v3/").key_prefix, "v3/")
+
+    def test_empty_key_prefix_stays_empty(self):
+        self.assertEqual(S3BucketConfig(name="b").key_prefix, "")
+
+    def test_leading_slash_raises(self):
+        with self.assertRaises(ValueError):
+            S3BucketConfig(name="b", key_prefix="/v3/")
+
+
+class TestResolvePublicUrl(unittest.TestCase):
+    DEFAULT = "https://bucket.s3.amazonaws.com/some/key"
+
+    def test_unknown_bucket_falls_back(self):
+        self.assertEqual(
+            resolve_public_url("not-a-real-bucket", "some/key", default=self.DEFAULT),
+            self.DEFAULT,
+        )
+
+    def test_known_bucket_without_matching_rule_falls_back(self):
+        # therock-dev-python only maps v4/whl/.
+        self.assertEqual(
+            resolve_public_url(
+                "therock-dev-python", "v4/other/thing.whl", default=self.DEFAULT
+            ),
+            self.DEFAULT,
+        )
+
+    def test_bucket_with_no_rules_falls_back(self):
+        self.assertEqual(
+            resolve_public_url(
+                "therock-ci-artifacts", "12345-linux/x.tar.xz", default=self.DEFAULT
+            ),
+            self.DEFAULT,
+        )
+
+    def test_whl_round_trips(self):
+        self.assertEqual(
+            resolve_public_url(
+                "therock-nightly-python", "v4/whl/gfx110X/x.whl", default=self.DEFAULT
+            ),
+            "https://rocm.nightlies.amd.com/whl-multi-arch/gfx110X/x.whl",
+        )
+
+    def test_tarball_round_trips(self):
+        self.assertEqual(
+            resolve_public_url(
+                "therock-dev-tarball", "v4/tarball/x.tar.gz", default=self.DEFAULT
+            ),
+            "https://rocm.devreleases.amd.com/tarball-multi-arch/x.tar.gz",
+        )
+
+    def test_deb_and_rpm_round_trip(self):
+        self.assertEqual(
+            resolve_public_url(
+                "therock-dev-packages", "v4/deb/20260101-1/x.deb", default=self.DEFAULT
+            ),
+            "https://rocm.devreleases.amd.com/packages-multi-arch/deb/20260101-1/x.deb",
+        )
+        self.assertEqual(
+            resolve_public_url(
+                "therock-dev-packages", "v4/rpm/20260101-1/x.rpm", default=self.DEFAULT
+            ),
+            "https://rocm.devreleases.amd.com/packages-multi-arch/rpm/20260101-1/x.rpm",
+        )
+
+    def test_every_seeded_rule_round_trips(self):
+        for config in all_bucket_configs():
+            for rule in config.cdn_rules:
+                with self.subTest(bucket=config.name, prefix=rule.key_prefix):
+                    self.assertEqual(
+                        resolve_public_url(
+                            config.name, rule.key_prefix + "a/b.txt", default="fallback"
+                        ),
+                        rule.url_prefix + "a/b.txt",
+                    )
+
+    def test_longest_prefix_wins(self):
+        config = S3BucketConfig(
+            "prefix-test",
+            cdn_rules=(
+                CdnRule("", "https://cdn.example.com/root/"),
+                CdnRule("v4/whl/", "https://cdn.example.com/whl/"),
+            ),
+        )
+        with mock.patch("_therock_utils.s3_buckets.s3_bucket_configs", [config]):
+            reset_bucket_registry()
+            self.assertEqual(
+                resolve_public_url("prefix-test", "v4/whl/x.whl", default="fallback"),
+                "https://cdn.example.com/whl/x.whl",
+            )
+            self.assertEqual(
+                resolve_public_url("prefix-test", "other/x.txt", default="fallback"),
+                "https://cdn.example.com/root/other/x.txt",
+            )
+
+
+class TestArtifactsBucketsHaveNoCdn(unittest.TestCase):
+    """Artifacts bucket URLs are machine-consumed and read directly from S3.
+
+    Adding a CDN rule to one of these buckets would silently retarget every CI
+    job-summary link and every artifact fetch. If that is ever intended, delete
+    this test deliberately rather than discovering the change in production.
+    """
+
+    def test_no_artifacts_bucket_has_cdn_rules(self):
+        for config in all_bucket_configs():
+            if config.name.endswith("-artifacts") or config.name.endswith(
+                "-artifacts-external"
+            ):
+                with self.subTest(bucket=config.name):
+                    self.assertEqual(config.cdn_rules, ())
+
+
+class TestForkPrConfigPreservesNewFields(unittest.TestCase):
+    """Fork PRs drop the IAM role, and must drop nothing else.
+
+    get_artifacts_bucket_config_for_workflow_run used to rebuild the config
+    field by field, which reset every field it did not name.
+    """
+
+    def test_fork_pr_keeps_all_other_fields(self):
+        original = require_bucket_config("therock-ci-artifacts-external")
+        config = get_artifacts_bucket_config_for_workflow_run(
+            "ROCm/TheRock",
+            workflow_run={
+                "id": 123,
+                "head_repository": {"full_name": "someuser/TheRock"},
+            },
+        )
+        self.assertIsNone(config.iam_role)
+        self.assertEqual(config.name, original.name)
+        self.assertEqual(config.region, original.region)
+        self.assertEqual(config.iam_account, original.iam_account)
+        self.assertEqual(config.key_prefix, original.key_prefix)
+        self.assertEqual(config.cdn_rules, original.cdn_rules)
+        self.assertEqual(
+            config.namespace_external_repos, original.namespace_external_repos
+        )
+
+    def test_covers_every_field(self):
+        """Guard against a new field being added without extending the test above."""
+        import dataclasses
+
+        self.assertEqual(
+            {f.name for f in dataclasses.fields(S3BucketConfig)},
+            {
+                "name",
+                "region",
+                "iam_account",
+                "iam_role",
+                "key_prefix",
+                "cdn_rules",
+                "namespace_external_repos",
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# Registry file loading
+# ---------------------------------------------------------------------------
+
+
+class RegistryFileTestCase(unittest.TestCase):
+    """Base class that writes registry files and always restores global state."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.addCleanup(set_bucket_config_file, None)
+
+    def write_registry(self, data, name="buckets.json") -> Path:
+        path = Path(self._tmp.name) / name
+        path.write_text(
+            data if isinstance(data, str) else json.dumps(data), encoding="utf-8"
+        )
+        return path
+
+    def use(self, data, *, via_env=False, name="buckets.json") -> Path:
+        path = self.write_registry(data, name=name)
+        if via_env:
+            patcher = mock.patch.dict(os.environ, {BUCKET_REGISTRY_ENV_VAR: str(path)})
+            patcher.start()
+            self.addCleanup(patcher.stop)
+            reset_bucket_registry()
+        else:
+            set_bucket_config_file(path)
+        return path
+
+
+_MINIMAL_DOWNSTREAM = {
+    "version": 1,
+    "buckets": [
+        {
+            "name": "downstream-artifacts",
+            "iam_role": "downstream",
+            "key_prefix": "v3/artifacts",
+            "cdn_rules": [
+                {
+                    "key_prefix": "v3/artifacts/",
+                    "url_prefix": "https://cdn.example.com/artifacts/",
+                }
+            ],
+        }
+    ],
+}
+
+
+class TestRegistryFileLoading(RegistryFileTestCase):
+    def test_registers_new_bucket(self):
+        self.use(_MINIMAL_DOWNSTREAM)
+        config = require_bucket_config("downstream-artifacts")
+        self.assertEqual(config.iam_role, "downstream")
+        # key_prefix is normalized with a trailing slash on load.
+        self.assertEqual(config.key_prefix, "v3/artifacts/")
+        self.assertEqual(
+            resolve_public_url(
+                "downstream-artifacts", "v3/artifacts/123-linux/x.tar.xz", default="raw"
+            ),
+            "https://cdn.example.com/artifacts/123-linux/x.tar.xz",
+        )
+
+    def test_in_tree_buckets_still_present(self):
+        self.use(_MINIMAL_DOWNSTREAM)
+        self.assertIsNotNone(lookup_bucket_config("therock-ci-artifacts"))
+
+    def test_env_var_path_works(self):
+        self.use(_MINIMAL_DOWNSTREAM, via_env=True)
+        self.assertIsNotNone(lookup_bucket_config("downstream-artifacts"))
+
+    def test_explicit_file_beats_env_var(self):
+        env_path = self.write_registry(
+            {"version": 1, "buckets": [{"name": "from-env"}]}, name="env.json"
+        )
+        flag_path = self.write_registry(
+            {"version": 1, "buckets": [{"name": "from-flag"}]}, name="flag.json"
+        )
+        with mock.patch.dict(os.environ, {BUCKET_REGISTRY_ENV_VAR: str(env_path)}):
+            set_bucket_config_file(flag_path)
+            self.assertIsNotNone(lookup_bucket_config("from-flag"))
+            self.assertIsNone(lookup_bucket_config("from-env"))
+
+    def test_clearing_explicit_file_restores_env_var(self):
+        env_path = self.write_registry(
+            {"version": 1, "buckets": [{"name": "from-env"}]}, name="env.json"
+        )
+        flag_path = self.write_registry(
+            {"version": 1, "buckets": [{"name": "from-flag"}]}, name="flag.json"
+        )
+        with mock.patch.dict(os.environ, {BUCKET_REGISTRY_ENV_VAR: str(env_path)}):
+            set_bucket_config_file(flag_path)
+            set_bucket_config_file(None)
+            self.assertIsNotNone(lookup_bucket_config("from-env"))
+
+    def test_defaults_fill_in(self):
+        self.use({"version": 1, "buckets": [{"name": "bare"}]})
+        config = require_bucket_config("bare")
+        self.assertEqual(config.region, "us-east-2")
+        self.assertIsNone(config.iam_role)
+        self.assertEqual(config.key_prefix, "")
+        self.assertEqual(config.cdn_rules, ())
+        self.assertFalse(config.namespace_external_repos)
+
+
+class TestRegistryFileErrors(RegistryFileTestCase):
+    def assert_load_error(self, data, *needles):
+        path = self.use(data)
+        with self.assertRaises(BucketRegistryError) as cm:
+            all_bucket_configs()
+        message = str(cm.exception)
+        # Every error names the offending file, so the user knows what to edit.
+        self.assertIn(str(path), message)
+        for needle in needles:
+            self.assertIn(needle, message)
+
+    def test_missing_file(self):
+        set_bucket_config_file(Path(self._tmp.name) / "nope.json")
+        with self.assertRaises(BucketRegistryError) as cm:
+            all_bucket_configs()
+        self.assertIn("nope.json", str(cm.exception))
+
+    def test_invalid_json(self):
+        self.assert_load_error("{not json", "invalid JSON")
+
+    def test_top_level_not_an_object(self):
+        self.assert_load_error([], "top level")
+
+    def test_missing_version(self):
+        self.assert_load_error({"buckets": []}, "version")
+
+    def test_unknown_version(self):
+        self.assert_load_error({"version": 99, "buckets": []}, "version")
+
+    def test_unknown_top_level_key(self):
+        self.assert_load_error(
+            {"version": 1, "bucket": []}, "unknown top-level key", "bucket"
+        )
+
+    def test_unknown_bucket_key(self):
+        self.assert_load_error(
+            {"version": 1, "buckets": [{"name": "x", "cdn_rule": []}]},
+            "cdn_rule",
+        )
+
+    def test_unknown_cdn_rule_key(self):
+        self.assert_load_error(
+            {
+                "version": 1,
+                "buckets": [
+                    {
+                        "name": "x",
+                        "cdn_rules": [
+                            {
+                                "key_prefix": "a/",
+                                "url_prefix": "https://x/",
+                                "urlprefix": "https://y/",
+                            }
+                        ],
+                    }
+                ],
+            },
+            "urlprefix",
+        )
+
+    def test_cdn_rule_missing_field(self):
+        self.assert_load_error(
+            {
+                "version": 1,
+                "buckets": [{"name": "x", "cdn_rules": [{"key_prefix": "a/"}]}],
+            },
+            "url_prefix",
+        )
+
+    def test_cdn_rule_non_https(self):
+        self.assert_load_error(
+            {
+                "version": 1,
+                "buckets": [
+                    {
+                        "name": "x",
+                        "cdn_rules": [
+                            {"key_prefix": "a/", "url_prefix": "http://insecure/"}
+                        ],
+                    }
+                ],
+            },
+            "https://",
+        )
+
+    def test_bucket_missing_name(self):
+        self.assert_load_error({"version": 1, "buckets": [{}]}, "name")
+
+    def test_duplicate_bucket_in_same_file(self):
+        self.assert_load_error(
+            {"version": 1, "buckets": [{"name": "dup"}, {"name": "dup"}]},
+            "more than once",
+        )
+
+    def test_key_prefix_with_leading_slash(self):
+        self.assert_load_error(
+            {"version": 1, "buckets": [{"name": "x", "key_prefix": "/v3/"}]},
+            "must not start with '/'",
+        )
+
+    def test_shadowing_in_tree_bucket_without_override(self):
+        self.assert_load_error(
+            {"version": 1, "buckets": [{"name": "therock-ci-artifacts"}]},
+            "override",
+        )
+
+    def test_selection_override_naming_unregistered_bucket(self):
+        self.assert_load_error(
+            {"version": 1, "artifacts_buckets": {"ci": "nowhere"}},
+            "nowhere",
+        )
+
+    def test_unknown_artifacts_selection_slot(self):
+        self.assert_load_error(
+            {"version": 1, "artifacts_buckets": {"staging": "therock-ci-artifacts"}},
+            "staging",
+        )
+
+    def test_unknown_release_selection_slot(self):
+        self.assert_load_error(
+            {"version": 1, "release_buckets": {"ci": {}}},
+            "ci",
+        )
+
+    def test_unknown_release_bucket_type(self):
+        self.assert_load_error(
+            {
+                "version": 1,
+                "release_buckets": {"dev": {"wheels": "therock-dev-python"}},
+            },
+            "wheels",
+        )
+
+
+class TestRegistryFileOverride(RegistryFileTestCase):
+    def test_override_replaces_in_tree_bucket_wholesale(self):
+        self.use(
+            {
+                "version": 1,
+                "buckets": [
+                    {
+                        "name": "therock-dev-python",
+                        "override": True,
+                        "key_prefix": "v9/",
+                    }
+                ],
+            }
+        )
+        config = require_bucket_config("therock-dev-python")
+        self.assertEqual(config.key_prefix, "v9/")
+        # Full replacement, not a field-wise merge: the in-tree iam_role and
+        # cdn_rules are gone rather than inherited.
+        self.assertIsNone(config.iam_role)
+        self.assertEqual(config.cdn_rules, ())
+
+
+class TestSelectionOverrides(RegistryFileTestCase):
+    REGISTRY = {
+        "version": 1,
+        "buckets": [
+            {"name": "downstream-artifacts", "key_prefix": "v3/artifacts/"},
+            {"name": "downstream-external", "namespace_external_repos": True},
+            {"name": "downstream-python"},
+        ],
+        "artifacts_buckets": {
+            "ci": "downstream-artifacts",
+            "ci-external": "downstream-external",
+        },
+        "release_buckets": {"nightly": {"python": "downstream-python"}},
+    }
+
+    def test_artifacts_ci_slot_is_redirected(self):
+        self.use(self.REGISTRY)
+        config = get_artifacts_bucket_config("ci", "ROCm/TheRock", False)
+        self.assertEqual(config.name, "downstream-artifacts")
+        self.assertEqual(config.key_prefix, "v3/artifacts/")
+
+    def test_artifacts_ci_external_slot_is_separate(self):
+        self.use(self.REGISTRY)
+        config = get_artifacts_bucket_config("ci", "ROCm/TheRock", True)
+        self.assertEqual(config.name, "downstream-external")
+
+    def test_unset_slot_keeps_built_in_formula(self):
+        self.use(self.REGISTRY)
+        self.assertEqual(
+            get_artifacts_bucket_config("nightly", "ROCm/TheRock", False).name,
+            "therock-nightly-artifacts",
+        )
+
+    def test_downstream_repo_uses_the_ci_external_slot(self):
+        """A non-TheRock repo is 'external' even when the PR is not from a fork.
+
+        This is why a downstream registry has to name both CI slots; the NPI
+        round trip below is the case that motivated the selection override.
+        """
+        self.use(self.REGISTRY)
+        self.assertEqual(
+            get_artifacts_bucket_config(
+                "ci", "AMD-ROCm-Internal/rocm-npi-dev", False
+            ).name,
+            "downstream-external",
+        )
+
+    def test_key_prefix_reaches_the_public_url(self):
+        """Full round trip: prefix present in the S3 key, absent from the CDN URL."""
+        from _therock_utils.workflow_outputs import WorkflowOutputRoot
+
+        self.use(
+            {
+                "version": 1,
+                "buckets": [
+                    {
+                        "name": "downstream-artifacts",
+                        "key_prefix": "v3/artifacts/",
+                        "cdn_rules": [
+                            {
+                                "key_prefix": "v3/artifacts/",
+                                "url_prefix": "https://cdn.example.com/artifacts/",
+                            }
+                        ],
+                    }
+                ],
+                "artifacts_buckets": {"ci-external": "downstream-artifacts"},
+            }
+        )
+        config = get_artifacts_bucket_config("ci", "downstream/repo", False)
+        root = WorkflowOutputRoot(
+            bucket=config.name,
+            external_repo="",
+            run_id="4242",
+            platform="linux",
+            key_prefix=config.key_prefix,
+        )
+        location = root.artifact_index()
+        self.assertEqual(
+            location.s3_uri,
+            "s3://downstream-artifacts/v3/artifacts/4242-linux/index.html",
+        )
+        self.assertEqual(
+            location.public_url,
+            "https://cdn.example.com/artifacts/4242-linux/index.html",
+        )
+
+    def test_release_slot_is_redirected(self):
+        self.use(self.REGISTRY)
+        self.assertEqual(
+            get_release_bucket_config("nightly", "python").name, "downstream-python"
+        )
+
+    def test_unset_release_slot_keeps_built_in_formula(self):
+        self.use(self.REGISTRY)
+        self.assertEqual(
+            get_release_bucket_config("nightly", "tarball").name,
+            "therock-nightly-tarball",
+        )
+        self.assertEqual(
+            get_release_bucket_config("dev", "python").name, "therock-dev-python"
+        )
+
+    def test_overriding_ci_alone_does_not_leak_into_ci_external(self):
+        """Fork uploads must not silently land in the trusted bucket."""
+        self.use(
+            {
+                "version": 1,
+                "buckets": [{"name": "downstream-artifacts"}],
+                "artifacts_buckets": {"ci": "downstream-artifacts"},
+            }
+        )
+        self.assertEqual(
+            get_artifacts_bucket_config("ci", "ROCm/TheRock", True).name,
+            "therock-ci-artifacts-external",
+        )
+
+    def test_invalid_release_type_still_rejected(self):
+        self.use(self.REGISTRY)
+        with self.assertRaises(ValueError):
+            get_artifacts_bucket_config("bogus", "ROCm/TheRock", False)
+
+
+class TestRequireBucketConfigError(unittest.TestCase):
+    def test_message_names_known_buckets_and_injection_mechanism(self):
+        with self.assertRaises(KeyError) as cm:
+            require_bucket_config("nope")
+        message = str(cm.exception)
+        self.assertIn("therock-ci-artifacts", message)
+        self.assertIn(BUCKET_REGISTRY_ENV_VAR, message)
+        self.assertIn("--bucket-config-file", message)
 
 
 if __name__ == "__main__":

--- a/build_tools/tests/workflow_outputs_test.py
+++ b/build_tools/tests/workflow_outputs_test.py
@@ -9,8 +9,14 @@ from unittest import mock
 
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 
+from _therock_utils import s3_buckets, workflow_outputs
 from _therock_utils.workflow_outputs import WorkflowOutputRoot
 from _therock_utils.storage_location import StorageLocation
+from _therock_utils.s3_buckets import (
+    CdnRule,
+    S3BucketConfig,
+    require_bucket_config,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -74,6 +80,46 @@ class TestWorkflowOutputRootPrefix(unittest.TestCase):
         root = self._make_root()
         with self.assertRaises(AttributeError):
             root.run_id = "99999"
+
+    # -- key_prefix --
+
+    def test_prefix_defaults_to_no_key_prefix(self):
+        """Omitting key_prefix must reproduce the pre-existing layout exactly."""
+        self.assertEqual(self._make_root().key_prefix, "")
+        self.assertEqual(self._make_root().prefix, "12345-linux")
+
+    def test_prefix_with_key_prefix(self):
+        root = self._make_root(key_prefix="v3/artifacts/")
+        self.assertEqual(root.prefix, "v3/artifacts/12345-linux")
+
+    def test_prefix_with_key_prefix_and_external_repo(self):
+        """key_prefix is the bucket's layout; external_repo namespaces within it."""
+        root = self._make_root(
+            key_prefix="v3/artifacts/", external_repo="Fork-TheRock/"
+        )
+        self.assertEqual(root.prefix, "v3/artifacts/Fork-TheRock/12345-linux")
+
+    def test_key_prefix_reaches_location_methods(self):
+        """relative_path must be the full S3 key, not a key missing its prefix."""
+        root = self._make_root(key_prefix="v3/artifacts/")
+        self.assertEqual(
+            root.artifact("blas_lib_gfx94X.tar.xz").relative_path,
+            "v3/artifacts/12345-linux/blas_lib_gfx94X.tar.xz",
+        )
+        self.assertEqual(
+            root.log_file("gfx94X-dcgpu", "build.log").relative_path,
+            "v3/artifacts/12345-linux/logs/gfx94X-dcgpu/build.log",
+        )
+        self.assertEqual(
+            root.artifact_index().s3_uri,
+            "s3://therock-ci-artifacts/v3/artifacts/12345-linux/index.html",
+        )
+
+    def test_key_prefix_local_path_uses_posix_separators_on_all_platforms(self):
+        """A slashed key_prefix must not break local staging paths on Windows."""
+        root = self._make_root(key_prefix="v3/artifacts/")
+        result = root.artifact("a.tar.xz").local_path(Path("/tmp/staging"))
+        self.assertEqual(result, Path("/tmp/staging/v3/artifacts/12345-linux/a.tar.xz"))
 
 
 # ---------------------------------------------------------------------------
@@ -300,7 +346,7 @@ class TestWorkflowOutputRootFromWorkflowRun(unittest.TestCase):
     @mock.patch("_therock_utils.workflow_outputs._retrieve_bucket_info")
     def test_basic_does_not_trigger_api(self, mock_retrieve):
         """By default, run_id is NOT passed as workflow_run_id."""
-        mock_retrieve.return_value = ("", "therock-ci-artifacts")
+        mock_retrieve.return_value = ("", require_bucket_config("therock-ci-artifacts"))
         root = WorkflowOutputRoot.from_workflow_run(run_id="12345", platform="linux")
         self.assertEqual(root.bucket, "therock-ci-artifacts")
         self.assertEqual(root.external_repo, "")
@@ -316,7 +362,10 @@ class TestWorkflowOutputRootFromWorkflowRun(unittest.TestCase):
     @mock.patch("_therock_utils.workflow_outputs._retrieve_bucket_info")
     def test_lookup_workflow_run_triggers_api(self, mock_retrieve):
         """With lookup_workflow_run=True, run_id IS passed as workflow_run_id."""
-        mock_retrieve.return_value = ("Fork-Repo/", "therock-ci-artifacts-external")
+        mock_retrieve.return_value = (
+            "Fork-Repo/",
+            require_bucket_config("therock-ci-artifacts-external"),
+        )
         root = WorkflowOutputRoot.from_workflow_run(
             run_id="99999",
             platform="windows",
@@ -335,7 +384,7 @@ class TestWorkflowOutputRootFromWorkflowRun(unittest.TestCase):
     @mock.patch("_therock_utils.workflow_outputs._retrieve_bucket_info")
     def test_with_workflow_run_dict(self, mock_retrieve):
         """When workflow_run is provided, it's passed through (no API call)."""
-        mock_retrieve.return_value = ("", "therock-ci-artifacts")
+        mock_retrieve.return_value = ("", require_bucket_config("therock-ci-artifacts"))
         fake_run = {"id": 12345}
         root = WorkflowOutputRoot.from_workflow_run(
             run_id="12345",
@@ -352,7 +401,7 @@ class TestWorkflowOutputRootFromWorkflowRun(unittest.TestCase):
     @mock.patch("_therock_utils.workflow_outputs._retrieve_bucket_info")
     def test_lookup_ignored_when_workflow_run_provided(self, mock_retrieve):
         """lookup_workflow_run is irrelevant when workflow_run is provided."""
-        mock_retrieve.return_value = ("", "therock-ci-artifacts")
+        mock_retrieve.return_value = ("", require_bucket_config("therock-ci-artifacts"))
         fake_run = {"id": 12345}
         root = WorkflowOutputRoot.from_workflow_run(
             run_id="12345",
@@ -368,6 +417,112 @@ class TestWorkflowOutputRootFromWorkflowRun(unittest.TestCase):
             workflow_run=fake_run,
             release_type=None,
         )
+
+
+class TestKeyPrefixAndCdnRoundTrip(unittest.TestCase):
+    """key_prefix and cdn_rules are independent, and compose correctly.
+
+    This is the downstream (rocm-npi-dev) shape: a bucket whose objects all live
+    under a versioned key prefix, fronted by a CDN that serves that prefix at its
+    root. The prefix must appear in the S3 key and be stripped from the CDN URL.
+    """
+
+    KEY_PREFIX = "v3/artifacts/"
+    CDN = "https://artifacts.example.com/"
+
+    def _register(self, **overrides):
+        config = S3BucketConfig(
+            name="downstream-artifacts",
+            key_prefix=self.KEY_PREFIX,
+            cdn_rules=(CdnRule(self.KEY_PREFIX, self.CDN),),
+            **overrides,
+        )
+        patcher = mock.patch.object(
+            s3_buckets,
+            "s3_bucket_configs",
+            list(s3_buckets.s3_bucket_configs) + [config],
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        s3_buckets.reset_bucket_registry()
+        self.addCleanup(s3_buckets.reset_bucket_registry)
+        return config
+
+    def test_prefix_in_s3_key_stripped_in_cdn_url(self):
+        config = self._register()
+        root = WorkflowOutputRoot(
+            bucket=config.name,
+            external_repo="",
+            run_id="12345",
+            platform="linux",
+            key_prefix=config.key_prefix,
+        )
+        loc = root.artifact("blas_lib_gfx94X.tar.xz")
+
+        # The prefix is part of the S3 key...
+        self.assertEqual(
+            loc.s3_uri,
+            "s3://downstream-artifacts/v3/artifacts/12345-linux/blas_lib_gfx94X.tar.xz",
+        )
+        self.assertEqual(
+            loc.https_url,
+            "https://downstream-artifacts.s3.amazonaws.com/"
+            "v3/artifacts/12345-linux/blas_lib_gfx94X.tar.xz",
+        )
+        # ...and is stripped by the CDN rule, which serves it at the root.
+        self.assertEqual(
+            loc.public_url,
+            "https://artifacts.example.com/12345-linux/blas_lib_gfx94X.tar.xz",
+        )
+
+    def test_independent_of_each_other(self):
+        """A bucket may have cdn_rules with no key_prefix, and vice versa.
+
+        TheRock's own release buckets are the first case; deriving one field from
+        the other would break them.
+        """
+        release = require_bucket_config("therock-nightly-python")
+        self.assertEqual(release.key_prefix, "")
+        self.assertTrue(release.cdn_rules)
+
+        artifacts = require_bucket_config("therock-ci-artifacts")
+        self.assertEqual(artifacts.key_prefix, "")
+        self.assertEqual(artifacts.cdn_rules, ())
+
+
+class TestNamespaceExternalRepos(unittest.TestCase):
+    """external_repo is driven by the bucket config flag, not a literal name."""
+
+    def _retrieve(self, config, github_repository):
+        with mock.patch.object(
+            workflow_outputs,
+            "get_artifacts_bucket_config_for_workflow_run",
+            return_value=config,
+        ):
+            return workflow_outputs._retrieve_bucket_info(
+                github_repository=github_repository
+            )
+
+    def test_shared_external_bucket_namespaces(self):
+        config = require_bucket_config("therock-ci-artifacts-external")
+        self.assertTrue(config.namespace_external_repos)
+        external_repo, returned = self._retrieve(config, "SomeUser/TheRock")
+        self.assertEqual(external_repo, "SomeUser-TheRock/")
+        self.assertIs(returned, config)
+
+    def test_dedicated_bucket_does_not_namespace(self):
+        config = require_bucket_config("therock-ci-artifacts")
+        self.assertFalse(config.namespace_external_repos)
+        external_repo, returned = self._retrieve(config, "ROCm/TheRock")
+        self.assertEqual(external_repo, "")
+        self.assertIs(returned, config)
+
+    def test_returns_config_not_name(self):
+        """The whole config is returned so from_workflow_run can read key_prefix."""
+        config = S3BucketConfig(name="downstream", key_prefix="v3/artifacts/")
+        _, returned = self._retrieve(config, "ROCm/TheRock")
+        self.assertIsInstance(returned, S3BucketConfig)
+        self.assertEqual(returned.key_prefix, "v3/artifacts/")
 
 
 if __name__ == "__main__":

--- a/docs/development/s3_buckets.md
+++ b/docs/development/s3_buckets.md
@@ -13,6 +13,7 @@ and explains the authentication needed to upload to them.
   - [Build system buckets](#build-system-buckets): `rocm-third-party-deps`
   - [Cache buckets](#cache-buckets): `therock-pytorch-sccache-*`
   - [Legacy buckets](#legacy-buckets): `therock-artifacts`, `therock-artifacts-external`
+- [Extending the inventory from another repository](#extending-the-inventory-from-another-repository)
 
 ## Authentication
 
@@ -150,6 +151,16 @@ Developer-facing current-release documentation should use the
 stream-specific `repo.amd.com` URLs above. CI may read artifact S3 URLs
 directly when consuming intermediate build outputs.
 
+The mappings in the CDN column below are also encoded as `cdn_rules` on each
+`S3BucketConfig` in
+[`build_tools/_therock_utils/s3_buckets.py`](/build_tools/_therock_utils/s3_buckets.py),
+so tooling can resolve them via `StorageLocation.public_url` instead of
+re-deriving them. A bucket or key prefix with no rule falls back to its raw S3
+URL. Not every cell below has a rule: the prerelease and release *package* CDNs
+serve a distro-partitioned apt/dnf repository rather than a prefix rewrite of
+the bucket, so no rule is emitted for them. **Keep the table and the rules in
+sync when either changes.**
+
 | Bucket                                                                                   | Contents        | IAM role             | CDN                                                                                                                                                                                     |
 | ---------------------------------------------------------------------------------------- | --------------- | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [`therock-dev-artifacts`](https://therock-dev-artifacts.s3.amazonaws.com/)               | Build outputs   | `therock-dev`        | —                                                                                                                                                                                       |
@@ -205,3 +216,86 @@ artifacts.
 | ------------------------------------------------------------------------------------ | ------------------------------- | ---------------------------- |
 | [`therock-artifacts`](https://therock-artifacts.s3.amazonaws.com/)                   | `therock-ci-artifacts`          | `therock-artifacts`          |
 | [`therock-artifacts-external`](https://therock-artifacts-external.s3.amazonaws.com/) | `therock-ci-artifacts-external` | `therock-artifacts-external` |
+
+## Extending the inventory from another repository
+
+Repositories that reuse TheRock's build tools against their own buckets can add
+to the inventory above with a JSON registry file, instead of patching the
+scripts. Point at it either way:
+
+- `--bucket-config-file <path>`, on `artifact_manager.py` subcommands. Prefer
+  this: it makes a single invocation self-describing, so the registry in use is
+  visible in the command line rather than inherited unnoticed from a parent
+  process.
+- `THEROCK_S3_BUCKETS_FILE=<path>` in the environment, for wrapper scripts that
+  shell out to several entry points and cannot pass a flag to each.
+
+Both are process-wide: whichever is used sets one registry for the whole
+invocation, read by every backend it builds. That is deliberate — the registry
+answers "which buckets exist and where do they map", which does not vary between
+the two ends of an `artifact_manager copy`. What does vary is the transport, and
+that is a separate per-end flag (`--source-transport`).
+
+The flag wins when both are set, and the choice is logged.
+
+```json
+{
+  "version": 1,
+  "buckets": [
+    {
+      "name": "therock-npi-artifacts",
+      "iam_role": "therock-npi",
+      "key_prefix": "v3/artifacts/",
+      "cdn_rules": [
+        {
+          "key_prefix": "v3/artifacts/",
+          "url_prefix": "https://genesis.example.com/artifacts/"
+        }
+      ]
+    }
+  ],
+  "artifacts_buckets": {
+    "ci": "therock-npi-artifacts",
+    "ci-external": "therock-npi-artifacts"
+  }
+}
+```
+
+`buckets` registers metadata. `key_prefix` is the prefix the bucket stores
+everything under, and is folded into every key the tools generate; it is
+normalized to a trailing `/` and must not begin with one. `cdn_rules` map a key
+prefix to a public URL prefix, longest match first.
+
+`namespace_external_repos` (default `false`) makes uploads to the bucket
+additionally namespaced by `{owner}-{repo}/`. Set it on any bucket that more
+than one repository writes to — `therock-ci-artifacts-external` is the in-tree
+example. Without it, keys are namespaced only by GitHub run ID, and run IDs are
+allocated per repository rather than globally, so two repositories sharing a
+bucket will eventually collide on a run ID and overwrite each other's artifacts.
+
+`artifacts_buckets` and `release_buckets` override *selection* — which bucket
+the lookup functions choose. Registration alone is not enough, because those
+functions compute a bucket name from a formula (`therock-{release_type}-artifacts`)
+that a downstream repository does not follow. Valid `artifacts_buckets` slots
+are `ci`, `ci-external`, `dev`, `nightly`, and `prerelease`; `release_buckets`
+is keyed by release type and then by `tarball`, `python`, or `packages`.
+
+Note the two CI slots. A repository other than `ROCm/TheRock` selects
+`ci-external` for **all** of its CI, not just fork PRs, so a downstream repo
+normally sets both — to the same bucket, if fork PRs need no separate
+destination. They are separate keys deliberately: overriding only `ci` must not
+silently redirect untrusted fork uploads into a trusted bucket.
+
+Merge rules:
+
+- Additive. A bucket name that already exists in TheRock's inventory is
+  **rejected** unless the entry sets `"override": true`, in which case it fully
+  replaces the built-in entry (no field-wise merge) and the replacement is
+  logged. Silently retargeting a production bucket from an inherited environment
+  variable would be the worst failure this mechanism could have, so it is
+  opt-in and loud.
+- Unknown keys at any level are an error. A typo'd `cdn_rule` would otherwise
+  mean "this bucket has no CDN", which is exactly the silently-wrong-URL
+  outcome the registry exists to prevent.
+- Selection overrides must name a bucket registered in the same file or in-tree.
+- Every error message names the file being loaded.

--- a/docs/development/s3_buckets.md
+++ b/docs/development/s3_buckets.md
@@ -133,6 +133,18 @@ prefix. For example, nightly Core tarballs are at
 https://nightly.repo.amd.com/rocm/core/tarball/ and nightly native packages
 are under https://nightly.repo.amd.com/rocm/core/packages/.
 
+That rewrite is encoded, not just documented: each product bucket carries
+`key_prefix="v5/"` and a `CdnRule` mapping `v5/` to
+`https://<stream>.repo.amd.com/`, so `StorageLocation.public_url` derives the
+address above from the S3 key. The rule is built from one
+`f"https://{stream}.repo.amd.com/"` formula rather than a per-stream table,
+because [RFC0012](../rfcs/RFC0012-Repo-Structure.md) gives every stream the same
+hierarchy under its own subdomain — a stream that has not finished cutting over
+needs no edit here when it does.
+
+None of the product buckets are readable over raw S3 — they carry
+`anonymous_s3_read=false`, and the stream CDN is the only public way in.
+
 Pip installs must use the aggregate index, such as
 https://nightly.repo.amd.com/rocm/whl-next/. Product-local Python indexes are
 publication and indexer inputs, not self-contained install entry points.
@@ -246,6 +258,7 @@ The flag wins when both are set, and the choice is logged.
       "name": "therock-npi-artifacts",
       "iam_role": "therock-npi",
       "key_prefix": "v3/artifacts/",
+      "anonymous_s3_read": false,
       "cdn_rules": [
         {
           "key_prefix": "v3/artifacts/",
@@ -266,6 +279,21 @@ everything under, and is folded into every key the tools generate; it is
 normalized to a trailing `/` and must not begin with one. `cdn_rules` map a key
 prefix to a public URL prefix, longest match first.
 
+A rule maps a *prefix*, not a whole bucket, because the public path is usually
+not the S3 path: `v5/rocm/core/tarball/` in `therock-repo-amd-nightly-core` is
+served at `https://nightly.repo.amd.com/rocm/core/tarball/`. The rule carries
+both the prefix to strip and the URL to substitute. For a bucket whose whole
+contents map to one URL, use `"key_prefix": ""`.
+
+`anonymous_s3_read` (default `true`) says whether the bucket can be read over
+raw S3 without credentials. It selects which URL `StorageLocation.download_url`
+hands to pip, apt/dnf, or a plain download: the raw S3 URL when reads there work
+(CI avoids CloudFront data-transfer charges that way), the CDN when they do not.
+Set it `false` for a private bucket — the prerelease and release buckets are
+private in-tree, and a private bucket handed a raw S3 URL produces a link that
+answers 403. A private bucket with no `cdn_rules` covering the key raises rather
+than returning an unusable URL.
+
 `namespace_external_repos` (default `false`) makes uploads to the bucket
 additionally namespaced by `{owner}-{repo}/`. Set it on any bucket that more
 than one repository writes to — `therock-ci-artifacts-external` is the in-tree
@@ -273,12 +301,22 @@ example. Without it, keys are namespaced only by GitHub run ID, and run IDs are
 allocated per repository rather than globally, so two repositories sharing a
 bucket will eventually collide on a run ID and overwrite each other's artifacts.
 
-`artifacts_buckets` and `release_buckets` override *selection* — which bucket
-the lookup functions choose. Registration alone is not enough, because those
-functions compute a bucket name from a formula (`therock-{release_type}-artifacts`)
-that a downstream repository does not follow. Valid `artifacts_buckets` slots
-are `ci`, `ci-external`, `dev`, `nightly`, and `prerelease`; `release_buckets`
-is keyed by release type and then by `tarball`, `python`, or `packages`.
+`artifacts_buckets`, `release_buckets` and `product_release_buckets` override
+*selection* — which bucket the lookup functions choose. Registration alone is
+not enough, because those functions compute a bucket name from a formula
+(`therock-{release_type}-artifacts`, `therock-repo-amd-{stream}-{product}`) that
+a downstream repository does not follow.
+
+| Key                       | Slots                                                                         |
+| ------------------------- | ----------------------------------------------------------------------------- |
+| `artifacts_buckets`       | `ci`, `ci-external`, `dev`, `dev-bkc`, `nightly`, `nightly-bkc`, `prerelease` |
+| `release_buckets`         | release type, then `tarball`, `python`, or `packages`                         |
+| `product_release_buckets` | release type, then `core`, `pytorch`, or `jax`                                |
+
+The BKC release types have their own `artifacts_buckets` slots even though they
+share dev's and nightly's buckets in-tree, so a downstream repository can
+redirect a BKC channel without also redirecting the channel it shares a bucket
+with.
 
 Note the two CI slots. A repository other than `ROCm/TheRock` selects
 `ci-external` for **all** of its CI, not just fork PRs, so a downstream repo


### PR DESCRIPTION
ISSUE ID : https://github.com/ROCm/TheRock/issues/7091

## Motivation

`StorageLocation.https_url` hardcodes `https://{bucket}.s3.amazonaws.com/{path}`, but most of
these buckets are fronted by a CDN. Those mappings live only as a prose table in
`docs/development/s3_buckets.md`, so nothing can read them — and everyone who needs a public URL
re-derives one by hand.

The repo.amd.com rewire (#7547, #7392, #7553) made this sharper rather than obsolete. RFC0012's
layout is a **key-prefix rewrite**:

```
s3://therock-repo-amd-nightly-core/v5/rocm/core/tarball/X
                 ↓  v5/ stripped
    https://nightly.repo.amd.com/rocm/core/tarball/X
```

Nothing in the tree derives that address. `v5/rocm/<product>/` is a hardcoded f-string in
`python_package_paths.py:127` and repeated through `publish_rocm_to_release_buckets.py`, and
`get_product_release_bucket_config` builds `therock-repo-amd-{stream}-{product}` from a formula
that `python_package_paths.py:65` now implements a second time — under a comment reading
"Centralized here". #7351 added a third copy of the `v5/rocm` prefix in
`download_python_packages.py:249`. The duplication this PR removes has been growing.

Downstream is the sharpest case. `rocm-npi-dev` monkey-patches
`WorkflowOutputRoot.from_workflow_run` in two scripts, stores its `v3/artifacts/` key prefix in
the **`external_repo`** field (a fork-namespace field — semantic abuse it documents itself), and
keeps two copies of an S3→CDN rewrite table installed by regex-sniffing TheRock's module layout
at run time. Its three rewrites are the same shape as `v5/`: one CDN host, three different
`v3/…` prefixes to strip.

## Technical Details

Four commits, reviewable in order.

**1. `CdnRule` and `.public_url`.** A frozen `CdnRule(key_prefix, url_prefix)` and a `cdn_rules`
field on `S3BucketConfig`. `StorageLocation.public_url` resolves through the registry, longest
matching prefix first, and falls back to `.https_url`.

`.https_url` deliberately stays the raw S3 URL rather than changing in place. It is named after a
fact; returning CloudFront from it removes any way to get the origin back, and would flip
behaviour at every call site the day someone adds a rule — in production CI for TheRock,
rocm-libraries, rocm-systems, llvm-project and rockrel. `storage_location.py` is bundled into the
artifact-index Lambda and has no project imports, so the resolver lives in `s3_buckets.py` behind
a function-local import.

**2. `key_prefix` on the bucket config.** It is a property of the bucket, not of a workflow run —
it applies to objects `WorkflowOutputRoot` never produces. Folded into `relative_path` at
construction so `relative_path` *is* the S3 key, which makes CDN stripping fall out of the
existing rule matching. This lets `external_repo` keep meaning "fork namespace", and the literal
`== "therock-ci-artifacts-external"` compare becomes a `namespace_external_repos` flag.

**3. Registry file.** `--bucket-config-file` on `artifact_manager.py`, or
`THEROCK_S3_BUCKETS_FILE` for wrapper scripts that shell out to several entry points. The flag
wins and the choice is logged. Merges are additive; shadowing an in-tree name is **rejected**
unless the entry sets `"override": true`, in which case it fully replaces and logs. Unknown keys
at any level are an error — a typo'd `cdn_rule` would otherwise mean "this bucket has no CDN",
exactly the silently-wrong-URL outcome the registry exists to prevent.

**4. Product buckets and `anonymous_s3_read`.** See below.

### Registering the v5 product buckets

`get_product_release_bucket_config` synthesized a config that was not in the inventory, so
`lookup_bucket_config` could not see it and every object in those buckets fell back to a raw S3
URL. They are now registered like any other bucket and the getter looks them up; the config it
returns is identical field for field, pinned by a test.

Each carries `key_prefix="v5/"` and a rule mapping `v5/` to `https://<stream>.repo.amd.com/`,
built from **one formula** rather than a per-stream table — RFC0012 gives every stream the same
hierarchy under its own subdomain, so a stream still cutting over needs no edit here when it
finishes.

### `anonymous_s3_read`

The split between machine-consumed URLs (raw S3, to avoid CloudFront egress charges) and
human-facing links (CDN) was a global policy standing in for a per-bucket fact — and the fact
does not hold globally. Probed anonymously on 2026-08-25 by requesting a key that does not exist,
so `404 NoSuchKey` distinguishes readable from `403 AccessDenied`:

| Readable | Refused |
| --- | --- |
| every `*-artifacts` bucket | every `*-packages` bucket |
| `dev`/`nightly` python + tarball | `prerelease`/`release` python + tarball |
| | all `therock-repo-amd-*` product buckets |

So the prerelease buckets are not merely expensive to read over raw S3, they are **unreadable** —
which is the root cause of #2139, and the same reason `rocm-npi-dev` passes a CloudFront URL as
its pip index in nine workflows.

`StorageLocation.download_url` now picks per bucket, and raises rather than returning a URL that
answers 403. **Nothing changes in TheRock today**: `package_find_links_url`,
`package_repository_url` and `tarball_urls` all resolve to artifacts buckets, which are readable
and keep the default.

### CDN rule verification

The inventory holds 24 rules across 16 distinct CDN prefixes. Probed 2026-08-25: every legacy
prefix and the `dev`, `nightly` and `rc` stream roots serve. Not yet reachable are
`bkc.repo.amd.com` (no DNS), `rc/rocm/core/tarball/`, and the `stable` paths — streams and paths
still being brought up.

That is deliberate. The registry encodes RFC0012's target layout, derived from a single
`f"https://{stream}.repo.amd.com/"` formula, so each becomes correct as it comes online with no
code change here. Emitting only "what serves today" would mean another round of hand-edits across
five files per stream.

Where a mapping is not a prefix rewrite at all, no rule is emitted: the prerelease and release
*package* CDNs serve a distro-partitioned apt/dnf repo, and no CDN is published for the ASAN
prefixes. No rule means the raw S3 URL, i.e. today's behaviour exactly.

### Blast radius

**Zero today.** Every `.public_url` call site migrated here resolves to a `therock-*-artifacts`
bucket, and all of those carry `cdn_rules=()`. `TestArtifactsBucketsHaveNoCdn` pins that, so a
future rule addition fails loudly rather than silently rewriting production CI job-summary links.

### Designs considered and rejected

Prior art: #4088, #4167, #4199. Both earlier URI designs were rejected in review and are not
revived:

- **`THEROCK_HTTPS_URL_<bucket>` env var** (#4088): one variable per bucket, no schema, no
  validation, cannot express key prefixes, cannot refuse to clobber a production bucket.
- **`StorageConfig` format-string templates** (#4199): rejected as encoding a schema with
  component replacement rules.

A per-bucket `cdn_url` string — the shape #7517 proposes — is not enough either. It supplies a
URL to prepend but no prefix length to strip, which is exactly what `v5/` and NPI's `v3/` need.
`CdnRule` pairs the two; for a whole-bucket mapping it degenerates to `CdnRule("", url)`.

The registry file differs from the rejected env var on every point: one pointer to one document,
validated on load, key-prefix aware, and shadowing requires explicit opt-in. It is still
process-wide state and the docs say so; the honest distinction is *explicit and validated*, not
*non-ambient*.

## Test Plan

- `cd build_tools && python -m pytest`
- `pre-commit run --all-files`
- Every CDN prefix and derived index URL fetched anonymously; every bucket probed for anonymous
  read. Results above.

New coverage in `s3_buckets_test.py`, `workflow_outputs_test.py` and
`find_artifacts_for_commit_test.py`: `CdnRule` normalization and rejection of malformed prefixes;
per-bucket round trips; longest-prefix-wins; registry file valid / invalid / duplicate /
unknown-key / unknown-version / shadow-without-override; `key_prefix` composition with and
without `external_repo`; the v5 round trip asserted as literal URLs;
`TestForkPrConfigPreservesNewFields`, which pins the one field-by-field config rebuild that
silently dropped every new field on fork PRs until it became a `dataclasses.replace`; and a
downstream round trip in the shape `rocm-npi-dev` needs, so an upstream refactor cannot break
that repo as silently as its module-sniffing patches allow today.

## Test Result

`cd build_tools && python -m pytest` on this branch (Linux, Python 3.12):
**2132 passed, 8 skipped, 244 subtests passed**, 0 failed.

`pre-commit run` clean across all 18 changed files.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
