### PR TITLE
fix(ci): regenerate consumer graph for kfdtest edges

### DIFF
--- a/test_tools/therock_consumer_graph.json
+++ b/test_tools/therock_consumer_graph.json
@@ -25,6 +25,7 @@
       "hipcc",
       "hipify",
       "hipthreads",
+      "kfdtest",
       "libhipcxx",
       "ocl-clr",
       "rdc",
@@ -211,6 +212,9 @@
     "consumers": []
   },
   "hipthreads": {
+    "consumers": []
+  },
+  "kfdtest": {
     "consumers": []
   },
   "libhipcxx": {
@@ -450,6 +454,7 @@
     "consumers": [
       "aqlprofile",
       "hip-clr",
+      "kfdtest",
       "ocl-clr",
       "rdc",
       "rocminfo",
@@ -698,6 +703,7 @@
     "consumers": [
       "amd-llvm",
       "amdsmi",
+      "kfdtest",
       "rocdecode",
       "rocjitsu",
       "rocjpeg",
@@ -771,6 +777,7 @@
     "consumers": [
       "amd-llvm",
       "hip-tests",
+      "kfdtest",
       "rocr-runtime",
       "rocrtst",
       "rocshmem",
@@ -814,6 +821,7 @@
   "therock-yaml-cpp": {
     "consumers": [
       "hipblaslt",
+      "kfdtest",
       "rocprofiler-sdk",
       "rocroller",
       "rocrtst"
@@ -822,6 +830,7 @@
   "therock-zlib": {
     "consumers": [
       "amd-llvm",
+      "kfdtest",
       "rdc",
       "rocgdb",
       "rocr-runtime",
@@ -833,6 +842,7 @@
     "consumers": [
       "amd-comgr",
       "amd-llvm",
+      "kfdtest",
       "rocgdb",
       "rocm-kpack",
       "rocr-runtime",


### PR DESCRIPTION
## Motivation

kfdtest was added as a subproject in #6334, but the committed consumer graph was never regenerated. The drift check compares the whole file, so any PR touching a graph-affecting path either fails it or has to carry these lines in an unrelated diff.

GitHub issue: https://github.com/ROCm/TheRock/issues/7298

## Technical Details

Regenerated `test_tools/therock_consumer_graph.json` with `check_consumer_graph_drift.py --write`. No other files change.

The diff is the kfdtest node plus its seven reverse edges from `core/CMakeLists.txt`: `amd-llvm`, `rocr-runtime`, `therock-libdrm`, `therock-numactl`, `therock-yaml-cpp`, `therock-zlib`, `therock-zstd`.

No behavior change. Selection can now emit `kfdtest`, but there is no `kfdtest` key in `fetch_test_configurations.py`, so no job is scheduled.

## Test Plan

Drift check, policy validation, selection unit tests, pre-commit.

## Test Result

- `--validate-policies`: OK, 18 component keys against 116 graph nodes
- `determine_rocm_test_dependencies_test.py`: 49 passed
- pre-commit: passed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.