### PR TITLE
feat(sysdeps): add optional bundled libfwupd for amd-smi UMA carveout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -403,6 +403,7 @@ set(THEROCK_BUNDLED_UTIL_LINUX)
 set(THEROCK_BUNDLED_ZLIB)
 set(THEROCK_BUNDLED_ZSTD)
 set(THEROCK_BUNDLED_AMDMESA)
+set(THEROCK_BUNDLED_FWUPD)
 
 
 if(THEROCK_BUNDLE_SYSDEPS)
@@ -447,6 +448,10 @@ if(THEROCK_BUNDLE_SYSDEPS)
     endif()
     if(THEROCK_ENABLE_SYSDEPS_UTIL_LINUX)
       set(THEROCK_BUNDLED_UTIL_LINUX therock-util-linux)
+    endif()
+    if(THEROCK_ENABLE_SYSDEPS_FWUPD)
+      # libfwupd + its private stack (glib -> libffi/pcre2, plus libcurl).
+      set(THEROCK_BUNDLED_FWUPD therock-libfwupd)
     endif()
   elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     find_program(MESON_BUILD meson)

--- a/third-party/sysdeps/linux/CMakeLists.txt
+++ b/third-party/sysdeps/linux/CMakeLists.txt
@@ -161,3 +161,29 @@ if(THEROCK_ENABLE_SYSDEPS_UTIL_LINUX)
       therock-util-linux
   )
 endif()
+
+# Optional sysdep: libfwupd (amd-smi routes the UMA carveout BIOS setting through
+# fwupd on UEFI-HII platforms) plus its private dependency stack. GLib pulls in
+# libffi and pcre2; libfwupd additionally needs libcurl. fwupd 2.1.x is the last
+# pre-Rust release series and no longer depends on libjcat or json-glib. zlib
+# (used by GLib's gio) is a core sysdep and is always available.
+if(THEROCK_ENABLE_SYSDEPS_FWUPD)
+  add_subdirectory(libffi)
+  add_subdirectory(pcre2)
+  add_subdirectory(libcurl)
+  add_subdirectory(glib)
+  add_subdirectory(libfwupd)
+  therock_provide_artifact(sysdeps-fwupd
+    TARGET_NEUTRAL
+    DESCRIPTOR artifact-fwupd.toml
+    COMPONENTS
+      dev
+      lib
+    SUBPROJECT_DEPS
+      therock-libffi
+      therock-pcre2
+      therock-libcurl
+      therock-glib
+      therock-libfwupd
+  )
+endif()

--- a/third-party/sysdeps/linux/artifact-fwupd.toml
+++ b/third-party/sysdeps/linux/artifact-fwupd.toml
@@ -1,0 +1,27 @@
+[options]
+unmatched_exclude = [
+  "lib/rocm_sysdeps/share/locale/**",
+  "lib/rocm_sysdeps/share/man/**",
+  "lib/rocm_sysdeps/share/gdb/**",
+  "lib/rocm_sysdeps/share/bash-completion/**",
+]
+
+# libffi
+[components.lib."third-party/sysdeps/linux/libffi/build/stage"]
+[components.dev."third-party/sysdeps/linux/libffi/build/stage"]
+
+# pcre2
+[components.lib."third-party/sysdeps/linux/pcre2/build/stage"]
+[components.dev."third-party/sysdeps/linux/pcre2/build/stage"]
+
+# libcurl
+[components.lib."third-party/sysdeps/linux/libcurl/build/stage"]
+[components.dev."third-party/sysdeps/linux/libcurl/build/stage"]
+
+# glib
+[components.lib."third-party/sysdeps/linux/glib/build/stage"]
+[components.dev."third-party/sysdeps/linux/glib/build/stage"]
+
+# libfwupd
+[components.lib."third-party/sysdeps/linux/libfwupd/build/stage"]
+[components.dev."third-party/sysdeps/linux/libfwupd/build/stage"]

--- a/third-party/sysdeps/linux/glib/CMakeLists.txt
+++ b/third-party/sysdeps/linux/glib/CMakeLists.txt
@@ -1,0 +1,126 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    # When included in TheRock, we download sources and set up the sub-project.
+    set(_source_dir "${CMAKE_CURRENT_BINARY_DIR}/source")
+    set(_download_stamp "${_source_dir}/download.stamp")
+
+    therock_subproject_fetch(therock-glib-sources
+      SOURCE_DIR "${_source_dir}"
+      # Originally from: https://download.gnome.org/sources/glib/2.74/glib-2.74.7.tar.xz
+      URL "https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/glib-2.74.7.tar.xz"
+      URL_HASH "SHA256=196ab86c27127a61b7a70c3ba6af7b97bdc01c07cd3b21abd5e778b955eccb1b"
+      TOUCH "${_download_stamp}"
+      DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    )
+
+    therock_cmake_subproject_declare(therock-glib
+      USE_DIST_AMDGPU_TARGETS
+      EXTERNAL_SOURCE_DIR .
+      FPRINT_SOURCE_DIR "${_source_dir}"
+      FPRINT_FILE_GLOBS "${CMAKE_CURRENT_LIST_DIR}/*"
+      BINARY_DIR build
+      NO_MERGE_COMPILE_COMMANDS
+      BACKGROUND_BUILD
+      OUTPUT_ON_FAILURE
+      CMAKE_ARGS
+        "-DSOURCE_DIR=${_source_dir}"
+        "-DPATCHELF=${PATCHELF}"
+        "-DMESON_BUILD=${MESON_BUILD}"
+        "-DPython3_EXECUTABLE=${Python3_EXECUTABLE}"
+      INSTALL_DESTINATION
+        lib/rocm_sysdeps
+      INTERFACE_INCLUDE_DIRS
+        lib/rocm_sysdeps/include
+      INTERFACE_LINK_DIRS
+        lib/rocm_sysdeps/lib
+      INTERFACE_INSTALL_RPATH_DIRS
+        lib/rocm_sysdeps/lib
+      INTERFACE_PKG_CONFIG_DIRS
+        lib/rocm_sysdeps/lib/pkgconfig
+      # glib links pcre2 (core), libffi (gobject) and zlib (gio).
+      RUNTIME_DEPS
+        therock-libffi
+        therock-pcre2
+        therock-zlib
+      EXTRA_DEPENDS
+        "${_download_stamp}"
+    )
+    therock_cmake_subproject_provide_package(therock-glib glib lib/rocm_sysdeps/lib/cmake/glib)
+    therock_cmake_subproject_activate(therock-glib)
+
+    therock_test_validate_shared_lib(
+      PATH build/dist/lib/rocm_sysdeps/lib
+      LIB_NAMES libglib-2.0.so libgobject-2.0.so libgio-2.0.so libgmodule-2.0.so libgthread-2.0.so
+    )
+
+    return()
+endif()
+
+# Otherwise, this is the sub-project build.
+cmake_minimum_required(VERSION 3.25)
+project(GLIB_BUILD VERSION "2.74.7")
+
+if(NOT PATCHELF OR NOT MESON_BUILD)
+  message(FATAL_ERROR "Missing PATCHELF or MESON_BUILD from super-project")
+endif()
+
+include("${THEROCK_SOURCE_DIR}/cmake/therock_meson_env.cmake")
+therock_get_meson_compiler_env(_meson_cc _meson_cxx)
+
+# Meson refuses to build if the source dir is a subdir of the build dir, so
+# make it a sibling.
+set(PATCH_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/../patch_source")
+
+add_custom_target(
+  meson_build ALL
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+  COMMAND
+    "${CMAKE_COMMAND}" -E rm -rf -- "${CMAKE_INSTALL_PREFIX}" "${PATCH_SOURCE_DIR}"
+  COMMAND
+    # Use cp -a rather than `cmake -E copy_directory`: GLib's test fixtures
+    # include (dangling) symlinks and special files that copy_directory rejects.
+    bash -c "cp -a '${SOURCE_DIR}' '${PATCH_SOURCE_DIR}'"
+  COMMAND
+    "${CMAKE_COMMAND}" -E chdir "${PATCH_SOURCE_DIR}"
+    "${CMAKE_COMMAND}" -E env
+      # Escaping hack (from libdrm): experimentally determined to persist through
+      # the layers. The version script gives glib's public symbols the shared
+      # AMDROCM_SYSDEPS version; hidden-visibility internals stay local.
+      "LDFLAGS=-Wl,-rpath='$$ORIGIN' -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/glib.map"
+      "CC=${_meson_cc}"
+      "CXX=${_meson_cxx}"
+      --
+      "${MESON_BUILD}" setup "${CMAKE_CURRENT_BINARY_DIR}"
+        --reconfigure
+        --prefix "/"
+        -Dpkgconfig.relocatable=true
+        -Dlibdir=lib
+        -Dtests=false
+        -Dman=false
+        -Dselinux=disabled
+        -Dlibmount=disabled
+        -Dnls=disabled
+        -Dglib_debug=disabled
+        -Dlibelf=disabled
+  COMMAND
+    "${MESON_BUILD}" compile --verbose
+  COMMAND
+    "${CMAKE_COMMAND}" -E env "DESTDIR=${CMAKE_INSTALL_PREFIX}" --
+      "${MESON_BUILD}" install
+  COMMAND
+    "${CMAKE_COMMAND}" -E env
+      "PATCHELF=${PATCHELF}"
+      "THEROCK_SOURCE_DIR=${THEROCK_SOURCE_DIR}"
+      "Python3_EXECUTABLE=${Python3_EXECUTABLE}" --
+    "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/patch_install.py" ${CMAKE_INSTALL_PREFIX}
+)
+
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/glib-config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/glib-config.cmake
+  @ONLY
+)
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/glib-config.cmake" DESTINATION lib/cmake/glib)

