### PR TITLE
build_tools: per-submodule CI labels and test:rocgdb group alias

### DIFF
--- a/build_tools/github_actions/bump_automation.py
+++ b/build_tools/github_actions/bump_automation.py
@@ -38,6 +38,10 @@ SUBMODULE_CONFIG = {
         "files": ROCM_SYSTEMS_FILES,
         "updater": "ref",
         "token_key": "systems",
+        # Changes to rocm-systems should run the full matrix of CI jobs:
+        #   * Build for all gfx archs
+        #   * Build for all variants (asan)
+        #   * All builds and tests (including downstream rocm-libraries jobs)
         "labels": [*COMMON_CI_LABELS, "ci:asan"],
     },
     "rocm-libraries": {
@@ -45,6 +49,10 @@ SUBMODULE_CONFIG = {
         "files": ROCM_LIBRARIES_FILES,
         "updater": "ci-env",
         "token_key": "libraries",
+        # Changes to rocm-libraries should run the full matrix of CI jobs:
+        #   * Build for all gfx archs
+        #   * Build for all variants (asan)
+        #   * All rocm-libraries tests
         "labels": [*COMMON_CI_LABELS, "ci:asan"],
     },
     "debug-tools/rocgdb/source": {
@@ -54,6 +62,9 @@ SUBMODULE_CONFIG = {
         # We will reuse the rocm-systems token for now.
         "token_key": "systems",
         "branch": "amd-staging-rocgdb-16",
+        # Changes to rocgdb can run a limited matrix of CI jobs:
+        #   * Build for all gfx archs
+        #   * rocgdb tests only (no impact on other project builds/tests)
         "labels": [*COMMON_CI_LABELS, "test:rocgdb"],
     },
     "third-party/sysdeps/linux/amd-mesa/mesa-fork": {

--- a/build_tools/github_actions/bump_automation.py
+++ b/build_tools/github_actions/bump_automation.py
@@ -16,7 +16,7 @@ THEROCK_MAIN_BRANCH = "main"
 BOT_NAME = "therockbot"
 BOT_EMAIL = "therockbot@amd.com"
 
-CI_LABELS = ["ci:run-all-archs", "ci:asan"]
+COMMON_CI_LABELS = ["ci:run-all-archs"]
 
 ROCM_SYSTEMS_FILES = [
     ".github/workflows/therock-ci-linux.yml",
@@ -38,12 +38,14 @@ SUBMODULE_CONFIG = {
         "files": ROCM_SYSTEMS_FILES,
         "updater": "ref",
         "token_key": "systems",
+        "labels": [*COMMON_CI_LABELS, "ci:asan"],
     },
     "rocm-libraries": {
         "repo": "ROCm/rocm-libraries",
         "files": ROCM_LIBRARIES_FILES,
         "updater": "ci-env",
         "token_key": "libraries",
+        "labels": [*COMMON_CI_LABELS, "ci:asan"],
     },
     "debug-tools/rocgdb/source": {
         "repo": "ROCm/rocgdb",
@@ -52,6 +54,7 @@ SUBMODULE_CONFIG = {
         # We will reuse the rocm-systems token for now.
         "token_key": "systems",
         "branch": "amd-staging-rocgdb-16",
+        "labels": [*COMMON_CI_LABELS, "test:rocgdb"],
     },
     "third-party/sysdeps/linux/amd-mesa/mesa-fork": {
         "repo": "ROCm/mesa-fork",
@@ -349,7 +352,7 @@ def create_therock_bump(submodule: str, token: str) -> None:
                 token,
                 f"repos/{THEROCK_REPO}/issues/{pr['number']}/labels",
                 method="POST",
-                data={"labels": CI_LABELS},
+                data={"labels": config["labels"]},
             )
         except RuntimeError as e:
             print(f"[WARN] Failed to apply CI labels to PR #{pr['number']}: {e}")

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -41,6 +41,13 @@ logging.basicConfig(level=logging.INFO)
 # more explicit, or use absolute paths.
 SCRIPT_DIR = Path("./build_tools/github_actions/test_executable_scripts")
 
+# Maps a group label (the part after "test:") to the individual test matrix
+# keys it expands to. Use this when a single label should select multiple
+# related jobs without relying on name-prefix inference.
+TEST_LABEL_GROUPS: dict[str, list[str]] = {
+    "rocgdb": ["rocgdb-cpu", "rocgdb-gpu"],
+}
+
 
 def _get_script_path(script_name: str) -> str:
     platform_path = SCRIPT_DIR / script_name
@@ -972,7 +979,12 @@ def run():
         # If test labels are populated, and the test job name is not in the test labels, skip the test
         # Note: Benchmarks never use test_labels (always empty list)
         parsed_test_labels = [c.split("test:")[-1] for c in test_labels]
-        if key != "sanity" and parsed_test_labels and key not in parsed_test_labels:
+        expanded_test_labels = [
+            member
+            for label in parsed_test_labels
+            for member in TEST_LABEL_GROUPS.get(label, [label])
+        ]
+        if key != "sanity" and expanded_test_labels and key not in expanded_test_labels:
             logging.info(f"Excluding job {job_name} since it's not in the test labels")
             continue
 

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -45,7 +45,7 @@ SCRIPT_DIR = Path("./build_tools/github_actions/test_executable_scripts")
 # keys it expands to. Use this when a single label should select multiple
 # related jobs without relying on name-prefix inference.
 TEST_LABEL_GROUPS: dict[str, list[str]] = {
-    "rocgdb": ["rocgdb-cpu", "rocgdb-gpu"],
+    "rocgdb": ["rocgdb-cpu", "rocgdb-gpu", "rocgdb-corefile"],
 }
 
 

--- a/build_tools/github_actions/tests/fetch_test_configurations_test.py
+++ b/build_tools/github_actions/tests/fetch_test_configurations_test.py
@@ -546,6 +546,69 @@ class FetchTestConfigurationsTest(unittest.TestCase):
         hipblas = next(j for j in components if j["job_name"] == "hipblas")
         self.assertEqual(hipblas["test_runner"], "linux-gfx942-default")
 
+    # -----------------------
+    # TEST_LABEL_GROUPS expansion
+    # -----------------------
+
+    def test_all_rocgdb_label_selects_cpu_and_gpu_jobs(self):
+        """test:rocgdb should expand to both rocgdb-cpu and rocgdb-gpu."""
+        os.environ["TEST_LABELS"] = json.dumps(["test:rocgdb"])
+
+        fetch_test_configurations.run()
+        components = self._get_components()
+
+        names = {job["job_name"] for job in components}
+        self.assertIn("rocgdb-cpu", names)
+        self.assertIn("rocgdb-gpu", names)
+
+    def test_all_rocgdb_label_excludes_unrelated_jobs(self):
+        """test:rocgdb should not include jobs outside the rocgdb group."""
+        os.environ["TEST_LABELS"] = json.dumps(["test:rocgdb"])
+
+        fetch_test_configurations.run()
+        components = self._get_components()
+
+        names = {job["job_name"] for job in components}
+        self.assertNotIn("rocblas", names)
+        self.assertNotIn("hipblas", names)
+
+    def test_group_label_and_individual_label_combine(self):
+        """A group label and a plain label together should union their jobs."""
+        os.environ["TEST_LABELS"] = json.dumps(["test:rocgdb", "test:rocblas"])
+
+        fetch_test_configurations.run()
+        components = self._get_components()
+
+        names = {job["job_name"] for job in components}
+        self.assertIn("rocgdb-cpu", names)
+        self.assertIn("rocgdb-gpu", names)
+        self.assertIn("rocblas", names)
+
+    def test_unknown_group_label_is_treated_as_literal(self):
+        """A test: label not in TEST_LABEL_GROUPS should fall through as a literal key."""
+        os.environ["TEST_LABELS"] = json.dumps(["test:rocblas"])
+
+        fetch_test_configurations.run()
+        components = self._get_components()
+
+        names = {job["job_name"] for job in components}
+        self.assertIn("rocblas", names)
+        self.assertNotIn("rocgdb-cpu", names)
+        self.assertNotIn("rocgdb-gpu", names)
+
+    def test_group_label_and_individual_member_label_do_not_duplicate(self):
+        """Passing test:rocgdb alongside an explicit member label should not produce duplicate jobs."""
+        os.environ["TEST_LABELS"] = json.dumps(
+            ["test:rocgdb", "test:rocgdb-cpu", "test:rocgdb-gpu"]
+        )
+
+        fetch_test_configurations.run()
+        components = self._get_components()
+
+        job_names = [job["job_name"] for job in components]
+        self.assertEqual(job_names.count("rocgdb-cpu"), 1)
+        self.assertEqual(job_names.count("rocgdb-gpu"), 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/build_tools/github_actions/tests/fetch_test_configurations_test.py
+++ b/build_tools/github_actions/tests/fetch_test_configurations_test.py
@@ -7,6 +7,7 @@ import os
 import sys
 import json
 import unittest
+from unittest.mock import patch
 
 # Add repo root to PYTHONPATH
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
@@ -552,10 +553,9 @@ class FetchTestConfigurationsTest(unittest.TestCase):
 
     def test_all_rocgdb_label_selects_cpu_and_gpu_jobs(self):
         """test:rocgdb should expand to both rocgdb-cpu and rocgdb-gpu."""
-        os.environ["TEST_LABELS"] = json.dumps(["test:rocgdb"])
-
-        fetch_test_configurations.run()
-        components = self._get_components()
+        with patch.dict(os.environ, {"TEST_LABELS": json.dumps(["test:rocgdb"])}):
+            fetch_test_configurations.run()
+            components = self._get_components()
 
         names = {job["job_name"] for job in components}
         self.assertIn("rocgdb-cpu", names)
@@ -563,10 +563,9 @@ class FetchTestConfigurationsTest(unittest.TestCase):
 
     def test_all_rocgdb_label_excludes_unrelated_jobs(self):
         """test:rocgdb should not include jobs outside the rocgdb group."""
-        os.environ["TEST_LABELS"] = json.dumps(["test:rocgdb"])
-
-        fetch_test_configurations.run()
-        components = self._get_components()
+        with patch.dict(os.environ, {"TEST_LABELS": json.dumps(["test:rocgdb"])}):
+            fetch_test_configurations.run()
+            components = self._get_components()
 
         names = {job["job_name"] for job in components}
         self.assertNotIn("rocblas", names)
@@ -574,10 +573,12 @@ class FetchTestConfigurationsTest(unittest.TestCase):
 
     def test_group_label_and_individual_label_combine(self):
         """A group label and a plain label together should union their jobs."""
-        os.environ["TEST_LABELS"] = json.dumps(["test:rocgdb", "test:rocblas"])
-
-        fetch_test_configurations.run()
-        components = self._get_components()
+        with patch.dict(
+            os.environ,
+            {"TEST_LABELS": json.dumps(["test:rocgdb", "test:rocblas"])},
+        ):
+            fetch_test_configurations.run()
+            components = self._get_components()
 
         names = {job["job_name"] for job in components}
         self.assertIn("rocgdb-cpu", names)
@@ -586,10 +587,9 @@ class FetchTestConfigurationsTest(unittest.TestCase):
 
     def test_unknown_group_label_is_treated_as_literal(self):
         """A test: label not in TEST_LABEL_GROUPS should fall through as a literal key."""
-        os.environ["TEST_LABELS"] = json.dumps(["test:rocblas"])
-
-        fetch_test_configurations.run()
-        components = self._get_components()
+        with patch.dict(os.environ, {"TEST_LABELS": json.dumps(["test:rocblas"])}):
+            fetch_test_configurations.run()
+            components = self._get_components()
 
         names = {job["job_name"] for job in components}
         self.assertIn("rocblas", names)
@@ -598,12 +598,16 @@ class FetchTestConfigurationsTest(unittest.TestCase):
 
     def test_group_label_and_individual_member_label_do_not_duplicate(self):
         """Passing test:rocgdb alongside an explicit member label should not produce duplicate jobs."""
-        os.environ["TEST_LABELS"] = json.dumps(
-            ["test:rocgdb", "test:rocgdb-cpu", "test:rocgdb-gpu"]
-        )
-
-        fetch_test_configurations.run()
-        components = self._get_components()
+        with patch.dict(
+            os.environ,
+            {
+                "TEST_LABELS": json.dumps(
+                    ["test:rocgdb", "test:rocgdb-cpu", "test:rocgdb-gpu"]
+                )
+            },
+        ):
+            fetch_test_configurations.run()
+            components = self._get_components()
 
         job_names = [job["job_name"] for job in components]
         self.assertEqual(job_names.count("rocgdb-cpu"), 1)

--- a/build_tools/github_actions/tests/fetch_test_configurations_test.py
+++ b/build_tools/github_actions/tests/fetch_test_configurations_test.py
@@ -551,8 +551,8 @@ class FetchTestConfigurationsTest(unittest.TestCase):
     # TEST_LABEL_GROUPS expansion
     # -----------------------
 
-    def test_all_rocgdb_label_selects_cpu_and_gpu_jobs(self):
-        """test:rocgdb should expand to both rocgdb-cpu and rocgdb-gpu."""
+    def test_all_rocgdb_label_selects_cpu_gpu_and_corefile_jobs(self):
+        """test:rocgdb should expand to rocgdb-cpu, rocgdb-gpu, and rocgdb-corefile."""
         with patch.dict(os.environ, {"TEST_LABELS": json.dumps(["test:rocgdb"])}):
             fetch_test_configurations.run()
             components = self._get_components()
@@ -560,6 +560,7 @@ class FetchTestConfigurationsTest(unittest.TestCase):
         names = {job["job_name"] for job in components}
         self.assertIn("rocgdb-cpu", names)
         self.assertIn("rocgdb-gpu", names)
+        self.assertIn("rocgdb-corefile", names)
 
     def test_all_rocgdb_label_excludes_unrelated_jobs(self):
         """test:rocgdb should not include jobs outside the rocgdb group."""
@@ -583,6 +584,7 @@ class FetchTestConfigurationsTest(unittest.TestCase):
         names = {job["job_name"] for job in components}
         self.assertIn("rocgdb-cpu", names)
         self.assertIn("rocgdb-gpu", names)
+        self.assertIn("rocgdb-corefile", names)
         self.assertIn("rocblas", names)
 
     def test_unknown_group_label_is_treated_as_literal(self):
@@ -602,7 +604,12 @@ class FetchTestConfigurationsTest(unittest.TestCase):
             os.environ,
             {
                 "TEST_LABELS": json.dumps(
-                    ["test:rocgdb", "test:rocgdb-cpu", "test:rocgdb-gpu"]
+                    [
+                        "test:rocgdb",
+                        "test:rocgdb-cpu",
+                        "test:rocgdb-gpu",
+                        "test:rocgdb-corefile",
+                    ]
                 )
             },
         ):
@@ -612,6 +619,7 @@ class FetchTestConfigurationsTest(unittest.TestCase):
         job_names = [job["job_name"] for job in components]
         self.assertEqual(job_names.count("rocgdb-cpu"), 1)
         self.assertEqual(job_names.count("rocgdb-gpu"), 1)
+        self.assertEqual(job_names.count("rocgdb-corefile"), 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Replaces the single `CI_LABELS` global in `bump_automation.py` with a `COMMON_CI_LABELS` base that each submodule expands. rocgdb bump PRs now get `ci:run-all-archs` and `test:rocgdb` rather than `ci:asan`, which is only relevant for rocm-systems and rocm-libraries.
- Adds `TEST_LABEL_GROUPS` to `fetch_test_configurations.py` — a dict that maps a group alias to the individual test matrix keys it expands to. The `rocgdb` group selects `rocgdb-cpu`, `rocgdb-gpu`, and `rocgdb-corefile`. Unknown labels continue to pass through as literal keys, so all existing `test:*` usage is unaffected.
- Adds intent comments to each `SUBMODULE_CONFIG` entry explaining what CI matrix the submodule change triggers.
- Switches new `TEST_LABEL_GROUPS` tests to use `patch.dict(os.environ)` rather than mutating the global environment directly.

JIRA ID: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)