### PR TITLE
ci: ignore hipMemcpyBatchAsync swap tests on gfx125X-dcgpu

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_hiptests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiptests.py
@@ -90,6 +90,9 @@ TEST_TO_IGNORE = {
     "gfx125X-dcgpu": {
         "linux": [
             "Unit_hipGraphAddMemcpyNode1D_Positive_Basic",
+            # ROCM-29275: SDMA COPY_SWAP hangs the GPU on gfx1250 (rocm-systems#9923).
+            "Unit_hipMemcpyBatchAsync_Swap",
+            "Unit_hipMemcpyBatchAsync_P2P_Swap",
         ]
     },
 }


### PR DESCRIPTION
## Motivation

Test is failing on gfx1250, PR pending long time(outage)

## Technical Details

Disable test until fix is available.

## Issue Tracking

JIRA ID : ROCM-29275

## Test Plan

CI expected to pass

## Test Result

Needs this to unblock gfx1250 testing

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
