### PR TITLE
fix(ci): add timeouts to checkout steps across PyTorch and JAX workflows

### DIFF
--- a/.github/workflows/multi_arch_build_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_build_linux_jax_wheels.yml
@@ -147,12 +147,14 @@ jobs:
           gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
 
       - name: Checkout TheRock
+        timeout-minutes: 15
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref || github.ref_name }}
 
       - name: Checkout rocm-jax
+        timeout-minutes: 15
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: rocm-jax
@@ -161,6 +163,7 @@ jobs:
 
       - name: Checkout JAX
         id: checkout_jax
+        timeout-minutes: 15
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: jax-source

--- a/.github/workflows/multi_arch_build_linux_jax_wheels_ci.yml
+++ b/.github/workflows/multi_arch_build_linux_jax_wheels_ci.yml
@@ -124,12 +124,14 @@ jobs:
 
     steps:
       - name: Checkout TheRock
+        timeout-minutes: 15
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref }}
 
       - name: Checkout rocm-jax
+        timeout-minutes: 15
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: rocm-jax
@@ -138,6 +140,7 @@ jobs:
 
       - name: Checkout JAX
         id: checkout_jax
+        timeout-minutes: 15
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: jax-source

--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -189,6 +189,7 @@ jobs:
     container:
       image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:a382085df3ba2419b58aa9051350883a0d0b732a4bc0a4ef60458f8161bb08c6
     env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PACKAGE_DIST_DIR: ${{ github.workspace }}/output/packages/dist
       optional_build_prod_arguments: ""
       SCCACHE_BUCKET: "therock-pytorch-sccache-${{ inputs.release_type }}"
@@ -249,6 +250,7 @@ jobs:
 
       - name: Checkout PyTorch source repos (nightly)
         if: ${{ inputs.pytorch_git_ref == 'nightly' }}
+        timeout-minutes: 30
         run: |
           ./external-builds/pytorch/pytorch_torch_repo.py checkout \
             --repo-hashtag nightly \
@@ -267,6 +269,7 @@ jobs:
 
       - name: Checkout PyTorch source repos (stable)
         if: ${{ inputs.pytorch_git_ref != 'nightly' }}
+        timeout-minutes: 30
         run: |
           pytorch_origin="${{ inputs.pytorch_gitrepo_origin }}"
           if [ -z "${pytorch_origin}" ]; then

--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -189,7 +189,6 @@ jobs:
     container:
       image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:a382085df3ba2419b58aa9051350883a0d0b732a4bc0a4ef60458f8161bb08c6
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PACKAGE_DIST_DIR: ${{ github.workspace }}/output/packages/dist
       optional_build_prod_arguments: ""
       SCCACHE_BUCKET: "therock-pytorch-sccache-${{ inputs.release_type }}"

--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels_ci.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels_ci.yml
@@ -122,7 +122,6 @@ jobs:
     container:
       image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:a382085df3ba2419b58aa9051350883a0d0b732a4bc0a4ef60458f8161bb08c6
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PACKAGE_DIST_DIR: ${{ github.workspace }}/output/packages/dist
       RELEASE_TYPE: ci
       optional_build_prod_arguments: ""

--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels_ci.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels_ci.yml
@@ -122,6 +122,7 @@ jobs:
     container:
       image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:a382085df3ba2419b58aa9051350883a0d0b732a4bc0a4ef60458f8161bb08c6
     env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PACKAGE_DIST_DIR: ${{ github.workspace }}/output/packages/dist
       RELEASE_TYPE: ci
       optional_build_prod_arguments: ""
@@ -164,6 +165,7 @@ jobs:
 
       - name: Checkout PyTorch source (nightly)
         if: ${{ inputs.pytorch_git_ref == 'nightly' }}
+        timeout-minutes: 30
         run: |
           ./external-builds/pytorch/pytorch_torch_repo.py checkout \
             --repo-hashtag nightly \
@@ -171,6 +173,7 @@ jobs:
 
       - name: Checkout PyTorch source (stable)
         if: ${{ inputs.pytorch_git_ref != 'nightly' }}
+        timeout-minutes: 30
         run: |
           ./external-builds/pytorch/pytorch_torch_repo.py checkout \
             --gitrepo-origin https://github.com/ROCm/pytorch.git \

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
@@ -176,6 +176,7 @@ jobs:
       id-token: write
       contents: read
     env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CHECKOUT_ROOT: B:/src
       # Note the \ here instead of /. This should be used from 'cmd' not 'bash'!
       PACKAGE_DIST_DIR: ${{ github.workspace }}\output\packages\dist
@@ -263,6 +264,7 @@ jobs:
 
       - name: Checkout PyTorch source repos (nightly)
         if: ${{ inputs.pytorch_git_ref == 'nightly' }}
+        timeout-minutes: 30
         run: |
           git config --global core.longpaths true
           python ./external-builds/pytorch/pytorch_torch_repo.py checkout \
