### PR TITLE
feat(ci): wire the amdrocm-repo package into native package CI

### DIFF
--- a/.github/workflows/multi_arch_build_native_linux_packages.yml
+++ b/.github/workflows/multi_arch_build_native_linux_packages.yml
@@ -67,25 +67,38 @@ permissions:
 run-name: Build ${{ inputs.native_package_type }} packages (${{ inputs.rocm_version }}, ${{ inputs.dist_amdgpu_families }}${{ inputs.release_type && format(', {0}', inputs.release_type) || '' }})
 
 jobs:
-  # Resolve the parameters used to build and test the amdrocm-repo package:
-  # the OS-profile build matrix for this package type, each profile's container
-  # image, the public CDN base URL for this release line (empty for lines with
-  # no public repo, e.g. ci), and the dated sub-folder for the nightly line.
+  # Resolve the parameters used to build and test the amdrocm-repo package: the
+  # OS-profile build matrix for this package type, each profile's container
+  # image, and -- for a build line that maps to a repo.amd.com stream -- that
+  # stream's name, packages base URL, signing-key URL, and build sub-folder.
+  #
+  # The build line and the stream are different vocabularies: the "release" line
+  # configures the "stable" stream. release_type stays the workflow input
+  # because it also selects the artifact bucket credentials; the stream is
+  # derived from it.
   setup_repo_params:
     name: Resolve amdrocm-repo parameters
-    # Only the lines listed here have a public repository, and they are the only
-    # consumers of these outputs. On any other line -- a pull request, or a dev
-    # build -- the jobs below skip, so this one would resolve parameters nothing
-    # reads.
-    if: inputs.enable_repo_package && contains(fromJSON('["prerelease", "nightly", "release"]'), inputs.release_type)
+    # Only the lines listed here map to a stream, and they are the only
+    # consumers of these outputs. On any other line -- a pull request, a dev
+    # build, or prerelease -- the jobs below skip, so this one would resolve
+    # parameters nothing reads.
+    #
+    # prerelease is absent deliberately. Its stream is rc.repo.amd.com, which
+    # currently serves no content on any distro, so a package pointing there
+    # could not refresh. Restoring it is one entry in _STREAM_ROOTS plus this
+    # list.
+    if: inputs.enable_repo_package && contains(fromJSON('["nightly", "release"]'), inputs.release_type)
     runs-on: ubuntu-24.04
     outputs:
       os_profiles: ${{ steps.derive.outputs.os_profiles }}
       images: ${{ steps.derive.outputs.images }}
+      stream: ${{ steps.derive.outputs.stream }}
       repo_base_url: ${{ steps.derive.outputs.repo_base_url }}
+      gpg_key_url: ${{ steps.derive.outputs.gpg_key_url }}
       repo_sub_folder: ${{ steps.derive.outputs.repo_sub_folder }}
     steps:
       - name: Checking out repository
+        timeout-minutes: 15
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ${{ inputs.repository || github.repository }}
@@ -224,7 +237,7 @@ jobs:
           python ./build_tools/packaging/linux/inspect_repo_package.py \
             --pkg-type "${{ inputs.native_package_type }}" \
             --rocm-version "${{ inputs.rocm_version }}" \
-            --repo-base-url https://example.com/rocm/packages-multi-arch/ \
+            --repo-base-url https://example.com/rocm/core/packages \
             --repo-sub-folder 20000101-inspect
 
       - name: Configure AWS credentials for artifact uploads
@@ -279,6 +292,7 @@ jobs:
       image: ${{ fromJSON(needs.setup_repo_params.outputs.images || '{}')[matrix.os_profile] }}
     steps:
       - name: Checkout
+        timeout-minutes: 15
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ${{ inputs.repository || github.repository }}
@@ -305,18 +319,23 @@ jobs:
 
       - name: Build amdrocm-repo
         run: |
-          # repo_sub_folder is empty except on the nightly line, where the builder
-          # requires the dated sub-folder; passing an empty value is accepted for
-          # the other lines.
+          # repo_sub_folder is empty except on a per-build stream, where the
+          # builder requires it; an empty value is accepted for the others.
+          #
+          # gpg_key_url is the full key URL, fetched verbatim, and is empty for
+          # an unsigned stream, which ships no key. It is a separate input
+          # because the key is not under the packages base: packages are at
+          # <root>/core/packages/ and the key beside core/.
           #
           # --verify-repo-url fails the build if the configured repository is not
           # served, so a package that installs cleanly but cannot refresh is
-          # caught here rather than by a user. It is a no-op on the nightly line,
-          # whose dated sub-folder is published by this same run.
+          # caught here rather than by a user. It is a no-op for a per-build
+          # stream, whose build folder is published by this same run.
           $PYTHON_CMD build_tools/packaging/linux/build_repo_package.py \
             --os-profile "${{ matrix.os_profile }}" \
-            --release-type "${{ inputs.release_type }}" \
+            --stream "${{ needs.setup_repo_params.outputs.stream }}" \
             --repo-base-url "${{ needs.setup_repo_params.outputs.repo_base_url }}" \
+            --gpg-key-url "${{ needs.setup_repo_params.outputs.gpg_key_url }}" \
             --repo-sub-folder "${{ needs.setup_repo_params.outputs.repo_sub_folder }}" \
             --rocm-version "${{ inputs.rocm_version }}" \
             --dest-dir repo-package-out \
@@ -374,6 +393,7 @@ jobs:
       ARTIFACT_RUN_ID: "${{ inputs.artifact_run_id != '' && inputs.artifact_run_id || github.run_id }}"
     steps:
       - name: Checkout
+        timeout-minutes: 15
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ${{ inputs.repository || github.repository }}

--- a/.github/workflows/multi_arch_build_native_linux_packages.yml
+++ b/.github/workflows/multi_arch_build_native_linux_packages.yml
@@ -50,6 +50,11 @@ on:
           set it manually.
         type: string
         default: ""
+      enable_repo_package:
+        description: "Build, verify and publish the amdrocm-repo package"
+        type: boolean
+        required: false
+        default: true
     outputs:
       package_repository_url:
         description: "Public repository URL for package installation"
@@ -62,6 +67,52 @@ permissions:
 run-name: Build ${{ inputs.native_package_type }} packages (${{ inputs.rocm_version }}, ${{ inputs.dist_amdgpu_families }}${{ inputs.release_type && format(', {0}', inputs.release_type) || '' }})
 
 jobs:
+  # Resolve the parameters used to build and test the amdrocm-repo package:
+  # the OS-profile build matrix for this package type, each profile's container
+  # image, the public CDN base URL for this release line (empty for lines with
+  # no public repo, e.g. ci), and the dated sub-folder for the nightly line.
+  setup_repo_params:
+    name: Resolve amdrocm-repo parameters
+    # Only the lines listed here have a public repository, and they are the only
+    # consumers of these outputs. On any other line -- a pull request, or a dev
+    # build -- the jobs below skip, so this one would resolve parameters nothing
+    # reads.
+    if: inputs.enable_repo_package && contains(fromJSON('["prerelease", "nightly", "release"]'), inputs.release_type)
+    runs-on: ubuntu-24.04
+    outputs:
+      os_profiles: ${{ steps.derive.outputs.os_profiles }}
+      images: ${{ steps.derive.outputs.images }}
+      repo_base_url: ${{ steps.derive.outputs.repo_base_url }}
+      repo_sub_folder: ${{ steps.derive.outputs.repo_sub_folder }}
+    steps:
+      - name: Checking out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || '' }}
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Install Python requirements
+        run: pip install jinja2
+
+      - name: Derive amdrocm-repo parameters
+        id: derive
+        run: |
+          profiles="$(python ./build_tools/packaging/linux/build_repo_package.py list-profiles \
+            --pkg-type '${{ inputs.native_package_type }}')"
+          echo "os_profiles=${profiles}" >> "$GITHUB_OUTPUT"
+          python ./build_tools/packaging/linux/get_url_repo_params.py get-container-image-map \
+            --os-profiles "${profiles}"
+          python ./build_tools/packaging/linux/get_url_repo_params.py get-public-repo-base-url \
+            --release-type '${{ inputs.release_type }}'
+          python ./build_tools/packaging/linux/get_url_repo_params.py get-nightly-sub-folder \
+            --release-type '${{ inputs.release_type }}' \
+            --run-id '${{ inputs.artifact_run_id != '' && inputs.artifact_run_id || github.run_id }}'
+
   build_native_packages:
     name: Build ${{ inputs.native_package_type }} packages
     runs-on: ${{ github.repository_owner == 'ROCm' && 'aws-linux-scale-rocm-prod' || 'ubuntu-24.04' }}
