### PR TITLE
feat(ci): Add top-level TheRock flag WINDOWS_DRIVER_ABI to align with downstream Drivers builds 

### DIFF
--- a/FLAGS.cmake
+++ b/FLAGS.cmake
@@ -105,6 +105,19 @@ therock_declare_flag(
     amd-llvm
 )
 
+therock_declare_flag(
+  NAME WINDOWS_DRIVER_BUILD
+  DEFAULT_VALUE OFF
+  DESCRIPTION "Windows: build for the AMD driver package (Control Flow Guard, driver comgr DLL name)"
+  GLOBAL_PROPAGATE_FLAG
+  CMAKE_VARS
+    COMGR_DLL_NAME=amd_comgr_drivers.dll
+  SUB_PROJECTS
+    amd-comgr
+    hip-clr
+    ocl-clr
+)
+
 ###############################################################################
 # Branch-specific flag overrides.
 # BRANCH_FLAGS.cmake is .gitignored on main but can be committed on

--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -87,6 +87,15 @@ if(WIN32)
   list(APPEND THEROCK_AMD_LLVM_DEFAULT_CXX_FLAGS -Wno-duplicate-decl-specifier)
 endif()
 
+# Options added to every subproject when THEROCK_FLAG_WINDOWS_DRIVER_BUILD is set.
+# The compile flag is spelled per compiler; the link flag goes through CMake's
+# LINKER: prefix, which handles the driver difference.
+# /machine and /DYNAMICBASE are omitted: CMake emits the former and the linker
+# defaults to the latter.
+set(THEROCK_WINDOWS_DRIVER_BUILD_MSVC_COMPILE_FLAGS "/guard:cf")
+set(THEROCK_WINDOWS_DRIVER_BUILD_CLANG_COMPILE_FLAGS "-mguard=cf")
+set(THEROCK_WINDOWS_DRIVER_BUILD_LINK_FLAGS "/guard:cf")
+
 # Generates a command prefix that can be prepended to any custom command line
 # to perform log/console redirection and pretty printing.
 # LOG_FILE: If given, command output will also be sent to this log file. If
@@ -866,6 +875,16 @@ function(therock_cmake_subproject_activate target_name)
   # deterministic output.
   if(WIN32)
     string(APPEND _init_contents "add_link_options(\"LINKER:/Brepro\")\n")
+  endif()
+
+  # Link half of the driver build options. This cannot go through
+  # CMAKE_<TYPE>_LINKER_FLAGS_INIT in the toolchain file: the private link dir
+  # handling above appends to CMAKE_<TYPE>_LINKER_FLAGS before enable_language()
+  # has populated it from *_INIT, which shadows the cache value and drops
+  # whatever the toolchain set.
+  if(MSVC AND THEROCK_FLAG_WINDOWS_DRIVER_BUILD)
+    string(APPEND _init_contents
+      "add_link_options(\"LINKER:${THEROCK_WINDOWS_DRIVER_BUILD_LINK_FLAGS}\")\n")
   endif()
 
   if(_dep_provider_file)
