### PR TITLE
[ci] Resolve ctest parallel override from a single key

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_runner.py
+++ b/build_tools/github_actions/test_executable_scripts/test_runner.py
@@ -175,7 +175,7 @@ environ_vars["ROCM_PATH"] = str(ROCM_PATH)
 #   suppressed.
 COMPONENT_OVERRIDES = {
     # ctest fragments live under libexec, not bin.
-    # ctest_parallel pinned to 1: tests are pytest runs that parallelize
+    # ctest_parallel_count pinned to 1: tests are pytest runs that parallelize
     # internally (-n), so concurrent ctest jobs over-subscribe.
     "rocprofiler-compute": {
         "test_dir": ["libexec", "rocprofiler-compute"],
@@ -183,7 +183,7 @@ COMPONENT_OVERRIDES = {
             "PATH": [["bin"]],
             "LD_LIBRARY_PATH": [["lib"]],
         },
-        "ctest_parallel": 1,
+        "ctest_parallel_count": 1,
     },
     # rocprofiler-systems tests are pytest-driven CTests living under
     # share/rocprofiler-systems/tests. They need the rocm bin on PATH so the
@@ -300,7 +300,7 @@ def apply_component_overrides(
     env,
     default_parallel_count,
 ):
-    """Apply component-specific overrides; returns (test_dir, ctest_parallel).
+    """Apply component-specific overrides; returns (test_dir, ctest_parallel_count).
 
     Precedence for test_dir resolution (highest -> lowest):
       1. test_dir_by_type[test_type] - TEST_TYPE-aware route (e.g. rocwmma
@@ -318,8 +318,12 @@ def apply_component_overrides(
     - 'env' sets literal environment variables (str.format() with the
       "{rocm_path}" placeholder).
 
-    ctest_parallel: per-component ctest -j override; falls back to
-    default_parallel_count when the component does not pin one.
+    ctest_parallel_count: per-component ctest -j override; falls back to
+    default_parallel_count when the component does not pin one. A value of 0
+    means "run serially" and is honoured by build_ctest_command(), which drops
+    the --parallel flag entirely. This is the single place the override is
+    resolved; callers use the returned value rather than re-reading
+    COMPONENT_OVERRIDES.
     """
     overrides = COMPONENT_OVERRIDES.get(job_name)
     if not overrides:
@@ -336,7 +340,7 @@ def apply_component_overrides(
     _prepend_env_paths(env, therock_dir, overrides.get("env_prepend_from_therock", {}))
     for env_key, value_template in overrides.get("env", {}).items():
         env[env_key] = value_template.format(rocm_path=str(rocm_path))
-    return test_dir, overrides.get("ctest_parallel", default_parallel_count)
+    return test_dir, overrides.get("ctest_parallel_count", default_parallel_count)
 
 
 TEST_DIR = str(Path(THEROCK_BIN_DIR) / TEST_COMPONENT)
@@ -546,14 +550,13 @@ def build_ctest_command(
     # Add common ctest parameters
     cmd.append("--output-on-failure")
 
-    # ctest_parallel_count is the module-level default (arch-tuned). Components
-    # can override it via COMPONENT_OVERRIDES[...]["ctest_parallel_count"];
-    # a value of 0 means "drop --parallel entirely" (serial execution).
-    component_parallel_count = COMPONENT_OVERRIDES.get(test_component_job_name, {}).get(
-        "ctest_parallel_count", ctest_parallel_count
-    )
-    if component_parallel_count > 0:
-        cmd.extend(["--parallel", f"{component_parallel_count}"])
+    # ctest_parallel_count already holds the resolved value: the module-level
+    # default (arch-tuned), overridden per component by
+    # COMPONENT_OVERRIDES[...]["ctest_parallel_count"] via
+    # apply_component_overrides() at import time. A value of 0 means "drop
+    # --parallel entirely" (serial execution).
+    if ctest_parallel_count > 0:
+        cmd.extend(["--parallel", f"{ctest_parallel_count}"])
 
     cmd.extend(
         [

--- a/build_tools/github_actions/tests/unit_test_runner.py
+++ b/build_tools/github_actions/tests/unit_test_runner.py
@@ -231,6 +231,24 @@ class ApplyComponentOverridesTest(unittest.TestCase):
         _, parallel = self._apply("rocwmma", 4)
         self.assertEqual(parallel, 4)
 
+    def test_zero_parallel_override_is_preserved(self):
+        # 0 is falsy but meaningful: it means "drop --parallel entirely".
+        # It must survive resolution rather than falling back to the default.
+        _, parallel = self._apply("rocprofiler-systems", 8)
+        self.assertEqual(parallel, 0)
+
+    def test_every_parallel_override_uses_the_canonical_key(self):
+        # apply_component_overrides() and build_ctest_command() must agree on
+        # one key name. A stray "ctest_parallel" entry would be silently
+        # ignored by one of them.
+        for job_name, overrides in test_runner.COMPONENT_OVERRIDES.items():
+            self.assertNotIn(
+                "ctest_parallel",
+                overrides,
+                f"{job_name} uses the obsolete 'ctest_parallel' key; "
+                "use 'ctest_parallel_count' instead",
+            )
+
 
 class ValidTestCategoriesTest(unittest.TestCase):
     """Tests for VALID_TEST_CATEGORIES and category validation."""


### PR DESCRIPTION
## Summary

`COMPONENT_OVERRIDES` in `test_runner.py` is read for the ctest parallel setting in two places, under two different key names:

```python
# apply_component_overrides()
return test_dir, overrides.get("ctest_parallel", default_parallel_count)

# build_ctest_command()
component_parallel_count = COMPONENT_OVERRIDES.get(test_component_job_name, {}).get(
    "ctest_parallel_count", ctest_parallel_count
)
```

`rocprofiler-compute` sets `ctest_parallel`; `rocprofiler-systems` sets `ctest_parallel_count`. The docblock above `COMPONENT_OVERRIDES` documents only `ctest_parallel_count`.

Both currently produce the intended `--parallel`, but only because `build_ctest_command()` falls back to the module-level global that `apply_component_overrides()` already wrote. The effective lookup is:

```
get("ctest_parallel_count", get("ctest_parallel", <arch default>))
```

So the two keys have different precedence, and the latent failure is that **a component setting only `ctest_parallel: 0` would not run serially** — the `0` is dropped by `apply_component_overrides()`'s own fallback before `build_ctest_command()` ever sees it. Anyone copying the `rocprofiler-compute` entry as a template would hit this.

Found while documenting this section for #7307.

## Changes

- `rocprofiler-compute`: rename its key to `ctest_parallel_count`.
- `apply_component_overrides()`: read `ctest_parallel_count`.
- `build_ctest_command()`: use the already-resolved module-level value instead of re-reading `COMPONENT_OVERRIDES`, leaving one resolution site rather than two.

**No behaviour change.** Verified across all paths:

| Component | Before | After |
| --- | --- | --- |
| rocprofiler-compute | `--parallel 1` | `--parallel 1` |
| rocprofiler-systems | serial (no flag) | serial (no flag) |
| everything else | arch default (`--parallel 1`) | arch default (`--parallel 1`) |

## Tests

Two regression tests added, both of which **fail on current `main`**:

- `test_zero_parallel_override_is_preserved` — `0` is falsy but meaningful; it must survive resolution rather than falling back to the default. Fails today with `AssertionError: 8 != 0`.
- `test_every_parallel_override_uses_the_canonical_key` — guards against a future component reintroducing the obsolete key name.

Confirmed by checking out the pre-fix `test_runner.py` and running the new tests against it:

```
FAILED ApplyComponentOverridesTest::test_every_parallel_override_uses_the_canonical_key
FAILED ApplyComponentOverridesTest::test_zero_parallel_override_is_preserved
2 failed, 30 deselected
```

## Test plan

- [x] `unit_test_runner.py` — 32 passed
- [x] New tests verified to fail against pre-fix code
- [x] `pre-commit run black` passes
- [ ] Confirm rocprofiler-compute and rocprofiler-systems test jobs behave identically in CI

## Related

- #7307 — documentation update for the same file. Independent; either can merge first.

Made with [Cursor](https://cursor.com)