### PR TITLE
ci: harden test container security posture

### DIFF
--- a/.github/workflows/test_native_linux_packages_install.yml
+++ b/.github/workflows/test_native_linux_packages_install.yml
@@ -196,7 +196,6 @@ jobs:
     runs-on: ${{ github.repository_owner == 'ROCm' && (inputs.test_runs_on || 'linux-gfx942-1gpu-ccs-csp-ossci-rocm') || 'ubuntu-24.04' }}
     container:
       image: ${{ needs.prepare_install_context.outputs.container_image }}
-      options: --ipc host
     env:
       REPO_URL: ${{ inputs.package_install_url }}
       GPG_KEY_URL: ${{ inputs.gpg_key_url || '' }}

--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -115,10 +115,7 @@ jobs:
       summary: ${{ steps.summary.outputs.summary }}
     container:
       image: ${{ contains(inputs.test_runs_on, 'linux') && 'ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:405945a40deaff9db90b9839c0f41d4cba4a383c1a7459b28627047bf6302a26' || null }}
-      # SYS_PTRACE is required by PyTorch's test infra, which uses gdb to
-      # collect stack traces on segfaults and hangs (torch/testing/_internal).
-      options: --ipc host
-        --cap-add=SYS_PTRACE
+      options:
         --group-add video
         --device /dev/kfd
         --device /dev/dri

--- a/.github/workflows/test_pytorch_wheels_full.yml
+++ b/.github/workflows/test_pytorch_wheels_full.yml
@@ -195,10 +195,7 @@ jobs:
       matrix: ${{ fromJSON(needs.prepare_matrix.outputs.matrix) }}
     container:
       image: ${{ contains(inputs.test_runs_on, 'linux') && 'ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:405945a40deaff9db90b9839c0f41d4cba4a383c1a7459b28627047bf6302a26' || null }}
-      # SYS_PTRACE is required by PyTorch's test infra which uses gdb to
-      # collect stack traces on segfaults and hangs (torch/testing/_internal).
       options: --shm-size=10g
-        --cap-add=SYS_PTRACE
         --group-add video
         --device /dev/kfd
         --device /dev/dri

--- a/.github/workflows/test_rocm_wheels.yml
+++ b/.github/workflows/test_rocm_wheels.yml
@@ -108,8 +108,7 @@ jobs:
     timeout-minutes: 30
     container:
       image: ${{ contains(inputs.test_runs_on, 'linux') && inputs.container_image_url != '' && inputs.container_image_url || null }}
-      options: --ipc host
-        --group-add video
+      options: --group-add video
         --device /dev/kfd
         --device /dev/dri
         --group-add 992

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -62,13 +62,11 @@ def _get_script_path(script_name: str) -> str:
 # --user 0:0 - Running as root, by recommendation of GitHub: https://docs.github.com/en/actions/reference/workflows-and-actions/dockerfile-support#user
 # --ulimit memlock=-1:-1 - Prevents memory allocation issues with ROCm inside container
 # --ulimit nofile=1048576:1048576 - Increase open file limit for RCCL
-# --security-opt seccomp=unconfined - enables memory mapping, and is recommended for containers running in HPC environments
 _BASE_CONTAINER_OPTIONS = [
     "--ipc host",
     "--user 0:0",
     "--ulimit memlock=-1:-1",
     "--ulimit nofile=1048576:1048576",
-    "--security-opt seccomp=unconfined",
 ]
 
 # GPU-specific container options (only applied when linux_cpu_runner != True)

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -58,12 +58,10 @@ def _get_script_path(script_name: str) -> str:
 
 
 # Base container options applied to all Linux containers
