### PR TITLE
Apply sysdeps version scripts per meson target, not project-wide

### DIFF
--- a/third-party/sysdeps/linux/libdrm/CMakeLists.txt
+++ b/third-party/sysdeps/linux/libdrm/CMakeLists.txt
@@ -82,11 +82,6 @@ add_custom_target(
     "${CMAKE_COMMAND}" -E chdir "${PATCH_SOURCE_DIR}"
     "${CMAKE_COMMAND}" -E env
       # Escaping hack: experimentally determined to persist through the layers.
-      # Symbol versioning is applied per library target by patch_source.sh, which
-      # adds link_args : ['-Wl,--version-script=...'] to each library(). It must
-      # not be passed project wide: meson duplicates such arguments in its
-      # compiler sanity check (1.12.0) and `ld` then reports
-      # "duplicate version tag `AMDROCM_SYSDEPS_1.0'".
       "LDFLAGS=-Wl,-rpath='$$ORIGIN'"
       "CC=${_meson_cc}"
       "CXX=${_meson_cxx}"

--- a/third-party/sysdeps/linux/libdrm/CMakeLists.txt
+++ b/third-party/sysdeps/linux/libdrm/CMakeLists.txt
@@ -82,7 +82,12 @@ add_custom_target(
     "${CMAKE_COMMAND}" -E chdir "${PATCH_SOURCE_DIR}"
     "${CMAKE_COMMAND}" -E env
       # Escaping hack: experimentally determined to persist through the layers.
-      "LDFLAGS=-Wl,-rpath='$$ORIGIN' -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/version.lds"
+      # Symbol versioning is applied per library target by patch_source.sh, which
+      # adds link_args : ['-Wl,--version-script=...'] to each library(). It must
+      # not be passed project wide: meson duplicates such arguments in its
+      # compiler sanity check (1.12.0) and `ld` then reports
+      # "duplicate version tag `AMDROCM_SYSDEPS_1.0'".
+      "LDFLAGS=-Wl,-rpath='$$ORIGIN'"
       "CC=${_meson_cc}"
       "CXX=${_meson_cxx}"
       --

--- a/third-party/sysdeps/linux/libdrm/patch_source.sh
+++ b/third-party/sysdeps/linux/libdrm/patch_source.sh
@@ -5,8 +5,10 @@
 set -e
 
 SOURCE_DIR="${1:?Source directory must be given}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DRM_MESON_BUILD="$SOURCE_DIR/meson.build"
 AMDGPU_MESON_BUILD="$SOURCE_DIR/amdgpu/meson.build"
+VERSION_LDS="$SCRIPT_DIR/version.lds"
 echo "Patching sources..."
 
 # Replace 'drm' in library() block with 'rocm_sysdeps_drm'
@@ -21,6 +23,20 @@ sed -i -E "/libdrm_amdgpu[[:space:]]*=[[:space:]]*library\(/,/\)/ s/^([[:space:]
 sed -i "/pkg\.generate\s*(/,/)/ s/\blibdrm_amdgpu,\s*//" "$AMDGPU_MESON_BUILD"
 # Add libraries tag to pkg.generate block
 sed -i "/pkg\.generate\s*(/a\  libraries : ['-L\${libdir}', '-ldrm_amdgpu']," $AMDGPU_MESON_BUILD
+
+# Apply symbol versioning to the library targets instead of to the whole project.
+# Passing -Wl,--version-script via LDFLAGS applies it to every link in the
+# project, and meson duplicates such arguments in its compiler sanity check
+# (1.12.0), which ld rejects with "duplicate version tag". Per-target link_args
+# are not duplicated and are the correct scope for a version script anyway.
+sed -i "/^libdrm = library($/,/^)$/ s|^\([[:space:]]*\)install : true,|\1link_args : ['-Wl,--version-script=$VERSION_LDS'],\n\1install : true,|" "$DRM_MESON_BUILD"
+sed -i "/^libdrm_amdgpu = library($/,/^)$/ s|^\([[:space:]]*\)install : true,|\1link_args : ['-Wl,--version-script=$VERSION_LDS'],\n\1install : true,|" "$AMDGPU_MESON_BUILD"
+for meson_build in "$DRM_MESON_BUILD" "$AMDGPU_MESON_BUILD"; do
+  if ! grep -q -- "--version-script" "$meson_build"; then
+    echo "ERROR: Failed to patch $meson_build with --version-script" >&2
+    exit 1
+  fi
+done
 
 # Append missing device IDs to amdgpu.ids
 AMDGPU_IDS="$SOURCE_DIR/data/amdgpu.ids"

--- a/third-party/sysdeps/linux/libpciaccess/CMakeLists.txt
+++ b/third-party/sysdeps/linux/libpciaccess/CMakeLists.txt
@@ -80,8 +80,12 @@ add_custom_target(
     # Run meson from the source directory to avoid this issue.
     "${CMAKE_COMMAND}" -E chdir "${SOURCE_DIR}"
     "${CMAKE_COMMAND}" -E env
-      # Apply symbol versioning via version.lds. RPATH is set post-install via patch_install.py.
-      "LDFLAGS=-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/version.lds"
+      # Symbol versioning is applied per library target by patch_source.sh, which
+      # adds link_args : ['-Wl,--version-script=...'] to the library(). It must
+      # not be passed project wide via LDFLAGS: meson duplicates such arguments
+      # in its compiler sanity check (1.12.0) and `ld` then reports
+      # "duplicate version tag `AMDROCM_SYSDEPS_1.0'".
+      # RPATH is set post-install via patch_install.py.
       "CC=${_meson_cc}"
       "CXX=${_meson_cxx}"
       --

--- a/third-party/sysdeps/linux/libpciaccess/CMakeLists.txt
+++ b/third-party/sysdeps/linux/libpciaccess/CMakeLists.txt
@@ -80,12 +80,6 @@ add_custom_target(
     # Run meson from the source directory to avoid this issue.
     "${CMAKE_COMMAND}" -E chdir "${SOURCE_DIR}"
     "${CMAKE_COMMAND}" -E env
-      # Symbol versioning is applied per library target by patch_source.sh, which
-      # adds link_args : ['-Wl,--version-script=...'] to the library(). It must
-      # not be passed project wide via LDFLAGS: meson duplicates such arguments
-      # in its compiler sanity check (1.12.0) and `ld` then reports
-      # "duplicate version tag `AMDROCM_SYSDEPS_1.0'".
-      # RPATH is set post-install via patch_install.py.
       "CC=${_meson_cc}"
       "CXX=${_meson_cxx}"
       --

--- a/third-party/sysdeps/linux/libpciaccess/patch_source.sh
+++ b/third-party/sysdeps/linux/libpciaccess/patch_source.sh
@@ -5,6 +5,8 @@
 set -e
 
 SOURCE_DIR="${1:?Source directory must be given}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VERSION_LDS="$SCRIPT_DIR/version.lds"
 
 echo "Patching libpciaccess sources to rename main library..."
 
@@ -20,6 +22,19 @@ if [ -f "$SRC_MESON_BUILD" ]; then
   sed -i "s/^  'pciaccess',$/  'rocm_sysdeps_pciaccess',/g" "$SRC_MESON_BUILD"
   # Update dependency declaration
   sed -i 's/link_with : libpciaccess/link_with : librocm_sysdeps_pciaccess/g' "$SRC_MESON_BUILD"
+  # Apply symbol versioning to the library target instead of to the whole
+  # project. Passing -Wl,--version-script via LDFLAGS applies it to every link in
+  # the project, and meson duplicates such arguments in its compiler sanity check
+  # (1.12.0), which ld rejects with "duplicate version tag". Per-target link_args
+  # are not duplicated and are the correct scope for a version script anyway.
+  # This script patches the source tree in place, so only add link_args once.
+  if ! grep -q -- "--version-script" "$SRC_MESON_BUILD"; then
+    sed -i "/^librocm_sysdeps_pciaccess = library($/,/^)$/ s|^\([[:space:]]*\)install : true,|\1link_args : ['-Wl,--version-script=$VERSION_LDS'],\n\1install : true,|" "$SRC_MESON_BUILD"
+  fi
+  if ! grep -q -- "--version-script" "$SRC_MESON_BUILD"; then
+    echo "ERROR: Failed to patch $SRC_MESON_BUILD with --version-script" >&2
+    exit 1
+  fi
 fi
 
 # Patch the root meson.build pkg.generate reference


### PR DESCRIPTION
## Motivation

Fixes #7286

A from-source Linux build with a freshly resolved `requirements.txt` (`meson>=1.7.0`
→ meson 1.12.0) fails in the essential `third-party-sysdeps` group. Both
`therock-libdrm` and `therock-libpciaccess` abort during meson's compiler sanity
check, which blocks every downstream group:

```
meson.build:21:0: ERROR: Compiler /usr/bin/cc cannot compile programs.   # libpciaccess
meson.build:26:0: ERROR: Compiler /usr/bin/cc cannot compile programs.   # libdrm
```

The real error only appears in `meson-logs/meson-log.txt`:

```
/usr/bin/ld: duplicate version tag `AMDROCM_SYSDEPS_1.0'
collect2: error: ld returned 1 exit status
```

CI does not see this because `dockerfiles/build_manylinux_x86_64.Dockerfile`
pre-installs `meson==1.7.0` before `requirements.txt` is processed, so the
`meson>=1.7.0` floor is already satisfied and pip never upgrades.

## Technical Details

**Root cause.** Both sysdeps pass `-Wl,--version-script=<pkg>/version.lds` to meson
via the `LDFLAGS` environment variable, which applies it to *every* link in the
project. meson 1.12.0 duplicates user-supplied link arguments in its compiler sanity
check, and a repeated `--version-script` naming the same tag is one of the few linker
flags that is not idempotent:

```
1.11.2:  cc ... sanity_check_for_c.c -D_FILE_OFFSET_BITS=64 -Wl,--version-script=version.lds
1.12.0:  cc ... sanity_check_for_c.c -D_FILE_OFFSET_BITS=64 -Wl,--version-script=version.lds -Wl,--version-script=version.lds
```

This reproduces with a two-line meson project and no TheRock code involved (see the
minimal reproducer in #7286). 1.12.0 is the newest meson on PyPI, so there is no
fixed release to move to.

**Fix.** Move the version script off the project-wide `LDFLAGS` and onto the
`library()` targets via per-target `link_args`, injected by the `patch_source.sh`
scripts that already rewrite these `meson.build` files to rename the libraries.
meson does not duplicate per-target `link_args`, so the sanity check never sees the
flag. This is also the correct scope independent of the meson bug: a version script
is only meaningful for the shared libraries, not for the tests and helper binaries
that a project-wide `LDFLAGS` also covers.

Changed files:

- `third-party/sysdeps/linux/libdrm/patch_source.sh` — add
  `link_args : ['-Wl,--version-script=...']` to the `libdrm` and `libdrm_amdgpu`
  `library()` calls, then verify the edit applied (mirroring the existing
  `libcap/patch_source.sh` pattern) so a future source bump fails loudly instead of
  silently dropping symbol versioning.
- `third-party/sysdeps/linux/libdrm/CMakeLists.txt` — drop `--version-script` from
  `LDFLAGS`, keeping `-Wl,-rpath='$ORIGIN'`.
- `third-party/sysdeps/linux/libpciaccess/patch_source.sh` — same `link_args`
  injection for the `librocm_sysdeps_pciaccess` target. This script patches the
  source tree in place and can run more than once, so the edit is guarded to be
  idempotent, and is likewise verified.
- `third-party/sysdeps/linux/libpciaccess/CMakeLists.txt` — drop the now-empty
  `LDFLAGS` entirely (RPATH there is applied post-install by `patch_install.py`).

`version.lds` is unchanged in both packages.

**Other meson sysdeps.** `util-linux` already does the right thing — `patch_source.sh`
overwrites `libmount.sym`/`libblkid.sym` and meson wires those in as per-target
`link_args` — and is unaffected. `amd-mesa` still passes `--version-script` through
`LDFLAGS` (`third-party/sysdeps/linux/amd-mesa/CMakeLists.txt`, both `meson setup`
invocations) and has the same latent failure, but it is an optional sysdep behind
`THEROCK_ENABLE_SYSDEPS_AMD_MESA`, builds from the `mesa-fork` submodule, and installs
more shared libraries than the three its `patch_source.sh` renames. I did not include
it here because I could not build-test a mesa change, and shipping an untested version
script move risks silently dropping versioning from an installed library. Tracked as a
follow-up in #7286. The remaining `--version-script` uses under `third-party/sysdeps/`
are autotools/CMake builds and are unaffected by the meson behaviour.

## Test Plan

Built both sysdeps standalone (the sub-project half of each `CMakeLists.txt`, driven
by `cmake` exactly as the superbuild drives it) in a container on Ubuntu 24.04,
gcc 13.3, GNU ld 2.42, against upstream libdrm 2.4.134 and libpciaccess 0.18.1 from
the mirrors in the fetch rules. Four-way matrix, sources re-extracted clean for every
cell:

| | meson 1.11.2 | meson 1.12.0 |
| --- | --- | --- |
| before this change | baseline | expected to fail |
| after this change | must still work | must now pass |

Then, for every produced `.so`:

- `readelf --version-info` — the `AMDROCM_SYSDEPS_1.0` version definition must still
  be present. This is the regression that matters: the fix must not quietly turn
  symbol versioning off.
- The exact set of `<symbol>@@AMDROCM_SYSDEPS_1.0` dynamic symbols, diffed against the
  pre-change meson 1.11.2 baseline.
- `build_tools/validate_shared_library.py`, the check the build already runs via
  `therock_test_validate_shared_lib`.
- `readelf -d` for `RUNPATH`, since `libdrm`'s `LDFLAGS` was edited.

Also checked that `libpciaccess/patch_source.sh` is idempotent (it patches in place),
and that the new verification guard actually fires when the edit does not apply.

## Test Result

Build matrix:

```
### meson versions: 1.12.0 / 1.11.2

########## BEFORE fix, meson 1.12.0 ##########
BUILD FAILED (libdrm/before-112)
meson.build:26:0: ERROR: Compiler /usr/bin/cc cannot compile programs.
BUILD FAILED (libpciaccess/before-112)
meson.build:21:0: ERROR: Compiler /usr/bin/cc cannot compile programs.

########## BEFORE fix, meson 1.11.2 (baseline) ##########
BUILD OK (libdrm/before-1112)
BUILD OK (libpciaccess/before-1112)

########## AFTER fix, meson 1.12.0 ##########
BUILD OK (libdrm/after-112)
BUILD OK (libpciaccess/after-112)

########## AFTER fix, meson 1.11.2 ##########
BUILD OK (libdrm/after-1112)
BUILD OK (libpciaccess/after-1112)
```

The pre-fix 1.12.0 failures are the duplicated flag, from `meson-logs/meson-log.txt`:

```
Sanity check compiler command line: /usr/bin/cc -D_FILE_OFFSET_BITS=64 -o sanity_check_for_c.exe \
  sanity_check_for_c.c -D_FILE_OFFSET_BITS=64 \
  -Wl,--version-script=.../libpciaccess/version.lds \
  -Wl,--version-script=.../libpciaccess/version.lds
...
Sanity check compile stderr:
/usr/bin/ld: duplicate version tag `AMDROCM_SYSDEPS_1.0'
collect2: error: ld returned 1 exit status
```

Symbol versioning after the change, on meson 1.12.0:

```
--- librocm_sysdeps_drm.so.2
Version definition section '.gnu.version_d' contains 2 entries:
  000000: Rev: 1  Flags: BASE  Index: 1  Cnt: 1  Name: librocm_sysdeps_drm.so.2
  0x001c: Rev: 1  Flags: none  Index: 2  Cnt: 1  Name: AMDROCM_SYSDEPS_1.0

--- librocm_sysdeps_drm_amdgpu.so.1
Version definition section '.gnu.version_d' contains 2 entries:
  000000: Rev: 1  Flags: BASE  Index: 1  Cnt: 1  Name: librocm_sysdeps_drm_amdgpu.so.1
  0x001c: Rev: 1  Flags: none  Index: 2  Cnt: 1  Name: AMDROCM_SYSDEPS_1.0

--- librocm_sysdeps_pciaccess.so.0
Version definition section '.gnu.version_d' contains 2 entries:
  000000: Rev: 1  Flags: BASE  Index: 1  Cnt: 1  Name: librocm_sysdeps_pciaccess.so.0
  0x001c: Rev: 1  Flags: none  Index: 2  Cnt: 1  Name: AMDROCM_SYSDEPS_1.0
```

The versioned symbol sets are byte-identical to the pre-change meson 1.11.2 baseline —
no symbol gained or lost versioning:

```
after/1.12.0  librocm_sysdeps_drm.so.2:          212 versioned syms, diff vs baseline: 0 lines
after/1.12.0  librocm_sysdeps_drm_amdgpu.so.1:    92 versioned syms, diff vs baseline: 0 lines
after/1.12.0  librocm_sysdeps_pciaccess.so.0:     58 versioned syms, diff vs baseline: 0 lines
after/1.11.2  librocm_sysdeps_drm.so.2:          212 versioned syms, diff vs baseline: 0 lines
after/1.11.2  librocm_sysdeps_drm_amdgpu.so.1:    92 versioned syms, diff vs baseline: 0 lines
after/1.11.2  librocm_sysdeps_pciaccess.so.0:     58 versioned syms, diff vs baseline: 0 lines
```

`build_tools/validate_shared_library.py`, RPATH, idempotency, and the new guard:

```
PASS librocm_sysdeps_drm.so.2
PASS librocm_sysdeps_drm_amdgpu.so.1
PASS librocm_sysdeps_pciaccess.so.0

librocm_sysdeps_drm.so.2:         RUNPATH [$ORIGIN]
librocm_sysdeps_drm_amdgpu.so.1:  RUNPATH [$ORIGIN]
librocm_sysdeps_pciaccess.so.0:   RUNPATH [$ORIGIN:$ORIGIN/rocm_sysdeps/lib]

libpciaccess patch_source.sh run 3x on the same tree ->
  link_args occurrences in src/meson.build: 1
  incremental rebuild after re-patch: ninja: no work to do.

patch_source.sh against a tree it cannot patch ->
  ERROR: Failed to patch /tmp/faketree/meson.build with --version-script  (exit 1)
```

## Notes on AI assistance

Per the AI tool use policy in `CONTRIBUTING.md`: the investigation in #7286, this
change, and this description were produced with AI assistance (Claude Code). I ran and
verified every result quoted above — the four-way build matrix, the `readelf` symbol
versioning check, the symbol-set diff against the pre-change baseline, and the
idempotency and guard checks. I am the author and am accountable for the change and
can answer questions about it in review.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
