### PR TITLE
Add a read-only HTTP artifact backend and explicit transport selection

### DIFF
--- a/build_tools/_therock_utils/artifact_backend.py
+++ b/build_tools/_therock_utils/artifact_backend.py
@@ -1,36 +1,37 @@
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-"""Abstraction layer for artifact storage backends (S3 or local directory).
+"""Abstraction layer for artifact storage backends (S3, HTTP, or local directory).
 
 This module provides a unified interface for artifact storage that works with
-both local directories (for prototyping/testing) and S3 (for CI/CD).
+local directories (for prototyping/testing), S3 (for CI/CD), and plain HTTPS
+(read-only, no credentials).
 
 TODO(scotttodd): Consolidate with StorageBackend in storage_backend.py? Both
 modules manage S3 clients and local directory mirroring. ArtifactBackend has
 download/list/exists operations that StorageBackend doesn't have yet.
 
-Environment-based switching:
-- THEROCK_LOCAL_STAGING_DIR set → use LocalDirectoryBackend
-- Otherwise → use S3Backend
+Backend selection is explicit via ``create_backend(transport=...)``. The
+``transport="auto"`` default resolves to LocalDirectoryBackend when
+THEROCK_LOCAL_STAGING_DIR is set and to S3Backend otherwise -- the writable
+backend for the current run, which is what ``create_backend_from_env`` used to
+mean before transport became an argument.
 """
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from html.parser import HTMLParser
 from pathlib import Path
-from typing import List, Optional, Set
+from typing import List, Optional
+from urllib.parse import unquote, urlparse
+import http.client
 import os
 import shutil
+import tempfile
+import urllib.error
+import urllib.request
 
+from .hash_util import calculate_hash
 from .workflow_outputs import WorkflowOutputRoot
-
-
-@dataclass
-class ArtifactLocation:
-    """Represents an artifact's location in the backend."""
-
-    artifact_key: str  # e.g., "blas_lib_gfx94X.tar.zst" or "blas_lib_gfx94X.tar.xz"
-    full_path: str  # Backend-specific full path/URI
 
 
 # Supported artifact archive extensions (in order of preference)
@@ -259,6 +260,12 @@ class S3Backend(ArtifactBackend):
 
     def list_artifacts(self, name_filter: Optional[str] = None) -> List[str]:
         """List S3 artifacts."""
+        # TODO: pass Delimiter="/" and skip CommonPrefixes. Without it this walks
+        # the whole subtree and reports e.g. logs/<stage>/ccache_logs.tar.zst as a
+        # run-root artifact named "ccache_logs.tar.zst", which then 404s on
+        # download. HTTPBackend does not have this bug because it reads only the
+        # run root's index. Left alone here because narrowing the listing changes
+        # behavior for every S3 caller and belongs in its own change.
         paginator = self.s3_client.get_paginator("list_objects_v2")
         page_iterator = paginator.paginate(Bucket=self.bucket, Prefix=self.s3_prefix)
 
@@ -327,42 +334,317 @@ class S3Backend(ArtifactBackend):
             self.s3_client.head_object(Bucket=self.bucket, Key=loc.relative_path)
             return True
         except Exception:
+            # TODO: Narrow this to ClientError with a 404/403 status. A 500 from
+            # S3 currently reads as "the artifact does not exist", the same bug
+            # HTTPBackend.artifact_exists below avoids.
             return False
 
 