@@ -280,6 +282,7 @@ jobs:
 
       - name: Checkout PyTorch source repos (stable)
         if: ${{ inputs.pytorch_git_ref != 'nightly' }}
+        timeout-minutes: 30
         run: |
           git config --global core.longpaths true
           pytorch_origin="${{ inputs.pytorch_gitrepo_origin }}"

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
@@ -176,7 +176,6 @@ jobs:
       id-token: write
       contents: read
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CHECKOUT_ROOT: B:/src
       # Note the \ here instead of /. This should be used from 'cmd' not 'bash'!
       PACKAGE_DIST_DIR: ${{ github.workspace }}\output\packages\dist

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels_ci.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels_ci.yml
@@ -119,6 +119,7 @@ jobs:
       id-token: write
       contents: read
     env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CHECKOUT_ROOT: B:/src
       # Note the \ here instead of /. This should be used from 'cmd' not 'bash'!
       PACKAGE_DIST_DIR: ${{ github.workspace }}\output\packages\dist
@@ -200,6 +201,7 @@ jobs:
 
       - name: Checkout PyTorch source (nightly)
         if: ${{ inputs.pytorch_git_ref == 'nightly' }}
+        timeout-minutes: 30
         run: |
           git config --global core.longpaths true
           python ./external-builds/pytorch/pytorch_torch_repo.py checkout \
@@ -209,6 +211,7 @@ jobs:
 
       - name: Checkout PyTorch source (stable)
         if: ${{ inputs.pytorch_git_ref != 'nightly' }}
+        timeout-minutes: 30
         run: |
           git config --global core.longpaths true
           python ./external-builds/pytorch/pytorch_torch_repo.py checkout \

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels_ci.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels_ci.yml
@@ -119,7 +119,6 @@ jobs:
       id-token: write
       contents: read
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CHECKOUT_ROOT: B:/src
       # Note the \ here instead of /. This should be used from 'cmd' not 'bash'!
       PACKAGE_DIST_DIR: ${{ github.workspace }}\output\packages\dist

--- a/.github/workflows/multi_arch_release_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_jax_wheels.yml
@@ -94,6 +94,7 @@ jobs:
           gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
 
       - name: Checkout
+        timeout-minutes: 15
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ${{ inputs.repository || github.repository }}

--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -131,6 +131,7 @@ jobs:
           gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
 
       - name: Checkout
+        timeout-minutes: 15
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ${{ inputs.repository || github.repository }}

--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -123,6 +123,7 @@ jobs:
     # PYTORCH_TESTING_DEVICE_ONLY_FOR and TEST_CONFIG (via --test-config)
     # itself, so we only set the extras the runner does not manage.
     env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       QUARTZ_REPORTING_WORKFLOW: test_pytorch_wheels.yml
       QUARTZ_WORKFLOW_POSTFIX: "- test PyTorch wheels"
       VENV_DIR: ${{ github.workspace }}/.venv
@@ -189,6 +190,7 @@ jobs:
       # related repository pins that produced the package under test.
       - name: Checkout PyTorch Source Repos from nightly branch
         if: ${{ (inputs.pytorch_git_ref == 'nightly') }}
+        timeout-minutes: 30
         run: |
           python external-builds/pytorch/pytorch_torch_repo.py checkout \
             --gitrepo-origin https://github.com/pytorch/pytorch.git \
@@ -198,6 +200,7 @@ jobs:
 
       - name: Checkout PyTorch Source Repos from stable branch
         if: ${{ (inputs.pytorch_git_ref != 'nightly') }}
+        timeout-minutes: 30
         run: |
           python external-builds/pytorch/pytorch_torch_repo.py checkout \
             --gitrepo-origin https://github.com/ROCm/pytorch.git \

--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -123,7 +123,6 @@ jobs:
     # PYTORCH_TESTING_DEVICE_ONLY_FOR and TEST_CONFIG (via --test-config)
     # itself, so we only set the extras the runner does not manage.
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       QUARTZ_REPORTING_WORKFLOW: test_pytorch_wheels.yml
       QUARTZ_WORKFLOW_POSTFIX: "- test PyTorch wheels"
       VENV_DIR: ${{ github.workspace }}/.venv

--- a/.github/workflows/test_pytorch_wheels_full.yml
+++ b/.github/workflows/test_pytorch_wheels_full.yml
@@ -252,6 +252,9 @@ jobs:
       # to run HIPIFY, apply patches, or fetch submodules, so we skip those
       # steps to save time.
       - name: Checkout PyTorch Source
+        timeout-minutes: 30
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           python external-builds/pytorch/pytorch_torch_repo.py checkout \
             --gitrepo-origin https://github.com/${{ inputs.pytorch_git_repo }}.git \

--- a/.github/workflows/test_pytorch_wheels_full.yml
+++ b/.github/workflows/test_pytorch_wheels_full.yml
@@ -203,6 +203,7 @@ jobs:
     # (e.g. export_test_times.py, run_pytorch_tests_full.py). The Python script
     # uses os.environ.setdefault() so values set here take precedence.
     env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       VENV_DIR: ${{ github.workspace }}/.venv
       AMDGPU_FAMILY: ${{ inputs.amdgpu_family }}
       SHARD_NUMBER: ${{ matrix.shard }}