--- a/third-party/sysdeps/linux/glib/glib-config.cmake.in
+++ b/third-party/sysdeps/linux/glib/glib-config.cmake.in
@@ -1,0 +1,22 @@
+# Traverse from lib/cmake/FOO -> the directory holding lib
+get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_DIR}" PATH)
+get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+if(_IMPORT_PREFIX STREQUAL "/")
+  set(_IMPORT_PREFIX "")
+endif()
+
+# GLib ships several interdependent libraries. Expose each as an imported target
+# under the canonical PkgConfig-style names so consumers can link them directly;
+# most consumers instead discover GLib through pkg-config.
+foreach(_comp glib-2.0 gobject-2.0 gmodule-2.0 gthread-2.0 gio-2.0)
+  if(NOT TARGET PkgConfig::${_comp})
+    add_library(PkgConfig::${_comp} SHARED IMPORTED)
+    set_target_properties(PkgConfig::${_comp} PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include/glib-2.0;${_IMPORT_PREFIX}/lib/glib-2.0/include"
+      IMPORTED_LOCATION "${_IMPORT_PREFIX}/lib/lib${_comp}.so"
+    )
+  endif()
+endforeach()
+
+set(_IMPORT_PREFIX)

--- a/third-party/sysdeps/linux/glib/glib.map
+++ b/third-party/sysdeps/linux/glib/glib.map
@@ -1,0 +1,3 @@
+AMDROCM_SYSDEPS_1.0 {
+global: *;
+};

--- a/third-party/sysdeps/linux/glib/patch_install.py
+++ b/third-party/sysdeps/linux/glib/patch_install.py
@@ -32,7 +32,9 @@ def sh(*args):
 
 
 def needed(patchelf_exe, path):
-    out = subprocess.check_output([patchelf_exe, "--print-needed", str(path)], text=True)
+    out = subprocess.check_output(
+        [patchelf_exe, "--print-needed", str(path)], text=True
+    )
     return out.split()
 
 

--- a/third-party/sysdeps/linux/glib/patch_install.py
+++ b/third-party/sysdeps/linux/glib/patch_install.py
@@ -1,0 +1,91 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+import os
+import platform
+import shutil
+import subprocess
+import sys
+
+repo_root = Path(__file__).resolve().parents[4]
+build_tools_path = repo_root / "build_tools"
+sys.path.insert(0, str(build_tools_path))
+from patch_linux_so import relativize_pc_file
+
+# GLib installs several interdependent shared libraries. We rename each to a
+# librocm_sysdeps_* SONAME so the bundle can coexist with a system GLib, then fix
+# up the inter-library NEEDED entries to point at the renamed siblings.
+GLIB_LIBS = ["glib-2.0", "gobject-2.0", "gmodule-2.0", "gthread-2.0", "gio-2.0"]
+
+
+def get_env_or_exit(var_name):
+    value = os.environ.get(var_name)
+    if value is None:
+        print(f"Error: {var_name} not defined")
+        sys.exit(1)
+    return value
+
+
+def sh(*args):
+    subprocess.run([str(a) for a in args], check=True)
+
+
+def needed(patchelf_exe, path):
+    out = subprocess.check_output([patchelf_exe, "--print-needed", str(path)], text=True)
+    return out.split()
+
+
+prefix = Path(sys.argv[1]) if len(sys.argv) > 1 else None
+if not prefix:
+    print("Error: Expected install prefix argument")
+    sys.exit(1)
+
+install_prefix = sys.argv[1]
+patchelf_exe = get_env_or_exit("PATCHELF")
+
+if platform.system() == "Linux":
+    lib_dir = Path(install_prefix) / "lib"
+    pkgconfig_dir = lib_dir / "pkgconfig"
+
+    # Remove static libs (*.a) and libtool descriptors (*.la).
+    for file_path in lib_dir.iterdir():
+        if file_path.suffix in (".a", ".la"):
+            file_path.unlink(missing_ok=True)
+
+    # Step 1: rename each library's SONAME and real file, and keep only the
+    # canonical linker symlink (lib<name>.so).
+    for name in GLIB_LIBS:
+        dev = lib_dir / f"lib{name}.so"
+        if not (dev.exists() or dev.is_symlink()):
+            continue
+        real = dev.resolve()
+        new_soname = f"librocm_sysdeps_{name}.so.0"
+        sh(patchelf_exe, "--set-soname", new_soname, real)
+        for link in lib_dir.glob(f"lib{name}.so*"):
+            if link.is_symlink():
+                link.unlink()
+        target = lib_dir / new_soname
+        if real != target:
+            shutil.move(str(real), str(target))
+        (lib_dir / f"lib{name}.so").symlink_to(new_soname)
+
+    # Step 2: repoint the inter-GLib NEEDED entries at the renamed siblings and
+    # normalise RUNPATH. Leaf deps (pcre2/libffi/zlib) are already the renamed
+    # sysdep SONAMEs because GLib links them from the bundle.
+    replacements = {f"lib{n}.so.0": f"librocm_sysdeps_{n}.so.0" for n in GLIB_LIBS}
+    for name in GLIB_LIBS:
+        target = lib_dir / f"librocm_sysdeps_{name}.so.0"
+        if not target.exists():
+            continue
+        current = needed(patchelf_exe, target)
+        for old, new in replacements.items():
+            if old in current:
+                sh(patchelf_exe, "--replace-needed", old, new, target)
+        sh(patchelf_exe, "--set-rpath", "$ORIGIN", target)
+
+    # Step 3: make the pkg-config files relocatable / free of absolute -L paths.
+    for name in GLIB_LIBS:
+        pc = pkgconfig_dir / f"{name}.pc"
+        if pc.exists():
+            relativize_pc_file(pc)