-def create_backend_from_env(
+class _IndexLinkParser(HTMLParser):
+    """Collects href values from an artifact index page.
+
+    A real parser rather than a regex: the generator emits attributes we do not
+    control the quoting of, and a regex that silently matches nothing turns a
+    broken page into "no artifacts found", which is indistinguishable from a run
+    that produced none.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.hrefs: List[str] = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag != "a":
+            return
+        for name, value in attrs:
+            if name == "href" and value:
+                self.hrefs.append(value)
+
+
+class HTTPBackend(ArtifactBackend):
+    """Read-only backend that fetches artifacts over plain HTTPS.
+
+    No credentials and no boto3: this reads the same public URLs a browser
+    would. Every URL comes from ``StorageLocation.public_url``, so it resolves
+    to a CDN for buckets that have one configured (see
+    ``_therock_utils/s3_buckets.py``) and to the raw S3 URL otherwise.
+
+    ``list_artifacts`` reads the generated directory index at
+    ``{prefix}/index.html``. Artifacts live directly at the run root, so a
+    single fetch enumerates all of them.
+
+    Uploads are not supported; use ``transport='s3'`` for those.
+
+    Usage::
+
+        output_root = WorkflowOutputRoot.from_workflow_run(
+            run_id="23309603946", platform="linux"
+        )
+        backend = HTTPBackend(output_root)
+        artifacts = backend.list_artifacts(name_filter="blas")
+        backend.download_artifact("blas_lib_gfx1200.tar.zst", Path("/tmp/blas.tar.zst"))
+    """
+
+    def __init__(self, output_root: WorkflowOutputRoot, *, timeout: float = 60.0):
+        self.output_root = output_root
+        self.timeout = timeout
+        self._artifact_cache: Optional[List[str]] = None
+
+    @property
+    def base_uri(self) -> str:
+        return self.output_root.root().public_url
+
+    def _download_file(self, url: str, dest: Path) -> None:
+        """Download a URL to a local path.
+
+        The download lands on a temporary file next to ``dest`` and is renamed
+        into place only after the body has been fully read, so an interrupted
+        transfer never leaves a truncated file at ``dest``. This matters more
+        here than it looks: a truncated download that happens to be replacing an
+        older copy would otherwise be indistinguishable from a good one, and
+        ``download_artifact`` only verifies a checksum when one is published.
+
+        Raises:
+            FileNotFoundError: The resource does not exist (HTTP 404 or 403).
+            ConnectionError: Network-level failure (timeout, DNS, TLS, or a
+                connection dropped mid-body).
+            urllib.error.HTTPError: Any other HTTP status, including 5xx.
+        """
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        fd, temp_name = tempfile.mkstemp(dir=dest.parent, prefix=f".{dest.name}.")
+        temp_path = Path(temp_name)
+        try:
+            # fdopen outermost so it owns the descriptor from the first line of
+            # the try: whatever raises below, the `with` closes it exactly once.
+            with os.fdopen(fd, "wb") as f:
+                with urllib.request.urlopen(url, timeout=self.timeout) as response:
+                    shutil.copyfileobj(response, f)
+            temp_path.replace(dest)
+        except urllib.error.HTTPError as e:
+            # HTTPError subclasses URLError, so it has to be caught first.
+            # 403 is included because S3 returns it instead of 404 for a missing
+            # key when the caller lacks ListBucket.
+            if e.code in (403, 404):
+                raise FileNotFoundError(f"Not found: {url}") from e
+            raise
+        except urllib.error.URLError as e:
+            raise ConnectionError(f"Failed to download {url}: {e}") from e
+        except (OSError, http.client.HTTPException) as e:
+            # A connection dropped part-way through the body surfaces here rather
+            # than as a URLError: urlopen already returned, so what fails is the
+            # read (IncompleteRead, ConnectionResetError, TimeoutError).
+            raise ConnectionError(f"Failed to download {url}: {e}") from e
+        finally:
+            # A no-op on the success path, where replace() already moved it.
+            temp_path.unlink(missing_ok=True)
+
+    def _parse_index_html(self, html_content: str) -> List[str]:
+        """Extract artifact filenames from an index page."""
+        parser = _IndexLinkParser()
+        parser.feed(html_content)
+
+        artifacts = []
+        for href in parser.hrefs:
+            # The generator percent-encodes hrefs; the filename on disk is the
+            # decoded form.
+            filename = unquote(href)
+            # Skip the parent link, nested index pages, and absolute links.
+            if filename.startswith(("..", "index", "#")) or urlparse(filename).scheme:
+                continue
+            if _is_artifact_archive(filename):
+                artifacts.append(filename)
+        return artifacts
+
+    def _fetch_index(self) -> List[str]:
+        """Fetch and parse the run's artifact index.
+
+        Raises:
+            FileNotFoundError: The index does not exist. This is an error rather
+                than an empty result: an index is written for every run that
+                uploaded anything, so a missing one means the run ID, platform,
+                or bucket is wrong, and returning [] would report that as
+                "this run has no artifacts".
+            ConnectionError: Network-level failure.
+            urllib.error.HTTPError: Any other HTTP status, including 5xx.
+        """
+        index_url = self.output_root.artifact_index().public_url
+        try:
+            with urllib.request.urlopen(index_url, timeout=self.timeout) as response:
+                html_content = response.read().decode("utf-8")
+        except urllib.error.HTTPError as e:
+            if e.code in (403, 404):
+                raise FileNotFoundError(
+                    f"No artifact index at {index_url}. Check the run ID, platform, "
+                    f"and bucket."
+                ) from e
+            raise
+        except urllib.error.URLError as e:
+            raise ConnectionError(f"Failed to fetch {index_url}: {e}") from e
+        return self._parse_index_html(html_content)
+
+    def list_artifacts(self, name_filter: Optional[str] = None) -> List[str]:
+        """List artifacts published for this run."""
+        if self._artifact_cache is None:
+            self._artifact_cache = sorted(set(self._fetch_index()))
+
+        artifacts = self._artifact_cache
+        if name_filter is not None:
+            artifacts = [a for a in artifacts if a.startswith(f"{name_filter}_")]
+        return sorted(artifacts)
+
+    def download_artifact(self, artifact_key: str, dest_path: Path) -> None:
+        """Download an artifact, verifying its sha256 if one is published.
+
+        Raises:
+            FileNotFoundError: The artifact does not exist.
+            ValueError: The published checksum does not match what was received.
+        """
+        artifact_url = self.output_root.artifact(artifact_key).public_url
+        self._download_file(artifact_url, dest_path)
+
+        checksum_key = f"{artifact_key}.sha256sum"
+        checksum_url = self.output_root.artifact(checksum_key).public_url
+        checksum_path = dest_path.parent / checksum_key
+        try:
+            self._download_file(checksum_url, checksum_path)
+        except FileNotFoundError:
+            # Artifacts may be published without a checksum. Scope this except
+            # to the download alone: a FileNotFoundError raised while verifying
+            # would otherwise be swallowed as "no checksum published".
+            print(f"WARNING: no checksum published for {artifact_key}, not verifying")
+            return
+
+        expected = checksum_path.read_text().split()[0]
+        actual = calculate_hash(dest_path, "sha256").hexdigest()
+        if expected != actual:
+            dest_path.unlink(missing_ok=True)
+            checksum_path.unlink(missing_ok=True)
+            raise ValueError(
+                f"Checksum mismatch for {artifact_key} downloaded from "
+                f"{artifact_url}: expected {expected}, got {actual}"
+            )
+
+    def upload_artifact(self, source_path: Path, artifact_key: str) -> None:
+        raise NotImplementedError(
+            "HTTPBackend is read-only; use transport='s3' to upload artifacts"
+        )
+
+    def copy_artifact(
+        self, artifact_key: str, source_backend: "ArtifactBackend"
+    ) -> None:
+        raise NotImplementedError(
+            "HTTPBackend is read-only; use transport='s3' to copy artifacts"
+        )
+
+    def artifact_exists(self, artifact_key: str) -> bool:
+        """Check whether an artifact is published for this run."""
+        # The cache only holds archives, so it cannot answer for a .sha256sum
+        # (which S3Backend.copy_artifact asks about). Fall through to a HEAD for
+        # anything the index would not have listed.
+        if self._artifact_cache is not None and _is_artifact_archive(artifact_key):
+            return artifact_key in self._artifact_cache
+
+        # Probe the same URL download_artifact would fetch, CDN included, rather
+        # than the raw S3 origin. This backend exists for readers with no AWS
+        # credentials, whose bucket may not be anonymously readable at all; a
+        # probe of an origin it cannot read would answer "absent" for artifacts
+        # that are published. Reading through the CDN and probing through it
+        # means both questions are asked about the same bytes.
+        artifact_url = self.output_root.artifact(artifact_key).public_url
+        request = urllib.request.Request(artifact_url, method="HEAD")
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout):
+                return True
+        except urllib.error.HTTPError as e:
+            if e.code in (403, 404):
+                return False
+            # A 5xx means the server could not answer, not that the object is
+            # absent. Reporting "does not exist" here would let a caller
+            # silently skip an artifact that is actually present.
+            raise
+        except urllib.error.URLError as e:
+            raise ConnectionError(f"Failed to probe {artifact_url}: {e}") from e
+
+
+# Transports accepted by create_backend. "auto" resolves to the writable
+# backend for the current run: local staging if configured, S3 otherwise.
+TRANSPORTS = ("auto", "s3", "http", "local")
+
+# Transports that can be written to. "http" is read-only.
+WRITABLE_TRANSPORTS = ("auto", "s3", "local")
+
+# Transports a `copy` can read from. Copying is a same-kind operation - S3
+# copies server-side and local copies on the filesystem - so an HTTP source has
+# no counterpart to copy into. Fetch it and push it instead.
+COPY_SOURCE_TRANSPORTS = ("auto", "s3", "local")
+
+
+def create_backend(
     run_id: Optional[str] = None,
     github_repository: Optional[str] = None,
     platform: Optional[str] = None,
+    *,
+    transport: str = "auto",
+    staging_dir: Optional[Path] = None,
 ) -> ArtifactBackend:
-    """Create the appropriate backend based on environment variables.
+    """Create an artifact backend for the given transport.
 
-    Environment variables:
-    - THEROCK_LOCAL_STAGING_DIR: If set, use local backend
-    - THEROCK_RUN_ID: Override run ID (default: "local" or GITHUB_RUN_ID)
-    - THEROCK_PLATFORM: Override platform (default: current platform)
+    Transport is a per-call argument rather than something inferred from ambient
+    state, because a single process can need two different backends at once:
+    ``artifact_manager copy`` builds a source and a destination and reads one
+    while writing the other, which is why it takes ``--source-transport`` and
+    ``--transport`` separately.
 
-    For S3 backend (when THEROCK_LOCAL_STAGING_DIR is not set):
-    - Uses WorkflowOutputRoot.from_workflow_run() for bucket selection
+    Args:
+        run_id: Run ID (default: THEROCK_RUN_ID, GITHUB_RUN_ID, or "local").
+        github_repository: Repository owning the run, for bucket selection.
+        platform: Platform name (default: THEROCK_PLATFORM or the current one).
+        transport: One of ``TRANSPORTS``.
+
+            * ``auto``  - local staging if THEROCK_LOCAL_STAGING_DIR (or
+              ``staging_dir``) is set, otherwise S3. The writable backend for
+              the current run.
+            * ``s3``    - S3 with boto3 credentials. Read/write.
+            * ``http``  - public HTTPS, no credentials. Read-only.
+            * ``local`` - a local staging directory. Read/write.
+        staging_dir: Staging directory for ``local`` (and for ``auto`` when set).
+            Defaults to THEROCK_LOCAL_STAGING_DIR.
+
+    Raises:
+        ValueError: Unknown transport, or ``local`` with no staging directory.
     """
     import platform as platform_module
 
-    local_staging = os.getenv("THEROCK_LOCAL_STAGING_DIR")
+    if transport not in TRANSPORTS:
+        raise ValueError(
+            f"Unknown transport {transport!r}, expected one of {', '.join(TRANSPORTS)}"
+        )
+
     platform_name = platform or os.getenv(
         "THEROCK_PLATFORM", platform_module.system().lower()
     )
     run_id = run_id or os.getenv("THEROCK_RUN_ID", os.getenv("GITHUB_RUN_ID", "local"))
+    staging = staging_dir or os.getenv("THEROCK_LOCAL_STAGING_DIR")
 
-    if local_staging:
-        output_root = WorkflowOutputRoot.for_local(
-            run_id=run_id, platform=platform_name
-        )
+    if transport == "auto":
+        transport = "local" if staging else "s3"
+
+    if transport == "local":
+        if not staging:
+            raise ValueError(
+                "transport='local' needs a staging directory; pass staging_dir or "
+                "set THEROCK_LOCAL_STAGING_DIR"
+            )
         return LocalDirectoryBackend(
-            staging_dir=Path(local_staging),
-            output_root=output_root,
+            staging_dir=Path(staging),
+            output_root=WorkflowOutputRoot.for_local(
+                run_id=run_id, platform=platform_name
+            ),
         )
 
     output_root = WorkflowOutputRoot.from_workflow_run(
         run_id=run_id, platform=platform_name, github_repository=github_repository
     )
+    if transport == "http":
+        return HTTPBackend(output_root=output_root)
     return S3Backend(output_root=output_root)

--- a/build_tools/_therock_utils/storage_location.py
+++ b/build_tools/_therock_utils/storage_location.py
@@ -55,10 +55,13 @@ class StorageLocation:
         """Raw S3 HTTPS URL, bypassing any CDN.
 
         Prefer ``.public_url`` for links a human will click. This stays the raw
-        S3 URL for machine-consumed URLs (package indexes, apt/dnf base URLs) and
-        for existence probes, where a CDN cache could give a stale answer and
-        where CI reads deliberately avoid CloudFront data-transfer charges. See
-        docs/development/s3_buckets.md.
+        S3 URL for machine-consumed URLs (package indexes, apt/dnf base URLs),
+        where CI reads deliberately avoid CloudFront data-transfer charges, and
+        for existence probes made by callers that also read from S3 directly,
+        where a CDN cache could otherwise give a stale answer about an object
+        the caller is about to fetch from the origin. A caller that reads over
+        the CDN should probe the CDN too, so that it asks about the same bytes
+        it will get. See docs/development/s3_buckets.md.
         """
         return f"https://{self.bucket}.s3.amazonaws.com/{self.relative_path}"
 

--- a/build_tools/artifact_manager.py
+++ b/build_tools/artifact_manager.py
@@ -64,9 +64,12 @@ from _therock_utils.build_topology import BuildTopology
 from _therock_utils.artifact_backend import (
     ArtifactBackend,
     ARTIFACT_EXTENSIONS,
+    COPY_SOURCE_TRANSPORTS,
     LocalDirectoryBackend,
     S3Backend,
-    create_backend_from_env,
+    TRANSPORTS,
+    WRITABLE_TRANSPORTS,
+    create_backend,
 )
 from _therock_utils.artifacts import ArtifactName, ArtifactPopulator
 from _therock_utils.hash_util import calculate_hash
@@ -441,10 +444,11 @@ def do_fetch(args: argparse.Namespace):
             return
 
     # Create backend
-    backend = create_backend_from_env(
+    backend = create_backend(
         run_id=args.run_id,
         github_repository=args.run_github_repo,
         platform=args.platform,
+        transport=args.transport,
     )
     log(f"Using backend: {backend.base_uri}")
 
@@ -776,10 +780,18 @@ def do_push(args: argparse.Namespace):
         )
 
     # Create backend
-    backend = create_backend_from_env(
+    if args.transport not in WRITABLE_TRANSPORTS:
+        log(
+            f"ERROR: push requires a writable transport "
+            f"({' or '.join(t for t in WRITABLE_TRANSPORTS if t != 'auto')}), "
+            f"got '{args.transport}'"
+        )
+        sys.exit(1)
+    backend = create_backend(
         run_id=args.run_id,
         github_repository=args.run_github_repo,
         platform=args.platform,
+        transport=args.transport,
     )
     log(f"Using backend: {backend.base_uri}")
 
@@ -949,22 +961,40 @@ def _create_source_backend(
     source_run_id: str,
     source_repository: Optional[str],
     local_staging_dir: Optional[Path],
+    transport: str = "auto",
 ) -> ArtifactBackend:
-    """Create a backend for the source run ID.
+    """Create a read backend for the source run ID.
 
-    For S3, uses WorkflowOutputRoot.from_workflow_run(lookup_workflow_run=True)
-    to resolve the correct bucket (which may differ from the current run's bucket).
+    Separate from create_backend because the source run may live in a different
+    bucket than the current run, which needs
+    WorkflowOutputRoot.from_workflow_run(lookup_workflow_run=True) to resolve.
 
     For local backends, creates a LocalDirectoryBackend in the same staging dir.
+
+    'http' is not accepted: the only caller is `copy`, which needs a source it
+    can copy from rather than merely read. See COPY_SOURCE_TRANSPORTS.
     """
-    if local_staging_dir or os.getenv("THEROCK_LOCAL_STAGING_DIR"):
-        staging = local_staging_dir or Path(os.environ["THEROCK_LOCAL_STAGING_DIR"])
-        output_root = WorkflowOutputRoot.for_local(
-            run_id=source_run_id, platform=platform
+    if transport not in COPY_SOURCE_TRANSPORTS:
+        raise ValueError(
+            f"Unknown copy source transport {transport!r}, expected one of "
+            f"{', '.join(COPY_SOURCE_TRANSPORTS)}"
         )
+
+    staging = local_staging_dir or os.getenv("THEROCK_LOCAL_STAGING_DIR")
+    if transport == "auto":
+        transport = "local" if staging else "s3"
+
+    if transport == "local":
+        if not staging:
+            raise ValueError(
+                "source transport 'local' needs --local-staging-dir or "
+                "THEROCK_LOCAL_STAGING_DIR"
+            )
         return LocalDirectoryBackend(
-            staging_dir=staging,
-            output_root=output_root,
+            staging_dir=Path(staging),
+            output_root=WorkflowOutputRoot.for_local(
+                run_id=source_run_id, platform=platform
+            ),
         )
 
     output_root = WorkflowOutputRoot.from_workflow_run(
@@ -1012,11 +1042,34 @@ def do_copy(args: argparse.Namespace):
         source_run_id=args.source_run_id,
         source_repository=args.source_repository,
         local_staging_dir=args.local_staging_dir,
+        transport=args.source_transport,
     )
-    dest_backend = create_backend_from_env(
+    if args.transport not in WRITABLE_TRANSPORTS:
+        log(
+            f"ERROR: copy requires a writable destination transport "
+            f"({' or '.join(t for t in WRITABLE_TRANSPORTS if t != 'auto')}), "
+            f"got '{args.transport}'"
+        )
+        sys.exit(1)
+    dest_backend = create_backend(
         run_id=args.run_id,
         platform=args.platform,
+        transport=args.transport,
     )
+    # Both ends must be the same kind of storage: S3 copies server-side and local
+    # copies on the filesystem, and neither can reach across. Before the two
+    # transports became separate flags this was guaranteed by construction, since
+    # one env-driven rule chose both. Now that they are chosen independently, say
+    # so up front rather than letting the first copy raise a TypeError.
+    if type(source_backend) is not type(dest_backend):
+        log(
+            f"ERROR: copy needs the source and destination on the same kind of "
+            f"storage, got {type(source_backend).__name__} (--source-transport "
+            f"'{args.source_transport}') and {type(dest_backend).__name__} "
+            f"(--transport '{args.transport}'). To move artifacts between "
+            f"storage kinds, run 'fetch' and then 'push'."
+        )
+        sys.exit(1)
 
     log(f"Source: {source_backend.base_uri}")
     log(f"Dest:   {dest_backend.base_uri}")
@@ -1207,6 +1260,14 @@ def _add_backend_args(parser: argparse.ArgumentParser):
         help="Local staging directory (sets THEROCK_LOCAL_STAGING_DIR)",
     )
     parser.add_argument(
+        "--transport",
+        choices=TRANSPORTS,
+        default=os.getenv("THEROCK_ARTIFACT_TRANSPORT", "auto"),
+        help="Artifact transport (default: 'auto', which is a local staging dir "
+        "if THEROCK_LOCAL_STAGING_DIR is set and S3 otherwise). 'http' reads "
+        "public HTTPS URLs with no credentials and cannot write.",
+    )
+    parser.add_argument(
         "--bucket-config-file",
         type=Path,
         default=None,
@@ -1353,6 +1414,17 @@ def main(argv: Optional[List[str]] = None):
         default=os.environ.get("GITHUB_REPOSITORY", "ROCm/TheRock"),
         help="GitHub repository for source-run-id in 'owner/repo' format "
         "(default: GITHUB_REPOSITORY or 'ROCm/TheRock').",
+    )
+    copy_parser.add_argument(
+        "--source-transport",
+        choices=COPY_SOURCE_TRANSPORTS,
+        default=os.getenv("THEROCK_ARTIFACT_SOURCE_TRANSPORT", "auto"),
+        help="Transport to read the source run with. Independent of --transport, "
+        "which is the destination: copy reads one location and writes another, "
+        "so the two are separate flags. 'http' is not offered here - copying is "
+        "a same-kind operation (S3 copies server-side, local copies on the "
+        "filesystem), so an HTTP source has nothing to copy into. Use "
+        "'fetch --transport http' followed by 'push' instead.",
     )
     copy_parser.add_argument(
         "--stage",

--- a/build_tools/fetch_artifacts.py
+++ b/build_tools/fetch_artifacts.py
@@ -38,6 +38,7 @@ If unspecified, we will create an anonymous boto file that can only acccess publ
 
 import argparse
 import concurrent.futures
+import os
 from pathlib import Path
 import platform
 import re
@@ -45,12 +46,18 @@ import shutil
 import sys
 
 from _therock_utils.archive_util import open_archive_for_read
-from _therock_utils.artifact_backend import ArtifactBackend, S3Backend
+from _therock_utils.artifact_backend import (
+    ArtifactBackend,
+    HTTPBackend,
+    S3Backend,
+    TRANSPORTS,
+)
 from _therock_utils.os_util import rmtree_with_retry
 from _therock_utils.artifacts import (
     ArtifactName,
     ArtifactPopulator,
 )
+from _therock_utils.s3_buckets import set_bucket_config_file
 from _therock_utils.workflow_outputs import WorkflowOutputRoot
 from artifact_manager import DownloadRequest, download_artifact
 
@@ -216,6 +223,17 @@ def extract_artifact(
 
 
 def run(args):
+    if args.bucket_config_file:
+        set_bucket_config_file(args.bucket_config_file)
+
+    if args.transport == "local":
+        log(
+            "ERROR: fetch_artifacts.py reads a published workflow run; "
+            "transport 'local' is not supported here. Use artifact_manager.py fetch "
+            "--transport local for a local staging directory."
+        )
+        sys.exit(1)
+
     run_github_repo = args.run_github_repo
     run_id = args.run_id
     artifact_group = args.artifact_group
@@ -227,7 +245,12 @@ def run(args):
         github_repository=run_github_repo,
         lookup_workflow_run=True,
     )
-    backend = S3Backend(output_root=output_root)
+    # Both transports read the same run; "http" needs no credentials but can only
+    # see what is published through the bucket's public URL.
+    if args.transport == "http":
+        backend = HTTPBackend(output_root=output_root)
+    else:
+        backend = S3Backend(output_root=output_root)
 
     # Parse individual GPU targets (comma-separated string to list).
     amdgpu_targets = (
@@ -380,6 +403,24 @@ def main(argv):
         default=False,
         help="If set, will only log which artifacts would be fetched without downloading or extracting",
         action=argparse.BooleanOptionalAction,
+    )
+    # Accepts the full transport vocabulary, not just the two this script can
+    # serve, so that a THEROCK_ARTIFACT_TRANSPORT shared with artifact_manager.py
+    # does not fail argument parsing here. 'local' is rejected in run().
+    parser.add_argument(
+        "--transport",
+        choices=TRANSPORTS,
+        default=os.getenv("THEROCK_ARTIFACT_TRANSPORT", "auto"),
+        help="How to read artifacts: 's3' (and 'auto') uses boto3 credentials, "
+        "'http' reads the bucket's public URL with no credentials (read-only)",
+    )
+    parser.add_argument(
+        "--bucket-config-file",
+        type=Path,
+        default=None,
+        help="JSON file registering S3 buckets outside TheRock's inventory. Takes "
+        "precedence over the THEROCK_S3_BUCKETS_FILE environment variable. "
+        "See build_tools/_therock_utils/s3_buckets.py for the schema.",
     )
 
     postprocess_group = parser.add_argument_group("Postprocessing")

--- a/build_tools/tests/artifact_backend_test.py
+++ b/build_tools/tests/artifact_backend_test.py
@@ -4,25 +4,38 @@
 
 """Unit tests for artifact_backend.py."""
 
+import contextlib
+import hashlib
+import io
+import json
 import os
 import socket
 import sys
 import tempfile
 import unittest
+import urllib.error
 from botocore import UNSIGNED
 from pathlib import Path
+from typing import List
 from unittest import mock
 
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 
 from _therock_utils.artifact_backend import (
     ArtifactBackend,
+    HTTPBackend,
     LocalDirectoryBackend,
     S3Backend,
-    create_backend_from_env,
+    create_backend,
 )
 from _therock_utils.workflow_outputs import WorkflowOutputRoot
-from _therock_utils.s3_buckets import S3BucketConfig, require_bucket_config
+from _therock_utils.s3_buckets import (
+    S3BucketConfig,
+    require_bucket_config,
+    set_bucket_config_file,
+)
+
+import generate_s3_index
 
 
 def _make_local_root(run_id="test-run-123", platform="linux"):
@@ -641,8 +654,12 @@ class TestS3BackendCredentials(unittest.TestCase):
             os.unlink(creds_path)
 
 
-class TestCreateBackendFromEnv(unittest.TestCase):
-    """Tests for create_backend_from_env factory function."""
+class TestCreateBackendEnvDefaults(unittest.TestCase):
+    """create_backend's defaults, which come from the environment.
+
+    Transport is an argument, but run ID, platform and staging directory still
+    default from the environment, because CI sets them once for the whole job.
+    """
 
     def test_local_backend_from_env(self):
         """Test that LocalDirectoryBackend is created when env var is set."""
@@ -655,7 +672,7 @@ class TestCreateBackendFromEnv(unittest.TestCase):
                     "THEROCK_PLATFORM": "windows",
                 },
             ):
-                backend = create_backend_from_env()
+                backend = create_backend()
 
                 self.assertIsInstance(backend, LocalDirectoryBackend)
                 self.assertIn("env-run-id", backend.base_uri)
@@ -670,7 +687,7 @@ class TestCreateBackendFromEnv(unittest.TestCase):
                     "THEROCK_LOCAL_STAGING_DIR": temp_dir,
                 },
             ):
-                backend = create_backend_from_env(
+                backend = create_backend(
                     run_id="override-run", platform="override-platform"
                 )
 
@@ -687,7 +704,7 @@ class TestCreateBackendFromEnv(unittest.TestCase):
             {"THEROCK_RUN_ID": "s3-run-id"},
             clear=True,
         ):
-            backend = create_backend_from_env()
+            backend = create_backend()
 
             self.assertIsInstance(backend, S3Backend)
             self.assertEqual(backend.bucket, "test-bucket")
@@ -709,12 +726,546 @@ class TestCreateBackendFromEnv(unittest.TestCase):
             },
             clear=True,
         ):
-            backend = create_backend_from_env(github_repository="ROCm/TheRock")
+            backend = create_backend(github_repository="ROCm/TheRock")
 
             self.assertIsInstance(backend, S3Backend)
             self.assertEqual(backend.bucket, "therock-ci-artifacts")
             # ROCm/TheRock has no external_repo prefix
             self.assertNotIn("SomeUser", backend.s3_prefix)
+
+
+class _FakeUrlOpen:
+    """Stand-in for urllib.request.urlopen backed by an in-memory URL map.
+
+    Values are either bytes (a 200 response) or an exception instance to raise.
+    Records every URL requested so tests can assert that nothing hit the network
+    that should have been served from cache.
+    """
+
+    def __init__(self, responses: dict):
+        self.responses = responses
+        self.requested: List[str] = []
+
+    def __call__(self, url_or_request, timeout=None):
+        url = getattr(url_or_request, "full_url", url_or_request)
+        self.requested.append(url)
+        if url not in self.responses:
+            raise urllib.error.HTTPError(url, 404, "Not Found", None, None)
+        value = self.responses[url]
+        if isinstance(value, Exception):
+            raise value
+        if hasattr(value, "read"):
+            return value
+        return io.BytesIO(value)
+
+
+class _FailingStream:
+    """A response body that delivers some bytes and then fails.
+
+    Models a connection dropped mid-transfer, which is the only way a truncated
+    file can actually appear: a URLError from urlopen is raised before any bytes
+    are written, so it cannot exercise the cleanup path.
+    """
+
+    def __init__(self, prefix: bytes, error: Exception):
+        self._buffer = io.BytesIO(prefix)
+        self._error = error
+
+    def read(self, size=-1):
+        chunk = self._buffer.read(size)
+        if not chunk:
+            raise self._error
+        return chunk
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+
+def _http_error(url, code):
+    return urllib.error.HTTPError(url, code, "Boom", None, None)
+
+
+def _make_index_html(filenames, title="index"):
+    """Build an index page using the real generator.
+
+    Calling the generator rather than hand-writing a fixture is the point of
+    this helper: if the emitted markup changes, HTTPBackend's parser has to keep
+    up, and these tests are what notices.
+    """
+    entries = [
+        generate_s3_index._FileEntry(
+            name=name, href=name, size_bytes=1024, last_modified=None
+        )
+        for name in filenames
+    ]
+    return generate_s3_index._generate_index_html(
+        title=title, entries=entries, parent_href="../index.html"
+    )
+
+
+class HTTPBackendTestCase(unittest.TestCase):
+    """Shared setup: a backend over a bucket with no CDN, plus URL helpers."""
+
+    def setUp(self):
+        self.output_root = WorkflowOutputRoot(
+            bucket="therock-ci-artifacts",
+            external_repo="",
+            run_id="12345",
+            platform="linux",
+        )
+        self.backend = HTTPBackend(self.output_root)
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.dest_dir = Path(self.temp_dir.name)
+
+    def url_for(self, filename):
+        return self.output_root.artifact(filename).public_url
+
+    @property
+    def index_url(self):
+        return self.output_root.artifact_index().public_url
+
+    def patch_urlopen(self, responses):
+        fake = _FakeUrlOpen(responses)
+        patcher = mock.patch("urllib.request.urlopen", fake)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        return fake
+
+
+class TestHTTPBackendIndexParsing(HTTPBackendTestCase):
+    """Tests for parsing the generated directory index."""
+
+    def test_parses_generator_output(self):
+        """The parser reads pages produced by generate_s3_index unchanged."""
+        html_content = _make_index_html(
+            ["blas_lib_gfx94X.tar.xz", "core_runtime_generic.tar.zst"]
+        )
+
+        artifacts = self.backend._parse_index_html(html_content)
+
+        self.assertEqual(
+            sorted(artifacts),
+            ["blas_lib_gfx94X.tar.xz", "core_runtime_generic.tar.zst"],
+        )
+
+    def test_percent_encoded_names_are_decoded(self):
+        """Hrefs are quoted by the generator, so the parser must unquote them."""
+        filename = "blas_lib_gfx942:xnack+.tar.xz"
+        html_content = _make_index_html([filename])
+
+        # Guard the premise: if the generator stopped encoding, this test would
+        # pass for the wrong reason.
+        self.assertIn("%3A", html_content)
+
+        self.assertEqual(self.backend._parse_index_html(html_content), [filename])
+
+    def test_non_archives_and_navigation_links_are_skipped(self):
+        html_content = _make_index_html(
+            [
+                "blas_lib_gfx94X.tar.xz",
+                "blas_lib_gfx94X.tar.xz.sha256sum",
+                "build.log",
+                "subdir/index.html",
+            ]
+        )
+
+        self.assertEqual(
+            self.backend._parse_index_html(html_content), ["blas_lib_gfx94X.tar.xz"]
+        )
+
+    def test_single_quoted_attributes_are_handled(self):
+        """A regex-based parser missed these; HTMLParser does not."""
+        html_content = "<a href='blas_lib_gfx94X.tar.xz'>blas</a>"
+
+        self.assertEqual(
+            self.backend._parse_index_html(html_content), ["blas_lib_gfx94X.tar.xz"]
+        )
+
+    def test_absolute_links_are_skipped(self):
+        html_content = '<a href="https://example.com/other_lib_generic.tar.xz">x</a>'
+
+        self.assertEqual(self.backend._parse_index_html(html_content), [])
+
+
+class TestHTTPBackendListArtifacts(HTTPBackendTestCase):
+    """Tests for list_artifacts and its index fetch."""
+
+    def test_lists_and_filters(self):
+        fake = self.patch_urlopen(
+            {
+                self.index_url: _make_index_html(
+                    ["blas_lib_gfx94X.tar.xz", "core_runtime_generic.tar.zst"]
+                ).encode("utf-8")
+            }
+        )
+
+        self.assertEqual(
+            self.backend.list_artifacts(),
+            ["blas_lib_gfx94X.tar.xz", "core_runtime_generic.tar.zst"],
+        )
+        self.assertEqual(
+            self.backend.list_artifacts(name_filter="blas"), ["blas_lib_gfx94X.tar.xz"]
+        )
+        # Second call is served from cache.
+        self.assertEqual(len(fake.requested), 1)
+
+    def test_missing_index_raises(self):
+        """A missing index is an error, not "this run has no artifacts"."""
+        self.patch_urlopen({})
+
+        with self.assertRaises(FileNotFoundError) as cm:
+            self.backend.list_artifacts()
+        self.assertIn(self.index_url, str(cm.exception))
+
+    def test_forbidden_index_raises_file_not_found(self):
+        """S3 answers 403 rather than 404 without ListBucket."""
+        self.patch_urlopen({self.index_url: _http_error(self.index_url, 403)})
+
+        with self.assertRaises(FileNotFoundError):
+            self.backend.list_artifacts()
+
+    def test_server_error_is_not_swallowed(self):
+        self.patch_urlopen({self.index_url: _http_error(self.index_url, 500)})
+
+        with self.assertRaises(urllib.error.HTTPError) as cm:
+            self.backend.list_artifacts()
+        self.assertEqual(cm.exception.code, 500)
+
+    def test_network_failure_raises_connection_error(self):
+        self.patch_urlopen({self.index_url: urllib.error.URLError("dns")})
+
+        with self.assertRaises(ConnectionError):
+            self.backend.list_artifacts()
+
+
+class TestHTTPBackendDownload(HTTPBackendTestCase):
+    """Tests for download_artifact and its checksum handling."""
+
+    ARTIFACT = "blas_lib_gfx94X.tar.xz"
+    CONTENT = b"artifact bytes"
+
+    def _checksum_line(self, content=None):
+        digest = hashlib.sha256(content or self.CONTENT).hexdigest()
+        return f"{digest}  {self.ARTIFACT}\n".encode("utf-8")
+
+    def test_downloads_and_verifies_checksum(self):
+        self.patch_urlopen(
+            {
+                self.url_for(self.ARTIFACT): self.CONTENT,
+                self.url_for(f"{self.ARTIFACT}.sha256sum"): self._checksum_line(),
+            }
+        )
+        dest = self.dest_dir / self.ARTIFACT
+
+        self.backend.download_artifact(self.ARTIFACT, dest)
+
+        self.assertEqual(dest.read_bytes(), self.CONTENT)
+
+    def test_checksum_mismatch_deletes_both_files(self):
+        self.patch_urlopen(
+            {
+                self.url_for(self.ARTIFACT): self.CONTENT,
+                self.url_for(f"{self.ARTIFACT}.sha256sum"): self._checksum_line(
+                    b"different bytes"
+                ),
+            }
+        )
+        dest = self.dest_dir / self.ARTIFACT
+
+        with self.assertRaises(ValueError) as cm:
+            self.backend.download_artifact(self.ARTIFACT, dest)
+
+        message = str(cm.exception)
+        self.assertIn(self.url_for(self.ARTIFACT), message)
+        self.assertIn(hashlib.sha256(self.CONTENT).hexdigest(), message)
+        self.assertFalse(dest.exists())
+        self.assertFalse((self.dest_dir / f"{self.ARTIFACT}.sha256sum").exists())
+
+    def test_missing_checksum_warns_and_keeps_artifact(self):
+        self.patch_urlopen({self.url_for(self.ARTIFACT): self.CONTENT})
+        dest = self.dest_dir / self.ARTIFACT
+
+        # Capture stdout rather than patching print: the assertion is about what
+        # the operator sees, and patching print would keep passing if the warning
+        # moved to a logger that writes nothing to the console.
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            self.backend.download_artifact(self.ARTIFACT, dest)
+
+        self.assertEqual(dest.read_bytes(), self.CONTENT)
+        self.assertIn("no checksum", stdout.getvalue())
+
+    def test_missing_artifact_raises_file_not_found(self):
+        self.patch_urlopen({})
+
+        with self.assertRaises(FileNotFoundError):
+            self.backend.download_artifact(self.ARTIFACT, self.dest_dir / self.ARTIFACT)
+
+    def test_network_failure_before_body_raises_connection_error(self):
+        self.patch_urlopen(
+            {self.url_for(self.ARTIFACT): urllib.error.URLError("reset")}
+        )
+        dest = self.dest_dir / self.ARTIFACT
+
+        with self.assertRaises(ConnectionError):
+            self.backend.download_artifact(self.ARTIFACT, dest)
+        self.assertFalse(dest.exists())
+
+    def test_interrupted_download_leaves_nothing_behind(self):
+        """A connection dropped mid-body must not leave a truncated artifact.
+
+        Downloading straight to dest would leave the partial bytes there, and a
+        truncated file is only caught when a checksum happens to be published -
+        download_artifact warns and returns when one is not.
+        """
+        self.patch_urlopen(
+            {
+                self.url_for(self.ARTIFACT): _FailingStream(
+                    b"first half", ConnectionResetError("connection reset by peer")
+                )
+            }
+        )
+        dest = self.dest_dir / self.ARTIFACT
+
+        with self.assertRaises(ConnectionError):
+            self.backend.download_artifact(self.ARTIFACT, dest)
+
+        self.assertFalse(dest.exists())
+        # Nor a temporary file: the download directory is where fetch unpacks
+        # from, so leftovers there are not inert.
+        self.assertEqual(sorted(p.name for p in self.dest_dir.iterdir()), [])
+
+    def test_interrupted_download_does_not_clobber_an_existing_file(self):
+        """The previous copy survives a failed re-download."""
+        dest = self.dest_dir / self.ARTIFACT
+        dest.write_bytes(b"the good copy")
+        self.patch_urlopen(
+            {
+                self.url_for(self.ARTIFACT): _FailingStream(
+                    b"first half", ConnectionResetError("connection reset by peer")
+                )
+            }
+        )
+
+        with self.assertRaises(ConnectionError):
+            self.backend.download_artifact(self.ARTIFACT, dest)
+
+        self.assertEqual(dest.read_bytes(), b"the good copy")
+
+
+class TestHTTPBackendArtifactExists(HTTPBackendTestCase):
+    """Tests for artifact_exists, including the cache guard."""
+
+    ARTIFACT = "blas_lib_gfx94X.tar.xz"
+
+    def _populate_cache(self, fake=None):
+        fake = fake or self.patch_urlopen(
+            {self.index_url: _make_index_html([self.ARTIFACT]).encode("utf-8")}
+        )
+        self.backend.list_artifacts()
+        return fake
+
+    def test_archive_answered_from_cache(self):
+        fake = self._populate_cache()
+        requests_before = len(fake.requested)
+
+        self.assertTrue(self.backend.artifact_exists(self.ARTIFACT))
+        self.assertFalse(self.backend.artifact_exists("other_lib_generic.tar.xz"))
+        self.assertEqual(len(fake.requested), requests_before)
+
+    def test_checksum_key_probes_despite_populated_cache(self):
+        """The index only lists archives, so a .sha256sum needs a HEAD.
+
+        S3Backend.copy_artifact asks exactly this question; answering it from
+        the archive-only cache would wrongly report the checksum as absent.
+        """
+        checksum_key = f"{self.ARTIFACT}.sha256sum"
+        fake = self.patch_urlopen(
+            {
+                self.index_url: _make_index_html([self.ARTIFACT]).encode("utf-8"),
+                self.url_for(checksum_key): b"digest",
+            }
+        )
+        self._populate_cache(fake)
+
+        self.assertTrue(self.backend.artifact_exists(checksum_key))
+        self.assertIn(self.url_for(checksum_key), fake.requested)
+
+    def test_head_probe_404_is_false(self):
+        self.patch_urlopen({})
+
+        self.assertFalse(self.backend.artifact_exists(self.ARTIFACT))
+
+    def test_head_probe_server_error_raises(self):
+        """A 5xx means "cannot answer", not "does not exist"."""
+        url = self.url_for(self.ARTIFACT)
+        self.patch_urlopen({url: _http_error(url, 500)})
+
+        with self.assertRaises(urllib.error.HTTPError):
+            self.backend.artifact_exists(self.ARTIFACT)
+
+    def test_head_probe_network_failure_raises_connection_error(self):
+        url = self.url_for(self.ARTIFACT)
+        self.patch_urlopen({url: urllib.error.URLError("dns")})
+
+        with self.assertRaises(ConnectionError):
+            self.backend.artifact_exists(self.ARTIFACT)
+
+
+class TestHTTPBackendIsReadOnly(HTTPBackendTestCase):
+    """Write operations fail loudly and say what to use instead."""
+
+    def test_upload_artifact_raises(self):
+        with self.assertRaises(NotImplementedError) as cm:
+            self.backend.upload_artifact(Path("/tmp/x.tar.xz"), "x.tar.xz")
+        self.assertIn("s3", str(cm.exception))
+
+    def test_copy_artifact_raises(self):
+        with self.assertRaises(NotImplementedError) as cm:
+            self.backend.copy_artifact("x.tar.xz", self.backend)
+        self.assertIn("s3", str(cm.exception))
+
+
+class TestHTTPBackendPublicUrl(unittest.TestCase):
+    """HTTPBackend inherits CDN awareness from the bucket registry.
+
+    This is the whole payoff of landing the bucket-config work first: the
+    backend has no URL configuration of its own.
+    """
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.addCleanup(set_bucket_config_file, None)
+
+    def _write_registry(self, payload):
+        path = Path(self.temp_dir.name) / "buckets.json"
+        path.write_text(json.dumps(payload))
+        set_bucket_config_file(path)
+        return path
+
+    def test_raw_s3_url_when_the_bucket_has_no_cdn(self):
+        backend = HTTPBackend(
+            WorkflowOutputRoot(
+                bucket="therock-ci-artifacts",
+                external_repo="",
+                run_id="12345",
+                platform="linux",
+            )
+        )
+
+        self.assertEqual(
+            backend.base_uri,
+            "https://therock-ci-artifacts.s3.amazonaws.com/12345-linux",
+        )
+
+    def test_cdn_url_and_stripped_key_prefix(self):
+        """A downstream bucket behind a CDN, registered from a file."""
+        self._write_registry(
+            {
+                "version": 1,
+                "buckets": [
+                    {
+                        "name": "downstream-artifacts",
+                        "key_prefix": "v3/artifacts/",
+                        "cdn_rules": [
+                            {
+                                "key_prefix": "v3/artifacts/",
+                                "url_prefix": "https://cdn.example.com/artifacts/",
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+        output_root = WorkflowOutputRoot(
+            bucket="downstream-artifacts",
+            external_repo="",
+            run_id="4242",
+            platform="linux",
+            key_prefix="v3/artifacts/",
+        )
+        backend = HTTPBackend(output_root)
+
+        # The S3 key keeps the prefix; the public URL has it swapped out.
+        self.assertEqual(
+            output_root.root().s3_uri,
+            "s3://downstream-artifacts/v3/artifacts/4242-linux",
+        )
+        self.assertEqual(
+            backend.base_uri, "https://cdn.example.com/artifacts/4242-linux"
+        )
+        self.assertEqual(
+            output_root.artifact_index().public_url,
+            "https://cdn.example.com/artifacts/4242-linux/index.html",
+        )
+
+
+class TestCreateBackendTransports(unittest.TestCase):
+    """Tests for explicit transport selection."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+
+    def test_unknown_transport_raises(self):
+        with self.assertRaises(ValueError) as cm:
+            create_backend(run_id="1", platform="linux", transport="ftp")
+        self.assertIn("ftp", str(cm.exception))
+
+    def test_local_transport(self):
+        backend = create_backend(
+            run_id="1",
+            platform="linux",
+            transport="local",
+            staging_dir=Path(self.temp_dir.name),
+        )
+        self.assertIsInstance(backend, LocalDirectoryBackend)
+
+    def test_local_transport_without_staging_dir_raises(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(ValueError) as cm:
+                create_backend(run_id="1", platform="linux", transport="local")
+        self.assertIn("staging", str(cm.exception))
+
+    @mock.patch("_therock_utils.workflow_outputs._retrieve_bucket_info")
+    def test_s3_transport(self, mock_retrieve):
+        mock_retrieve.return_value = ("", require_bucket_config("therock-ci-artifacts"))
+        with mock.patch.dict(os.environ, {}, clear=True):
+            backend = create_backend(run_id="1", platform="linux", transport="s3")
+        self.assertIsInstance(backend, S3Backend)
+
+    @mock.patch("_therock_utils.workflow_outputs._retrieve_bucket_info")
+    def test_http_transport(self, mock_retrieve):
+        mock_retrieve.return_value = ("", require_bucket_config("therock-ci-artifacts"))
+        with mock.patch.dict(os.environ, {}, clear=True):
+            backend = create_backend(run_id="1", platform="linux", transport="http")
+        self.assertIsInstance(backend, HTTPBackend)
+
+    @mock.patch("_therock_utils.workflow_outputs._retrieve_bucket_info")
+    def test_auto_transport_prefers_s3_without_staging(self, mock_retrieve):
+        mock_retrieve.return_value = ("", require_bucket_config("therock-ci-artifacts"))
+        with mock.patch.dict(os.environ, {}, clear=True):
+            backend = create_backend(run_id="1", platform="linux", transport="auto")
+        self.assertIsInstance(backend, S3Backend)
+
+    def test_auto_transport_prefers_local_staging(self):
+        with mock.patch.dict(
+            os.environ, {"THEROCK_LOCAL_STAGING_DIR": self.temp_dir.name}, clear=True
+        ):
+            backend = create_backend(run_id="1", platform="linux", transport="auto")
+        self.assertIsInstance(backend, LocalDirectoryBackend)
+
+    def test_auto_never_selects_the_read_only_transport(self):
+        """`auto` must always yield a writable backend."""
+        from _therock_utils.artifact_backend import WRITABLE_TRANSPORTS
+
+        self.assertIn("auto", WRITABLE_TRANSPORTS)
+        self.assertNotIn("http", WRITABLE_TRANSPORTS)
 
 
 if __name__ == "__main__":

--- a/build_tools/tests/artifact_manager_tool_test.py
+++ b/build_tools/tests/artifact_manager_tool_test.py
@@ -26,7 +26,11 @@ def is_windows():
 
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 
-from _therock_utils.artifact_backend import ArtifactBackend, LocalDirectoryBackend
+from _therock_utils.artifact_backend import (
+    ArtifactBackend,
+    LocalDirectoryBackend,
+    S3Backend,
+)
 from _therock_utils.workflow_outputs import WorkflowOutputRoot
 
 # Minimal topology TOML for testing push/fetch behavior.
@@ -260,7 +264,7 @@ class TestPushFailureExitCode(ArtifactManagerTestBase):
     """Tests that push command exits with non-zero code on upload failures."""
 
     @mock.patch("artifact_manager._delay_for_retry")
-    @mock.patch("artifact_manager.create_backend_from_env")
+    @mock.patch("artifact_manager.create_backend")
     def test_push_fails_when_all_uploads_fail(self, mock_backend_factory, mock_delay):
         """Test that push exits with code 1 when all uploads fail."""
         import artifact_manager
@@ -291,7 +295,7 @@ class TestPushFailureExitCode(ArtifactManagerTestBase):
         mock_backend_factory.assert_called_once()
 
     @mock.patch("artifact_manager._delay_for_retry")
-    @mock.patch("artifact_manager.create_backend_from_env")
+    @mock.patch("artifact_manager.create_backend")
     def test_push_fails_when_some_uploads_fail(self, mock_backend_factory, mock_delay):
         """Test that push exits with code 1 when some (but not all) uploads fail."""
         import artifact_manager
@@ -490,7 +494,7 @@ class TestFetchFailureExitCode(ArtifactManagerTestBase):
     """Tests that fetch command exits with non-zero code on download failures."""
 
     @mock.patch("artifact_manager._delay_for_retry")
-    @mock.patch("artifact_manager.create_backend_from_env")
+    @mock.patch("artifact_manager.create_backend")
     def test_fetch_fails_when_download_fails(self, mock_backend_factory, mock_delay):
         """Test that fetch exits with code 1 when download fails."""
         import artifact_manager
@@ -1137,7 +1141,7 @@ class TestFetchDownloadCache(ArtifactManagerTestBase):
         with (
             mock.patch("artifact_manager.extract_artifact", mock_extract),
             mock.patch(
-                "artifact_manager.create_backend_from_env",
+                "artifact_manager.create_backend",
                 return_value=failing_backend,
             ),
         ):
@@ -1293,7 +1297,7 @@ class TestCopy(ArtifactManagerTestBase):
 
     @mock.patch("artifact_manager._delay_for_retry")
     @mock.patch("artifact_manager._create_source_backend")
-    @mock.patch("artifact_manager.create_backend_from_env")
+    @mock.patch("artifact_manager.create_backend")
     def test_copy_fails_when_copy_fails(
         self, mock_dest_factory, mock_source_factory, mock_delay
     ):
@@ -1505,6 +1509,222 @@ class ParseTargetFamiliesTest(unittest.TestCase):
         self.assertIn("gfx110X-all", result)
         self.assertIn("gfx1100", result)
         self.assertIn("gfx1101", result)
+
+
+class TestTransportSelection(ArtifactManagerTestBase):
+    """Tests for --transport / --source-transport on the CLI."""
+
+    def _common_argv(self):
+        return [
+            "--topology",
+            str(self.topology_path),
+            "--local-staging-dir",
+            str(self.staging_dir),
+            "--platform",
+            TEST_PLATFORM,
+        ]
+
+    def test_push_rejects_the_read_only_transport(self):
+        import artifact_manager
+
+        self._create_fake_precompressed_artifact("test-artifact", "lib", "generic")
+        argv = [
+            "push",
+            "--stage",
+            "upstream-stage",
+            "--build-dir",
+            str(self.build_dir),
+            "--transport",
+            "http",
+            *self._common_argv(),
+        ]
+
+        with self.assertRaises(SystemExit) as ctx:
+            artifact_manager.main(argv)
+
+        self.assertEqual(ctx.exception.code, 1)
+
+    def test_copy_rejects_a_read_only_destination(self):
+        import artifact_manager
+
+        argv = [
+            "copy",
+            "--stage",
+            "upstream-stage",
+            "--source-run-id",
+            "999",
+            "--transport",
+            "http",
+            *self._common_argv(),
+        ]
+
+        with self.assertRaises(SystemExit) as ctx:
+            artifact_manager.main(argv)
+
+        self.assertEqual(ctx.exception.code, 1)
+
+    @mock.patch("artifact_manager.create_backend")
+    @mock.patch("artifact_manager._create_source_backend")
+    def test_copy_passes_the_source_transport_through(
+        self, mock_source_factory, mock_dest_factory
+    ):
+        """The source and destination transports are independent.
+
+        This is the case no process-wide setting can express: one invocation
+        reads from one location and writes to another.
+        """
+        import artifact_manager
+
+        source_backend = LocalDirectoryBackend(
+            staging_dir=self.staging_dir,
+            output_root=WorkflowOutputRoot.for_local(
+                run_id="999", platform=TEST_PLATFORM
+            ),
+        )
+        mock_source_factory.return_value = source_backend
+        mock_dest_factory.return_value = source_backend
+
+        argv = [
+            "copy",
+            "--stage",
+            "upstream-stage",
+            "--source-run-id",
+            "999",
+            "--source-transport",
+            "s3",
+            *self._common_argv(),
+        ]
+        artifact_manager.main(argv)
+
+        self.assertEqual(
+            mock_source_factory.call_args.kwargs["transport"],
+            "s3",
+            "copy must read the source with --source-transport",
+        )
+        self.assertEqual(
+            mock_dest_factory.call_args.kwargs["transport"],
+            "auto",
+            "the destination must keep its own --transport, not inherit the source's",
+        )
+
+    def test_copy_rejects_a_read_only_source(self):
+        """`copy` is a same-kind operation, so HTTP has no counterpart to copy into.
+
+        Rejected by argparse rather than at the first transfer, so the error
+        names the alternative (fetch, then push) instead of a TypeError.
+        """
+        import artifact_manager
+
+        argv = [
+            "copy",
+            "--stage",
+            "upstream-stage",
+            "--source-run-id",
+            "999",
+            "--source-transport",
+            "http",
+            *self._common_argv(),
+        ]
+
+        with self.assertRaises(SystemExit) as ctx:
+            artifact_manager.main(argv)
+
+        self.assertEqual(ctx.exception.code, 2)
+
+    @mock.patch("artifact_manager.create_backend")
+    @mock.patch("artifact_manager._create_source_backend")
+    def test_copy_rejects_mismatched_storage_kinds(
+        self, mock_source_factory, mock_dest_factory
+    ):
+        """Local source, S3 destination: neither can reach the other's storage.
+
+        Independent transports made this reachable from the CLI; before them one
+        env-driven rule chose both ends, so it could not happen.
+        """
+        import artifact_manager
+
+        mock_source_factory.return_value = LocalDirectoryBackend(
+            staging_dir=self.staging_dir,
+            output_root=WorkflowOutputRoot.for_local(
+                run_id="999", platform=TEST_PLATFORM
+            ),
+        )
+        mock_dest_factory.return_value = S3Backend(
+            output_root=WorkflowOutputRoot(
+                bucket="therock-ci-artifacts",
+                external_repo="",
+                run_id="999",
+                platform=TEST_PLATFORM,
+            )
+        )
+
+        argv = [
+            "copy",
+            "--stage",
+            "upstream-stage",
+            "--source-run-id",
+            "999",
+            "--source-transport",
+            "local",
+            "--transport",
+            "s3",
+            *self._common_argv(),
+        ]
+
+        with self.assertRaises(SystemExit) as ctx:
+            artifact_manager.main(argv)
+
+        self.assertEqual(ctx.exception.code, 1)
+
+    def test_fetch_passes_the_transport_through(self):
+        import artifact_manager
+
+        with mock.patch("artifact_manager.create_backend") as mock_factory:
+            mock_factory.return_value = LocalDirectoryBackend(
+                staging_dir=self.staging_dir,
+                output_root=WorkflowOutputRoot.for_local(
+                    run_id="local", platform=TEST_PLATFORM
+                ),
+            )
+            argv = [
+                "fetch",
+                "--stage",
+                "downstream-stage",
+                "--output-dir",
+                str(self.output_dir),
+                "--transport",
+                "http",
+                *self._common_argv(),
+            ]
+            artifact_manager.main(argv)
+
+        self.assertEqual(mock_factory.call_args.kwargs["transport"], "http")
+
+    def test_transport_defaults_from_the_environment(self):
+        import artifact_manager
+
+        with mock.patch.dict(
+            os.environ, {"THEROCK_ARTIFACT_TRANSPORT": "s3"}, clear=False
+        ):
+            # The default is read at parser construction, so build a fresh one.
+            with mock.patch("artifact_manager.create_backend") as mock_factory:
+                mock_factory.return_value = LocalDirectoryBackend(
+                    staging_dir=self.staging_dir,
+                    output_root=WorkflowOutputRoot.for_local(
+                        run_id="local", platform=TEST_PLATFORM
+                    ),
+                )
+                argv = [
+                    "fetch",
+                    "--stage",
+                    "downstream-stage",
+                    "--output-dir",
+                    str(self.output_dir),
+                    *self._common_argv(),
+                ]
+                artifact_manager.main(argv)
+
+        self.assertEqual(mock_factory.call_args.kwargs["transport"], "s3")
 
 
 if __name__ == "__main__":

--- a/build_tools/tests/fetch_artifacts_test.py
+++ b/build_tools/tests/fetch_artifacts_test.py
@@ -5,11 +5,14 @@ from pathlib import Path
 import os
 import sys
 import unittest
+from unittest import mock
 from unittest.mock import MagicMock
 
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 
-from _therock_utils.artifact_backend import ArtifactBackend
+import fetch_artifacts
+from _therock_utils.artifact_backend import ArtifactBackend, HTTPBackend, S3Backend
+from _therock_utils.s3_buckets import S3BucketConfig
 from fetch_artifacts import (
     list_artifacts_for_group,
     filter_artifacts,
@@ -258,6 +261,73 @@ class ArtifactsIndexPageTest(unittest.TestCase):
         self.assertIn("foo_run", filtered)
         self.assertNotIn("bar_test", filtered)
         self.assertNotIn("bar_run", filtered)
+
+
+class TransportSelectionTest(unittest.TestCase):
+    """Tests for --transport on fetch_artifacts.py."""
+
+    def _argv(self, *extra):
+        return ["--run-id", "12345", "--dry-run", *extra]
+
+    def _parse(self, *extra):
+        """Parse args without running, by intercepting run()."""
+        with mock.patch.object(fetch_artifacts, "run") as mock_run:
+            fetch_artifacts.main(self._argv(*extra))
+        return mock_run.call_args[0][0]
+
+    def test_default_transport_is_auto(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(self._parse().transport, "auto")
+
+    def test_env_var_supplies_the_default(self):
+        with mock.patch.dict(
+            os.environ, {"THEROCK_ARTIFACT_TRANSPORT": "http"}, clear=True
+        ):
+            self.assertEqual(self._parse().transport, "http")
+
+    def test_flag_beats_the_env_var(self):
+        with mock.patch.dict(
+            os.environ, {"THEROCK_ARTIFACT_TRANSPORT": "http"}, clear=True
+        ):
+            self.assertEqual(self._parse("--transport", "s3").transport, "s3")
+
+    def test_accepts_transports_it_cannot_serve(self):
+        """'local' parses so that a shared env var does not break arg parsing.
+
+        artifact_manager.py and this script read the same
+        THEROCK_ARTIFACT_TRANSPORT; rejecting a value at parse time here would
+        make setting it for one break the other. run() rejects it instead.
+        """
+        self.assertEqual(self._parse("--transport", "local").transport, "local")
+
+    def test_local_transport_exits_with_a_pointer_to_artifact_manager(self):
+        args = mock.MagicMock(transport="local", bucket_config_file=None)
+        with self.assertRaises(SystemExit) as cm:
+            fetch_artifacts.run(args)
+        self.assertEqual(cm.exception.code, 1)
+
+    @mock.patch("_therock_utils.workflow_outputs._retrieve_bucket_info")
+    def _backend_for(self, transport, mock_retrieve):
+        mock_retrieve.return_value = ("", S3BucketConfig(name="therock-ci-artifacts"))
+        captured = {}
+
+        def capture(backend, **kwargs):
+            captured["backend"] = backend
+            return set()
+
+        with mock.patch.object(
+            fetch_artifacts, "list_artifacts_for_group", side_effect=capture
+        ):
+            # Nothing to fetch, so run() exits 1 after building the backend.
+            with self.assertRaises(SystemExit):
+                fetch_artifacts.main(self._argv("--transport", transport))
+        return captured["backend"]
+
+    def test_http_transport_builds_an_http_backend(self):
+        self.assertIsInstance(self._backend_for("http"), HTTPBackend)
+
+    def test_s3_transport_builds_an_s3_backend(self):
+        self.assertIsInstance(self._backend_for("s3"), S3Backend)
 
 
 if __name__ == "__main__":

--- a/docs/development/workflow_outputs.md
+++ b/docs/development/workflow_outputs.md
@@ -10,12 +10,12 @@ Every CI workflow run produces a set of outputs (build artifacts, logs,
 manifests, python packages) that are uploaded to S3. Three modules in
 `_therock_utils` handle the path computation and I/O:
 
-| Module             | Role                         | Key types                                                   |
-| ------------------ | ---------------------------- | ----------------------------------------------------------- |
-| `storage_location` | Backend-agnostic location    | `StorageLocation`                                           |
-| `workflow_outputs` | CI path computation (no I/O) | `WorkflowOutputRoot`                                        |
-| `storage_backend`  | Upload I/O (write)           | `StorageBackend`, `S3StorageBackend`, `LocalStorageBackend` |
-| `artifact_backend` | Download I/O (read)          | `ArtifactBackend`, `S3Backend`, `LocalDirectoryBackend`     |
+| Module             | Role                         | Key types                                                              |
+| ------------------ | ---------------------------- | ---------------------------------------------------------------------- |
+| `storage_location` | Backend-agnostic location    | `StorageLocation`                                                      |
+| `workflow_outputs` | CI path computation (no I/O) | `WorkflowOutputRoot`                                                   |
+| `storage_backend`  | Upload I/O (write)           | `StorageBackend`, `S3StorageBackend`, `LocalStorageBackend`            |
+| `artifact_backend` | Download I/O (read)          | `ArtifactBackend`, `S3Backend`, `HTTPBackend`, `LocalDirectoryBackend` |
 
 `StorageLocation` is the bridge between path computation and I/O.
 `WorkflowOutputRoot` produces `StorageLocation` instances; backends consume them.
@@ -283,6 +283,43 @@ backend.upload_directory(source_dir, dest_location, include=["*.tar.xz*"])
 
 Content-type is inferred from file extension — callers don't need to specify it.
 
+### ArtifactBackend
+
+An abstract base class for reading (and, for the writable transports, writing)
+build artifact archives. Use `create_backend()` and pass an explicit transport.
+
+```python
+from _therock_utils.artifact_backend import create_backend
+
+backend = create_backend(run_id="12345")  # transport="auto"
+backend = create_backend(run_id="12345", transport="http")  # read-only, no credentials
+
+backend.list_artifacts(name_filter="blas")
+backend.download_artifact("blas_lib_gfx94X.tar.xz", dest_path)
+```
+
+| Transport | Backend                 | Credentials | Writable |
+| --------- | ----------------------- | ----------- | -------- |
+| `auto`    | local staging, else S3  | as below    | yes      |
+| `s3`      | `S3Backend`             | boto3 chain | yes      |
+| `http`    | `HTTPBackend`           | none        | no       |
+| `local`   | `LocalDirectoryBackend` | none        | yes      |
+
+Transport is an explicit argument rather than something inferred from the
+environment, because `artifact_manager.py copy` builds a source and a
+destination backend in one process and no process-wide setting can express
+that. `artifact_manager.py` exposes it as `--transport` (and
+`--source-transport` on `copy`); `fetch_artifacts.py` exposes `--transport`.
+Both default from `THEROCK_ARTIFACT_TRANSPORT`, and the flag always wins.
+
+`HTTPBackend` reads the same public URLs a browser would, via
+`StorageLocation.public_url`. That means it follows a bucket's CDN mapping
+automatically when one is configured in
+[`s3_buckets.py`](/build_tools/_therock_utils/s3_buckets.py), and falls back to
+the raw S3 URL otherwise — the backend itself holds no URL configuration. It
+lists artifacts by reading the generated `index.html` for the run, so it can
+only see what has been published there.
+
 ### Adding new output types
 
 To add a new output type:
@@ -307,9 +344,9 @@ To add a new output type:
 
 ### Download scripts
 
-| File                                                                        | Uses                                                                           |
-| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| [`fetch_artifacts.py`](/build_tools/fetch_artifacts.py)                     | `WorkflowOutputRoot.from_workflow_run(lookup_workflow_run=True)` + `S3Backend` |
-| [`find_artifacts_for_commit.py`](/build_tools/find_artifacts_for_commit.py) | `WorkflowOutputRoot.from_workflow_run(workflow_run=...)` for bucket/prefix     |
-| [`artifact_backend.py`](/build_tools/_therock_utils/artifact_backend.py)    | `WorkflowOutputRoot` for `S3Backend` construction                              |
-| [`artifact_manager.py`](/build_tools/artifact_manager.py)                   | Via `create_backend_from_env()`                                                |
+| File                                                                        | Uses                                                                                         |
+| --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| [`fetch_artifacts.py`](/build_tools/fetch_artifacts.py)                     | `WorkflowOutputRoot.from_workflow_run(lookup_workflow_run=True)` + `S3Backend`/`HTTPBackend` |
+| [`find_artifacts_for_commit.py`](/build_tools/find_artifacts_for_commit.py) | `WorkflowOutputRoot.from_workflow_run(workflow_run=...)` for bucket/prefix                   |
+| [`artifact_backend.py`](/build_tools/_therock_utils/artifact_backend.py)    | `WorkflowOutputRoot` for backend construction; `public_url` for `HTTPBackend`                |
+| [`artifact_manager.py`](/build_tools/artifact_manager.py)                   | Via `create_backend(transport=...)`                                                          |


### PR DESCRIPTION
ISSUE ID : https://github.com/ROCm/TheRock/issues/7091

## Motivation

Fetching artifacts requires AWS credentials today, because `S3Backend` is the only reader.
Everything published is already served over public HTTPS, so a reader with no credentials should
be able to fetch and checksum-verify the same artifacts.

That reader already exists downstream, hand-rolled. `rocm-npi-dev`'s
`.github/scripts/fetch_artifacts.py` is an independent reimplementation of this backend against
the *same* page format — `generate_s3_index.py` output, plain anchors, `.tar.xz`, hrefs
`unquote`d — and it has **no checksum verification**. That it converged on the same parser design
is reassuring; that it is missing the verification step is the reason to replace it rather than
leave it.

Salvaged from #4088, rebased and reworked. Stacked on #7238, which is what lets every URL here go
through `StorageLocation.public_url`: CloudFront where a bucket has a rule, raw S3 where it does
not, with no backend-specific configuration.

## Technical Details

**`HTTPBackend`** — read-only, `urllib` only, constructor `(output_root, *, timeout=60.0)`.
`list_artifacts` does a single fetch of the run's `index.html`; artifacts live directly at the run
root, so one fetch enumerates all of them.

The `gfx_families` fan-out from #4088 is **gone**: #4465 replaced per-family artifact indexes with
a single directory index, so there is nothing left to fan out over. The 40-line commented-out
`_discover_gfx_families_from_master_index` stub and the unreferenced `ArtifactLocation` dataclass
go with it.

Four fixes over the salvaged code, all real bugs:

1. **`_fetch_index` caught bare `Exception` and returned `[]`.** Silent-empty is the worst failure
   mode for "no artifacts found". Now `HTTPError` (which must precede `URLError`, being a
   subclass) and `URLError` are handled specifically, and a missing index raises
   `FileNotFoundError` naming the URL.
2. **Index parsing moves from regex to `html.parser.HTMLParser`.** The regex broke on
   single-quoted attributes and returned `[]` rather than erroring on an unexpected page. Hrefs
   are also `unquote`d — `generate_s3_index.py` emits `quote(entry.href)` and the salvaged parser
   never decoded it.
3. **`download_artifact`'s `except FileNotFoundError` wrapped both the checksum download and the
   verification**, so a `FileNotFoundError` from verification was swallowed as "no checksum".
   Narrowed to the download. `_verify_checksum` is dropped (it returned `False` for both "no file"
   and "bad checksum") in favour of the in-repo `hash_util.calculate_hash(path, "sha256")` idiom;
   the mismatch error names both digests and the URL.
4. **`artifact_exists` cache guard.** The index parser keeps only `.tar.xz`/`.tar.zst`, so a
   `.sha256sum` query answered from cache wrongly returned `False` — and `copy_artifact` asks
   exactly that. HEAD-probes otherwise; 403/404 → `False`, 500 re-raises, because a 500 is not
   "doesn't exist".

Downloads land on a `tempfile.mkstemp` in the destination directory and are `Path.replace()`d into
place only on success. A connection dropped mid-body would otherwise leave a truncated artifact
where fetch unpacks from, caught only when a checksum happens to be published.

`upload_artifact` and `copy_artifact` raise `NotImplementedError` pointing at `transport='s3'`.

**Explicit transport selection.** Backend choice was env-driven, which cannot express what
`artifact_manager copy` does — one process builds a source *and* a destination backend. The old
trigger also conflated two axes: `THEROCK_AMDGPU_FAMILIES` meant both "use HTTP" and "which
indexes to read". `create_backend(output_root, *, transport="auto", staging_dir=None)` takes
`auto|s3|http|local`; `--transport` is added to `artifact_manager fetch` and `fetch_artifacts.py`,
and `--source-transport` to `copy`. `push` and the destination end of `copy` accept only writable
transports, and `--source-transport` only those with a writable counterpart — argparse rejects
`http` there so the error names the alternative (fetch, then push) instead of surfacing as a
`TypeError` at the first transfer. Env defaults are applied via argparse `default=os.getenv(...)`,
matching the existing idiom, so an explicit flag always wins.

One deliberate asymmetry, commented at the site: `artifact_exists` HEAD-probes `.public_url`, not
the raw origin. This backend exists for readers with no AWS credentials, whose bucket may not be
anonymously readable at all — #7238 verified that the prerelease, release and product buckets all
refuse anonymous S3 reads. Probing an origin it cannot read would answer "absent" for artifacts
that are published. Reading through the CDN and probing through it asks both questions about the
same bytes.

### Not to be confused with #7517

That PR also parses an index, but a different one: `index_generation_s3_tar.py` output, which
embeds a JSON array for client-side filtering rather than listing anchors. Different page,
different format, different generator. Adjacent, not duplicated.

## Test Plan

- `cd build_tools && python -m pytest`
- `pre-commit run --all-files`

New coverage in `artifact_backend_test.py`, `artifact_manager_tool_test.py` and
`fetch_artifacts_test.py`. The highest-value one: the sample index HTML is **generated by calling
`generate_s3_index._generate_index_html`** rather than hand-written, so the parser and the
generator cannot drift apart silently. It includes a percent-encoded filename to pin the `unquote`
fix.

Also: 404 → `FileNotFoundError`, 500 re-raised, `URLError` → `ConnectionError`; checksum match,
mismatch-deletes-both, and missing-checksum-warns; `artifact_exists` for a `.sha256sum` key
against a populated cache; a connection dropped mid-body leaves neither a truncated artifact nor a
temp file, and does not clobber an existing good copy; each transport value on each subcommand,
including the two rejections (`copy --source-transport http`, and a local source with an S3
destination).

## Test Result

`cd build_tools && python -m pytest` on this branch (Linux, Python 3.12):
**2180 passed, 8 skipped, 244 subtests passed**, 0 failed.

`pre-commit run` clean across all changed files.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