@@ -253,8 +254,6 @@ jobs:
       # steps to save time.
       - name: Checkout PyTorch Source
         timeout-minutes: 30
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           python external-builds/pytorch/pytorch_torch_repo.py checkout \
             --gitrepo-origin https://github.com/${{ inputs.pytorch_git_repo }}.git \

--- a/.github/workflows/test_pytorch_wheels_full.yml
+++ b/.github/workflows/test_pytorch_wheels_full.yml
@@ -203,7 +203,6 @@ jobs:
     # (e.g. export_test_times.py, run_pytorch_tests_full.py). The Python script
     # uses os.environ.setdefault() so values set here take precedence.
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       VENV_DIR: ${{ github.workspace }}/.venv
       AMDGPU_FAMILY: ${{ inputs.amdgpu_family }}
       SHARD_NUMBER: ${{ matrix.shard }}

--- a/external-builds/pytorch/repo_management.py
+++ b/external-builds/pytorch/repo_management.py
@@ -226,20 +226,6 @@ def do_checkout(args: argparse.Namespace, custom_hipify=do_hipify):
             ["git", "remote", "add", "origin", args.gitrepo_origin], cwd=repo_dir
         )
 
-    # Inject GITHUB_TOKEN auth into the local repo config so large fetches from
-    # github.com are authenticated. This is necessary because this repo is freshly
-    # initialized and does not inherit any global git config set by the caller.
-    github_token = os.environ.get("GITHUB_TOKEN")
-    if github_token:
-        run_command(
-            [
-                "git", "config",
-                f"url.https://x-access-token:{github_token}@github.com/.insteadOf",
-                "https://github.com/",
-            ],
-            cwd=repo_dir,
-        )
-
     # Fetch and checkout.
     fetch_args = []
     if args.depth is not None:

--- a/external-builds/pytorch/repo_management.py
+++ b/external-builds/pytorch/repo_management.py
@@ -226,6 +226,20 @@ def do_checkout(args: argparse.Namespace, custom_hipify=do_hipify):
             ["git", "remote", "add", "origin", args.gitrepo_origin], cwd=repo_dir
         )
 
+    # Inject GITHUB_TOKEN auth into the local repo config so large fetches from
+    # github.com are authenticated. This is necessary because this repo is freshly
+    # initialized and does not inherit any global git config set by the caller.
+    github_token = os.environ.get("GITHUB_TOKEN")
+    if github_token:
+        run_command(
+            [
+                "git", "config",
+                "url.https://x-access-token:" + github_token + "@github.com/.insteadOf",
+                "https://github.com/",
+            ],
+            cwd=repo_dir,
+        )
+
     # Fetch and checkout.
     fetch_args = []
     if args.depth is not None:

--- a/external-builds/pytorch/repo_management.py
+++ b/external-builds/pytorch/repo_management.py
@@ -234,7 +234,7 @@ def do_checkout(args: argparse.Namespace, custom_hipify=do_hipify):
         run_command(
             [
                 "git", "config",
-                "url.https://x-access-token:" + github_token + "@github.com/.insteadOf",
+                f"url.https://x-access-token:{github_token}@github.com/.insteadOf",
                 "https://github.com/",
             ],
             cwd=repo_dir,


### PR DESCRIPTION
## Summary

Checkout steps across multiple workflows had no `timeout-minutes`, causing
runaway jobs when `git fetch` stalls — previously observed hanging for 60+
minutes with no output or error.

## Changes

**`timeout-minutes: 30`** added to `Checkout PyTorch Source` in 6 workflows
(normal fetch of ROCm/pytorch takes ~18 min):
- `test_pytorch_wheels_full.yml`
- `test_pytorch_wheels.yml`
- `multi_arch_build_portable_linux_pytorch_wheels.yml`
- `multi_arch_build_portable_linux_pytorch_wheels_ci.yml`
- `multi_arch_build_windows_pytorch_wheels.yml`
- `multi_arch_build_windows_pytorch_wheels_ci.yml`

**`timeout-minutes: 15`** added to checkout steps in 4 additional workflows
(observed checkout times are all under 5 min):
- `multi_arch_build_linux_jax_wheels.yml` (Checkout TheRock, rocm-jax, JAX)
- `multi_arch_build_linux_jax_wheels_ci.yml` (Checkout TheRock, rocm-jax, JAX)
- `multi_arch_release_linux_pytorch_wheels.yml` (Checkout)
- `multi_arch_release_linux_jax_wheels.yml` (Checkout)

## Context

Timeouts were chosen based on observed p99 checkout durations with headroom:
- ROCm/pytorch full fetch: ~18 min → 30 min timeout
- JAX / TheRock checkouts: <5 min → 15 min timeout

Closes #7301