### PR TITLE
[core] Remove hipcc runtime dep from clr (hipconfig deprecation)

### DIFF
--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -1743,7 +1743,7 @@ function(_therock_cmake_subproject_setup_toolchain
     # The "amd-llvm" and "amd-hip" toolchains are configured very similarly so
     # we commingle them, but they are different:
     #   "amd-llvm": Just the base LLVM compiler and device libraries. This
-    #     doesn't know anything about hip (i.e. it doesn't have hipconfig, etc).
+    #     doesn't know anything about hip (i.e. it doesn't have HIP headers, etc).
     #   "amd-hip": Superset of "amd-llvm" which also includes HIP headers and
     #     HIP version info.
     # The main difference is that for "amd-llvm", we derive the configuration from

--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -252,7 +252,7 @@ if(THEROCK_ENABLE_COMPILER)
 
   ##############################################################################
   # hipcc
-  # Provides hipcc and hipconfig
+  # Provides hipcc (deprecated) and hipconfig (deprecated)
   ##############################################################################
 
   therock_cmake_subproject_declare(hipcc

--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -252,7 +252,7 @@ if(THEROCK_ENABLE_COMPILER)
 
   ##############################################################################
   # hipcc
-  # Provides hipcc (deprecated) and hipconfig (deprecated)
+  # Provides hipcc (legacy) and hipconfig (legacy)
   ##############################################################################
 
   therock_cmake_subproject_declare(hipcc

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -244,8 +244,6 @@ if(THEROCK_ENABLE_HIP_RUNTIME)
   # clr
   # The primary HIP compiler and runtime target. This is also the project used
   # to root the "amd-hip" compiler toolchain and is a superset of amd-llvm.
-  # As a particularly sharp edge, the `hipconfig` tool is really only fully
-  # functional from this project (which contributes version and metadata).
   ##############################################################################
   set(HIP_CLR_CMAKE_ARGS)
   set(HIP_CLR_RUNTIME_DEPS)
@@ -311,7 +309,6 @@ if(THEROCK_ENABLE_HIP_RUNTIME)
     RUNTIME_DEPS
       amd-llvm
       amd-comgr
-      hipcc     # For hipconfig
       rocm-core
       rocm-kpack
       ${HIP_CLR_RUNTIME_DEPS}


### PR DESCRIPTION

JIRA ID: ROCM-8370

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
hipcc was listed as a RUNTIME_DEP of clr solely because clr needed hipconfig. Now that hipconfig is being deprecated and removed, this dependency is no longer required.

<!-- Most pull requests should be associated with at least one GitHub issue -->

<!-- GitHub issue: https://github.com/ROCm/TheRock/issues/1234 -->
ROCM-8370 : https://amd-hub.atlassian.net/browse/ROCM-8370

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
