### PR TITLE
ci(hipthreads): Disable hipthreads packaging for the current ROCm release

### DIFF
--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -384,8 +384,10 @@ def _run_kpack_split(
             "nlohmann-json",
             # rocshmem only provides a static library.
             "rocshmem",
-            # hipthreads only provides a static library.
-            "hipthreads",
+            # hipthreads is disabled for current ROCm release and will be
+            # reintroduced in one of the later releases (TheRock#7292). It only
+            # provides a static library.
+            # "hipthreads",
             # rocjitsu emulation suite.
             "rocjitsu",
             "mirage",

--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -3539,80 +3539,6 @@
   },
 
   {
-    "Package": "amdrocm-threads",
-    "Version": "",
-    "Architecture": "amd64",
-    "BuildArch": "x86_64",
-    "DEBDepends": [
-      "amdrocm-runtime",
-      "amdrocm-sysdeps"
-    ],
-    "RPMRequires": [
-      "amdrocm-runtime",
-      "amdrocm-sysdeps"
-    ],
-    "Maintainer": "hipThreads Maintainer <hipthreads-ci@amd.com>",
-    "Description_Short": "AMD ROCm hipThreads library development files",
-    "Description_Long": "hipThreads provides std::thread-like concurrency primitives that run on AMD GPUs (headers, static library, and CMake package config)",
-    "Section": "devel",
-    "Priority": "optional",
-    "Group": "unknown",
-    "License": "MIT",
-    "Vendor": "Advanced Micro Devices, Inc",
-    "Homepage": "https://github.com/ROCm/rocm-libraries",
-    "Artifactory": [
-      {
-        "Artifact": "hipthreads",
-        "Artifact_Subdir": [
-          {
-            "Name": "hipthreads",
-            "Components": [
-              "dev"
-            ]
-          }
-        ]
-      }
-    ],
-    "Gfxarch": "False"
-  },
-
-  {
-    "Package": "amdrocm-threads-test",
-    "Version": "",
-    "Architecture": "amd64",
-    "BuildArch": "x86_64",
-    "DEBDepends": [
-      "amdrocm-threads"
-    ],
-    "RPMRequires": [
-      "amdrocm-threads"
-    ],
-    "Maintainer": "hipThreads Maintainer <hipthreads-ci@amd.com>",
-    "Description_Short": "AMD ROCm hipThreads library tests",
-    "Description_Long": "Test suite and example sources for the hipThreads library",
-    "Section": "devel",
-    "Priority": "optional",
-    "Group": "unknown",
-    "License": "MIT",
-    "Vendor": "Advanced Micro Devices, Inc",
-    "Homepage": "https://github.com/ROCm/rocm-libraries",
-    "Artifactory": [
-      {
-        "Artifact": "hipthreads",
-        "Artifact_Subdir": [
-          {
-            "Name": "hipthreads",
-            "Components": [
-              "test"
-            ]
-          }
-        ]
-      }
-    ],
-    "Gfxarch": "False"
-  },
-
-  {
     "Comments": "Meta Package defintions start from here. There will not be any artifactory for meta packages.",
     "Package": "amdrocm-core",
     "Version": "",
@@ -3801,7 +3727,6 @@
       "amdrocm-hipfile-devel",
       "amdrocm-decode-devel",
       "amdrocm-jpeg-devel",
-      "amdrocm-threads",
       "amdrocm-rpp-devel"
     ],
     "RPMRequires": [
@@ -3822,7 +3747,6 @@
       "amdrocm-hipfile-devel",
       "amdrocm-decode-devel",
       "amdrocm-jpeg-devel",
-      "amdrocm-threads",
       "amdrocm-rpp-devel"
     ],
     "Maintainer": "ROCm Dev Support <rocm-dev.support@amd.com>",


### PR DESCRIPTION
hipThreads is being reverted from the current ROCm release and will be reintroduced in a later one, so it must not ship in the packages.

Disables packaging only, the build and CI stay enabled on main, which was confirmed fine for nightlies and the BKC drops.

Re-enabling is a revert of this PR.

Closes #7292
Related: #7181 (libhipcxx disablement)