--- a/third-party/sysdeps/linux/libcurl/CMakeLists.txt
+++ b/third-party/sysdeps/linux/libcurl/CMakeLists.txt
@@ -1,0 +1,105 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    # When included in TheRock, we download sources and set up the sub-project.
+    set(_source_dir "${CMAKE_CURRENT_BINARY_DIR}/source")
+    set(_download_stamp "${_source_dir}/download.stamp")
+
+    therock_subproject_fetch(therock-libcurl-sources
+      SOURCE_DIR "${_source_dir}"
+      # Originally from: https://curl.se/download/curl-8.5.0.tar.xz
+      URL "https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/curl-8.5.0.tar.xz"
+      URL_HASH "SHA256=42ab8db9e20d8290a3b633e7fbb3cec15db34df65fd1015ef8ac1e4723750eeb"
+      TOUCH "${_download_stamp}"
+      DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    )
+
+    therock_cmake_subproject_declare(therock-libcurl
+      USE_DIST_AMDGPU_TARGETS
+      EXTERNAL_SOURCE_DIR .
+      FPRINT_SOURCE_DIR "${_source_dir}"
+      FPRINT_FILE_GLOBS "${CMAKE_CURRENT_LIST_DIR}/*"
+      BINARY_DIR build
+      NO_MERGE_COMPILE_COMMANDS
+      BACKGROUND_BUILD
+      OUTPUT_ON_FAILURE
+      CMAKE_ARGS
+        "-DSOURCE_DIR=${_source_dir}"
+        "-DPATCHELF=${PATCHELF}"
+        "-DPython3_EXECUTABLE=${Python3_EXECUTABLE}"
+      INSTALL_DESTINATION
+        lib/rocm_sysdeps
+      INTERFACE_INCLUDE_DIRS
+        lib/rocm_sysdeps/include
+      INTERFACE_LINK_DIRS
+        lib/rocm_sysdeps/lib
+      INTERFACE_INSTALL_RPATH_DIRS
+        lib/rocm_sysdeps/lib
+      INTERFACE_PKG_CONFIG_DIRS
+        lib/rocm_sysdeps/lib/pkgconfig
+      EXTRA_DEPENDS
+        "${_download_stamp}"
+    )
+    therock_cmake_subproject_provide_package(therock-libcurl CURL lib/rocm_sysdeps/lib/cmake/libcurl)
+    therock_cmake_subproject_activate(therock-libcurl)
+
+    therock_test_validate_shared_lib(
+      PATH build/dist/lib/rocm_sysdeps/lib
+      LIB_NAMES libcurl.so
+    )
+
+    return()
+endif()
+
+# Otherwise, this is the sub-project build.
+cmake_minimum_required(VERSION 3.25)
+project(LIBCURL_BUILD VERSION "8.5.0")
+
+if(NOT PATCHELF)
+  message(FATAL_ERROR "Missing PATCHELF from super-project")
+endif()
+
+set(patch_source_commands)
+list(APPEND patch_source_commands   COMMAND
+    bash "${CMAKE_CURRENT_SOURCE_DIR}/patch_source.sh" "${SOURCE_DIR}")
+
+add_custom_target(
+  build ALL
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+
+  COMMAND
+    ${patch_source_commands}
+  COMMAND
+    "${CMAKE_COMMAND}" -E env
+      # curl controls its own symbol exports via libtool + hidden visibility,
+      # which conflicts with an added version script, so rely on the SONAME
+      # rename alone for coexistence. TLS is intentionally omitted: amd-smi only
+      # uses libfwupd's local (D-Bus) BIOS-setting path.
+      "LDFLAGS=${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath=\\'\\$$\\$$ORIGIN\\'"
+      --
+    "${SOURCE_DIR}/configure"
+      --prefix "${CMAKE_INSTALL_PREFIX}"
+      --libdir "${CMAKE_INSTALL_PREFIX}/lib"
+      --disable-static
+      --without-ssl
+      --without-libpsl
+      --disable-ldap
+      --disable-manual
+  COMMAND
+    make V=1
+  COMMAND
+    make install
+  COMMAND
+    "${CMAKE_COMMAND}" -E env
+      "PATCHELF=${PATCHELF}" --
+    "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/patch_install.py" ${CMAKE_INSTALL_PREFIX}
+)
+
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/libcurl-config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/libcurl-config.cmake
+  @ONLY
+)
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libcurl-config.cmake" DESTINATION lib/cmake/libcurl)

--- a/third-party/sysdeps/linux/libcurl/libcurl-config.cmake.in
+++ b/third-party/sysdeps/linux/libcurl/libcurl-config.cmake.in
@@ -1,0 +1,17 @@
+# Traverse from lib/cmake/FOO -> the directory holding lib
+get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_DIR}" PATH)
+get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+if(_IMPORT_PREFIX STREQUAL "/")
+  set(_IMPORT_PREFIX "")
+endif()
+
+if(NOT TARGET CURL::libcurl)
+  add_library(CURL::libcurl SHARED IMPORTED)
+  set_target_properties(CURL::libcurl PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
+    IMPORTED_LOCATION "${_IMPORT_PREFIX}/lib/libcurl.so"
+  )
+endif()
+
+set(_IMPORT_PREFIX)

