### PR TITLE
Derive release index URLs instead of hand-copying them

### DIFF
--- a/build_tools/_therock_utils/s3_buckets.py
+++ b/build_tools/_therock_utils/s3_buckets.py
@@ -159,6 +159,15 @@ _RELEASE_STREAM_BY_TYPE = {
     "prerelease": "rc",
 }
 
+# Channels a user can install *from*, deliberately wider than
+# _RELEASE_STREAM_BY_TYPE, which is the set a workflow can publish *to*. The
+# stable channel has no automated upload credentials - it is promoted by hand -
+# so the publish path must keep rejecting it, but it is the channel most users
+# install from, and setup_venv.py's "stable" index already pointed at it.
+# Keeping the read set and the write set separate is what lets one widen
+# without widening the other.
+_INDEX_STREAM_BY_RELEASE_TYPE = {**_RELEASE_STREAM_BY_TYPE, "release": "stable"}
+
 # The key prefix every product bucket stores under, stripped from the public URL:
 # s3://therock-repo-amd-nightly-core/v5/rocm/core/tarball/X is served at
 # https://nightly.repo.amd.com/rocm/core/tarball/X.
@@ -222,12 +231,26 @@ _RELEASE_CDN = "https://repo.amd.com/rocm/"
 #   * The artifacts buckets - no CDN, matching the '-' column in s3_buckets.md.
 # A bucket with no matching rule falls back to its raw S3 URL, which is the
 # behavior every caller had before CDN rules existed.
+# The key prefix under which each legacy bucket type publishes the index users
+# point tools at, keyed by the bucket_type get_legacy_release_index_url takes.
+# The rule helpers below build their CdnRule from this, so the prefix a rule
+# matches and the prefix an index URL is derived from cannot drift apart.
+# "packages" has no entry: those CDNs serve a distro-partitioned apt/dnf repo
+# rather than a rewrite of the bucket layout, so there is no single index URL.
+_LEGACY_INDEX_KEY_PREFIXES = {
+    "python": "v4/whl/",
+    "tarball": "v4/tarball/",
+}
+
+
 def _whl_cdn_rules(cdn: str) -> tuple[CdnRule, ...]:
-    return (CdnRule("v4/whl/", cdn + "whl-multi-arch/"),)
+    return (CdnRule(_LEGACY_INDEX_KEY_PREFIXES["python"], cdn + "whl-multi-arch/"),)
 
 
 def _tarball_cdn_rules(cdn: str) -> tuple[CdnRule, ...]:
-    return (CdnRule("v4/tarball/", cdn + "tarball-multi-arch/"),)
+    return (
+        CdnRule(_LEGACY_INDEX_KEY_PREFIXES["tarball"], cdn + "tarball-multi-arch/"),
+    )
 
 
 def _package_cdn_rules(cdn: str) -> tuple[CdnRule, ...]:
@@ -341,6 +364,8 @@ _ALLOWED_RELEASE_TYPES = {
 }
 
 _ALLOWED_RELEASE_BUCKET_TYPES = {"tarball", "python", "packages"}
+
+_ALLOWED_INDEX_RELEASE_TYPES = set(_INDEX_STREAM_BY_RELEASE_TYPE)
 
 # _ALLOWED_RELEASE_PRODUCTS and _RELEASE_STREAM_BY_TYPE are defined above the
 # bucket inventory, which is generated from them.
@@ -647,7 +672,13 @@ def load_bucket_registry_file(path: str) -> _BucketRegistry:
     raw_release = data.get("release_buckets", {})
     if not isinstance(raw_release, dict):
         raise BucketRegistryError(f"{path}: 'release_buckets' must be an object")
