### PR TITLE
fix(sanitizers): silence -Woption-ignored for HOST_ASAN builds

### DIFF
--- a/cmake/therock_sanitizers.cmake
+++ b/cmake/therock_sanitizers.cmake
@@ -47,6 +47,20 @@ function(therock_sanitizer_configure
     string(APPEND _stanza "string(APPEND CMAKE_CXX_FLAGS_INIT \" -fsanitize=${_sanitizer_string} -fno-omit-frame-pointer -g\")\n")
     string(APPEND _stanza "string(APPEND CMAKE_C_FLAGS_INIT \" -fsanitize=${_sanitizer_string} -fno-omit-frame-pointer -g\")\n")
 
+    # HOST_ASAN is host-only, but -fsanitize=address lands in the global
+    # CMAKE_CXX_FLAGS_INIT and so also reaches the HIP device compile. Clang
+    # requires xnack+ for device ASAN and drops the flag with -Woption-ignored,
+    # which is fatal in subprojects built with -Werror (e.g. MIOpen).
+    # Dropping the flag is the intended behavior here, so silence the warning.
+    # https://github.com/ROCm/TheRock/issues/6207
+    #
+    # This is a stopgap. The better fix is to keep the flag off the device
+    # compile entirely via -Xarch_host; see #7164. Revert this when that lands.
+    if(_sanitizer STREQUAL "HOST_ASAN")
+      string(APPEND _stanza "string(APPEND CMAKE_CXX_FLAGS_INIT \" -Wno-option-ignored\")\n")
+      string(APPEND _stanza "string(APPEND CMAKE_C_FLAGS_INIT \" -Wno-option-ignored\")\n")
+    endif()
+
     # Sharp edge: The -shared-libsan flag is compiler frontend specific:
     #   gcc (and gfortran): defaults to shared sanitizer linkage
     #   clang: defaults to static linkage and requires -shared-libsan to link shared


### PR DESCRIPTION
Stopgap to unblock the host-asan math-libs stage. Alternative to #7164, which is the better fix.

Issue: https://github.com/ROCm/TheRock/issues/6207

### Problem

`HOST_ASAN` is host-only, but `-fsanitize=address` is appended to the global `CMAKE_CXX_FLAGS_INIT`, so it also reaches the HIP device compile. Only `ASAN`/`TSAN` rewrite `GPU_TARGETS` to `xnack+`, so under `HOST_ASAN` the device target stays plain `gfx942`, where clang drops the flag:

```
clang++: error: ignoring '-fsanitize=address' option for offload arch 'gfx942' as it is not
currently supported there. Use it with an offload arch containing 'xnack+' instead
[-Werror,-Woption-ignored]
```

MIOpen builds with `-Werror`, so this fails 194 TUs and blocks the stage.

### Change

Append `-Wno-option-ignored` in the `HOST_ASAN` branch only. Dropping the flag on the device compile is the intended behavior for a host-only sanitizer build, so the warning is not actionable here.

### Verification

Built a HIP TU through the generated toolchain file with `-Werror`:

- Compiles and links clean
- Host instrumentation present, device instrumentation correctly absent (2 vs 26 `__asan_report*` compared to a full ASAN `xnack+` build)
- Device target ID unchanged at `gfx942`
- `ASAN` and `TSAN` stanzas verified unchanged

### Tradeoff

This silences the diagnostic rather than keeping the flag off the device compile. #7164 does the latter with `-Xarch_host`, which is the cleaner fix, and should supersede this. Opening as a draft so it is available if the stage needs unblocking before #7164 is ready.