--- a/third-party/sysdeps/linux/libcurl/patch_install.py
+++ b/third-party/sysdeps/linux/libcurl/patch_install.py
@@ -1,0 +1,61 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+import os
+import platform
+import subprocess
+import sys
+
+repo_root = Path(__file__).resolve().parents[4]
+build_tools_path = repo_root / "build_tools"
+sys.path.insert(0, str(build_tools_path))
+from patch_linux_so import update_library_links, relativize_pc_file
+
+
+# Fetch an environment variable or exit if it is not found.
+def get_env_or_exit(var_name):
+    value = os.environ.get(var_name)
+    if value is None:
+        print(f"Error: {var_name} not defined")
+        sys.exit(1)
+    return value
+
+
+# Validate the install prefix argument.
+prefix = Path(sys.argv[1]) if len(sys.argv) > 1 else None
+if not prefix:
+    print("Error: Expected install prefix argument")
+    sys.exit(1)
+
+# 1st argument is the installation prefix.
+install_prefix = sys.argv[1]
+
+patchelf_exe = get_env_or_exit("PATCHELF")
+
+if platform.system() == "Linux":
+    # Specify the directory containing the libraries.
+    lib_dir = Path(install_prefix) / "lib"
+    pkgconfig_dir = lib_dir / "pkgconfig"
+
+    # Remove static libs (*.a) and descriptors (*.la).
+    for file_path in lib_dir.iterdir():
+        if file_path.suffix in (".a", ".la"):
+            file_path.unlink(missing_ok=True)
+
+    # Update library linking
+    source = lib_dir / "librocm_sysdeps_curl.so"
+    update_library_links(source, "libcurl.so")
+
+    # Clean up RUNPATH to only contain $ORIGIN
+    target_lib = lib_dir / "libcurl.so"
+    if target_lib.exists():
+        try:
+            subprocess.run([patchelf_exe, "--set-rpath", "$ORIGIN", str(target_lib)], check=True)
+        except subprocess.CalledProcessError as e:
+            print(f"Warning: Failed to set RPATH on {target_lib}: {e}", flush=True)
+
+    # Make .pc file relocatable
+    libcurl_pc = pkgconfig_dir / "libcurl.pc"
+    if libcurl_pc.exists():
+        relativize_pc_file(libcurl_pc)

--- a/third-party/sysdeps/linux/libcurl/patch_install.py
+++ b/third-party/sysdeps/linux/libcurl/patch_install.py
@@ -51,7 +51,9 @@ if platform.system() == "Linux":
     target_lib = lib_dir / "libcurl.so"
     if target_lib.exists():
         try:
-            subprocess.run([patchelf_exe, "--set-rpath", "$ORIGIN", str(target_lib)], check=True)
+            subprocess.run(
+                [patchelf_exe, "--set-rpath", "$ORIGIN", str(target_lib)], check=True
+            )
         except subprocess.CalledProcessError as e:
             print(f"Warning: Failed to set RPATH on {target_lib}: {e}", flush=True)
 

--- a/third-party/sysdeps/linux/libcurl/patch_source.sh
+++ b/third-party/sysdeps/linux/libcurl/patch_source.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/bash
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+set -e
+
+SOURCE_DIR="${1:?Source directory must be given}"
+
+echo "Patching sources..."
+# Prefix the libcurl libtool target across every Makefile.in (lib/ defines it,
+# src/ links it) so the shared library gets SONAME librocm_sysdeps_curl.so and
+# can coexist with a system libcurl. The symbol version script is injected via
+# LDFLAGS by the parent CMakeLists.
+find "$SOURCE_DIR" -name Makefile.in -exec sed -i \
+  -e 's/libcurl\.la/librocm_sysdeps_curl.la/g' \
+  -e 's/libcurl_la_/librocm_sysdeps_curl_la_/g' {} +

--- a/third-party/sysdeps/linux/libffi/CMakeLists.txt
+++ b/third-party/sysdeps/linux/libffi/CMakeLists.txt
@@ -1,0 +1,102 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    # When included in TheRock, we download sources and set up the sub-project.
+    set(_source_dir "${CMAKE_CURRENT_BINARY_DIR}/source")
+    set(_download_stamp "${_source_dir}/download.stamp")
+
+    therock_subproject_fetch(therock-libffi-sources
+      SOURCE_DIR "${_source_dir}"
+      # Originally from: https://github.com/libffi/libffi/releases/download/v3.4.6/libffi-3.4.6.tar.gz
+      URL "https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/libffi-3.4.6.tar.gz"
+      URL_HASH "SHA256=b0dea9df23c863a7a50e825440f3ebffabd65df1497108e5d437747843895a4e"
+      TOUCH "${_download_stamp}"
+      # Preserve timestamps so autotools does not try to re-run.
+      DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    )
+
+    therock_cmake_subproject_declare(therock-libffi
+      USE_DIST_AMDGPU_TARGETS
+      EXTERNAL_SOURCE_DIR .
+      FPRINT_SOURCE_DIR "${_source_dir}"
+      FPRINT_FILE_GLOBS "${CMAKE_CURRENT_LIST_DIR}/*"
+      BINARY_DIR build
+      NO_MERGE_COMPILE_COMMANDS
+      BACKGROUND_BUILD
+      OUTPUT_ON_FAILURE
+      CMAKE_ARGS
+        "-DSOURCE_DIR=${_source_dir}"
+        "-DPATCHELF=${PATCHELF}"
+        "-DPython3_EXECUTABLE=${Python3_EXECUTABLE}"
+      INSTALL_DESTINATION
+        lib/rocm_sysdeps
+      INTERFACE_INCLUDE_DIRS
+        lib/rocm_sysdeps/include
+      INTERFACE_LINK_DIRS
+        lib/rocm_sysdeps/lib
+      INTERFACE_INSTALL_RPATH_DIRS
+        lib/rocm_sysdeps/lib
+      INTERFACE_PKG_CONFIG_DIRS
+        lib/rocm_sysdeps/lib/pkgconfig
+      EXTRA_DEPENDS
+        "${_download_stamp}"
+    )
+    therock_cmake_subproject_provide_package(therock-libffi libffi lib/rocm_sysdeps/lib/cmake/libffi)
+    therock_cmake_subproject_activate(therock-libffi)
+
+    therock_test_validate_shared_lib(
+      PATH build/dist/lib/rocm_sysdeps/lib
+      LIB_NAMES libffi.so
+    )
+
+    return()
+endif()
+
+# Otherwise, this is the sub-project build.
+cmake_minimum_required(VERSION 3.25)
+project(LIBFFI_BUILD VERSION "3.4.6")
+
+if(NOT PATCHELF)
+  message(FATAL_ERROR "Missing PATCHELF from super-project")
+endif()
+
+set(patch_source_commands)
+list(APPEND patch_source_commands   COMMAND
+    bash "${CMAKE_CURRENT_SOURCE_DIR}/patch_source.sh" "${SOURCE_DIR}")
+
+add_custom_target(
+  build ALL
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+
+  COMMAND
+    ${patch_source_commands}
+  COMMAND
+    "${CMAKE_COMMAND}" -E env
+      # Escaping: Double $ to satisfy CMake, then double $ to satisfy configure,
+      # then escaped single quotes to make it to the linker command line.
+      "LDFLAGS=${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath=\\'\\$$\\$$ORIGIN\\'"
+      --
+    "${SOURCE_DIR}/configure"
+      --prefix "${CMAKE_INSTALL_PREFIX}"
+      --libdir "${CMAKE_INSTALL_PREFIX}/lib"
+      --includedir "${CMAKE_INSTALL_PREFIX}/include"
+      --disable-static
+      --disable-docs
+  COMMAND
+    make V=1
+  COMMAND
+    make install
+  COMMAND
+    "${CMAKE_COMMAND}" -E env
+      "PATCHELF=${PATCHELF}" --
+    "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/patch_install.py" ${CMAKE_INSTALL_PREFIX}
+)
+
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/libffi-config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/libffi-config.cmake
+  @ONLY
+)
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libffi-config.cmake" DESTINATION lib/cmake/libffi)