-    _reject_unknown_keys(raw_release, _ALLOWED_RELEASE_TYPES, "release_buckets", path)
+    # Validated against the wider install-from set, not the publish-to set: a
+    # downstream repo redirecting its "release" channel needs the slot to exist
+    # here, and get_legacy_release_index_url reads it. Rejecting "release" would
+    # make that lookup a branch nothing could ever reach.
+    _reject_unknown_keys(
+        raw_release, _ALLOWED_INDEX_RELEASE_TYPES, "release_buckets", path
+    )
     release_buckets = {
         release_type: _parse_selection_map(
             inner,
@@ -759,6 +790,11 @@ def cdn_url_for(bucket: str, relative_path: str) -> str | None:
     config = lookup_bucket_config(bucket)
     if config is None:
         return None
+    return _cdn_url_for_config(config, relative_path)
+
+
+def _cdn_url_for_config(config: S3BucketConfig, relative_path: str) -> str | None:
+    """CDN URL for a key under a config already in hand, or None if no rule applies."""
     for rule in sorted(config.cdn_rules, key=lambda r: len(r.key_prefix), reverse=True):
         if relative_path.startswith(rule.key_prefix):
             return rule.url_prefix + relative_path[len(rule.key_prefix) :]
@@ -853,6 +889,18 @@ def get_release_bucket_config(
             f"bucket_type={bucket_type!r} is invalid, "
             f"expected one of {_ALLOWED_RELEASE_BUCKET_TYPES}"
         )
+    return _select_legacy_release_bucket(release_type, bucket_type)
+
+
+def _select_legacy_release_bucket(
+    release_type: str, bucket_type: str
+) -> S3BucketConfig:
+    """Resolve a (release_type, bucket_type) slot to a legacy release bucket.
+
+    Split out so get_legacy_release_index_url shares the registry-override path
+    without inheriting get_release_bucket_config's narrower release_type
+    validation - "release" is installable from but not publishable to.
+    """
     if release_type == "dev-bkc":
         bucket_name = f"therock-dev-{bucket_type}"
     elif release_type == "nightly-bkc":
@@ -884,6 +932,24 @@ def get_release_stream(release_type: str) -> str:
         raise ValueError(
             f"release_type={release_type!r} is invalid, "
             f"expected one of {_ALLOWED_RELEASE_TYPES}"
+        ) from e
+
+
+def get_index_release_stream(release_type: str) -> str:
+    """Stream a user installs a channel from.
+
+    Like ``get_release_stream`` but also accepts ``"release"`` (the manually
+    promoted stable channel), which can be installed from but not published to.
+
+    Raises:
+        ValueError: If release_type is invalid.
+    """
+    try:
+        return _INDEX_STREAM_BY_RELEASE_TYPE[release_type]
+    except KeyError as e:
+        raise ValueError(
+            f"release_type={release_type!r} is invalid, "
+            f"expected one of {sorted(_ALLOWED_INDEX_RELEASE_TYPES)}"
         ) from e
 
 
@@ -925,10 +991,72 @@ def get_product_release_bucket_config(
     return require_bucket_config(bucket_name)
 
 
-def get_release_package_index_url(release_type: str) -> str:
-    """Return the aggregate pip index URL for a final release stream."""
-    stream = get_release_stream(release_type)
-    return f"https://{stream}.repo.amd.com/rocm/whl-next/"
+def get_release_package_index_url(release_type: str, product: str | None = None) -> str:
+    """Public pip index URL for a release channel.
+
+    Args:
+        release_type: A publishable release type, or ``"release"`` for the
+            stable channel.
+        product: ``None`` for the aggregate index users install from, or
+            ``"core"``/``"pytorch"``/``"jax"`` for a product-local index.
+            Product-local indexes are publication and indexer inputs; a user
+            installing ROCm wants the aggregate one.
+
+    Raises:
+        ValueError: If release_type or product is invalid.
+    """
+    stream = get_index_release_stream(release_type)
+    if product is None:
+        return f"{release_stream_url(stream)}rocm/whl-next/"
+    if product not in _ALLOWED_RELEASE_PRODUCTS:
+        raise ValueError(
+            f"product={product!r} is invalid, "
+            f"expected one of {sorted(_ALLOWED_RELEASE_PRODUCTS)}"
+        )
+    return f"{release_stream_url(stream)}rocm/{product}/whl-next/"
+
+
+def get_release_tarball_index_url(release_type: str) -> str:
+    """Public directory users browse for a channel's ROCm tarballs."""
+    stream = get_index_release_stream(release_type)
+    return f"{release_stream_url(stream)}rocm/core/tarball/"
+
+
+def get_legacy_release_index_url(release_type: str, bucket_type: str = "python") -> str:
+    """Public index URL for the pre-RFC0012 release buckets.
+
+    Derived from the selected bucket's ``cdn_rules`` rather than from a copy of
+    the mapping, so the prefix a rule matches and the prefix an index URL is
+    built from cannot drift apart. Releases published before the repo.amd.com
+    rewire still live here.
+
+    Raises:
+        ValueError: If release_type or bucket_type is invalid, or the selected
+            bucket publishes no CDN rule covering the index prefix.
+    """
+    if release_type not in _ALLOWED_INDEX_RELEASE_TYPES:
+        raise ValueError(
+            f"release_type={release_type!r} is invalid, "
+            f"expected one of {sorted(_ALLOWED_INDEX_RELEASE_TYPES)}"
+        )
+    if bucket_type not in _LEGACY_INDEX_KEY_PREFIXES:
+        raise ValueError(
+            f"bucket_type={bucket_type!r} has no public index, "
+            f"expected one of {sorted(_LEGACY_INDEX_KEY_PREFIXES)}"
+        )
+
+    config = _select_legacy_release_bucket(release_type, bucket_type)
+    key_prefix = _LEGACY_INDEX_KEY_PREFIXES[bucket_type]
+    # Resolved against the config just selected rather than re-looked-up by name,
+    # so a registry redirect cannot be undone by a same-named in-tree entry.
+    url = _cdn_url_for_config(config, key_prefix)
+    if url is None:
+        raise ValueError(
+            f"bucket {config.name!r} (release_type={release_type!r}, "
+            f"bucket_type={bucket_type!r}) has no CDN rule covering "
+            f"{key_prefix!r}, so it has no public index URL"
+        )
+    return url
 
 
 def get_artifacts_bucket_config_for_workflow_run(

--- a/build_tools/github_actions/publish_jax_to_release_bucket.py
+++ b/build_tools/github_actions/publish_jax_to_release_bucket.py
@@ -13,6 +13,7 @@ _BUILD_TOOLS_DIR = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_BUILD_TOOLS_DIR))
 
 from _therock_utils.s3_buckets import (
+    get_legacy_release_index_url,
     get_product_release_bucket_config,
     get_release_bucket_config,
     get_release_package_index_url,
@@ -23,14 +24,6 @@ from _therock_utils.storage_location import StorageLocation
 from github_actions.github_actions_api import gha_set_output
 
 logger = logging.getLogger(__name__)
-
-LEGACY_MULTI_ARCH_INDEX_URLS = {
-    "dev": "https://rocm.devreleases.amd.com/whl-multi-arch/",
-    "dev-bkc": "https://rocm.devreleases.amd.com/whl-multi-arch/",
-    "nightly": "https://rocm.nightlies.amd.com/whl-multi-arch/",
-    "nightly-bkc": "https://rocm.nightlies.amd.com/whl-multi-arch/",
-    "prerelease": "https://rocm.prereleases.amd.com/whl-multi-arch/",
-}
 
 
 def _publish_structured(source_dir, dest_bucket, index, backend) -> None:
@@ -100,7 +93,7 @@ def main(argv: list[str]) -> None:
         logger.info("Uploaded %d wheel files", count)
         if count == 0:
             raise FileNotFoundError(f"No wheels found at {args.source_dir}")
-        package_index_url = LEGACY_MULTI_ARCH_INDEX_URLS[args.release_type]
+        package_index_url = get_legacy_release_index_url(args.release_type)
 
     gha_set_output({"package_index_url": package_index_url})
 

--- a/build_tools/github_actions/publish_pytorch_to_release_bucket.py
+++ b/build_tools/github_actions/publish_pytorch_to_release_bucket.py
@@ -30,6 +30,7 @@ _BUILD_TOOLS_DIR = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_BUILD_TOOLS_DIR))
 
 from _therock_utils.s3_buckets import (
+    get_legacy_release_index_url,
     get_product_release_bucket_config,
     get_release_bucket_config,
     get_release_package_index_url,
@@ -40,15 +41,6 @@ from _therock_utils.storage_location import StorageLocation
 from github_actions.github_actions_api import gha_set_output
 
 logger = logging.getLogger(__name__)
-
-
-LEGACY_MULTI_ARCH_INDEX_URLS = {
-    "dev": "https://rocm.devreleases.amd.com/whl-multi-arch/",
-    "dev-bkc": "https://rocm.devreleases.amd.com/whl-multi-arch/",
-    "nightly": "https://rocm.nightlies.amd.com/whl-multi-arch/",
-    "nightly-bkc": "https://rocm.nightlies.amd.com/whl-multi-arch/",
-    "prerelease": "https://rocm.prereleases.amd.com/whl-multi-arch/",
-}
 
 
 def _publish_structured(source_dir, dest_bucket, index, backend) -> None:
@@ -118,7 +110,7 @@ def main(argv: list[str]) -> None:
         logger.info("Uploaded %d wheel files", count)
         if count == 0:
             raise FileNotFoundError(f"No wheels found at {args.source_dir}")
-        package_index_url = LEGACY_MULTI_ARCH_INDEX_URLS[args.release_type]
+        package_index_url = get_legacy_release_index_url(args.release_type)
 
     gha_set_output({"package_index_url": package_index_url})
 

--- a/build_tools/github_actions/summarize_test_pytorch_workflow.py
+++ b/build_tools/github_actions/summarize_test_pytorch_workflow.py
@@ -21,7 +21,11 @@ The script can be tested locally with inputs like this:
 import argparse
 import platform
 import sys
+from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from _therock_utils.s3_buckets import get_release_package_index_url
 from github_actions_api import *
 
 
@@ -107,7 +111,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--index-url",
         type=str,
-        default="https://nightly.repo.amd.com/rocm/whl-next/",
+        default=get_release_package_index_url("nightly"),
         help="Full URL for a release index to use with 'pip install --index-url='",
     )
     parser.add_argument(

--- a/build_tools/setup_venv.py
+++ b/build_tools/setup_venv.py
@@ -50,14 +50,20 @@ import sys
 import time
 
 from github_actions.github_actions_api import *
+from _therock_utils.s3_buckets import get_release_package_index_url
 
 is_windows = platform.system() == "Windows"
 
-ROCM_INDEX_URLS_MAP = {
-    "stable": "https://stable.repo.amd.com/rocm/whl-next/",
-    "prerelease": "https://rc.repo.amd.com/rocm/whl-next/",
-    "nightly": "https://nightly.repo.amd.com/rocm/whl-next/",
-    "dev": "https://dev.repo.amd.com/rocm/whl-next/",
+# User-facing --index-name spellings, mapped to the release types
+# get_release_package_index_url takes. Only "stable" differs: the release type
+# is spelled "release" internally, but "stable" is the name users have typed
+# since before the repo.amd.com streams existed, and it now also matches the
+# stream's own name.
+INDEX_NAME_TO_RELEASE_TYPE = {
+    "stable": "release",
+    "prerelease": "prerelease",
+    "nightly": "nightly",
+    "dev": "dev",
 }
 
 
@@ -239,8 +245,11 @@ def install_packages_into_venv(
         raise ValueError("Can't set both index_url and index_name")
 
     if index_name:
-        # Look up known index name.
-        index_url = ROCM_INDEX_URLS_MAP[index_name]
+        # Derived from the bucket inventory rather than a copy of the mapping,
+        # so this index and the ones the publish scripts announce cannot drift.
+        index_url = get_release_package_index_url(
+            INDEX_NAME_TO_RELEASE_TYPE[index_name]
+        )
 
     if index_url == "":
         pip_install_cmd.append("--no-index")
@@ -378,7 +387,7 @@ def main(argv: list[str]):
     install_options.add_argument(
         "--index-name",
         type=str,
-        choices=["stable", "prerelease", "nightly", "dev"],
+        choices=sorted(INDEX_NAME_TO_RELEASE_TYPE),
         help="Shorthand for a named index",
     )
     install_options.add_argument(

--- a/build_tools/tests/s3_buckets_test.py
+++ b/build_tools/tests/s3_buckets_test.py
@@ -20,9 +20,12 @@ from _therock_utils.s3_buckets import (
     cdn_url_for,
     get_artifacts_bucket_config,
     get_artifacts_bucket_config_for_workflow_run,
+    get_index_release_stream,
+    get_legacy_release_index_url,
     get_product_release_bucket_config,
     get_release_package_index_url,
     get_release_stream,
+    get_release_tarball_index_url,
     get_release_bucket_config,
     lookup_bucket_config,
     require_bucket_config,
@@ -32,6 +35,7 @@ from _therock_utils.s3_buckets import (
     set_bucket_config_file,
 )
 from _therock_utils.storage_location import StorageLocation
+from setup_venv import INDEX_NAME_TO_RELEASE_TYPE
 
 
 # ---------------------------------------------------------------------------
@@ -670,6 +674,122 @@ class TestProductReleaseBuckets(unittest.TestCase):
     def test_invalid_product_is_rejected(self):
         with self.assertRaises(ValueError):
             get_product_release_bucket_config("nightly", "tensorflow")
+
+
+class TestReleaseIndexUrls(unittest.TestCase):
+    """The public index URLs users install from.
+
+    Every expected value is written out in full rather than rebuilt from the
+    same streams and CdnRules the implementation reads. These URLs appear in
+    install instructions and are passed to pip, so a test that derived them
+    would agree with any rule the code happens to hold, including a wrong one.
+    """
+
+    def test_aggregate_pip_index(self):
+        expected = {
+            "dev": "https://dev.repo.amd.com/rocm/whl-next/",
+            "dev-bkc": "https://bkc.repo.amd.com/rocm/whl-next/",
+            "nightly": "https://nightly.repo.amd.com/rocm/whl-next/",
+            "nightly-bkc": "https://bkc.repo.amd.com/rocm/whl-next/",
+            "prerelease": "https://rc.repo.amd.com/rocm/whl-next/",
+            "release": "https://stable.repo.amd.com/rocm/whl-next/",
+        }
+        for release_type, url in expected.items():
+            with self.subTest(release_type=release_type):
+                self.assertEqual(get_release_package_index_url(release_type), url)
+
+    def test_setup_venv_index_names_are_unchanged(self):
+        """The four --index-name values still resolve to what they did before.
+
+        setup_venv.py held these as a literal map; it now derives them. Same
+        strings either way, so no command line changes.
+        """
+        expected = {
+            "stable": "https://stable.repo.amd.com/rocm/whl-next/",
+            "prerelease": "https://rc.repo.amd.com/rocm/whl-next/",
+            "nightly": "https://nightly.repo.amd.com/rocm/whl-next/",
+            "dev": "https://dev.repo.amd.com/rocm/whl-next/",
+        }
+        for index_name, url in expected.items():
+            with self.subTest(index_name=index_name):
+                self.assertEqual(
+                    get_release_package_index_url(
+                        INDEX_NAME_TO_RELEASE_TYPE[index_name]
+                    ),
+                    url,
+                )
+
+    def test_product_local_index(self):
+        self.assertEqual(
+            get_release_package_index_url("nightly", "pytorch"),
+            "https://nightly.repo.amd.com/rocm/pytorch/whl-next/",
+        )
+        self.assertEqual(
+            get_release_package_index_url("dev", "jax"),
+            "https://dev.repo.amd.com/rocm/jax/whl-next/",
+        )
+
+    def test_tarball_index(self):
+        self.assertEqual(
+            get_release_tarball_index_url("nightly"),
+            "https://nightly.repo.amd.com/rocm/core/tarball/",
+        )
+        self.assertEqual(
+            get_release_tarball_index_url("release"),
+            "https://stable.repo.amd.com/rocm/core/tarball/",
+        )
+
+    def test_legacy_index_urls_match_the_maps_they_replaced(self):
+        """Byte-identical to the LEGACY_MULTI_ARCH_INDEX_URLS copies deleted here.
+
+        Those lived in publish_pytorch_to_release_bucket.py and
+        publish_jax_to_release_bucket.py, identical in both.
+        """
+        expected = {
+            "dev": "https://rocm.devreleases.amd.com/whl-multi-arch/",
+            "dev-bkc": "https://rocm.devreleases.amd.com/whl-multi-arch/",
+            "nightly": "https://rocm.nightlies.amd.com/whl-multi-arch/",
+            "nightly-bkc": "https://rocm.nightlies.amd.com/whl-multi-arch/",
+            "prerelease": "https://rocm.prereleases.amd.com/whl-multi-arch/",
+        }
+        for release_type, url in expected.items():
+            with self.subTest(release_type=release_type):
+                self.assertEqual(get_legacy_release_index_url(release_type), url)
+
+    def test_legacy_tarball_index(self):
+        self.assertEqual(
+            get_legacy_release_index_url("nightly", "tarball"),
+            "https://rocm.nightlies.amd.com/tarball-multi-arch/",
+        )
+        self.assertEqual(
+            get_legacy_release_index_url("release", "tarball"),
+            "https://repo.amd.com/rocm/tarball-multi-arch/",
+        )
+
+    def test_release_is_installable_from_but_not_publishable_to(self):
+        """The read set is wider than the write set, on purpose.
+
+        The stable buckets have no automated upload credentials, so the publish
+        path must keep rejecting "release" - but it is the channel most users
+        install from.
+        """
+        self.assertEqual(get_index_release_stream("release"), "stable")
+        with self.assertRaises(ValueError):
+            get_release_stream("release")
+        with self.assertRaises(ValueError):
+            get_release_bucket_config("release", "python")
+
+    def test_invalid_inputs_rejected(self):
+        with self.assertRaises(ValueError):
+            get_release_package_index_url("bogus")
+        with self.assertRaises(ValueError):
+            get_release_package_index_url("nightly", "tensorflow")
+        with self.assertRaises(ValueError):
+            get_legacy_release_index_url("bogus")
+        with self.assertRaises(ValueError):
+            # "packages" has no single index: that CDN serves a
+            # distro-partitioned apt/dnf repo, not a prefix rewrite.
+            get_legacy_release_index_url("nightly", "packages")
 
 
 class TestAnonymousS3Read(unittest.TestCase):

--- a/docs/development/s3_buckets.md
+++ b/docs/development/s3_buckets.md
@@ -145,6 +145,30 @@ needs no edit here when it does.
 None of the product buckets are readable over raw S3 — they carry
 `anonymous_s3_read=false`, and the stream CDN is the only public way in.
 
+#### Index URLs
+
+For "which URL does a user install this channel from", call these rather than
+reading `cdn_rules` or writing the URL out:
+
+```python
+from _therock_utils.s3_buckets import (
+    get_release_package_index_url,
+    get_release_tarball_index_url,
+    get_legacy_release_index_url,
+)
+
+get_release_package_index_url("nightly")  # pip --index-url
+get_release_package_index_url("nightly", "pytorch")  # product-local index
+get_release_tarball_index_url("release")  # where users browse tarballs
+get_legacy_release_index_url("nightly")  # pre-RFC0012 layout
+```
+
+They accept `release` in addition to the publishable release types. The stable
+channel is promoted by hand and has no automated upload credentials, so
+`get_release_bucket_config` and `get_release_stream` keep rejecting it — but it
+is the channel most users install from, so the read side accepts it. Keeping the
+two sets separate is what lets one widen without widening the other.
+
 Pip installs must use the aggregate index, such as
 https://nightly.repo.amd.com/rocm/whl-next/. Product-local Python indexes are
 publication and indexer inputs, not self-contained install entry points.


### PR DESCRIPTION
ISSUE ID : https://github.com/ROCm/TheRock/issues/7091

## Motivation

The public "which URL do I install this channel from" mapping is still written out by hand, and
after the repo.amd.com rewire there are now **two** families of it instead of one:

| Copy | Where |
| --- | --- |
| `ROCM_INDEX_URLS_MAP` (new stream URLs) | `setup_venv.py:56` |
| `LEGACY_MULTI_ARCH_INDEX_URLS` | `publish_pytorch_to_release_bucket.py:45` |
| the same dict again, verbatim | `publish_jax_to_release_bucket.py:27` |
| the nightly index as an argparse default | `summarize_test_pytorch_workflow.py:110` |

The legacy map did not go away when the streams landed — it was renamed and extended with BKC
keys. `main` already has `get_release_package_index_url`, but only for the aggregate wheel index,
and nothing uses it from `setup_venv.py`.

Stacked on #7239 for a linear review order; it shares no files with that PR.

## Technical Details

Extends `main`'s `get_release_package_index_url` rather than adding a rival name, and adds two
siblings:

```python
get_release_package_index_url("nightly")             # aggregate pip index
get_release_package_index_url("nightly", "pytorch")  # product-local index
get_release_tarball_index_url("release")             # where users browse tarballs
get_legacy_release_index_url("nightly")              # pre-RFC0012 layout
```

`get_legacy_release_index_url` derives from the selected bucket's `cdn_rules` rather than from a
copy of the mapping. The `v4/whl/` and `v4/tarball/` prefixes are now stated once, in
`_LEGACY_INDEX_KEY_PREFIXES`, and the seeded `CdnRule`s are built from it — the prefix a rule
matches and the prefix an index URL is built from have to be the same string or the lookup
silently misses, so they should not be two literals kept in sync by hand.

All eight derived URLs are **byte-identical** to the literals they replace.

### The read set is wider than the write set

`get_release_stream` and `get_release_bucket_config` keep rejecting `"release"`: the stable
buckets have no automated upload credentials — they are promoted by hand — so nothing may publish
there. But it is the channel most users install from, and `setup_venv.py`'s `stable` index already
pointed at it. `get_index_release_stream` accepts it and the publish-side lookups do not, which is
what lets one widen without widening the other.

The registry file's `release_buckets` map is validated against the same wider set, so a downstream
repo can redirect its `release` channel; validating it against the publish set would leave
`get_legacy_release_index_url` reading a slot no file could ever fill.

`setup_venv.py` keeps `stable` as the user-facing `--index-name` spelling, aliased to the
`release` release type, so no command lines change.

### A note on `stable`

`https://stable.repo.amd.com/rocm/whl-next/` currently returns 404 — that stream has not finished
cutting over. This PR does not introduce or fix that: it is the exact value `main` already holds
in `setup_venv.py` after #7547, and the consolidation preserves it. Flagging it because it means
`--index-name stable` does not work today, which is worth someone's attention independently of
this change.

## Test Plan

- `cd build_tools && python -m pytest`
- `pre-commit run --all-files`
- Every derived index URL fetched anonymously. The `dev` and `nightly` streams and every legacy
  index serve; `rc/rocm/core/tarball/` and the `stable` paths are not up yet.

Every expected URL in `TestReleaseIndexUrls` is asserted as a literal rather than rebuilt from the
same streams and rules the implementation reads. These go to pip, so a test that derived them
would agree with any rule the code happens to hold, including a wrong one. That includes an
explicit check that the four `--index-name` values resolve to exactly what `setup_venv.py` held
before, and that the five legacy values match the deleted `LEGACY_MULTI_ARCH_INDEX_URLS` entries.

Also covered: `"release"` is accepted by the read path and rejected by both publish-side lookups;
`"packages"` has no single index and raises, because that CDN serves a distro-partitioned apt/dnf
repo rather than a prefix rewrite.

## Test Result

`cd build_tools && python -m pytest` on this branch (Linux, Python 3.12):
**2188 passed, 8 skipped, 259 subtests passed**, 0 failed.

`pre-commit run` clean across all changed files.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
