### PR TITLE
fix(ci): add workflow_dispatch check to runner override logic (#7262)

### DIFF
--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -232,7 +232,7 @@ jobs:
       amdgpu_targets: ${{ inputs.amdgpu_targets }}
       # Route to the appropriate runner:
       #   1. For user-triggered workflow_dispatch, honor test_runs_on input if provided.
-      #      User-triggered means github.actor does NOT contain 'github-actions'.
+      #      Only applies to workflow_dispatch events (not PR/workflow_call chains).
       #      Bot-triggered runs (e.g., nightly from rockrel) skip this and use rules below.
       #   2. Multi-GPU components use the multi-GPU runner (required for correct execution)
       #   3. Benchmark components use the dedicated benchmark runner
@@ -240,7 +240,8 @@ jobs:
       #   5. Per-component runner (set by fetch_test_configurations.py)
       test_runs_on: >-
         ${{
-          (!contains(github.actor, 'github-actions') &&
+          (github.event_name == 'workflow_dispatch' &&
+            !contains(github.actor, 'github-actions') &&
             inputs.test_runs_on != '' &&
             inputs.test_runs_on) ||
           (matrix.components.multi_gpu_runner != '' &&


### PR DESCRIPTION
The test_runs_on override condition was missing the workflow_dispatch event check, causing PR-triggered runs (e.g., from systems-assistant[bot]) to incorrectly override multi_gpu_runner. This routed rocshmem tests to 1-GPU runners where they failed with "invalid device ordinal".

The fix adds `github.event_name == 'workflow_dispatch'` to ensure the user override only applies to direct workflow_dispatch triggers, not PR/workflow_call chains.

Fixes #7262

working here: https://github.com/ROCm/TheRock/actions/runs/31486833896/job/93764060278
<img width="1332" height="507" alt="Screenshot 2026-08-11 043049" src="https://github.com/user-attachments/assets/f591369c-8d8c-4650-b888-2d05a80e017c" />

rockrel is "manually triggered": https://github.com/ROCm/rockrel/actions/runs/31458430661 so logic applies.