--- a/third-party/sysdeps/linux/libffi/libffi-config.cmake.in
+++ b/third-party/sysdeps/linux/libffi/libffi-config.cmake.in
@@ -1,0 +1,17 @@
+# Traverse from lib/cmake/FOO -> the directory holding lib
+get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_DIR}" PATH)
+get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+if(_IMPORT_PREFIX STREQUAL "/")
+  set(_IMPORT_PREFIX "")
+endif()
+
+if(NOT TARGET libffi::libffi)
+  add_library(libffi::libffi SHARED IMPORTED)
+  set_target_properties(libffi::libffi PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
+    IMPORTED_LOCATION "${_IMPORT_PREFIX}/lib/libffi.so"
+  )
+endif()
+
+set(_IMPORT_PREFIX)

--- a/third-party/sysdeps/linux/libffi/libffi.map
+++ b/third-party/sysdeps/linux/libffi/libffi.map
@@ -1,0 +1,3 @@
+AMDROCM_SYSDEPS_1.0 {
+global: *;
+};

--- a/third-party/sysdeps/linux/libffi/patch_install.py
+++ b/third-party/sysdeps/linux/libffi/patch_install.py
@@ -51,7 +51,9 @@ if platform.system() == "Linux":
     target_lib = lib_dir / "libffi.so"
     if target_lib.exists():
         try:
-            subprocess.run([patchelf_exe, "--set-rpath", "$ORIGIN", str(target_lib)], check=True)
+            subprocess.run(
+                [patchelf_exe, "--set-rpath", "$ORIGIN", str(target_lib)], check=True
+            )
         except subprocess.CalledProcessError as e:
             print(f"Warning: Failed to set RPATH on {target_lib}: {e}", flush=True)
 

--- a/third-party/sysdeps/linux/libffi/patch_install.py
+++ b/third-party/sysdeps/linux/libffi/patch_install.py
@@ -1,0 +1,61 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+import os
+import platform
+import subprocess
+import sys
+
+repo_root = Path(__file__).resolve().parents[4]
+build_tools_path = repo_root / "build_tools"
+sys.path.insert(0, str(build_tools_path))
+from patch_linux_so import update_library_links, relativize_pc_file
+
+
+# Fetch an environment variable or exit if it is not found.
+def get_env_or_exit(var_name):
+    value = os.environ.get(var_name)
+    if value is None:
+        print(f"Error: {var_name} not defined")
+        sys.exit(1)
+    return value
+
+
+# Validate the install prefix argument.
+prefix = Path(sys.argv[1]) if len(sys.argv) > 1 else None
+if not prefix:
+    print("Error: Expected install prefix argument")
+    sys.exit(1)
+
+# 1st argument is the installation prefix.
+install_prefix = sys.argv[1]
+
+patchelf_exe = get_env_or_exit("PATCHELF")
+
+if platform.system() == "Linux":
+    # Specify the directory containing the libraries.
+    lib_dir = Path(install_prefix) / "lib"
+    pkgconfig_dir = lib_dir / "pkgconfig"
+
+    # Remove static libs (*.a) and descriptors (*.la).
+    for file_path in lib_dir.iterdir():
+        if file_path.suffix in (".a", ".la"):
+            file_path.unlink(missing_ok=True)
+
+    # Update library linking
+    source = lib_dir / "librocm_sysdeps_ffi.so"
+    update_library_links(source, "libffi.so")
+
+    # Clean up RUNPATH to only contain $ORIGIN
+    target_lib = lib_dir / "libffi.so"
+    if target_lib.exists():
+        try:
+            subprocess.run([patchelf_exe, "--set-rpath", "$ORIGIN", str(target_lib)], check=True)
+        except subprocess.CalledProcessError as e:
+            print(f"Warning: Failed to set RPATH on {target_lib}: {e}", flush=True)
+
+    # Make .pc file relocatable
+    libffi_pc = pkgconfig_dir / "libffi.pc"
+    if libffi_pc.exists():
+        relativize_pc_file(libffi_pc)

--- a/third-party/sysdeps/linux/libffi/patch_source.sh
+++ b/third-party/sysdeps/linux/libffi/patch_source.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/bash
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+set -e
+
+SOURCE_DIR="${1:?Source directory must be given}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIBFFI_MAKEFILE="$SOURCE_DIR/Makefile.in"
+LIBFFI_MAPFILE="$SOURCE_DIR/libffi.map.in"
+
+echo "Patching sources..."
+# Prefix the installed libtool target (and its generated automake variables) so
+# the shared library gets SONAME librocm_sysdeps_ffi.so and can coexist with a
+# system libffi of the same SONAME.
+sed -i 's/libffi\.la/librocm_sysdeps_ffi.la/g' "$LIBFFI_MAKEFILE"
+sed -i 's/libffi_la_/librocm_sysdeps_ffi_la_/g' "$LIBFFI_MAKEFILE"
+
+# libffi generates its linker version script by running the C preprocessor over
+# libffi.map.in; add -P so cpp does not emit line markers that would corrupt the
+# (now plain) version script.
+sed -i 's/-E -x assembler-with-cpp/-E -P -x assembler-with-cpp/' "$LIBFFI_MAKEFILE"
+
+# Replace the existing version symbols with our custom ones.
+echo "Updating version script..."
+cp "$SCRIPT_DIR/libffi.map" "$LIBFFI_MAPFILE"