@@ -1732,6 +1751,18 @@ function(_therock_cmake_subproject_setup_toolchain
     string(APPEND _toolchain_contents "set(CMAKE_CXX_FLAGS_INIT \"@CMAKE_CXX_FLAGS@\")\n")
     string(APPEND _toolchain_contents "set(CMAKE_EXE_LINKER_FLAGS_INIT \"@CMAKE_EXE_LINKER_FLAGS@\")\n")
     string(APPEND _toolchain_contents "set(CMAKE_SHARED_LINKER_FLAGS_INIT \"@CMAKE_SHARED_LINKER_FLAGS@\")\n")
+  endif()
+
+  # Compile half of the driver build options. The link half is emitted as
+  # add_link_options() in the project_init file.
+  if(MSVC AND THEROCK_FLAG_WINDOWS_DRIVER_BUILD)
+    if(compiler_toolchain)
+      set(_driver_build_compile_flags "${THEROCK_WINDOWS_DRIVER_BUILD_CLANG_COMPILE_FLAGS}")
+    else()
+      set(_driver_build_compile_flags "${THEROCK_WINDOWS_DRIVER_BUILD_MSVC_COMPILE_FLAGS}")
+    endif()
+    string(APPEND _toolchain_contents "string(APPEND CMAKE_C_FLAGS_INIT \" ${_driver_build_compile_flags}\")\n")
+    string(APPEND _toolchain_contents "string(APPEND CMAKE_CXX_FLAGS_INIT \" ${_driver_build_compile_flags}\")\n")
   endif()
 
   # Customize debug info generation.

--- a/third-party/sysdeps/common/zlib/CMakeLists.txt
+++ b/third-party/sysdeps/common/zlib/CMakeLists.txt
@@ -66,6 +66,19 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   list(APPEND patch_source_commands   COMMAND
     bash "${CMAKE_CURRENT_SOURCE_DIR}/patch_source.sh" "${CMAKE_CURRENT_BINARY_DIR}/s")
 endif()
+
+# The nested configure below does not otherwise inherit compile flags, and zlib
+# links statically into shipped binaries.
+set(driver_build_flag_args)
+if(WIN32 AND THEROCK_FLAG_WINDOWS_DRIVER_BUILD)
+  list(APPEND driver_build_flag_args
+    "-DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}"
+    "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}"
+    "-DCMAKE_EXE_LINKER_FLAGS=${CMAKE_EXE_LINKER_FLAGS}"
+    "-DCMAKE_SHARED_LINKER_FLAGS=${CMAKE_SHARED_LINKER_FLAGS}"
+  )
+endif()
+
 # zlib provides a CMakeLists.txt, however, we have to do some post-processing
 # of the libraries in order to prepare them for our use, so we invoke it as
 # a sub-build. We do this uniformly across all platforms because it is easier
@@ -93,6 +106,7 @@ add_custom_target(
       "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
       "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
       "-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}"
+      ${driver_build_flag_args}
       # Force lib/ to match the hardcoded paths throughout this file.
       -DCMAKE_INSTALL_LIBDIR=lib
       # On Windows we only use the static library; skip the shared build

--- a/third-party/sysdeps/common/zstd/CMakeLists.txt
+++ b/third-party/sysdeps/common/zstd/CMakeLists.txt
@@ -97,6 +97,18 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
        bash "${CMAKE_CURRENT_SOURCE_DIR}/patch_source.sh" "${SOURCE_DIR}")
 endif()
 
+# The nested configure below does not otherwise inherit compile flags, and zstd
+# links statically into shipped binaries.
+set(driver_build_flag_args)
+if(WIN32 AND THEROCK_FLAG_WINDOWS_DRIVER_BUILD)
+  list(APPEND driver_build_flag_args
+    "-DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}"
+    "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}"
+    "-DCMAKE_EXE_LINKER_FLAGS=${CMAKE_EXE_LINKER_FLAGS}"
+    "-DCMAKE_SHARED_LINKER_FLAGS=${CMAKE_SHARED_LINKER_FLAGS}"
+  )
+endif()
+
 add_custom_target(
   build ALL
   WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
@@ -114,6 +126,7 @@ add_custom_target(
       "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
       "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
       "-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}"
+      ${driver_build_flag_args}
       -DZSTD_BUILD_TESTS=OFF
       -DZSTD_LEGACY_SUPPORT=OFF
       -DZSTD_BUILD_PROGRAMS=OFF


### PR DESCRIPTION
## Motivation

The AMD driver package build compiles every Windows component with Control Flow
Guard and loads comgr under a driver-specific DLL name. TheRock does neither.
Adds a flag for both, default `OFF`.

Not addressed: CRT linkage, SDK/toolset pinning.

ISSUE ID https://github.com/ROCm/TheRock/issues/1293

<!-- GitHub issue: -->

## Technical Details

`THEROCK_FLAG_WINDOWS_DRIVER_BUILD` (default `OFF`, no effect off Windows):

1. **CFG** — `/guard:cf` compile (`-mguard=cf` under `COMPILER_TOOLCHAIN`) and
   `LINKER:/guard:cf` link. `/machine` and `/DYNAMICBASE` omitted: CMake emits
   the former, the linker defaults to the latter.
2. **`COMGR_DLL_NAME=amd_comgr_drivers.dll`** via the flag system's
   `CMAKE_VARS`/`SUB_PROJECTS`, scoped to `amd-comgr`, `hip-clr`, `ocl-clr`.
   Both CLR projects build `rocclr`, which is where the name is consumed.

The compile half goes in the generated toolchain file (as
`THEROCK_MINIMAL_DEBUG_INFO` does). The link half must use `add_link_options()`
in `_init.cmake` instead: that file runs during `project()` before
`enable_language()` populates `CMAKE_<TYPE>_LINKER_FLAGS` from `*_INIT`, so the
existing `string(APPEND CMAKE_SHARED_LINKER_FLAGS " /LIBPATH:...")` shadows the
cache and drops anything the toolchain set. The first build of this PR produced
binaries with `/guard:cf` on every compile line and no CFG bit.

zlib/zstd sysdeps run a nested `cmake` that forwards only compilers, so flags
are forwarded there too — CFG instrumentation is per-object, so linking with
`/guard:cf` cannot retrofit checks into uninstrumented static libs.

Files: `FLAGS.cmake`, `cmake/therock_subproject.cmake`,
`third-party/sysdeps/common/{zlib,zstd}/CMakeLists.txt`.

## Test Plan

Full clean Windows build, flag `ON`: MSVC 19.44, Ninja, `gfx110X-all`,
`THEROCK_ENABLE_ALL=OFF` + `COMPILER`/`HIP_RUNTIME`/`OCL_RUNTIME`. Then
`dumpbin /headers` over `dist/rocm/bin`. Configure-only check of the `OFF` path.

## Test Result

`BUILD_EXIT_CODE=0`, no compile or link errors. CFG set on all 11 shipped
binaries (`amd_comgr_drivers.dll`, `amdhip64_7.dll`, `amdocl64.dll`,
`hiprtc*.dll`, `cltrace.dll`, `OpenCL.dll`, `rocm_kpack.dll`, `clinfo.exe`,
`hipInfo.exe`, `hipcc.exe`) plus clang/lld-link; none missing. comgr built and
loaded as `amd_comgr_drivers.dll`. Flag `OFF`: no guard references, no
`COMGR_DLL_NAME` injection, forwarding intact.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.