### PR TITLE
feat(flags): add LLVM_ENABLE_ASSERTIONS build flag, default OFF

### DIFF
--- a/FLAGS.cmake
+++ b/FLAGS.cmake
@@ -94,6 +94,17 @@ therock_declare_flag(
   DESCRIPTION "Emit ROCR-Runtime and rocminfo from core-runtime on Windows"
 )
 
+therock_declare_flag(
+  NAME LLVM_ENABLE_ASSERTIONS
+  DEFAULT_VALUE OFF
+  DESCRIPTION "Build amd-llvm with LLVM assertions enabled. In CI costs roughly 20% more build time overall and up to 35% on device-heavy stages."
+  ISSUE "https://github.com/ROCm/TheRock/pull/6102"
+  CMAKE_VARS
+    LLVM_ENABLE_ASSERTIONS=ON
+  SUB_PROJECTS
+    amd-llvm
+)
+
 ###############################################################################
 # Branch-specific flag overrides.
 # BRANCH_FLAGS.cmake is .gitignored on main but can be committed on


### PR DESCRIPTION
## Motivation

Make LLVM assertions available as an opt-in build flag so integration branches can run CI and PSDB with an assertions-enabled compiler, while `main` and everything that releases from it are unaffected.

Assertions catch compiler defects that are otherwise silent. 
A recent example: an AMDGPU wave32 DWARF CFI bug aborted the build with assertions on, but with them off the same code path quietly emitted a `.cfi_llvm_register_pair` naming DWARF register `-1` — shipping corrupt call-frame information instead of failing. Surfacing that class of bug is the point of the flag.

This PR relates to PR #6102

## Technical Details

- A single addition to `FLAGS.cmake` declaring the flag.
- **Default OFF, and a no-op until enabled.**
- **Per-build override:** `-DTHEROCK_FLAG_LLVM_ENABLE_ASSERTIONS=ON`.
- **Per-branch default via `BRANCH_CONFIG.json`.** The file is gitignored on `main` (`/BRANCH_CONFIG.json`) but can be committed on an integration branch, where `build_tools/topology_to_cmake.py` turns it into a `therock_override_flag_default()` call at configure time.

### Build time cost

Measured in https://github.com/ROCm/TheRock/pull/6102/ on a controlled pair of CI runs carrying identical patches at the same compiler pin and differing only in this flag:
| | Assertions OFF | Assertions ON | Delta |
| --- | --- | --- | --- |
| Aggregate build time | 818.2 min | 984.5 min | +20.3% |
| Linux | | | +20.9% |
| Windows | | | +19.8% |
| Stages compiling device code | | | +15% to +35% |


Worst case was Math Libs `gfx110X-all` at +35%, and the critical path grows by roughly 40 minutes. The compiler binary is also larger and slower, and is ABI-incompatible with a non-assertions build, since `LLVM_ABI_BREAKING_CHECKS` defaults to `WITH_ASSERTS`. The code clang emits for compiles that succeed is unchanged. This cost is why the flag defaults OFF and is opted into per branch rather than enabled globally.

## Test Plan

No-op for `main`, tested on the branch.

## Test Result

No-op for `main, behaved as expected on the branch.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