--- a/third-party/sysdeps/linux/libfwupd/CMakeLists.txt
+++ b/third-party/sysdeps/linux/libfwupd/CMakeLists.txt
@@ -1,0 +1,127 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    # When included in TheRock, we download sources and set up the sub-project.
+    set(_source_dir "${CMAKE_CURRENT_BINARY_DIR}/source")
+    set(_download_stamp "${_source_dir}/download.stamp")
+
+    therock_subproject_fetch(therock-libfwupd-sources
+      SOURCE_DIR "${_source_dir}"
+      # Originally from: https://github.com/fwupd/fwupd/archive/refs/tags/2.1.7.tar.gz
+      # 2.1.x is the last pre-Rust release series (Rust/FFI lands in 2.2.x/main)
+      # and no longer depends on libjcat or json-glib.
+      URL "https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/fwupd-2.1.7.tar.gz"
+      URL_HASH "SHA256=338ea5b139f9a37447ff2215d0a8d2cf23851fb5a39fba7b1b0ded52a40240cc"
+      TOUCH "${_download_stamp}"
+      DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    )
+
+    therock_cmake_subproject_declare(therock-libfwupd
+      USE_DIST_AMDGPU_TARGETS
+      EXTERNAL_SOURCE_DIR .
+      FPRINT_SOURCE_DIR "${_source_dir}"
+      FPRINT_FILE_GLOBS "${CMAKE_CURRENT_LIST_DIR}/*"
+      BINARY_DIR build
+      NO_MERGE_COMPILE_COMMANDS
+      BACKGROUND_BUILD
+      OUTPUT_ON_FAILURE
+      CMAKE_ARGS
+        "-DSOURCE_DIR=${_source_dir}"
+        "-DPATCHELF=${PATCHELF}"
+        "-DMESON_BUILD=${MESON_BUILD}"
+        "-DPython3_EXECUTABLE=${Python3_EXECUTABLE}"
+      INSTALL_DESTINATION
+        lib/rocm_sysdeps
+      INTERFACE_INCLUDE_DIRS
+        lib/rocm_sysdeps/include
+      INTERFACE_LINK_DIRS
+        lib/rocm_sysdeps/lib
+      INTERFACE_INSTALL_RPATH_DIRS
+        lib/rocm_sysdeps/lib
+      INTERFACE_PKG_CONFIG_DIRS
+        lib/rocm_sysdeps/lib/pkgconfig
+      # libfwupd links GLib (gio/gio-unix/glib) and libcurl.
+      RUNTIME_DEPS
+        therock-glib
+        therock-libcurl
+      EXTRA_DEPENDS
+        "${_download_stamp}"
+    )
+    therock_cmake_subproject_provide_package(therock-libfwupd libfwupd lib/rocm_sysdeps/lib/cmake/libfwupd)
+    therock_cmake_subproject_activate(therock-libfwupd)
+
+    therock_test_validate_shared_lib(
+      PATH build/dist/lib/rocm_sysdeps/lib
+      LIB_NAMES libfwupd.so
+    )
+
+    return()
+endif()
+
+# Otherwise, this is the sub-project build.
+cmake_minimum_required(VERSION 3.25)
+project(LIBFWUPD_BUILD VERSION "2.1.7")
+
+if(NOT PATCHELF OR NOT MESON_BUILD)
+  message(FATAL_ERROR "Missing PATCHELF or MESON_BUILD from super-project")
+endif()
+
+include("${THEROCK_SOURCE_DIR}/cmake/therock_meson_env.cmake")
+therock_get_meson_compiler_env(_meson_cc _meson_cxx)
+
+# Meson refuses to build if the source dir is a subdir of the build dir, so
+# make it a sibling.
+set(PATCH_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/../patch_source")
+
+add_custom_target(
+  meson_build ALL
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+  COMMAND
+    "${CMAKE_COMMAND}" -E rm -rf -- "${CMAKE_INSTALL_PREFIX}" "${PATCH_SOURCE_DIR}"
+  COMMAND
+    # cp -a: the fwupd tree contains symlinks/special files under tests/.
+    bash -c "cp -a '${SOURCE_DIR}' '${PATCH_SOURCE_DIR}'"
+  COMMAND
+    "${CMAKE_COMMAND}" -E chdir "${PATCH_SOURCE_DIR}"
+    "${CMAKE_COMMAND}" -E env
+      # libfwupd already versions its symbols (LIBFWUPD_*), so we do not add a
+      # second version script; the SONAME rename handles coexistence.
+      "LDFLAGS=-Wl,-rpath='$$ORIGIN'"
+      "CC=${_meson_cc}"
+      "CXX=${_meson_cxx}"
+      --
+      "${MESON_BUILD}" setup "${CMAKE_CURRENT_BINARY_DIR}"
+        --reconfigure
+        --prefix "/"
+        -Dpkgconfig.relocatable=true
+        -Dlibdir=lib
+        # library-only build: no daemon, plugins, tools, or Rust.
+        -Dbuild=library
+        -Ddocs=disabled
+        -Dman=false
+        -Dtests=false
+        -Dintrospection=disabled
+        -Dpolkit=disabled
+        -Dsystemd=disabled
+        -Dbash_completion=false
+  COMMAND
+    "${MESON_BUILD}" compile --verbose
+  COMMAND
+    "${CMAKE_COMMAND}" -E env "DESTDIR=${CMAKE_INSTALL_PREFIX}" --
+      "${MESON_BUILD}" install
+  COMMAND
+    "${CMAKE_COMMAND}" -E env
+      "PATCHELF=${PATCHELF}"
+      "THEROCK_SOURCE_DIR=${THEROCK_SOURCE_DIR}"
+      "Python3_EXECUTABLE=${Python3_EXECUTABLE}" --
+    "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/patch_install.py" ${CMAKE_INSTALL_PREFIX}
+)
+
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/libfwupd-config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/libfwupd-config.cmake
+  @ONLY
+)
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libfwupd-config.cmake" DESTINATION lib/cmake/libfwupd)

--- a/third-party/sysdeps/linux/libfwupd/libfwupd-config.cmake.in
+++ b/third-party/sysdeps/linux/libfwupd/libfwupd-config.cmake.in
@@ -1,0 +1,17 @@
+# Traverse from lib/cmake/FOO -> the directory holding lib
+get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_DIR}" PATH)
+get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+if(_IMPORT_PREFIX STREQUAL "/")
+  set(_IMPORT_PREFIX "")
+endif()
+
+if(NOT TARGET libfwupd::libfwupd)
+  add_library(libfwupd::libfwupd SHARED IMPORTED)
+  set_target_properties(libfwupd::libfwupd PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include/fwupd-1"
+    IMPORTED_LOCATION "${_IMPORT_PREFIX}/lib/libfwupd.so"
+  )
+endif()
+
+set(_IMPORT_PREFIX)

