### PR TITLE
docs(readme): warn about disk space and build time for source builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ Multi-arch releases (all GPU architectures):
 
 ## Building from source
 
+> [!WARNING]
+> **Disk Space Requirement:** Building from source requires approximately 200 GB of free disk space. Builds will fail if you run out of space mid-compilation.
+
 We keep the following instructions for recent, commonly used operating system
 versions. Most build failures are due to minor operating system differences in
 dependencies and project setup. Refer to the

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Multi-arch releases (all GPU architectures):
 ## Building from source
 
 > [!WARNING]
-> **Disk Space Requirement:** Building from source requires approximately 200 GB of free disk space. Builds will fail if you run out of space mid-compilation.
+> **Disk Space and Build Time Requirements:** Building from source requires approximately 200 GB of free disk space and can take multiple hours to compile. Builds will fail if you run out of space.
 
 We keep the following instructions for recent, commonly used operating system
 versions. Most build failures are due to minor operating system differences in


### PR DESCRIPTION
## Motivation
Opened on behalf of @amd1890

Closes #6500. Makes the source-build disk space (~200 GB) and build-time requirement visible up front in the README, where users see it before starting.

## Technical Details

Adds a `[!WARNING]` at the top of "Building from source".

## Test Plan

Docs-only.

## Test Result

N/A.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