@@ -153,6 +204,29 @@ jobs:
             --packages-dir "${{ env.PACKAGE_DIST_DIR }}" \
             --pkg-type ${{ inputs.native_package_type }}
 
+      # Build the amdrocm-repo package for every OS profile of this package type
+      # and check that its payload is the expected files, at the expected paths,
+      # owned by root. This container can build both package types but has
+      # neither dnf nor zypper, so the packages are inspected rather than
+      # installed; per-distro install coverage lives in
+      # test_native_linux_packages_install.yml.
+      #
+      # Restricted to the pull-request line. It is a gate there, and a gate has
+      # to be able to fail the job -- which on a release line would also stop the
+      # content packages being uploaded. The released lines build the real
+      # package in stage_repo_package instead, which cannot block them.
+      #
+      # The repository URL is a placeholder and is never contacted: the build
+      # needs no key it has to fetch and no repository it has to reach.
+      - name: Build and inspect amdrocm-repo packages
+        if: inputs.enable_repo_package && inputs.release_type == 'ci'
+        run: |
+          python ./build_tools/packaging/linux/inspect_repo_package.py \
+            --pkg-type "${{ inputs.native_package_type }}" \
+            --rocm-version "${{ inputs.rocm_version }}" \
+            --repo-base-url https://example.com/rocm/packages-multi-arch/ \
+            --repo-sub-folder 20000101-inspect
+
       - name: Configure AWS credentials for artifact uploads
         uses: ./.github/actions/configure_aws_artifacts_credentials
         with:
@@ -183,3 +257,178 @@ jobs:
           workflow_step_outputs: ${{ toJSON(steps) }}
           gh_app_client_id: ${{ secrets.GH_APP_HAULY_CID }}
           gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