--- a/third-party/sysdeps/linux/libfwupd/patch_install.py
+++ b/third-party/sysdeps/linux/libfwupd/patch_install.py
@@ -1,0 +1,68 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+import os
+import platform
+import shutil
+import subprocess
+import sys
+
+repo_root = Path(__file__).resolve().parents[4]
+build_tools_path = repo_root / "build_tools"
+sys.path.insert(0, str(build_tools_path))
+from patch_linux_so import relativize_pc_file
+
+# libfwupd's SONAME (soversion 3). Its GLib/libcurl dependencies are already the
+# renamed sysdep SONAMEs (it links them from the bundle), so no NEEDED fixup is
+# required here.
+_SONAME = "librocm_sysdeps_fwupd.so.3"
+
+
+def get_env_or_exit(var_name):
+    value = os.environ.get(var_name)
+    if value is None:
+        print(f"Error: {var_name} not defined")
+        sys.exit(1)
+    return value
+
+
+def sh(*args):
+    subprocess.run([str(a) for a in args], check=True)
+
+
+prefix = Path(sys.argv[1]) if len(sys.argv) > 1 else None
+if not prefix:
+    print("Error: Expected install prefix argument")
+    sys.exit(1)
+
+install_prefix = sys.argv[1]
+patchelf_exe = get_env_or_exit("PATCHELF")
+
+if platform.system() == "Linux":
+    lib_dir = Path(install_prefix) / "lib"
+    pkgconfig_dir = lib_dir / "pkgconfig"
+
+    # Remove static libs (*.a) and libtool descriptors (*.la).
+    for file_path in lib_dir.iterdir():
+        if file_path.suffix in (".a", ".la"):
+            file_path.unlink(missing_ok=True)
+
+    # Rename the SONAME/real file and keep only the canonical linker symlink.
+    dev = lib_dir / "libfwupd.so"
+    if dev.exists() or dev.is_symlink():
+        real = dev.resolve()
+        sh(patchelf_exe, "--set-soname", _SONAME, real)
+        for link in lib_dir.glob("libfwupd.so*"):
+            if link.is_symlink():
+                link.unlink()
+        target = lib_dir / _SONAME
+        if real != target:
+            shutil.move(str(real), str(target))
+        (lib_dir / "libfwupd.so").symlink_to(_SONAME)
+        sh(patchelf_exe, "--set-rpath", "$ORIGIN", target)
+
+    # Make the pkg-config file relocatable / free of absolute -L paths.
+    fwupd_pc = pkgconfig_dir / "fwupd.pc"
+    if fwupd_pc.exists():
+        relativize_pc_file(fwupd_pc)

--- a/third-party/sysdeps/linux/pcre2/CMakeLists.txt
+++ b/third-party/sysdeps/linux/pcre2/CMakeLists.txt
@@ -1,0 +1,101 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    # When included in TheRock, we download sources and set up the sub-project.
+    set(_source_dir "${CMAKE_CURRENT_BINARY_DIR}/source")
+    set(_download_stamp "${_source_dir}/download.stamp")
+
+    therock_subproject_fetch(therock-pcre2-sources
+      SOURCE_DIR "${_source_dir}"
+      # Originally from: https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.42/pcre2-10.42.tar.bz2
+      URL "https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/pcre2-10.42.tar.bz2"
+      URL_HASH "SHA256=8d36cd8cb6ea2a4c2bb358ff6411b0c788633a2a45dabbf1aeb4b701d1b5e840"
+      TOUCH "${_download_stamp}"
+      DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    )
+
+    therock_cmake_subproject_declare(therock-pcre2
+      USE_DIST_AMDGPU_TARGETS
+      EXTERNAL_SOURCE_DIR .
+      FPRINT_SOURCE_DIR "${_source_dir}"
+      FPRINT_FILE_GLOBS "${CMAKE_CURRENT_LIST_DIR}/*"
+      BINARY_DIR build
+      NO_MERGE_COMPILE_COMMANDS
+      BACKGROUND_BUILD
+      OUTPUT_ON_FAILURE
+      CMAKE_ARGS
+        "-DSOURCE_DIR=${_source_dir}"
+        "-DPATCHELF=${PATCHELF}"
+        "-DPython3_EXECUTABLE=${Python3_EXECUTABLE}"
+      INSTALL_DESTINATION
+        lib/rocm_sysdeps
+      INTERFACE_INCLUDE_DIRS
+        lib/rocm_sysdeps/include
+      INTERFACE_LINK_DIRS
+        lib/rocm_sysdeps/lib
+      INTERFACE_INSTALL_RPATH_DIRS
+        lib/rocm_sysdeps/lib
+      INTERFACE_PKG_CONFIG_DIRS
+        lib/rocm_sysdeps/lib/pkgconfig
+      EXTRA_DEPENDS
+        "${_download_stamp}"
+    )
+    therock_cmake_subproject_provide_package(therock-pcre2 pcre2 lib/rocm_sysdeps/lib/cmake/pcre2)
+    therock_cmake_subproject_activate(therock-pcre2)
+
+    therock_test_validate_shared_lib(
+      PATH build/dist/lib/rocm_sysdeps/lib
+      LIB_NAMES libpcre2-8.so
+    )
+
+    return()
+endif()
+
+# Otherwise, this is the sub-project build.
+cmake_minimum_required(VERSION 3.25)
+project(PCRE2_BUILD VERSION "10.42")
+
+if(NOT PATCHELF)
+  message(FATAL_ERROR "Missing PATCHELF from super-project")
+endif()
+
+set(patch_source_commands)
+list(APPEND patch_source_commands   COMMAND
+    bash "${CMAKE_CURRENT_SOURCE_DIR}/patch_source.sh" "${SOURCE_DIR}")
+
+add_custom_target(
+  build ALL
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+
+  COMMAND
+    ${patch_source_commands}
+  COMMAND
+    "${CMAKE_COMMAND}" -E env
+      # pcre2 has no symbol version script of its own, so inject the shared
+      # AMDROCM_SYSDEPS version directly via the linker.
+      "LDFLAGS=${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath=\\'\\$$\\$$ORIGIN\\' -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/pcre2.map"
+      --
+    "${SOURCE_DIR}/configure"
+      --prefix "${CMAKE_INSTALL_PREFIX}"
+      --libdir "${CMAKE_INSTALL_PREFIX}/lib"
+      --disable-static
+      --enable-unicode
+      --enable-jit
+  COMMAND
+    make V=1
+  COMMAND
+    make install
+  COMMAND
+    "${CMAKE_COMMAND}" -E env
+      "PATCHELF=${PATCHELF}" --
+    "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/patch_install.py" ${CMAKE_INSTALL_PREFIX}
+)
+
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/pcre2-config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/pcre2-config.cmake
+  @ONLY
+)
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/pcre2-config.cmake" DESTINATION lib/cmake/pcre2)

