### PR TITLE
ci(pytorch): enable gfx1250 builds for release/2.13 (#7160)

### DIFF
--- a/build_tools/github_actions/configure_pytorch_release_matrix.py
+++ b/build_tools/github_actions/configure_pytorch_release_matrix.py
@@ -61,9 +61,8 @@ UNSUPPORTED_AMDGPU_FAMILIES = {
         "release/2.11": {"gfx90c"},
         # gfx125x supported for PyTorch 2.12 via https://github.com/ROCm/pytorch/pull/3421.
         "release/2.12": {},
-        # gfx125x not yet enabled for PyTorch release/2.13 (ROCm/pytorch fork).
-        # See https://github.com/ROCm/TheRock/issues/5833.
-        "release/2.13": {"gfx125X-dcgpu", "gfx90c"},
+        # gfx125x supported for PyTorch 2.13 via https://github.com/ROCm/pytorch/pull/3532.
+        "release/2.13": {"gfx90c"},
         # gfx125x supported on upstream pytorch/pytorch nightly via pytorch#188597.
         # gfx90c excluded: blocked until CK submodule bump in pytorch nightly.
         "nightly": {"gfx90c"},

--- a/build_tools/github_actions/tests/configure_pytorch_release_matrix_test.py
+++ b/build_tools/github_actions/tests/configure_pytorch_release_matrix_test.py
@@ -99,7 +99,7 @@ class ConfigurePytorchReleaseMatrixTest(unittest.TestCase):
                     release_type="dev",
                     python_versions=["3.12"],
                     pytorch_git_refs=[pytorch_git_ref],
-                    amdgpu_families="gfx94X-dcgpu;gfx125X-dcgpu",
+                    amdgpu_families="gfx94X-dcgpu;gfx90c",
                     platform="linux",
                 )
 


### PR DESCRIPTION
Cherry-picks commit 409fe01 to the ROCm 10.0 release branch.

JIRA ID: AIRDEL-33

---

enable 1250 builds for release/2.13