### PR TITLE
docs: fix two broken repo-relative links

### DIFF
--- a/docs/development/github_actions_debugging.md
+++ b/docs/development/github_actions_debugging.md
@@ -186,7 +186,7 @@ pipeline can take several hours sharded across multiple types of build and test
 machines.
 
 The [`.github/workflows/build_windows_python_packages.yml`](/.github/workflows/build_windows_python_packages.yml)
-and [`.github/workflows/build_portable_linux_python_packages.yml`](.github/workflows/build_portable_linux_python_packages.yml)
+and [`.github/workflows/build_portable_linux_python_packages.yml`](/.github/workflows/build_portable_linux_python_packages.yml)
 workflows are both runnable from personal repository forks. By default they
 download artifacts from a recent workflow run in the https://github.com/ROCm/TheRock
 repository. You can customize where artifacts are downloaded from by setting

--- a/tests/extended_tests/benchmark/README.md
+++ b/tests/extended_tests/benchmark/README.md
@@ -77,7 +77,7 @@ The following benchmark tests are defined in `tests/extended_tests/benchmark/ben
 | `gfx90x`   | Linux    | MI200 (CDNA2)         | Yes                 | Not enabled          |
 | `gfx1151`  | Linux    | RDNA 3.5              | Yes                 | Not enabled          |
 
-> **Note:** All benchmarks are **architecture-agnostic** and support any ROCm-compatible GPU. The table above lists GPU families actively used in CI testing. To add support for additional GPU families, update [`amdgpu_family_matrix.py`](../amdgpu_family_matrix.py) with appropriate `benchmark-runs-on` runners.
+> **Note:** All benchmarks are **architecture-agnostic** and support any ROCm-compatible GPU. The table above lists GPU families actively used in CI testing. To add support for additional GPU families, update [`amdgpu_family_matrix.py`](/build_tools/github_actions/amdgpu_family_matrix.py) with appropriate `benchmark-runs-on` runners.
 
 ## Architecture
 


### PR DESCRIPTION
## Motivation

Two markdown links are written repo-relative but render directory-relative, so both 404 on github.com.

## Technical Details

- `docs/development/github_actions_debugging.md:189` — the correct form is on the line immediately above, in the same sentence: the sibling `build_windows_python_packages.yml` link already carries a leading `/`, this one does not.
- `tests/extended_tests/benchmark/README.md:80` — `../amdgpu_family_matrix.py` resolves to `tests/extended_tests/amdgpu_family_matrix.py`, which is not tracked; the file is at `build_tools/github_actions/amdgpu_family_matrix.py`.

## Test Plan

Documentation only. Every repo-relative markdown link in the tree was resolved against `git ls-files`: 395 link targets across 81 markdown files, 6 broken.

## Test Result

All 6, and what happens to each:

| Path | Fate |
| --- | --- |
| `docs/development/github_actions_debugging.md:189` | fixed here |
| `tests/extended_tests/benchmark/README.md:80` | fixed here |
| `docs/development/README.md:24` → `test_runner_info.md` | already removed by #7253 |
| `docs/development/workflow_outputs.md:305` | left alone, open pull requests touch this file |
| `external-builds/pytorch/README.md:199` | left alone, open pull requests touch this file |
| `build_tools/third_party/implib/doc/ReduceLibraryInterface.md:32` | vendored upstream, not yours to fix |

`pre-commit run` passes on both edited files for the `mdformat`, `mixed-line-ending`, `end-of-file-fixer` and `trailing-whitespace` hooks. I did not run `pre-commit run --all-files`.

Happy to contribute the link checker as a pre-commit hook if you would rather prevent the class than fix the instances.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