--- a/third-party/sysdeps/linux/pcre2/patch_install.py
+++ b/third-party/sysdeps/linux/pcre2/patch_install.py
@@ -1,0 +1,67 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+import os
+import platform
+import subprocess
+import sys
+
+repo_root = Path(__file__).resolve().parents[4]
+build_tools_path = repo_root / "build_tools"
+sys.path.insert(0, str(build_tools_path))
+from patch_linux_so import update_library_links, relativize_pc_file
+
+
+# Fetch an environment variable or exit if it is not found.
+def get_env_or_exit(var_name):
+    value = os.environ.get(var_name)
+    if value is None:
+        print(f"Error: {var_name} not defined")
+        sys.exit(1)
+    return value
+
+
+# Validate the install prefix argument.
+prefix = Path(sys.argv[1]) if len(sys.argv) > 1 else None
+if not prefix:
+    print("Error: Expected install prefix argument")
+    sys.exit(1)
+
+# 1st argument is the installation prefix.
+install_prefix = sys.argv[1]
+
+patchelf_exe = get_env_or_exit("PATCHELF")
+
+if platform.system() == "Linux":
+    # Specify the directory containing the libraries.
+    lib_dir = Path(install_prefix) / "lib"
+    pkgconfig_dir = lib_dir / "pkgconfig"
+
+    # Remove static libs (*.a) and descriptors (*.la).
+    for file_path in lib_dir.iterdir():
+        if file_path.suffix in (".a", ".la"):
+            file_path.unlink(missing_ok=True)
+
+    # We only ship the 8-bit library that GLib links against; drop the POSIX
+    # wrapper library and its pkg-config file.
+    for posix_file in lib_dir.glob("libpcre2-posix.*"):
+        posix_file.unlink(missing_ok=True)
+    (pkgconfig_dir / "libpcre2-posix.pc").unlink(missing_ok=True)
+
+    # Update library linking
+    source = lib_dir / "librocm_sysdeps_pcre2-8.so"
+    update_library_links(source, "libpcre2-8.so")
+
+    # Clean up RUNPATH to only contain $ORIGIN
+    target_lib = lib_dir / "libpcre2-8.so"
+    if target_lib.exists():
+        try:
+            subprocess.run([patchelf_exe, "--set-rpath", "$ORIGIN", str(target_lib)], check=True)
+        except subprocess.CalledProcessError as e:
+            print(f"Warning: Failed to set RPATH on {target_lib}: {e}", flush=True)
+
+    # Make .pc file relocatable
+    pcre2_pc = pkgconfig_dir / "libpcre2-8.pc"
+    if pcre2_pc.exists():
+        relativize_pc_file(pcre2_pc)

--- a/third-party/sysdeps/linux/pcre2/patch_install.py
+++ b/third-party/sysdeps/linux/pcre2/patch_install.py
@@ -57,7 +57,9 @@ if platform.system() == "Linux":
     target_lib = lib_dir / "libpcre2-8.so"
     if target_lib.exists():
         try:
-            subprocess.run([patchelf_exe, "--set-rpath", "$ORIGIN", str(target_lib)], check=True)
+            subprocess.run(
+                [patchelf_exe, "--set-rpath", "$ORIGIN", str(target_lib)], check=True
+            )
         except subprocess.CalledProcessError as e:
             print(f"Warning: Failed to set RPATH on {target_lib}: {e}", flush=True)
 

--- a/third-party/sysdeps/linux/pcre2/patch_source.sh
+++ b/third-party/sysdeps/linux/pcre2/patch_source.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/bash
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+set -e
+
+SOURCE_DIR="${1:?Source directory must be given}"
+PCRE2_MAKEFILE="$SOURCE_DIR/Makefile.in"
+
+echo "Patching sources..."
+# Prefix the 8-bit libtool target (and its generated automake variables) so the
+# shared library gets SONAME librocm_sysdeps_pcre2-8.so and can coexist with a
+# system libpcre2-8. The symbol version script is injected via LDFLAGS.
+sed -i 's/libpcre2-8\.la/librocm_sysdeps_pcre2-8.la/g' "$PCRE2_MAKEFILE"
+sed -i 's/libpcre2_8_la_/librocm_sysdeps_pcre2_8_la_/g' "$PCRE2_MAKEFILE"

--- a/third-party/sysdeps/linux/pcre2/pcre2-config.cmake.in
+++ b/third-party/sysdeps/linux/pcre2/pcre2-config.cmake.in
@@ -1,0 +1,17 @@
+# Traverse from lib/cmake/FOO -> the directory holding lib
+get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_DIR}" PATH)
+get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+if(_IMPORT_PREFIX STREQUAL "/")
+  set(_IMPORT_PREFIX "")
+endif()
+
+if(NOT TARGET pcre2::pcre2)
+  add_library(pcre2::pcre2 SHARED IMPORTED)
+  set_target_properties(pcre2::pcre2 PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
+    IMPORTED_LOCATION "${_IMPORT_PREFIX}/lib/libpcre2-8.so"
+  )
+endif()
+
+set(_IMPORT_PREFIX)

--- a/third-party/sysdeps/linux/pcre2/pcre2.map
+++ b/third-party/sysdeps/linux/pcre2/pcre2.map
@@ -1,0 +1,3 @@
+AMDROCM_SYSDEPS_1.0 {
+global: *;
+};


### PR DESCRIPTION
## Motivation

`amd-smi` reads and sets the UMA "carveout" (dedicated GPU memory) BIOS setting on APUs. On UEFI-HII platforms — notably HP Strix Halo systems (ZBook Ultra G1a, Z2 Mini G1a) — the amdgpu `/sys/class/drm/<card>/device/uma/carveout` sysfs node is absent, and the setting is only reachable through the **fwupd** daemon's BIOS-settings interface. To let amd-smi talk to fwupd via `libfwupd` (over D-Bus) rather than shelling out to `fwupdmgr`, we need `libfwupd` and its dependency stack bundled as a portable sysdep.

## What this adds

An **optional** Linux sysdep artifact (`sysdeps-fwupd`, gated on `THEROCK_ENABLE_SYSDEPS_FWUPD`, off by default) that bundles:

| library | version | notes |
| --- | --- | --- |
| libffi | 3.4.6 | GLib (gobject) dependency |
| pcre2 | 10.42 | GLib core dependency |
| glib | 2.74.7 | glib/gobject/gio/gmodule/gthread |
| libcurl | 8.5.0 | built without TLS — the BIOS path is local D-Bus only |
| libfwupd | 2.1.7 | `-Dbuild=library` |

`zlib` (used by GLib's gio) is already a core sysdep, so it is reused.

### Why fwupd 2.1.7
2.1.x is the last release series **before** the Rust/FFI work that lands in 2.2.x / `main`, and it no longer depends on `libjcat` or `json-glib` (both are internal now). This keeps the stack small and Rust-free.

## Details
- Each library installs under `lib/rocm_sysdeps`, is SONAME-prefixed `librocm_sysdeps_*`, and is symbol-versioned `AMDROCM_SYSDEPS_1.0`, following the existing `libmnl` (autotools) and `libdrm` (meson) sysdep patterns.
- GLib's five interdependent libraries are renamed post-build via `patchelf --set-soname` / `--replace-needed`.
- Build-host requirements: `meson` (already required for bundled sysdeps) plus the `jinja2` Python module (used by fwupd's code generation).

## Testing
- Each sysdep builds standalone and produces the expected renamed, symbol-versioned `.so`.
- The assembled bundle links with **zero unresolved dependencies** (only `libz` → the zlib core sysdep, plus libc).
- The resulting `libfwupd.so` was validated on a real **HP ZBook Ultra G1a** (Ubuntu 26.04): it connects to the system fwupd daemon and reads the UMA carveout BIOS setting through `libfwupd`.

## Follow-ups (not in this PR)
- The five source tarballs need mirroring to the `rocm-third-party-deps` S3 bucket (upstream URLs + SHA256s are recorded in each `CMakeLists.txt`).
- The amd-smi consumer change (linking `THEROCK_BUNDLED_FWUPD`) is separate.


## Issue Tracking

JIRA ID : AILITOOLS-306