+
+  # Build the amdrocm-repo package for each OS profile of this package type on the
+  # public release lines and stage it as a workflow artifact. Best-effort: a build
+  # failure here must never block the release, so the job cannot fail the workflow.
+  # Publishing to a public download location is handled separately.
+  stage_repo_package:
+    name: Stage amdrocm-repo (${{ matrix.os_profile }})
+    needs: [setup_repo_params]
+    if: inputs.enable_repo_package && needs.setup_repo_params.outputs.repo_base_url != ''
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        # setup_repo_params does not run on the lines with no public repository,
+        # and a skipped job's outputs are empty strings, which fromJSON cannot
+        # parse. Fall back to an empty matrix so this job skips cleanly.
+        os_profile: ${{ fromJSON(needs.setup_repo_params.outputs.os_profiles || '[]') }}
+    runs-on: ${{ github.repository_owner == 'ROCm' && 'aws-linux-scale-rocm-prod' || 'ubuntu-24.04' }}
+    container:
+      image: ${{ fromJSON(needs.setup_repo_params.outputs.images || '{}')[matrix.os_profile] }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || '' }}
+
+      - name: Install system prerequisites
+        run: |
+          bash build_tools/packaging/linux/setup_repo_build_deps.sh \
+            --os-profile "${{ matrix.os_profile }}"
+
+      - name: Setup Python
+        run: |
+          bash build_tools/packaging/linux/setup_python_cmd.sh \
+            --os-profile "${{ matrix.os_profile }}" \
+            --install-runtime \
+            --output-format github
+
+      - name: Install Python dependencies
+        run: |
+          $PYTHON_CMD -m venv /tmp/repo-venv
+          /tmp/repo-venv/bin/python -m pip install --upgrade pip
+          /tmp/repo-venv/bin/python -m pip install jinja2
+          echo "PYTHON_CMD=/tmp/repo-venv/bin/python" >> "$GITHUB_ENV"
+
+      - name: Build amdrocm-repo
+        run: |
+          # repo_sub_folder is empty except on the nightly line, where the builder
+          # requires the dated sub-folder; passing an empty value is accepted for
+          # the other lines.
+          #
+          # --verify-repo-url fails the build if the configured repository is not
+          # served, so a package that installs cleanly but cannot refresh is
+          # caught here rather than by a user. It is a no-op on the nightly line,
+          # whose dated sub-folder is published by this same run.
+          $PYTHON_CMD build_tools/packaging/linux/build_repo_package.py \
+            --os-profile "${{ matrix.os_profile }}" \
+            --release-type "${{ inputs.release_type }}" \
+            --repo-base-url "${{ needs.setup_repo_params.outputs.repo_base_url }}" \
+            --repo-sub-folder "${{ needs.setup_repo_params.outputs.repo_sub_folder }}" \
+            --rocm-version "${{ inputs.rocm_version }}" \
+            --dest-dir repo-package-out \
+            --verify-repo-url
+
+      - name: Upload amdrocm-repo package
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: amdrocm-repo-${{ inputs.native_package_type }}-${{ matrix.os_profile }}
+          path: repo-package-out/*.${{ inputs.native_package_type }}
+          if-no-files-found: error
+
+      # This job is continue-on-error so a staging failure never blocks the
+      # release; surface it as a warning + job-summary line so the soft-fail is
+      # not silent. A failure here can mean the configured repository is no
+      # longer reachable, which is what --verify-repo-url detects.
+      - name: Report staging failure
+        if: failure()
+        run: |
+          msg="amdrocm-repo staging FAILED for ${{ matrix.os_profile }} (${{ inputs.native_package_type }}, ${{ inputs.release_type }}). The configured repository may be unreachable."
+          echo "::warning::${msg}"
+          echo "WARNING: ${msg}" >> "$GITHUB_STEP_SUMMARY"
+
+  # Publish the built amdrocm-repo packages to the per-run packages location,
+  # alongside the native content packages, as standalone per-distro files (a
+  # repo/<os_profile>/ sibling of the content repository, not part of its index).
+  # They become publicly reachable once the release promotion step copies the
+  # per-run tree to the public CDN. This runs in a generic container (not the
+  # per-distro build containers) because the AWS credentials action requires
+  # python on PATH, which the per-distro Python setup does not provide.
+  # Non-blocking: a publish failure must never block the release.
+  #
+  # The release line is excluded: it has no automated upload credentials by
+  # design (the release artifacts bucket grants no write role), so resolving that
+  # bucket fails outright. The release package is published by the ROCm release
+  # process instead. Without this exclusion the job would fail on every release
+  # run and report a spurious "not published" warning.
+  publish_repo_package:
+    name: Publish amdrocm-repo (${{ matrix.os_profile }})
+    needs: [setup_repo_params, stage_repo_package]
+    if: inputs.enable_repo_package && needs.setup_repo_params.outputs.repo_base_url != '' && inputs.release_type != 'release'
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        # setup_repo_params does not run on the lines with no public repository,
+        # and a skipped job's outputs are empty strings, which fromJSON cannot
+        # parse. Fall back to an empty matrix so this job skips cleanly.
+        os_profile: ${{ fromJSON(needs.setup_repo_params.outputs.os_profiles || '[]') }}
+    runs-on: ${{ github.repository_owner == 'ROCm' && 'aws-linux-scale-rocm-prod' || 'ubuntu-24.04' }}
+    container:
+      image: ghcr.io/rocm/no_rocm_image_ubuntu24_04:latest
+    env:
+      RELEASE_TYPE: ${{ inputs.release_type }}
+      ARTIFACT_RUN_ID: "${{ inputs.artifact_run_id != '' && inputs.artifact_run_id || github.run_id }}"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || '' }}
+
+      - name: Setup Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Install Python dependencies
+        run: pip install boto3
+
+      - name: Download amdrocm-repo package
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: amdrocm-repo-${{ inputs.native_package_type }}-${{ matrix.os_profile }}
+          path: repo-package-out
+
+      - name: Configure AWS credentials for artifact uploads
+        uses: ./.github/actions/configure_aws_artifacts_credentials
+        with:
+          release_type: ${{ inputs.release_type }}
+
+      - name: Publish amdrocm-repo package
+        id: publish
+        run: |
+          # Bucket and per-run prefix are derived by WorkflowOutputRoot, the
+          # same way the content upload resolves them, so the file lands beside
+          # the content packages. ARTIFACT_RUN_ID matches what that upload used.
+          # Resolution reads RELEASE_TYPE, GITHUB_REPOSITORY and the event
+          # payload, all present in this job.
+          #
+          # One artifact holds one package. Match explicitly rather than globbing
+          # into a variable: several matches would be joined by newlines and
+          # passed on as a single filename.
+          mapfile -t pkgs < <(find repo-package-out -maxdepth 1 -type f \
+            -name "*.${{ inputs.native_package_type }}")
+          if [ "${#pkgs[@]}" -ne 1 ]; then
+            echo "::error::expected exactly one .${{ inputs.native_package_type }} in repo-package-out, found ${#pkgs[@]}"
+            exit 1
+          fi
+          pkg="${pkgs[0]}"
+          python build_tools/packaging/linux/publish_repo_package.py \
+            --file "$pkg" \
+            --run-id "${ARTIFACT_RUN_ID}" \
+            --os-profile "${{ matrix.os_profile }}" \
+            --pkg-type "${{ inputs.native_package_type }}"
+
+      # This job is continue-on-error so a publish failure never blocks the
+      # release; surface it as a warning + job-summary line so the soft-fail is
+      # not silent.
+      - name: Report publish failure
+        if: failure()
+        run: |
+          msg="amdrocm-repo was NOT published for ${{ matrix.os_profile }} (${{ inputs.native_package_type }}, ${{ inputs.release_type }})."
+          echo "::warning::${msg}"
+          echo "WARNING: ${msg}" >> "$GITHUB_STEP_SUMMARY"

--- a/build_tools/packaging/linux/inspect_repo_package.py
+++ b/build_tools/packaging/linux/inspect_repo_package.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+r"""Build every amdrocm-repo profile of one package type and verify its payload.
+
+This is a build-time check, not an install test. It builds the package for each
+OS profile of the given package type and asserts that the archive contains the
+files it is supposed to install, at the right paths, owned by root. The build
+container has dpkg and rpm but no dnf or zypper, so the packages can be built
+and inspected there but not installed; per-distro install coverage lives in
+``test_native_linux_packages_install.yml``.
+
+Each profile is built twice, because the two shapes install different files:
+
+  unsigned (nightly)      the repository file only
+  signed   (prerelease)   the repository file and the signing key
+
+The signed build is what covers the key paths. Those were renamed so that
+``amdrocm-repo`` does not claim a file already owned by the amdgpu driver
+packages, and this is the only place CI checks that the renamed paths are the
+ones that ship and that the previous paths are gone.
+
+Neither build reaches the network:
+
+  * The unsigned line is not a signed line, so no key is loaded, and the
+    repository URL check is skipped for it.
+  * The signed line reads its key from ``--gpg-key-file``, which returns before
+    the build-time key fetch. The key is generated here, offline, and thrown
+    away; it never signs anything and never leaves the build.
+  * The repository URL check is opt-in and is not requested.
+
+The repository URL is therefore a placeholder and the built packages are for
+inspection only. They are written to temporary directories and discarded.
+
+Usage:
+  python build_tools/packaging/linux/inspect_repo_package.py \
+      --pkg-type deb \
+      --rocm-version 7.14.0~dev20260811 \
+      --repo-base-url https://example.com/rocm/packages-multi-arch/ \
+      --repo-sub-folder 20000101-inspect
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path, PurePosixPath
+
+_THIS_DIR = Path(__file__).resolve().parent
+
+if str(_THIS_DIR) not in sys.path:
+    sys.path.insert(0, str(_THIS_DIR))
+
+from build_repo_package import (
+    DEB_KEYRING_PATH,
+    OS_PROFILES,
+    REPO_ID,
+    RPM_GPG_KEY_PATH,
+    list_profiles,
+)
+
+_BUILDER = _THIS_DIR / "build_repo_package.py"
+
+# The two release lines that produce the unsigned and signed payload shapes.
+# The unsigned line requires a dated sub-folder and the signed line rejects one,
+# so they are passed different arguments.
+_UNSIGNED_RELEASE_TYPE = "nightly"
+_SIGNED_RELEASE_TYPE = "prerelease"
+
+# Everything the package installs is owned by root, whatever user builds it.
+_EXPECTED_OWNER = "root/root"
+
+# Key paths used before the rename. The amdgpu driver setup installs its key at
+# the deb path below, and neither dpkg nor rpm will unpack two packages that
+# claim the same file, so shipping these names again would make amdrocm-repo and
+# the driver mutually uninstallable. Asserted absent from every build.
+_SUPERSEDED_KEY_PATHS = (
+    PurePosixPath("/usr/share/keyrings/rocm.gpg"),
+    PurePosixPath("/etc/pki/rpm-gpg/RPM-GPG-KEY-rocm"),
+)
+
+
+def repo_file_path(os_profile: str) -> PurePosixPath:
+    """Return the repository configuration file this profile installs."""
+    profile = OS_PROFILES[os_profile]
+    if profile["pkg_type"] == "deb":
+        return PurePosixPath(f"/etc/apt/sources.list.d/{REPO_ID}.sources")
+    return PurePosixPath(profile["rpm_repo_dir"]) / f"{REPO_ID}.repo"
+
+
+def key_path(os_profile: str) -> PurePosixPath:
+    """Return the signing key path this profile installs when signed."""
+    if OS_PROFILES[os_profile]["pkg_type"] == "deb":
+        return PurePosixPath(DEB_KEYRING_PATH)
+    return PurePosixPath(RPM_GPG_KEY_PATH)
+
+
+def expected_paths(os_profile: str, signed: bool) -> set[PurePosixPath]:
+    """Return the paths a build of this profile must install."""
+    paths = {repo_file_path(os_profile)}
+    if signed:
+        paths.add(key_path(os_profile))
+    return paths
+
+
+def forbidden_paths(os_profile: str, signed: bool) -> set[PurePosixPath]:
+    """Return the paths a build of this profile must not install."""
+    paths = set(_SUPERSEDED_KEY_PATHS)
+    if not signed:
+        # An unsigned line ships no key at all: the repository it configures is
+        # unsigned, so a key here would be inert at best and misleading at worst.
+        paths.add(key_path(os_profile))
+    return paths
+
+
+def parse_deb_contents(text: str) -> list[tuple[PurePosixPath, str]]:
+    """Parse ``dpkg-deb -c`` output into ``(path, owner)`` pairs.
+
+    Entries are relative to the package root and are reported with a leading
+    ``./``; they are normalised to absolute paths so both package types compare
+    against the same values. Directory entries are included, since they carry
+    ownership too.
+    """
+    entries = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        # <mode> <owner>/<group> <size> <date> <time> <path>
+        fields = line.split(maxsplit=5)
+        if len(fields) < 6:
+            continue
+        owner, name = fields[1], fields[5]
+        # Symlinks are reported as "target -> source"; keep the target.
+        name = name.split(" -> ", 1)[0]
+        entries.append((PurePosixPath("/") / name.removeprefix("./"), owner))
+    return entries
+
+
+def parse_rpm_contents(text: str) -> list[tuple[PurePosixPath, str]]:
+    """Parse the ``rpm -qp --qf`` listing into ``(path, owner)`` pairs.
+
+    The query emits ``<path>|<user>|<group>`` per file, already absolute. Owner
+    is rejoined with a slash so it matches the deb representation.
+    """
+    entries = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        fields = line.split("|")
+        if len(fields) != 3:
+            continue
+        name, user, group = fields
+        entries.append((PurePosixPath(name), f"{user}/{group}"))
+    return entries
+
+
+def check_payload(
+    entries: list[tuple[PurePosixPath, str]],
+    expected: set[PurePosixPath],
+    forbidden: set[PurePosixPath],
+) -> list[str]:
+    """Return a list of problems with a package's payload, empty if it is sound.
+
+    Paths are compared in full. A substring or suffix comparison would be unsafe
+    here: "amdrocm.gpg" ends with "rocm.gpg", so a loose check would accept the
+    superseded name that the rename exists to eliminate.
+    """
+    problems = []
+    present = {path for path, _ in entries}
+
+    for path in sorted(expected):
+        if path not in present:
+            problems.append(f"missing expected file: {path}")
+
+    for path in sorted(forbidden):
+        if path in present:
+            problems.append(f"installs a file it must not ship: {path}")
+
+    for path, owner in entries:
+        if owner != _EXPECTED_OWNER:
+            problems.append(f"{path} is owned by {owner}, expected {_EXPECTED_OWNER}")
+
+    return problems
+
+
+def _run(argv: list[str], **kwargs) -> subprocess.CompletedProcess:
+    """Run a command, capturing output so a successful build stays quiet."""
+    return subprocess.run(
+        argv, check=True, text=True, capture_output=True, encoding="utf-8", **kwargs
+    )
+
+
+def generate_throwaway_key(dest: Path) -> Path:
+    """Generate a signing key for the signed build and export it armored.
+
+    The key exists only to exercise the code path that embeds a key in the
+    package. It is generated into a private keyring directory, used once, and
+    discarded with the temporary tree. A real key cannot be used: committing key
+    material is forbidden, and fetching one would defeat the offline property.
+    """
+    home = dest / "gnupg"
+    home.mkdir(mode=0o700)
+    env = dict(os.environ, GNUPGHOME=str(home))
+    _run(
+        [
+            "gpg",
+            "--batch",
+            "--pinentry-mode",
+            "loopback",
+            "--passphrase",
+            "",
+            "--quick-generate-key",
+            "TheRock Package Inspection <noreply@example.com>",
+            "rsa2048",
+            "sign",
+            "0",
+        ],
+        env=env,
+    )
+    armored = _run(["gpg", "--armor", "--export"], env=env).stdout
+    key_file = dest / "inspect-key.asc"
+    key_file.write_text(armored, encoding="utf-8")
+    return key_file
+
+
+def build_package(
+    os_profile: str,
+    signed: bool,
+    dest_dir: Path,
+    rocm_version: str,
+    repo_base_url: str,
+    repo_sub_folder: str,
+    gpg_key_file: Path,
+) -> Path:
+    """Build one package and return its path."""
+    argv = [
+        sys.executable,
+        str(_BUILDER),
+        "--os-profile",
+        os_profile,
+        "--repo-base-url",
+        repo_base_url,
+        "--rocm-version",
+        rocm_version,
+        "--dest-dir",
+        str(dest_dir),
+    ]
+    if signed:
+        argv += [
+            "--release-type",
+            _SIGNED_RELEASE_TYPE,
+            "--gpg-key-file",
+            str(gpg_key_file),
+        ]
+    else:
+        # The dated sub-folder is required on the unsigned line and rejected on
+        # every other line, so it is passed here and nowhere else.
+        argv += [
+            "--release-type",
+            _UNSIGNED_RELEASE_TYPE,
+            "--repo-sub-folder",
+            repo_sub_folder,
+        ]
+
+    try:
+        _run(argv)
+    except subprocess.CalledProcessError as e:
+        # rpmbuild is verbose and only interesting when it fails.
+        sys.stderr.write(e.stdout or "")
+        sys.stderr.write(e.stderr or "")
+        raise
+
+    pkg_type = OS_PROFILES[os_profile]["pkg_type"]
+    built = sorted(dest_dir.glob(f"*.{pkg_type}"))
+    if len(built) != 1:
+        raise RuntimeError(
+            f"expected exactly one .{pkg_type} in {dest_dir}, found {len(built)}"
+        )
+    return built[0]
+
+
+def read_payload(package: Path, pkg_type: str) -> list[tuple[PurePosixPath, str]]:
+    """Return the ``(path, owner)`` payload of a built package."""
+    if pkg_type == "deb":
+        return parse_deb_contents(_run(["dpkg-deb", "-c", str(package)]).stdout)
+    listing = _run(
+        [
+            "rpm",
+            "-qp",
+            "--qf",
+            "[%{FILENAMES}|%{FILEUSERNAME}|%{FILEGROUPNAME}\n]",
+            str(package),
+        ]
+    ).stdout
+    return parse_rpm_contents(listing)
+
+
+def inspect_profile(
+    os_profile: str,
+    signed: bool,
+    work_dir: Path,
+    args: argparse.Namespace,
+    gpg_key_file: Path,
+) -> list[str]:
+    """Build one profile in one shape and return any problems with its payload."""
+    dest_dir = work_dir / f"{os_profile}-{'signed' if signed else 'unsigned'}"
+    dest_dir.mkdir()
+    package = build_package(
+        os_profile,
+        signed,
+        dest_dir,
+        args.rocm_version,
+        args.repo_base_url,
+        args.repo_sub_folder,
+        gpg_key_file,
+    )
+    entries = read_payload(package, OS_PROFILES[os_profile]["pkg_type"])
+    return check_payload(
+        entries,
+        expected_paths(os_profile, signed),
+        forbidden_paths(os_profile, signed),
+    )
+
+
+def parse_args(argv=None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Build and verify the payload of the amdrocm-repo packages.",
+    )
+    p.add_argument(
+        "--pkg-type",
+        required=True,
+        choices=["deb", "rpm"],
+        help="Package type whose OS profiles are built",
+    )
+    p.add_argument(
+        "--rocm-version",
+        required=True,
+        help="ROCm version to build with",
+    )
+    p.add_argument(
+        "--repo-base-url",
+        required=True,
+        help="Placeholder repository base URL; never contacted",
+    )
+    p.add_argument(
+        "--repo-sub-folder",
+        required=True,
+        help="Placeholder dated sub-folder for the unsigned build",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    args = parse_args(argv)
+    profiles = list_profiles(args.pkg_type)
+    if not profiles:
+        raise SystemExit(f"no OS profiles build {args.pkg_type} packages")
+
+    failures = []
+    with tempfile.TemporaryDirectory() as tmp:
+        work_dir = Path(tmp)
+        gpg_key_file = generate_throwaway_key(work_dir)
+        for os_profile in profiles:
+            for signed in (False, True):
+                shape = "signed" if signed else "unsigned"
+                problems = inspect_profile(
+                    os_profile, signed, work_dir, args, gpg_key_file
+                )
+                if problems:
+                    failures.append((os_profile, shape, problems))
+                    for problem in problems:
+                        print(f"FAIL {os_profile} ({shape}): {problem}")
+                else:
+                    print(f"ok   {os_profile} ({shape})")
+
+    if failures:
+        print(f"\n{len(failures)} package(s) have an unexpected payload")
+        return 1
+    print(
+        f"\nall {len(profiles) * 2} {args.pkg_type} packages have the expected payload"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build_tools/packaging/linux/inspect_repo_package.py
+++ b/build_tools/packaging/linux/inspect_repo_package.py
@@ -23,9 +23,9 @@ ones that ship and that the previous paths are gone.
 
 Neither build reaches the network:
 
-  * The unsigned line is not a signed line, so no key is loaded, and the
+  * The unsigned stream loads no key, and the
     repository URL check is skipped for it.
-  * The signed line reads its key from ``--gpg-key-file``, which returns before
+  * The signed stream reads its key from ``--gpg-key-file``, which returns before
     the build-time key fetch. The key is generated here, offline, and thrown
     away; it never signs anything and never leaves the build.
   * The repository URL check is opt-in and is not requested.
@@ -56,18 +56,19 @@ if str(_THIS_DIR) not in sys.path:
 from build_repo_package import (
     DEB_KEYRING_PATH,
     OS_PROFILES,
-    REPO_ID,
     RPM_GPG_KEY_PATH,
     list_profiles,
+    repo_id,
 )
 
 _BUILDER = _THIS_DIR / "build_repo_package.py"
 
-# The two release lines that produce the unsigned and signed payload shapes.
-# The unsigned line requires a dated sub-folder and the signed line rejects one,
-# so they are passed different arguments.
-_UNSIGNED_RELEASE_TYPE = "nightly"
-_SIGNED_RELEASE_TYPE = "prerelease"
+# The two streams that produce the unsigned and signed payload shapes. The
+# per-build stream requires a build sub-folder and the flat one rejects it, so
+# they are passed different arguments. Within this module signedness and stream
+# select each other, which is why the helpers below take only ``signed``.
+_UNSIGNED_STREAM = "nightly"
+_SIGNED_STREAM = "stable"
 
 # Everything the package installs is owned by root, whatever user builds it.
 _EXPECTED_OWNER = "root/root"
@@ -82,12 +83,17 @@ _SUPERSEDED_KEY_PATHS = (
 )
 
 
-def repo_file_path(os_profile: str) -> PurePosixPath:
-    """Return the repository configuration file this profile installs."""
+def repo_file_path(os_profile: str, stream: str) -> PurePosixPath:
+    """Return the repository configuration file this profile installs.
+
+    The filename carries the stream, so it cannot be derived from the profile
+    alone.
+    """
     profile = OS_PROFILES[os_profile]
+    stem = repo_id(stream)
     if profile["pkg_type"] == "deb":
-        return PurePosixPath(f"/etc/apt/sources.list.d/{REPO_ID}.sources")
-    return PurePosixPath(profile["rpm_repo_dir"]) / f"{REPO_ID}.repo"
+        return PurePosixPath(f"/etc/apt/sources.list.d/{stem}.sources")
+    return PurePosixPath(profile["rpm_repo_dir"]) / f"{stem}.repo"
 
 
 def key_path(os_profile: str) -> PurePosixPath:
@@ -97,9 +103,14 @@ def key_path(os_profile: str) -> PurePosixPath:
     return PurePosixPath(RPM_GPG_KEY_PATH)
 
 
+def stream_for(signed: bool) -> str:
+    """Return the stream this inspection builds for a given signedness."""
+    return _SIGNED_STREAM if signed else _UNSIGNED_STREAM
+
+
 def expected_paths(os_profile: str, signed: bool) -> set[PurePosixPath]:
     """Return the paths a build of this profile must install."""
-    paths = {repo_file_path(os_profile)}
+    paths = {repo_file_path(os_profile, stream_for(signed))}
     if signed:
         paths.add(key_path(os_profile))
     return paths
@@ -109,7 +120,7 @@ def forbidden_paths(os_profile: str, signed: bool) -> set[PurePosixPath]:
     """Return the paths a build of this profile must not install."""
     paths = set(_SUPERSEDED_KEY_PATHS)
     if not signed:
-        # An unsigned line ships no key at all: the repository it configures is
+        # An unsigned stream ships no key at all: the repository it configures is
         # unsigned, so a key here would be inert at best and misleading at worst.
         paths.add(key_path(os_profile))
     return paths
@@ -251,17 +262,17 @@ def build_package(
     ]
     if signed:
         argv += [
-            "--release-type",
-            _SIGNED_RELEASE_TYPE,
+            "--stream",
+            _SIGNED_STREAM,
             "--gpg-key-file",
             str(gpg_key_file),
         ]
     else:
-        # The dated sub-folder is required on the unsigned line and rejected on
-        # every other line, so it is passed here and nowhere else.
+        # The build sub-folder is required on a per-build stream and rejected on
+        # a flat one, so it is passed here and nowhere else.
         argv += [
-            "--release-type",
-            _UNSIGNED_RELEASE_TYPE,
+            "--stream",
+            _UNSIGNED_STREAM,
             "--repo-sub-folder",
             repo_sub_folder,
         ]

--- a/build_tools/tests/inspect_repo_package_test.py
+++ b/build_tools/tests/inspect_repo_package_test.py
@@ -23,13 +23,15 @@ sys.path.insert(0, str(_LINUX_DIR))
 
 import inspect_repo_package as irp  # noqa: E402
 
-# Captured from `dpkg-deb -c` on an unsigned ubuntu2404 build.
-DEB_UNSIGNED_LISTING = """\
+# Captured from `dpkg-deb -c` on ubuntu2404 builds. The repo filename carries
+# the stream, so the signed and unsigned listings differ in it as well as in
+# whether a keyring is present -- deriving one from the other would hide that.
+_DEB_LISTING = """\
 drwxr-xr-x root/root         0 2026-08-11 16:15 ./
 drwxr-xr-x root/root         0 2026-08-11 16:15 ./etc/
 drwxr-xr-x root/root         0 2026-08-11 16:15 ./etc/apt/
 drwxr-xr-x root/root         0 2026-08-11 16:15 ./etc/apt/sources.list.d/
--rw-r--r-- root/root       150 2026-08-11 16:15 ./etc/apt/sources.list.d/amdrocm.sources
+-rw-r--r-- root/root       150 2026-08-11 16:15 ./etc/apt/sources.list.d/{stem}.sources
 drwxr-xr-x root/root         0 2026-08-11 16:15 ./usr/
 drwxr-xr-x root/root         0 2026-08-11 16:15 ./usr/share/
 drwxr-xr-x root/root         0 2026-08-11 16:15 ./usr/share/doc/
@@ -37,9 +39,10 @@ drwxr-xr-x root/root         0 2026-08-11 16:15 ./usr/share/doc/amdrocm-repo/
 -rw-r--r-- root/root       177 2026-08-11 16:15 ./usr/share/doc/amdrocm-repo/changelog.gz
 """
 
-# Captured from `dpkg-deb -c` on a signed ubuntu2404 build.
+DEB_UNSIGNED_LISTING = _DEB_LISTING.format(stem="amdrocm-nightly")
+
 DEB_SIGNED_LISTING = (
-    DEB_UNSIGNED_LISTING
+    _DEB_LISTING.format(stem="amdrocm-stable")
     + """\
 drwxr-xr-x root/root         0 2026-08-11 16:15 ./usr/share/keyrings/
 -rw-r--r-- root/root       651 2026-08-11 16:15 ./usr/share/keyrings/amdrocm.gpg
@@ -49,26 +52,26 @@ drwxr-xr-x root/root         0 2026-08-11 16:15 ./usr/share/keyrings/
 # Captured from `rpm -qp --qf` on a signed sles16 build.
 RPM_SIGNED_LISTING = """\
 /etc/pki/rpm-gpg/RPM-GPG-KEY-amdrocm|root|root
-/etc/zypp/repos.d/amdrocm.repo|root|root
+/etc/zypp/repos.d/amdrocm-stable.repo|root|root
 """
 
 
 class TestRepoFilePath:
     def test_deb_uses_sources_list_d(self):
-        assert irp.repo_file_path("ubuntu2404") == PurePosixPath(
-            "/etc/apt/sources.list.d/amdrocm.sources"
+        assert irp.repo_file_path("ubuntu2404", "stable") == PurePosixPath(
+            "/etc/apt/sources.list.d/amdrocm-stable.sources"
         )
 
     @pytest.mark.parametrize("os_profile", ["rhel8", "rhel10"])
     def test_rhel_uses_yum_repos_d(self, os_profile):
-        assert irp.repo_file_path(os_profile) == PurePosixPath(
-            "/etc/yum.repos.d/amdrocm.repo"
+        assert irp.repo_file_path(os_profile, "stable") == PurePosixPath(
+            "/etc/yum.repos.d/amdrocm-stable.repo"
         )
 
     def test_sles_uses_zypp_repos_d(self):
         """SLES keeps repository files in /etc/zypp/repos.d, not /etc/yum.repos.d."""
-        assert irp.repo_file_path("sles16") == PurePosixPath(
-            "/etc/zypp/repos.d/amdrocm.repo"
+        assert irp.repo_file_path("sles16", "stable") == PurePosixPath(
+            "/etc/zypp/repos.d/amdrocm-stable.repo"
         )
 
 
@@ -90,19 +93,20 @@ class TestKeyPath:
 
 class TestExpectedPaths:
     def test_unsigned_expects_only_the_repo_file(self):
+        # Unsigned means the per-build stream, so the filename says nightly.
         assert irp.expected_paths("ubuntu2404", signed=False) == {
-            PurePosixPath("/etc/apt/sources.list.d/amdrocm.sources")
+            PurePosixPath("/etc/apt/sources.list.d/amdrocm-nightly.sources")
         }
 
     def test_signed_expects_the_key_too(self):
         assert irp.expected_paths("ubuntu2404", signed=True) == {
-            PurePosixPath("/etc/apt/sources.list.d/amdrocm.sources"),
+            PurePosixPath("/etc/apt/sources.list.d/amdrocm-stable.sources"),
             PurePosixPath("/usr/share/keyrings/amdrocm.gpg"),
         }
 
     def test_signed_rpm_expects_the_key_too(self):
         assert irp.expected_paths("sles16", signed=True) == {
-            PurePosixPath("/etc/zypp/repos.d/amdrocm.repo"),
+            PurePosixPath("/etc/zypp/repos.d/amdrocm-stable.repo"),
             PurePosixPath("/etc/pki/rpm-gpg/RPM-GPG-KEY-amdrocm"),
         }
 
@@ -140,7 +144,7 @@ class TestParseDebContents:
     def test_paths_are_absolute_and_owners_captured(self):
         entries = dict(irp.parse_deb_contents(DEB_UNSIGNED_LISTING))
         assert (
-            entries[PurePosixPath("/etc/apt/sources.list.d/amdrocm.sources")]
+            entries[PurePosixPath("/etc/apt/sources.list.d/amdrocm-nightly.sources")]
             == "root/root"
         )
 
@@ -170,13 +174,15 @@ class TestParseRpmContents:
     def test_paths_and_owners(self):
         assert irp.parse_rpm_contents(RPM_SIGNED_LISTING) == [
             (PurePosixPath("/etc/pki/rpm-gpg/RPM-GPG-KEY-amdrocm"), "root/root"),
-            (PurePosixPath("/etc/zypp/repos.d/amdrocm.repo"), "root/root"),
+            (PurePosixPath("/etc/zypp/repos.d/amdrocm-stable.repo"), "root/root"),
         ]
 
     def test_non_root_owner_is_preserved(self):
-        entries = irp.parse_rpm_contents("/etc/zypp/repos.d/amdrocm.repo|bin|wheel\n")
+        entries = irp.parse_rpm_contents(
+            "/etc/zypp/repos.d/amdrocm-stable.repo|bin|wheel\n"
+        )
         assert entries == [
-            (PurePosixPath("/etc/zypp/repos.d/amdrocm.repo"), "bin/wheel")
+            (PurePosixPath("/etc/zypp/repos.d/amdrocm-stable.repo"), "bin/wheel")
         ]
 
     def test_malformed_lines_are_skipped(self):
@@ -207,7 +213,9 @@ class TestCheckPayload:
     def test_missing_expected_file_is_reported_by_name(self):
         listing = "drwxr-xr-x root/root 0 2026-08-11 16:15 ./etc/apt/\n"
         problems = self._check(listing, "ubuntu2404", False)
-        assert any("/etc/apt/sources.list.d/amdrocm.sources" in p for p in problems)
+        assert any(
+            "/etc/apt/sources.list.d/amdrocm-nightly.sources" in p for p in problems
+        )
         assert any(p.startswith("missing expected file") for p in problems)
 
     def test_wrong_owner_is_reported(self):

--- a/build_tools/tests/inspect_repo_package_test.py
+++ b/build_tools/tests/inspect_repo_package_test.py
@@ -1,0 +1,246 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for inspect_repo_package.py.
+
+inspect_repo_package.py lives in build_tools/packaging/linux/, which is not on
+the path that conftest.py sets up (it only adds build_tools/). Add it explicitly.
+Importing the module is side-effect-free thanks to its ``__main__`` guard.
+
+Only the pure functions are covered here: path derivation, listing parsers, and
+the payload check. Building a package needs dpkg, rpm and gpg, none of which are
+available on every leg this suite runs on, so that is left to the container
+verification. The listings below are real output captured from a build.
+"""
+
+import sys
+from pathlib import Path, PurePosixPath
+
+import pytest
+
+_LINUX_DIR = Path(__file__).resolve().parents[1] / "packaging" / "linux"
+sys.path.insert(0, str(_LINUX_DIR))
+
+import inspect_repo_package as irp  # noqa: E402
+
+# Captured from `dpkg-deb -c` on an unsigned ubuntu2404 build.
+DEB_UNSIGNED_LISTING = """\
+drwxr-xr-x root/root         0 2026-08-11 16:15 ./
+drwxr-xr-x root/root         0 2026-08-11 16:15 ./etc/
+drwxr-xr-x root/root         0 2026-08-11 16:15 ./etc/apt/
+drwxr-xr-x root/root         0 2026-08-11 16:15 ./etc/apt/sources.list.d/
+-rw-r--r-- root/root       150 2026-08-11 16:15 ./etc/apt/sources.list.d/amdrocm.sources
+drwxr-xr-x root/root         0 2026-08-11 16:15 ./usr/
+drwxr-xr-x root/root         0 2026-08-11 16:15 ./usr/share/
+drwxr-xr-x root/root         0 2026-08-11 16:15 ./usr/share/doc/
+drwxr-xr-x root/root         0 2026-08-11 16:15 ./usr/share/doc/amdrocm-repo/
+-rw-r--r-- root/root       177 2026-08-11 16:15 ./usr/share/doc/amdrocm-repo/changelog.gz
+"""
+
+# Captured from `dpkg-deb -c` on a signed ubuntu2404 build.
+DEB_SIGNED_LISTING = (
+    DEB_UNSIGNED_LISTING
+    + """\
+drwxr-xr-x root/root         0 2026-08-11 16:15 ./usr/share/keyrings/
+-rw-r--r-- root/root       651 2026-08-11 16:15 ./usr/share/keyrings/amdrocm.gpg
+"""
+)
+
+# Captured from `rpm -qp --qf` on a signed sles16 build.
+RPM_SIGNED_LISTING = """\
+/etc/pki/rpm-gpg/RPM-GPG-KEY-amdrocm|root|root
+/etc/zypp/repos.d/amdrocm.repo|root|root
+"""
+
+
+class TestRepoFilePath:
+    def test_deb_uses_sources_list_d(self):
+        assert irp.repo_file_path("ubuntu2404") == PurePosixPath(
+            "/etc/apt/sources.list.d/amdrocm.sources"
+        )
+
+    @pytest.mark.parametrize("os_profile", ["rhel8", "rhel10"])
+    def test_rhel_uses_yum_repos_d(self, os_profile):
+        assert irp.repo_file_path(os_profile) == PurePosixPath(
+            "/etc/yum.repos.d/amdrocm.repo"
+        )
+
+    def test_sles_uses_zypp_repos_d(self):
+        """SLES keeps repository files in /etc/zypp/repos.d, not /etc/yum.repos.d."""
+        assert irp.repo_file_path("sles16") == PurePosixPath(
+            "/etc/zypp/repos.d/amdrocm.repo"
+        )
+
+
+class TestKeyPath:
+    def test_deb_keyring_is_the_renamed_path(self):
+        assert irp.key_path("ubuntu2404") == PurePosixPath(
+            "/usr/share/keyrings/amdrocm.gpg"
+        )
+
+    def test_rpm_key_is_the_renamed_path(self):
+        assert irp.key_path("rhel10") == PurePosixPath(
+            "/etc/pki/rpm-gpg/RPM-GPG-KEY-amdrocm"
+        )
+
+    @pytest.mark.parametrize("os_profile", sorted(irp.OS_PROFILES))
+    def test_key_path_is_never_a_superseded_path(self, os_profile):
+        assert irp.key_path(os_profile) not in irp._SUPERSEDED_KEY_PATHS
+
+
+class TestExpectedPaths:
+    def test_unsigned_expects_only_the_repo_file(self):
+        assert irp.expected_paths("ubuntu2404", signed=False) == {
+            PurePosixPath("/etc/apt/sources.list.d/amdrocm.sources")
+        }
+
+    def test_signed_expects_the_key_too(self):
+        assert irp.expected_paths("ubuntu2404", signed=True) == {
+            PurePosixPath("/etc/apt/sources.list.d/amdrocm.sources"),
+            PurePosixPath("/usr/share/keyrings/amdrocm.gpg"),
+        }
+
+    def test_signed_rpm_expects_the_key_too(self):
+        assert irp.expected_paths("sles16", signed=True) == {
+            PurePosixPath("/etc/zypp/repos.d/amdrocm.repo"),
+            PurePosixPath("/etc/pki/rpm-gpg/RPM-GPG-KEY-amdrocm"),
+        }
+
+    @pytest.mark.parametrize("os_profile", sorted(irp.OS_PROFILES))
+    @pytest.mark.parametrize("signed", [False, True])
+    def test_paths_are_posix_on_every_platform(self, os_profile, signed):
+        """Target paths must not pick up the host's path flavour.
+
+        These name locations inside a Linux package. Rendering them with the
+        local flavour yields backslashes when the suite runs on Windows.
+        """
+        for path in irp.expected_paths(os_profile, signed):
+            assert "\\" not in str(path)
+            assert str(path).startswith("/")
+
+
+class TestForbiddenPaths:
+    def test_superseded_paths_are_forbidden_even_when_signed(self):
+        forbidden = irp.forbidden_paths("ubuntu2404", signed=True)
+        assert PurePosixPath("/usr/share/keyrings/rocm.gpg") in forbidden
+        assert PurePosixPath("/etc/pki/rpm-gpg/RPM-GPG-KEY-rocm") in forbidden
+
+    def test_unsigned_also_forbids_the_current_key_path(self):
+        assert irp.key_path("ubuntu2404") in irp.forbidden_paths(
+            "ubuntu2404", signed=False
+        )
+
+    def test_signed_does_not_forbid_the_current_key_path(self):
+        assert irp.key_path("ubuntu2404") not in irp.forbidden_paths(
+            "ubuntu2404", signed=True
+        )
+
+
+class TestParseDebContents:
+    def test_paths_are_absolute_and_owners_captured(self):
+        entries = dict(irp.parse_deb_contents(DEB_UNSIGNED_LISTING))
+        assert (
+            entries[PurePosixPath("/etc/apt/sources.list.d/amdrocm.sources")]
+            == "root/root"
+        )
+
+    def test_directories_are_included(self):
+        present = {p for p, _ in irp.parse_deb_contents(DEB_UNSIGNED_LISTING)}
+        assert PurePosixPath("/etc/apt/sources.list.d") in present
+
+    def test_non_root_owner_is_preserved(self):
+        listing = "-rw-r--r-- tester/tester 150 2026-08-11 16:15 ./etc/apt/x.sources\n"
+        assert irp.parse_deb_contents(listing) == [
+            (PurePosixPath("/etc/apt/x.sources"), "tester/tester")
+        ]
+
+    def test_symlink_target_is_used(self):
+        listing = (
+            "lrwxrwxrwx root/root 0 2026-08-11 16:15 ./etc/a.conf -> /etc/b.conf\n"
+        )
+        assert irp.parse_deb_contents(listing) == [
+            (PurePosixPath("/etc/a.conf"), "root/root")
+        ]
+
+    def test_blank_and_short_lines_are_skipped(self):
+        assert irp.parse_deb_contents("\n   \ngarbage\n") == []
+
+
+class TestParseRpmContents:
+    def test_paths_and_owners(self):
+        assert irp.parse_rpm_contents(RPM_SIGNED_LISTING) == [
+            (PurePosixPath("/etc/pki/rpm-gpg/RPM-GPG-KEY-amdrocm"), "root/root"),
+            (PurePosixPath("/etc/zypp/repos.d/amdrocm.repo"), "root/root"),
+        ]
+
+    def test_non_root_owner_is_preserved(self):
+        entries = irp.parse_rpm_contents("/etc/zypp/repos.d/amdrocm.repo|bin|wheel\n")
+        assert entries == [
+            (PurePosixPath("/etc/zypp/repos.d/amdrocm.repo"), "bin/wheel")
+        ]
+
+    def test_malformed_lines_are_skipped(self):
+        assert irp.parse_rpm_contents("\nnot-a-listing\n") == []
+
+
+class TestCheckPayload:
+    def _check(self, listing, os_profile, signed, parser=None):
+        parser = parser or irp.parse_deb_contents
+        return irp.check_payload(
+            parser(listing),
+            irp.expected_paths(os_profile, signed),
+            irp.forbidden_paths(os_profile, signed),
+        )
+
+    def test_real_unsigned_deb_passes(self):
+        assert self._check(DEB_UNSIGNED_LISTING, "ubuntu2404", False) == []
+
+    def test_real_signed_deb_passes(self):
+        assert self._check(DEB_SIGNED_LISTING, "ubuntu2404", True) == []
+
+    def test_real_signed_rpm_passes(self):
+        assert (
+            self._check(RPM_SIGNED_LISTING, "sles16", True, irp.parse_rpm_contents)
+            == []
+        )
+
+    def test_missing_expected_file_is_reported_by_name(self):
+        listing = "drwxr-xr-x root/root 0 2026-08-11 16:15 ./etc/apt/\n"
+        problems = self._check(listing, "ubuntu2404", False)
+        assert any("/etc/apt/sources.list.d/amdrocm.sources" in p for p in problems)
+        assert any(p.startswith("missing expected file") for p in problems)
+
+    def test_wrong_owner_is_reported(self):
+        listing = DEB_UNSIGNED_LISTING.replace(
+            "root/root       150", "tester/tester   150"
+        )
+        problems = self._check(listing, "ubuntu2404", False)
+        assert any("owned by tester/tester" in p for p in problems)
+
+    def test_key_on_an_unsigned_build_is_rejected(self):
+        problems = self._check(DEB_SIGNED_LISTING, "ubuntu2404", False)
+        assert any("/usr/share/keyrings/amdrocm.gpg" in p for p in problems)
+
+    def test_superseded_deb_keyring_name_is_rejected(self):
+        """The rename is load-bearing: the old name collides with the driver.
+
+        A suffix or substring comparison would pass this case, because
+        "amdrocm.gpg" ends with "rocm.gpg". It must not.
+        """
+        listing = DEB_SIGNED_LISTING.replace(
+            "./usr/share/keyrings/amdrocm.gpg", "./usr/share/keyrings/rocm.gpg"
+        )
+        problems = self._check(listing, "ubuntu2404", True)
+        assert any("/usr/share/keyrings/rocm.gpg" in p for p in problems)
+        assert any("must not ship" in p for p in problems)
+
+    def test_superseded_rpm_key_name_is_rejected(self):
+        listing = RPM_SIGNED_LISTING.replace(
+            "/etc/pki/rpm-gpg/RPM-GPG-KEY-amdrocm", "/etc/pki/rpm-gpg/RPM-GPG-KEY-rocm"
+        )
+        problems = self._check(listing, "sles16", True, irp.parse_rpm_contents)
+        assert any("RPM-GPG-KEY-rocm" in p for p in problems)
+
+    def test_empty_payload_reports_every_expected_path(self):
+        problems = self._check("", "sles16", True, irp.parse_rpm_contents)
+        assert len(problems) == 2


### PR DESCRIPTION
## Motivation

Setting up a ROCm package repository currently takes a user several manual steps. The `amdrocm-repo` package reduces that to a single install: it ships the repository configuration file and, on the signed release lines, the signing key.

This pull request wires the package into the existing native package pipeline, so that it is built and checked on CI runs, built for real on the released lines, and uploaded alongside the native content packages.

This is the fourth of four pull requests:

- PR 0 (#7004) added `packaging/linux/tests` to `testpaths`, so PR 2's tests under that directory run in CI.
- PR 1 (#7269) adds the builder, its templates, its unit tests and the user documentation.
- PR 2 (#7276) adds the publish helper and the workflow output type it writes to.
- PR 3 (this one) wires the CI workflow.

It stays a draft until #7269 and #7276 merge. Until then `unit-tests`, `Build DEB Packages` and `Build RPM Packages` fail, because the new unit test and the new CI step both call `build_repo_package.py`, which #7269 adds. `therock-pr-bot` waits on those checks, so it fails too.

Closes #6986.

## Technical Details

Everything is in `.github/workflows/multi_arch_build_native_linux_packages.yml`, apart from one new script and its unit tests.

### Jobs

| Job | Purpose | Runs on |
|---|---|---|
| `setup_repo_params` | Resolves the profile matrix, per-profile container image, repository URL and nightly sub-folder | prerelease, nightly, release |
| `stage_repo_package` | Builds the real package per profile and uploads it as an artifact | same, `continue-on-error` |
| `publish_repo_package` | Uploads it to `<run_id>-linux/packages/<format>/repo/<os_profile>/`, beside the content packages but outside their index | same minus release, `continue-on-error` |

The release line has no artifacts bucket, so publishing is skipped there. The other two are `continue-on-error`, so this package cannot fail a release build.

### Build and inspect step

A new step in `build_native_packages` builds each OS profile twice, unsigned and signed, and asserts the payload: expected files, at expected paths, owned by root, with the signing key only at its current path. It runs offline against a placeholder URL. The logic is in `build_tools/packaging/linux/inspect_repo_package.py`.

Three things the diff does not make obvious:

- **`ci` line only.** `build_native_packages` is on the release path, so a gate that can fail the job would otherwise let this package stop a release. The released lines build for real in `stage_repo_package`, which cannot block.
- **Inspects, not installs.** One Ubuntu container, no matrix, no dnf or zypper. Per-distro installs belong in `test_native_linux_packages_install.yml`, which is blocked on its GPU runner and a required `package_install_url`.
- **Both signing forms.** They install different files, and the signed build is the only CI check on the key paths, which were renamed to avoid a file conflict with the amdgpu driver packages. It uses a throwaway key via `--gpg-key-file`, so no key is fetched.

`enable_repo_package`, a `workflow_call` boolean defaulting to `true`, gates the three jobs and the step. Existing callers are unchanged.

### Reads of a published repository

`stage_repo_package` keeps `--verify-repo-url` and fetches the repository index on the prerelease and release lines. It catches a package that installs but cannot refresh, and those runs publish to the line they read. Nightly is skipped, because its dated folder is published by the same run.

No pull request reaches a published repository. `ci` has no entry in `_PUBLIC_REPO_BASE_URLS`, so `repo_base_url` is empty and `stage_repo_package` skips. The earlier `test_repo_package` job, which refreshed against live prerelease on every pull request, is deleted.

### Note for reviewers

That job was the only CI caller of PR 2's (#7276) `--repo-package-dir` and `--repo-config-only`. They keep their unit tests and gain a CI caller in the follow-up above.

## Test Plan

The branch cannot test itself yet, because `build_repo_package.py` belongs to PR 1 (#7269). Verification used a local scratch tree with PR 1 and PR 2 merged in, entirely in throwaway containers.

| What it proves | How |
|---|---|
| The new script is correct | Unit tests over path derivation, both output parsers and the payload check, using real `dpkg-deb -c` and `rpm -qp` output as fixtures |
| Nothing else regressed | Full `build_tools` suite as CI runs it, diffing failure names with and without this pull request, not counts |
| The step is offline | Run for both package types with `--network none` |
| The checks can fail | Negative controls: old key file names restored, repository file dropped, ownership changed, two packages left where publish expects one |
| The packages install | All eight installed by hand on `ubuntu:24.04`, `redhat/ubi8`, `ubi10` and `bci-base:16.0` |
| The Windows leg is safe | Unit tests re-run with the module bound to Windows path semantics |
| CI hygiene | `actionlint`, `pre-commit`, and the unit tests that walk the workflow directory |

## Test Result

Everything passes. The rows below match the table above.

| What it proves | Result |
|---|---|
| The new script is correct | 41 unit tests passed |
| Nothing else regressed | 1975 passed, and the 8 failures are identical by name with and without this pull request. `scan_tools` 31 passed, `test_tools` 49 passed |
| The step is offline | 8 builds passed with no network, covering four profiles unsigned and signed |
| The checks can fail | Every negative control fired, and undoing each one returned the check to passing |
| The packages install | 8 of 8 |
| The Windows leg is safe | 27 of the 41 unit tests fail when the module is bound to Windows path semantics |
| CI hygiene | `actionlint`, `pre-commit` and the 23 workflow tests passed |

The manual install confirmed three things payload inspection cannot. The deb keyring is dearmored binary at mode 0644, which apt requires when a source pins `Signed-By`. The rpm key is ASCII armored and `rpm --import` accepts it. Removing the package cleans up every file it installed.

Four things cannot be verified outside GitHub Actions and are worth watching on the first CI run:

1. Whether a skipped `setup_repo_params` produces clean skips in the jobs reading its outputs. Those reads are guarded with the pattern already used elsewhere in this repository, but `actionlint` cannot check the behaviour either way.
2. `stage_repo_package` and `publish_repo_package` running for real, including the AWS credentials action and the upload.
3. A refresh against a real repository. The packages built here point at a placeholder URL.
4. The `windows-2022` leg, which was simulated locally rather than run.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