-# --ipc host - Allows shared memory between host and container
 # --user 0:0 - Running as root, by recommendation of GitHub: https://docs.github.com/en/actions/reference/workflows-and-actions/dockerfile-support#user
 # --ulimit memlock=-1:-1 - Prevents memory allocation issues with ROCm inside container
 # --ulimit nofile=1048576:1048576 - Increase open file limit for RCCL
 _BASE_CONTAINER_OPTIONS = [
-    "--ipc host",
     "--user 0:0",
     "--ulimit memlock=-1:-1",
     "--ulimit nofile=1048576:1048576",

--- a/dockerfiles/no_rocm_image_ubuntu24_04.Dockerfile
+++ b/dockerfiles/no_rocm_image_ubuntu24_04.Dockerfile
@@ -4,23 +4,29 @@ FROM ubuntu:24.04
 
 RUN apt update && apt install sudo -y
 
-# Create tester user with sudo privileges and render/video permissions
-RUN useradd -m -s /bin/bash -U -G sudo tester
+# Create tester user with render/video permissions (no sudo group membership).
+RUN useradd -m -s /bin/bash -U tester
 RUN groupadd -g 109 render && usermod -a -G render,video tester
-# New added for disable sudo password
-RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
-# Set as default user
-USER tester
+# Grant tester passwordless sudo only for the specific commands needed by CI:
+#   apt / apt-get   - runtime package installation in test workflows
+#   tee             - writing APT keyrings and source-list entries under /etc/apt/
+#   mkdir / chmod   - creating the /etc/apt/keyrings/ directory and fixing its permissions
+#   dmesg           - reading kernel ring buffer in GPU diagnostics
+RUN echo 'tester ALL=(ALL) NOPASSWD: /usr/bin/apt-get, /usr/bin/apt, /usr/bin/tee, /bin/mkdir, /bin/chmod, /usr/bin/mkdir, /usr/bin/chmod, /usr/bin/dmesg, /bin/dmesg' \
+    > /etc/sudoers.d/tester \
+    && chmod 0440 /etc/sudoers.d/tester
 
-RUN sudo apt-get update -y \
-    && sudo apt-get install -y software-properties-common \
-    && sudo add-apt-repository -y ppa:git-core/ppa \
-    && sudo apt-get update -y \
-    && sudo apt-get install -y --no-install-recommends \
+# Install build-time packages as root before switching to tester.
+RUN apt-get update -y \
+    && apt-get install -y software-properties-common \
+    && add-apt-repository -y ppa:git-core/ppa \
+    && apt-get update -y \
+    && apt-get install -y --no-install-recommends \
     curl \
     ca-certificates \
     git \
+    git-lfs \
     jq \
     unzip \
     zip \
@@ -31,12 +37,11 @@ RUN sudo apt-get update -y \
     wget \
     psmisc \
     libgfortran5 \
-    valgrind
+    valgrind \
+    python3-setuptools \
+    python3-wheel
 
-RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash && \
-    sudo apt-get install git-lfs
-
-RUN sudo apt-get update -y && \
-    sudo apt-get install -y python3-setuptools python3-wheel
+# Set as default user
+USER tester
 
 WORKDIR /home/tester/


### PR DESCRIPTION
Addresses ROCM-26826 and ROCM-26887. Three commits, one per change, for bisectability.

**Drop \`seccomp=unconfined\`**

Running with seccomp disabled gives containers access to the full Linux syscall table (bpf, mount, kexec_load, etc.), which none of our GPU tests need. The Docker default profile already permits the syscalls required for normal GPU workloads. Tests that genuinely need ptrace (rocgdb, rocprofiler-sdk) already request \`SYS_PTRACE\` explicitly via \`--cap-add\`, which is the correctly scoped alternative.

**Drop \`--ipc host\`**

Sharing the host IPC namespace exposes the host's \`/dev/shm\` and all POSIX IPC objects to every test container. No job actually needed it: RCCL and rocSHMEM use GPU IPC (peer-to-peer HIP memory handles via KFD), not POSIX shared memory. The PyTorch full-test workflow already uses the correctly scoped \`--shm-size=10g\` for the shared memory it genuinely needs. Also removes unjustified \`SYS_PTRACE\` from both PyTorch wheel workflows — our test drivers don't invoke gdb or ptrace.

**Narrow tester sudo grant**

The base image previously granted \`tester\` blanket \`NOPASSWD:ALL\` sudo, leaving a trivial privilege escalation path via \`sudo bash\`. This commit replaces that with a scoped \`/etc/sudoers.d/tester\` drop-in that allows only the commands CI actually needs at runtime: \`apt\`, \`apt-get\`, \`tee\`, \`mkdir\`, \`chmod\`, and \`dmesg\`. The \`tester\` user is removed from the \`sudo\` group entirely. The git-lfs packagecloud installer script (the only \`sudo bash\` call in the image build) is replaced with a direct \`apt-get install git-lfs\`, and all remaining build-time installs are consolidated into a single root-level \`RUN\` block before the \`USER tester\` switch.

Note: dropping \`--user 0:0\` is not included in this PR. The GHA runner writes \`/_temp/_runner_file_commands/\` state files as root from the host; containers running as a non-root user cannot write back to them, breaking \`actions/checkout\` post-step cleanup. This is the documented reason GitHub recommends \`--user 0:0\` for containerized jobs.

JIRA ID : ROCM-26826
JIRA ID : ROCM-26827