### PR TITLE
ci: enable gfx90c for nightly PyTorch builds

### DIFF
--- a/build_tools/github_actions/configure_pytorch_release_matrix.py
+++ b/build_tools/github_actions/configure_pytorch_release_matrix.py
@@ -64,8 +64,7 @@ UNSUPPORTED_AMDGPU_FAMILIES = {
         # gfx125x supported for PyTorch 2.13 via https://github.com/ROCm/pytorch/pull/3532.
         "release/2.13": {"gfx90c"},
         # gfx125x supported on upstream pytorch/pytorch nightly via pytorch#188597.
-        # gfx90c excluded: blocked until CK submodule bump in pytorch nightly.
-        "nightly": {"gfx90c"},
+        "nightly": {},
     },
     "windows": {
         "release/2.11": {"gfx90c"},


### PR DESCRIPTION
## Motivation

Enable gfx90c torch nightly builds.

Relates to https://github.com/ROCm/TheRock/issues/6805

## Technical Details

Upstream PyTorch nightly branch now pins https://github.com/ROCm/composable_kernel/tree/5a74dec07a894484b9489d0c0e00cd3b52652d18 which includes gfx90c support resolving any of the `CK_BUFFER_RESOURCE_3RD_DWORD undeclared for gfx90c` errors we were guarding against.

## Test Plan

https://github.com/ROCm/TheRock/actions/runs/31419258422/job/93555777554

## Test Result

Expected - Nightly torch build pass on gfx90c.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
