### PR TITLE
packaging: add ROCm ASAN wheel production

### DIFF
--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -23,8 +23,14 @@ Example
 import argparse
 import functools
 import json
+import os
 from pathlib import Path
+from pathlib import PurePosixPath
+import re
 import sys
+
+from elftools.common.exceptions import ELFError
+from elftools.elf.elffile import ELFFile
 
 from _therock_utils.artifacts import ArtifactCatalog, ArtifactName
 from _therock_utils.cmake_amdgpu_targets import amdgpu_family_map, expand_families
@@ -64,6 +70,209 @@ def load_therock_manifest(artifact_dir: Path) -> dict:
             f"Is base_lib_generic present in {artifact_dir}?"
         )
     return json.loads(manifest_path.read_text())
+
+
+def _asan_build_id_from_manifest(manifest: dict) -> str | None:
+    """Derive a stable build ID from a nightly artifact manifest."""
+    package_version = manifest.get("rocm_package_version", "")
+    match = re.search(r"(?:a|rc)(\d{8,})$", package_version)
+    return match.group(1) if match else None
+
+
+def resolve_package_version(args: argparse.Namespace, manifest: dict) -> str:
+    """Resolve the package version, enforcing ASAN/release isolation."""
+    import compute_rocm_package_version
+
+    is_asan = getattr(args, "asan", False)
+    asan_build_id = getattr(args, "asan_build_id", None)
+    version = getattr(args, "version", "")
+
+    if asan_build_id and not is_asan:
+        raise ValueError("--asan-build-id requires --asan")
+
+    if not is_asan:
+        if version:
+            return version
+        print("::: Version not specified, choosing a default")
+        resolved = compute_rocm_package_version.compute_version(
+            custom_version_suffix=".dev0"
+        )
+        print(f"::: Version defaulting to {resolved}")
+        return resolved
+
+    base_version = manifest.get("rocm_version")
+    if not base_version:
+        raise ValueError(
+            "ASAN packaging requires rocm_version in therock_manifest.json"
+        )
+
+    if version:
+        expected = re.compile(
+            rf"^{re.escape(base_version)}\+asan\.[a-z0-9]+(?:\.[a-z0-9]+)*$"
+        )
+        if not expected.fullmatch(version):
+            raise ValueError(
+                "--asan requires a canonical ASAN wheel version matching "
+                f"{base_version}+asan.<build-id>; got {version!r}"
+            )
+        return version
+
+    if asan_build_id is None:
+        asan_build_id = _asan_build_id_from_manifest(manifest)
+    resolved = compute_rocm_package_version.compute_version(
+        release_type="asan",
+        override_base_version=base_version,
+        asan_build_id=asan_build_id,
+    )
+    print(f"::: ASAN wheel version defaulting to {resolved}")
+    return resolved
+
+
+def find_asan_runtime_rpath(artifacts: ArtifactCatalog) -> str:
+    """Find the Clang ASAN runtime directory in staged artifacts."""
+    runtime_dirs: set[str] = set()
+    for relpath, entry in artifacts.pm.matches():
+        relpath = PurePosixPath(relpath)
+        if entry.is_file() and relpath.match(
+            "lib/llvm/lib/clang/*/lib/linux/libclang_rt.asan-*.so"
+        ):
+            runtime_dirs.add(relpath.parent.as_posix())
+
+    if not runtime_dirs:
+        raise RuntimeError(
+            "--asan was requested but no shared Clang ASAN runtime was found "
+            "in the input artifacts"
+        )
+    if len(runtime_dirs) != 1:
+        raise RuntimeError(
+            "ASAN artifacts contain multiple Clang runtime directories: "
+            + ", ".join(sorted(runtime_dirs))
+        )
+    return runtime_dirs.pop()
+
+
+def _elf_dynamic_info(path: Path) -> tuple[list[str], list[str]] | None:
+    """Return an ELF's NEEDED entries and RPATH/RUNPATH entries."""
+    try:
+        with path.open("rb") as stream:
+            elf = ELFFile(stream)
+            dynamic = elf.get_section_by_name(".dynamic")
+            if dynamic is None:
+                return ([], [])
+            needed: list[str] = []
+            rpaths: list[str] = []
+            for tag in dynamic.iter_tags():
+                if tag.entry.d_tag == "DT_NEEDED":
+                    needed.append(tag.needed)
+                elif tag.entry.d_tag == "DT_RPATH":
+                    rpaths.extend(tag.rpath.split(":"))
+                elif tag.entry.d_tag == "DT_RUNPATH":
+                    rpaths.extend(tag.runpath.split(":"))
+            return needed, rpaths
+    except (ELFError, OSError, ValueError):
+        return None
+
+
+def _rpath_resolves_directory(
+    *,
+    binary_path: Path,
+    rpaths: list[str],
+    expected_dir: Path,
+    binary_platform_root: Path | None = None,
+    expected_platform_root: Path | None = None,
+) -> bool:
+    """Checks an ELF RPATH against its directory in the installed wheel set.
+
+    Package staging directories are isolated from each other, but the contents
+    of every package's ``platform/`` directory are merged into one
+    site-packages directory when the wheels are installed. When platform roots
+    are supplied, project both paths into that common layout before resolving
+    ``$ORIGIN``. Omitting them retains the direct filesystem check used for
+    paths that are already in a merged layout.
+    """
+    if (binary_platform_root is None) != (expected_platform_root is None):
+        raise ValueError(
+            "binary_platform_root and expected_platform_root must be supplied together"
+        )
+
+    if binary_platform_root is not None and expected_platform_root is not None:
+        install_root = Path("/site-packages")
+        try:
+            binary_path = install_root / binary_path.resolve().relative_to(
+                binary_platform_root.resolve()
+            )
+            expected_dir = install_root / expected_dir.resolve().relative_to(
+                expected_platform_root.resolve()
+            )
+        except ValueError:
+            return False
+
+    expected_dir = expected_dir.resolve()
+    for rpath in rpaths:
+        for origin_syntax in ("$ORIGIN", "${ORIGIN}"):
+            if not rpath.startswith(origin_syntax):
+                continue
+            relative = rpath[len(origin_syntax) :].lstrip("/")
+            candidate = Path(os.path.normpath(binary_path.parent / relative))
+            if candidate.resolve() == expected_dir:
+                return True
+    return False
+
+
+def validate_asan_runtime_resolution(
+    *,
+    core: PopulatedDistPackage,
+    packages: list[PopulatedDistPackage],
+    runtime_rpath: str,
+    require_instrumented: bool,
+) -> None:
+    """Validate that packaged ASAN-linked ELFs resolve the core runtime."""
+    runtime_dir = core.platform_dir / runtime_rpath
+    runtimes = sorted(runtime_dir.glob("libclang_rt.asan-*.so"))
+    if not runtimes:
+        raise RuntimeError(
+            f"ASAN runtime was not packaged in rocm-sdk-core at {runtime_dir}"
+        )
+
+    instrumented_count = 0
+    unresolved: list[Path] = []
+    for package in packages:
+        for _, path in package.files.materialized_relpaths.values():
+            if not path.is_file():
+                continue
+            dynamic_info = _elf_dynamic_info(path)
+            if dynamic_info is None:
+                continue
+            needed, rpaths = dynamic_info
+            if not any(name.startswith("libclang_rt.asan-") for name in needed):
+                continue
+            instrumented_count += 1
+            if not _rpath_resolves_directory(
+                binary_path=path,
+                rpaths=rpaths,
+                expected_dir=runtime_dir,
+                binary_platform_root=package.platform_dir.parent,
+                expected_platform_root=core.platform_dir.parent,
+            ):
+                unresolved.append(path)
+
+    if unresolved:
+        paths = "\n  ".join(str(path) for path in unresolved[:20])
+        extra = (
+            "" if len(unresolved) <= 20 else f"\n  ... ({len(unresolved) - 20} more)"
+        )
+        raise RuntimeError(
+            "ASAN-linked packaged ELFs cannot resolve the rocm-sdk-core "
+            f"runtime directory:\n  {paths}{extra}"
+        )
+    if require_instrumented and not instrumented_count:
+        raise RuntimeError(
+            "--asan was requested but no packaged ELF links the shared ASAN runtime"
+        )
+    print(
+        "::: ASAN RPATH validation passed: "
+        f"{instrumented_count} instrumented ELF(s), runtime {runtime_rpath}"
+    )
 
 
 def ensure_profiler_library_symlinks(profiler: PopulatedDistPackage) -> None:
@@ -189,6 +398,7 @@ def validate_required_dist_packages(
 
 def run(args: argparse.Namespace):
     manifest = load_therock_manifest(args.artifact_dir)
+    args.version = resolve_package_version(args, manifest)
     kpack_split = manifest.get("flags", {}).get("KPACK_SPLIT_ARTIFACTS", False)
     if kpack_split:
         print("::: Detected KPACK_SPLIT_ARTIFACTS — producing host + device wheels")
@@ -215,6 +425,11 @@ def run(args: argparse.Namespace):
         windows_targets = expand_families(args.windows_amdgpu_families, family_map)
 
     artifacts = ArtifactCatalog(args.artifact_dir)
+    asan_runtime_rpath = (
+        find_asan_runtime_rpath(artifacts) if getattr(args, "asan", False) else None
+    )
+    if asan_runtime_rpath:
+        print(f"::: ASAN runtime detected at {asan_runtime_rpath}")
     validate_kpack_split_target_completeness(
         kpack_split=kpack_split,
         artifact_dir=args.artifact_dir,
@@ -237,6 +452,8 @@ def run(args: argparse.Namespace):
     core = PopulatedDistPackage(params, logical_name="core")
     core.rpath_dep(core, "lib/llvm/lib")
     core.rpath_dep(core, "lib/rocm_sysdeps/lib")
+    if asan_runtime_rpath:
+        core.rpath_dep(core, asan_runtime_rpath)
     core.populate_runtime_files(
         params.filter_artifacts(
             core_artifact_filter,
@@ -266,6 +483,8 @@ def run(args: argparse.Namespace):
         profiler.rpath_dep(core, "lib")
         profiler.rpath_dep(core, "lib/llvm/lib")
         profiler.rpath_dep(core, "lib/rocm_sysdeps/lib")
+        if asan_runtime_rpath:
+            profiler.rpath_dep(core, asan_runtime_rpath)
         profiler.populate_runtime_files(profiler_artifacts)
         ensure_profiler_library_symlinks(profiler)
 
@@ -295,9 +514,9 @@ def run(args: argparse.Namespace):
         )
 
     if kpack_split:
-        _run_kpack_split(args, params, core)
+        _run_kpack_split(args, params, core, asan_runtime_rpath)
     else:
-        _run_legacy(args, params, core)
+        _run_legacy(args, params, core, asan_runtime_rpath)
 
     if args.build_packages:
         validate_required_dist_packages(
@@ -315,7 +534,10 @@ def run(args: argparse.Namespace):
 
 
 def _run_kpack_split(
-    args: argparse.Namespace, params: Parameters, core: PopulatedDistPackage
+    args: argparse.Namespace,
+    params: Parameters,
+    core: PopulatedDistPackage,
+    asan_runtime_rpath: str | None,
 ):
     """Kpack-split mode: arch-neutral host libraries + per-ISA device wheels."""
 
@@ -326,6 +548,8 @@ def _run_kpack_split(
     lib.rpath_dep(core, "lib/host-math/lib")
     # rpp needs libomp, which ships in core under lib/llvm/lib.
     lib.rpath_dep(core, "lib/llvm/lib")
+    if asan_runtime_rpath:
+        lib.rpath_dep(core, asan_runtime_rpath)
     lib.populate_runtime_files(
         params.filter_artifacts(
             filter=functools.partial(libraries_artifact_filter, "generic"),
@@ -335,6 +559,13 @@ def _run_kpack_split(
     # Build core + libraries wheels. The rocm, rocm-sdk-devel, and
     # rocm-sdk-device staging dirs do not exist yet, so the default scan
     # in build_packages will not accidentally include them.
+    if asan_runtime_rpath:
+        validate_asan_runtime_resolution(
+            core=core,
+            packages=list(params.populated_packages),
+            runtime_rpath=asan_runtime_rpath,
+            require_instrumented=True,
+        )
     if args.build_packages:
         build_packages(args.dest_dir, wheel_compression=args.wheel_compression)
 
@@ -348,11 +579,20 @@ def _run_kpack_split(
         dev = PopulatedDistPackage(params, logical_name="device", target_family=target)
         dev.rpath_dep(core, "lib")
         dev.rpath_dep(core, "lib/rocm_sysdeps/lib")
+        if asan_runtime_rpath:
+            dev.rpath_dep(core, asan_runtime_rpath)
         dev.populate_device_files(
             params.filter_artifacts(
                 filter=functools.partial(device_artifact_filter, target),
             )
         )
+        if asan_runtime_rpath:
+            validate_asan_runtime_resolution(
+                core=core,
+                packages=[dev],
+                runtime_rpath=asan_runtime_rpath,
+                require_instrumented=False,
+            )
         if args.build_packages:
             build_packages(
                 args.dest_dir,
@@ -402,7 +642,10 @@ def _run_kpack_split(
 
 
 def _run_legacy(
-    args: argparse.Namespace, params: Parameters, core: PopulatedDistPackage
+    args: argparse.Namespace,
+    params: Parameters,
+    core: PopulatedDistPackage,
+    asan_runtime_rpath: str | None,
 ):
     """Legacy mode: per-family libraries wheels with embedded device code."""
 
@@ -416,6 +659,8 @@ def _run_legacy(
         lib.rpath_dep(core, "lib/host-math/lib")
         # rpp needs libomp, which ships in core under lib/llvm/lib.
         lib.rpath_dep(core, "lib/llvm/lib")
+        if asan_runtime_rpath:
+            lib.rpath_dep(core, asan_runtime_rpath)
         lib.populate_runtime_files(
             params.filter_artifacts(
                 filter=functools.partial(libraries_artifact_filter, target_family),
@@ -430,6 +675,13 @@ def _run_legacy(
     # Build non-devel, non-meta wheels first — the rocm and rocm-sdk-devel
     # staging dirs do not exist yet, so the default scan in build_packages
     # will not accidentally include them.
+    if asan_runtime_rpath:
+        validate_asan_runtime_resolution(
+            core=core,
+            packages=list(params.populated_packages),
+            runtime_rpath=asan_runtime_rpath,
+            require_instrumented=True,
+        )
     if args.build_packages:
         build_packages(args.dest_dir, wheel_compression=args.wheel_compression)
 
@@ -647,6 +899,23 @@ def main(argv: list[str]):
         help="Package versions (defaults to an automatic dev version)",
     )
     p.add_argument(
+        "--asan",
+        default=False,
+        action="store_true",
+        help=(
+            "Build locally versioned ASAN wheels, require the shared Clang "
+            "ASAN runtime, and validate cross-wheel runtime RPATHs"
+        ),
+    )
+    p.add_argument(
+        "--asan-build-id",
+        default=None,
+        help=(
+            "Build identifier for --asan (defaults to the source artifact's "
+            "nightly date, then today's date)"
+        ),
+    )
+    p.add_argument(
         "--version-suffix",
         default="",
         help="Version suffix to append to package names on disk",
@@ -686,18 +955,6 @@ def main(argv: list[str]):
         ),
     )
     args = p.parse_args(argv)
-
-    if not args.version:
-        print(f"::: Version not specified, choosing a default")
-        import compute_rocm_package_version
-
-        # Generate a default version like `7.10.0.dev0`.
-        # This is a simple and predictable version, compared to using
-        # `release_type="dev"`, which appends the git commit hash.
-        args.version = compute_rocm_package_version.compute_version(
-            custom_version_suffix=".dev0"
-        )
-        print(f"::: Version defaulting to {args.version}")
 
     run(args)
 

--- a/build_tools/compute_rocm_package_version.py
+++ b/build_tools/compute_rocm_package_version.py
@@ -34,6 +34,9 @@ Sample usage:
 
   python compute_rocm_package_version.py --release-type=nightly --override-base-version=7.99.0
   # 7.99.0a20251021
+
+  python compute_rocm_package_version.py --release-type=asan --asan-build-id=20260807
+  # rocm_package_version=10.1.0+asan.20260807
 """
 
 import argparse
@@ -41,6 +44,7 @@ from datetime import datetime
 from pathlib import Path
 import json
 import os
+import re
 import subprocess
 import sys
 
@@ -105,6 +109,28 @@ def get_current_date():
     return datetime.today().strftime("%Y%m%d")
 
 
+def normalize_asan_build_id(build_id: str | None) -> str:
+    """Return a PEP 440 local-version-safe ASAN build identifier.
+
+    ASAN wheels are intentionally isolated from release wheels with a local
+    version of the form ``+asan.<build-id>``. Dots, hyphens and underscores
+    are equivalent separators under PEP 440, so normalize all of them to dots
+    to keep filenames and dependency pins deterministic.
+    """
+    if build_id is None:
+        return get_current_date()
+
+    build_id = build_id.strip()
+    if not build_id:
+        raise ValueError("ASAN build ID must not be empty")
+    if not re.fullmatch(r"[A-Za-z0-9]+(?:[._-][A-Za-z0-9]+)*", build_id):
+        raise ValueError(
+            "ASAN build ID must contain only alphanumeric components separated "
+            "by '.', '-' or '_'"
+        )
+    return re.sub(r"[._-]+", ".", build_id).lower()
+
+
 def compute_version(
     package_type: str = "wheel",
     release_type: str | None = None,
@@ -112,21 +138,28 @@ def compute_version(
     prerelease_version: str | None = None,
     override_base_version: str | None = None,
     override_git_sha: str | None = None,
+    asan_build_id: str | None = None,
 ) -> str:
     """Compute package version based on package type and release type.
 
     Args:
         package_type: Type of package ("wheel", "deb", or "rpm")
-        release_type: Release type ("ci", "dev", "nightly", "prerelease", or "release")
+        release_type: Release type ("asan", "ci", "dev", "nightly",
+            "prerelease", or "release")
         custom_version_suffix: Custom suffix to override automatic suffix
         prerelease_version: Prerelease version number
         override_base_version: Override the base version from version.json
         override_git_sha: Explicit git SHA override, forwarded to get_git_sha().
             See get_git_sha() for details on when this is needed.
+        asan_build_id: Optional ASAN wheel build identifier. Defaults to the
+            current date and is only valid with ``release_type="asan"``.
 
     Returns:
         Computed version string appropriate for the package type
     """
+    if asan_build_id is not None and release_type != "asan":
+        raise ValueError("asan_build_id requires release_type='asan'")
+
     if override_base_version:
         base_version = override_base_version
     else:
@@ -140,6 +173,8 @@ def compute_version(
             # Trust the custom suffix to satisfy the general rules:
             # https://packaging.python.org/en/latest/specifications/version-specifiers/
             version_suffix = custom_version_suffix
+        elif release_type == "asan":
+            version_suffix = f"+asan.{normalize_asan_build_id(asan_build_id)}"
         elif release_type in ("ci", "dev"):
             # Construct a dev release version:
             # https://packaging.python.org/en/latest/specifications/version-specifiers/#developmental-releases
@@ -167,6 +202,8 @@ def compute_version(
 
     # Handle native packages (deb/rpm)
     else:  # package_type in ["deb", "rpm"]
+        if release_type == "asan":
+            raise ValueError("ASAN package versions are only supported for wheels")
         if custom_version_suffix:
             # Custom suffix uses the provided value
             version_suffix_str = f"{custom_version_suffix}"
@@ -216,10 +253,11 @@ def main(argv):
     release_type_group.add_argument(
         "--release-type",
         type=str,
-        choices=["ci", "dev", "nightly", "prerelease", "release"],
+        choices=["asan", "ci", "dev", "nightly", "prerelease", "release"],
         help=(
             "The type of package version to produce. "
-            "'ci' uses dev-style versions; 'release' is only valid for deb/rpm."
+            "'ci' uses dev-style versions; 'asan' is wheel-only; "
+            "'release' is only valid for deb/rpm."
         ),
     )
     release_type_group.add_argument(
@@ -246,6 +284,14 @@ def main(argv):
         help="Explicit git SHA to embed in the version instead of auto-detecting",
     )
 
+    parser.add_argument(
+        "--asan-build-id",
+        help=(
+            "Build identifier for --release-type=asan (defaults to YYYYMMDD). "
+            "The wheel version is <base>+asan.<build-id>."
+        ),
+    )
+
     args = parser.parse_args(argv)
 
     # Validation
@@ -259,9 +305,17 @@ def main(argv):
             "--prerelease-version is required when release type is 'prerelease'"
         )
 
-    # Compute versions for all three package types: wheel, deb, and rpm
+    if args.release_type != "asan" and args.asan_build_id:
+        parser.error("--asan-build-id requires --release-type=asan")
+
+    # ASAN packaging is deliberately wheel-only. Native package production is
+    # a separate release pipeline and must not accidentally consume this local
+    # version scheme.
     outputs = {}
-    for pkg_type in ["wheel", "deb", "rpm"]:
+    package_types = (
+        ["wheel"] if args.release_type == "asan" else ["wheel", "deb", "rpm"]
+    )
+    for pkg_type in package_types:
         version = compute_version(
             package_type=pkg_type,
             release_type=args.release_type,
@@ -269,6 +323,7 @@ def main(argv):
             prerelease_version=args.prerelease_version,
             override_base_version=args.override_base_version,
             override_git_sha=args.override_git_sha,
+            asan_build_id=args.asan_build_id,
         )
 
         # Set appropriate output variable based on package type

--- a/build_tools/linux_portable_build.py
+++ b/build_tools/linux_portable_build.py
@@ -69,6 +69,7 @@ def do_build(args: argparse.Namespace, *, rest_args: list[str]):
     # Pass through environment variables that control build behavior.
     # These are set by CI workflows to enable features like build profiling.
     passthrough_env_vars = [
+        "CMAKE_BUILD_PARALLEL_LEVEL",
         "EXTRA_C_COMPILER_LAUNCHER",
         "EXTRA_CXX_COMPILER_LAUNCHER",
         "THEROCK_BUILD_PROF_LOG_DIR",

--- a/build_tools/packaging/python/stage_local_asan_index.py
+++ b/build_tools/packaging/python/stage_local_asan_index.py
@@ -1,0 +1,500 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Stage ASan Python packages in a strictly local package index.
+
+The output layout intentionally mirrors the proposed ASan publication prefix::
+
+    <output-root>/whl-asan/gfx942-all/
+      *.whl
+      *.tar.gz
+      index.html
+      index-manifest.json
+      simple/
+        index.html
+        <normalized-project>/index.html
+
+``index.html`` is suitable for ``pip --find-links``. The ``simple`` subtree is
+a PEP 503-style repository suitable for ``pip --index-url``. This tool only
+accepts filesystem paths and has no upload or network code.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict, dataclass
+from email.parser import BytesParser
+from html import escape
+import hashlib
+import json
+from pathlib import Path, PurePosixPath
+import re
+import shutil
+import sys
+import tarfile
+import tempfile
+from urllib.parse import quote
+import zipfile
+
+from generate_local_index import generate_simple_index
+
+
+DEFAULT_FAMILY = "gfx942-all"
+DEFAULT_VERSION_PREFIX = "10.1.0+asan."
+PHASE1_PROJECTS = frozenset(
+    {
+        "rocm",
+        "rocm-sdk-core",
+        "rocm-sdk-libraries",
+        "rocm-sdk-device-gfx942",
+        "rocm-sdk-devel",
+    }
+)
+PHASE1_ARTIFACT_TYPES = {
+    project: "sdist" if project == "rocm" else "wheel" for project in PHASE1_PROJECTS
+}
+_FAMILY_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+@dataclass(frozen=True)
+class PackageRecord:
+    filename: str
+    artifact_type: str
+    project: str
+    normalized_project: str
+    version: str
+    sha256: str
+    size: int
+
+
+def normalize_project_name(name: str) -> str:
+    """Normalize a Python distribution name as specified by PEP 503."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _read_sdist_metadata(path: Path) -> bytes:
+    """Read the authoritative top-level PKG-INFO from an sdist.
+
+    Setuptools sdists can also contain a generated ``*.egg-info/PKG-INFO``.
+    The root ``<sdist-root>/PKG-INFO`` is authoritative. Auxiliary copies are
+    accepted only when their normalized contents agree with it.
+    """
+    try:
+        with tarfile.open(path, "r:gz") as sdist:
+            metadata_files = sorted(
+                (
+                    member
+                    for member in sdist.getmembers()
+                    if member.isfile() and member.name.endswith("/PKG-INFO")
+                ),
+                key=lambda member: member.name,
+            )
+            canonical_files = [
+                member
+                for member in metadata_files
+                if len(PurePosixPath(member.name).parts) == 2
+                and PurePosixPath(member.name).parts[0] not in {"", ".", "..", "/"}
+            ]
+            if len(canonical_files) != 1:
+                raise ValueError(
+                    f"Expected exactly one top-level <sdist-root>/PKG-INFO in "
+                    f"{path}, found {len(canonical_files)}"
+                )
+
+            canonical_file = sdist.extractfile(canonical_files[0])
+            if canonical_file is None:
+                raise ValueError(f"Cannot read PKG-INFO in {path}")
+            canonical_bytes = canonical_file.read()
+            normalized_canonical = canonical_bytes.replace(b"\r\n", b"\n").rstrip(
+                b"\n"
+            )
+
+            for member in metadata_files:
+                if member is canonical_files[0]:
+                    continue
+                metadata_file = sdist.extractfile(member)
+                if metadata_file is None:
+                    raise ValueError(f"Cannot read {member.name} in {path}")
+                nested_bytes = metadata_file.read()
+                normalized_nested = nested_bytes.replace(b"\r\n", b"\n").rstrip(
+                    b"\n"
+                )
+                if normalized_nested != normalized_canonical:
+                    raise ValueError(
+                        f"Auxiliary PKG-INFO {member.name} disagrees with "
+                        f"{canonical_files[0].name} in {path}"
+                    )
+            return canonical_bytes
+    except tarfile.TarError as exc:
+        raise ValueError(f"Invalid sdist archive: {path}") from exc
+
+
+def inspect_package(path: Path, version_prefix: str) -> PackageRecord:
+    """Read and validate identity from wheel METADATA or sdist PKG-INFO."""
+    if not path.is_file():
+        raise ValueError(f"Not a package file: {path}")
+
+    if path.suffix == ".whl":
+        artifact_type = "wheel"
+        try:
+            with zipfile.ZipFile(path) as wheel:
+                metadata_files = [
+                    name
+                    for name in wheel.namelist()
+                    if name.endswith(".dist-info/METADATA")
+                ]
+                if len(metadata_files) != 1:
+                    raise ValueError(
+                        f"Expected exactly one .dist-info/METADATA in {path}, "
+                        f"found {len(metadata_files)}"
+                    )
+                metadata_bytes = wheel.read(metadata_files[0])
+        except zipfile.BadZipFile as exc:
+            raise ValueError(f"Invalid wheel archive: {path}") from exc
+    elif path.name.endswith(".tar.gz"):
+        artifact_type = "sdist"
+        metadata_bytes = _read_sdist_metadata(path)
+    else:
+        raise ValueError(f"Unsupported package file: {path}")
+
+    metadata = BytesParser().parsebytes(metadata_bytes)
+
+    project = metadata.get("Name")
+    version = metadata.get("Version")
+    if not project or not version:
+        raise ValueError(f"Package metadata lacks Name or Version: {path}")
+    if not version.lower().startswith(version_prefix.lower()):
+        raise ValueError(
+            f"Package {path.name} has version {version!r}; expected prefix "
+            f"{version_prefix!r}"
+        )
+
+    return PackageRecord(
+        filename=path.name,
+        artifact_type=artifact_type,
+        project=project,
+        normalized_project=normalize_project_name(project),
+        version=version,
+        sha256=sha256_file(path),
+        size=path.stat().st_size,
+    )
+
+
+def _write_text_atomic(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        mode="w", encoding="utf-8", dir=path.parent, delete=False
+    ) as temp:
+        temp.write(content)
+        temp_path = Path(temp.name)
+    temp_path.replace(path)
+
+
+def _html_page(title: str, links: list[tuple[str, str]]) -> str:
+    lines = [
+        "<!DOCTYPE html>",
+        "<html>",
+        "<head>",
+        '  <meta charset="utf-8">',
+        f"  <title>{escape(title)}</title>",
+        "</head>",
+        "<body>",
+        f"  <h1>{escape(title)}</h1>",
+    ]
+    lines.extend(
+        f'  <a href="{escape(href, quote=True)}">{escape(label)}</a><br>'
+        for href, label in links
+    )
+    lines.extend(["</body>", "</html>", ""])
+    return "\n".join(lines)
+
+
+def _write_indexes(
+    index_dir: Path, family: str, records: list[PackageRecord]
+) -> None:
+    """Write flat find-links and PEP 503 indexes for staged packages."""
+    generate_simple_index(
+        output_path=index_dir / "index.html",
+        local_files=[index_dir / record.filename for record in records],
+        title=f"ROCm 10.1 ASan Python Packages - {family}",
+    )
+
+    by_project: dict[str, list[PackageRecord]] = {}
+    for record in records:
+        by_project.setdefault(record.normalized_project, []).append(record)
+
+    simple_dir = index_dir / "simple"
+    root_links = [(f"./{quote(project)}/", project) for project in sorted(by_project)]
+    _write_text_atomic(
+        simple_dir / "index.html", _html_page("Simple index", root_links)
+    )
+
+    for project, project_records in sorted(by_project.items()):
+        links = [
+            (
+                f"../../{quote(record.filename)}#sha256={record.sha256}",
+                record.filename,
+            )
+            for record in sorted(project_records, key=lambda item: item.filename)
+        ]
+        _write_text_atomic(
+            simple_dir / project / "index.html",
+            _html_page(f"Links for {project}", links),
+        )
+
+
+def _write_manifest(index_dir: Path, family: str, records: list[PackageRecord]) -> None:
+    manifest = {
+        "schema_version": 1,
+        "index_kind": "local-only",
+        "relative_path": f"whl-asan/{family}",
+        "package_count": len(records),
+        "packages": [asdict(record) for record in records],
+    }
+    _write_text_atomic(
+        index_dir / "index-manifest.json",
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+    )
+
+
+def _validate_family(family: str) -> None:
+    if not _FAMILY_RE.fullmatch(family) or family in {".", ".."}:
+        raise ValueError(f"Invalid family name: {family!r}")
+
+
+def _validate_phase1_set(records: list[PackageRecord]) -> None:
+    found_projects = {record.normalized_project for record in records}
+    missing = sorted(PHASE1_PROJECTS - found_projects)
+    if missing:
+        raise ValueError(
+            "Local index is missing required Phase 1 projects: " + ", ".join(missing)
+        )
+    for project, artifact_type in PHASE1_ARTIFACT_TYPES.items():
+        if not any(
+            record.normalized_project == project
+            and record.artifact_type == artifact_type
+            for record in records
+        ):
+            raise ValueError(
+                f"Phase 1 project {project} requires a {artifact_type} artifact"
+            )
+
+
+def _validate_consistent_versions(records: list[PackageRecord]) -> None:
+    versions = sorted({record.version for record in records})
+    if len(versions) != 1:
+        raise ValueError(
+            "Local index must contain exactly one package version; found: "
+            + ", ".join(versions)
+        )
+
+
+def stage_index(
+    input_dir: Path,
+    output_root: Path,
+    *,
+    family: str = DEFAULT_FAMILY,
+    version_prefix: str = DEFAULT_VERSION_PREFIX,
+    require_phase1_set: bool = False,
+) -> Path:
+    """Validate and copy packages into a local ``whl-asan`` index."""
+    _validate_family(family)
+    input_dir = input_dir.resolve()
+    if not input_dir.is_dir():
+        raise FileNotFoundError(f"Input directory does not exist: {input_dir}")
+    wheel_dir = input_dir / "dist" if (input_dir / "dist").is_dir() else input_dir
+    source_packages = sorted(
+        path
+        for pattern in ("*.whl", "*.tar.gz")
+        for path in wheel_dir.glob(pattern)
+        if path.is_file()
+    )
+    if not source_packages:
+        raise FileNotFoundError(f"No wheel or sdist files found in {wheel_dir}")
+
+    source_records = {
+        package.name: inspect_package(package, version_prefix)
+        for package in source_packages
+    }
+    index_dir = output_root.resolve() / "whl-asan" / family
+    index_dir.mkdir(parents=True, exist_ok=True)
+
+    # Never silently replace a differently-built package with the same filename.
+    for source in source_packages:
+        destination = index_dir / source.name
+        if (
+            destination.exists()
+            and sha256_file(destination) != source_records[source.name].sha256
+        ):
+            raise FileExistsError(
+                "Refusing to overwrite package with different contents: "
+                f"{destination}"
+            )
+
+    for source in source_packages:
+        destination = index_dir / source.name
+        if not destination.exists():
+            shutil.copy2(source, destination)
+
+    staged_packages = sorted(
+        path
+        for pattern in ("*.whl", "*.tar.gz")
+        for path in index_dir.glob(pattern)
+    )
+    records = [
+        inspect_package(package, version_prefix) for package in staged_packages
+    ]
+    records.sort(key=lambda item: (item.normalized_project, item.filename))
+    _validate_consistent_versions(records)
+
+    if require_phase1_set:
+        _validate_phase1_set(records)
+
+    _write_indexes(index_dir, family, records)
+    _write_manifest(index_dir, family, records)
+    return index_dir
+
+
+def verify_index(
+    output_root: Path,
+    *,
+    family: str = DEFAULT_FAMILY,
+    version_prefix: str = DEFAULT_VERSION_PREFIX,
+    require_phase1_set: bool = False,
+) -> Path:
+    """Verify wheel hashes, metadata, completeness, and generated indexes."""
+    _validate_family(family)
+    index_dir = output_root.resolve() / "whl-asan" / family
+    manifest_path = index_dir / "index-manifest.json"
+    if not manifest_path.is_file():
+        raise FileNotFoundError(f"Manifest not found: {manifest_path}")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if manifest.get("index_kind") != "local-only":
+        raise ValueError(f"Unexpected index kind in {manifest_path}")
+    if manifest.get("relative_path") != f"whl-asan/{family}":
+        raise ValueError(f"Unexpected index path in {manifest_path}")
+
+    expected = {item["filename"]: item for item in manifest.get("packages", [])}
+    actual_names = {
+        path.name
+        for pattern in ("*.whl", "*.tar.gz")
+        for path in index_dir.glob(pattern)
+    }
+    if actual_names != set(expected):
+        raise ValueError(
+            "Staged packages differ from manifest: "
+            f"expected={sorted(expected)}, actual={sorted(actual_names)}"
+        )
+
+    records = []
+    for filename in sorted(expected):
+        record = inspect_package(index_dir / filename, version_prefix)
+        if asdict(record) != expected[filename]:
+            raise ValueError(f"Package does not match manifest: {filename}")
+        records.append(record)
+
+    _validate_consistent_versions(records)
+    if require_phase1_set:
+        _validate_phase1_set(records)
+
+    required_indexes = [index_dir / "index.html", index_dir / "simple" / "index.html"]
+    required_indexes.extend(
+        index_dir / "simple" / record.normalized_project / "index.html"
+        for record in records
+    )
+    missing_indexes = sorted(
+        str(path) for path in required_indexes if not path.is_file()
+    )
+    if missing_indexes:
+        raise FileNotFoundError("Missing index files: " + ", ".join(missing_indexes))
+
+    flat_index = (index_dir / "index.html").read_text(encoding="utf-8")
+    simple_root = (index_dir / "simple" / "index.html").read_text(
+        encoding="utf-8"
+    )
+    for record in records:
+        if f'./{quote(record.filename)}' not in flat_index:
+            raise ValueError(
+                f"Package missing from find-links index: {record.filename}"
+            )
+        if f'./{quote(record.normalized_project)}/' not in simple_root:
+            raise ValueError(
+                f"Project missing from simple index: {record.normalized_project}"
+            )
+        project_index = (
+            index_dir / "simple" / record.normalized_project / "index.html"
+        ).read_text(encoding="utf-8")
+        expected_link = (
+            f"../../{quote(record.filename)}#sha256={record.sha256}"
+        )
+        if expected_link not in project_index:
+            raise ValueError(
+                f"Package missing from project index: {record.filename}"
+            )
+    return index_dir
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    stage = subparsers.add_parser(
+        "stage", help="Validate, copy, and index wheels and sdists"
+    )
+    stage.add_argument("--input-dir", type=Path, required=True)
+    stage.add_argument("--output-root", type=Path, required=True)
+
+    verify = subparsers.add_parser("verify", help="Verify an existing local index")
+    verify.add_argument("--output-root", type=Path, required=True)
+
+    for command in (stage, verify):
+        command.add_argument("--family", default=DEFAULT_FAMILY)
+        command.add_argument("--version-prefix", default=DEFAULT_VERSION_PREFIX)
+        command.add_argument(
+            "--require-phase1-set",
+            action="store_true",
+            help=(
+                "Require the rocm selector sdist plus core, libraries, gfx942 "
+                "device, and devel wheels"
+            ),
+        )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        if args.command == "stage":
+            index_dir = stage_index(
+                args.input_dir,
+                args.output_root,
+                family=args.family,
+                version_prefix=args.version_prefix,
+                require_phase1_set=args.require_phase1_set,
+            )
+        else:
+            index_dir = verify_index(
+                args.output_root,
+                family=args.family,
+                version_prefix=args.version_prefix,
+                require_phase1_set=args.require_phase1_set,
+            )
+    except (FileExistsError, FileNotFoundError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    print(index_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/build_tools/packaging/tests/stage_local_asan_index_test.py
+++ b/build_tools/packaging/tests/stage_local_asan_index_test.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the strictly local ASan wheel index."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tarfile
+import tempfile
+import unittest
+import zipfile
+from io import BytesIO
+
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent / "python"))
+
+from stage_local_asan_index import (  # noqa: E402
+    PHASE1_PROJECTS,
+    main,
+    normalize_project_name,
+    stage_index,
+    verify_index,
+)
+
+
+def _wheel_filename(project: str, version: str) -> str:
+    distribution = project.replace("-", "_")
+    return f"{distribution}-{version}-py3-none-any.whl"
+
+
+def _write_wheel(
+    directory: Path,
+    project: str,
+    version: str = "10.1.0+asan.20260807",
+    *,
+    marker: str = "",
+) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / _wheel_filename(project, version)
+    dist_info = f"{project.replace('-', '_')}-{version}.dist-info"
+    with zipfile.ZipFile(path, "w") as wheel:
+        wheel.writestr(
+            f"{dist_info}/METADATA",
+            "Metadata-Version: 2.1\n"
+            f"Name: {project}\n"
+            f"Version: {version}\n\n{marker}",
+        )
+        wheel.writestr(
+            f"{dist_info}/WHEEL",
+            "Wheel-Version: 1.0\nTag: py3-none-any\n",
+        )
+        wheel.writestr(f"{dist_info}/RECORD", "")
+    return path
+
+
+def _write_sdist(
+    directory: Path,
+    project: str,
+    version: str = "10.1.0+asan.20260807",
+    *,
+    nested_metadata: bytes | None = None,
+) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"{project}-{version}.tar.gz"
+    package_root = f"{project}-{version}"
+    metadata = (
+        "Metadata-Version: 2.1\n"
+        f"Name: {project}\n"
+        f"Version: {version}\n"
+    ).encode()
+    info = tarfile.TarInfo(f"{package_root}/PKG-INFO")
+    info.size = len(metadata)
+    with tarfile.open(path, "w:gz") as sdist:
+        sdist.addfile(info, BytesIO(metadata))
+        nested_info = tarfile.TarInfo(
+            f"{package_root}/src/{project}.egg-info/PKG-INFO"
+        )
+        nested_payload = metadata if nested_metadata is None else nested_metadata
+        nested_info.size = len(nested_payload)
+        sdist.addfile(nested_info, BytesIO(nested_payload))
+    return path
+
+
+class TestProjectNormalization(unittest.TestCase):
+    def test_pep503_normalization(self):
+        self.assertEqual(normalize_project_name("ROCm_SDK.Device"), "rocm-sdk-device")
+
+
+class TestStageLocalAsanIndex(unittest.TestCase):
+    def test_accepts_matching_setuptools_egg_info_metadata(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            sdist = _write_sdist(root / "packages", "rocm")
+
+            index_dir = stage_index(root / "packages", root / "local")
+
+            self.assertTrue((index_dir / sdist.name).is_file())
+
+    def test_rejects_disagreeing_setuptools_egg_info_metadata(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            _write_sdist(
+                root / "packages",
+                "rocm",
+                nested_metadata=(
+                    b"Metadata-Version: 2.1\n"
+                    b"Name: rocm\n"
+                    b"Version: 10.1.0+asan.different\n"
+                ),
+            )
+
+            with self.assertRaisesRegex(ValueError, "disagrees with"):
+                stage_index(root / "packages", root / "local")
+
+    def test_rejects_multiple_top_level_metadata_candidates(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            packages = root / "packages"
+            packages.mkdir()
+            path = packages / "rocm-10.1.0+asan.20260807.tar.gz"
+            metadata = (
+                b"Metadata-Version: 2.1\n"
+                b"Name: rocm\n"
+                b"Version: 10.1.0+asan.20260807\n"
+            )
+            with tarfile.open(path, "w:gz") as sdist:
+                for package_root in ("rocm-first", "rocm-second"):
+                    info = tarfile.TarInfo(f"{package_root}/PKG-INFO")
+                    info.size = len(metadata)
+                    sdist.addfile(info, BytesIO(metadata))
+
+            with self.assertRaisesRegex(ValueError, "top-level.*found 2"):
+                stage_index(packages, root / "local")
+
+    def test_pip_resolves_flat_and_simple_indexes_without_network(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            _write_wheel(root / "packages", "rocm-sdk-core")
+            index_dir = stage_index(root / "packages", root / "local")
+
+            common = [
+                sys.executable,
+                "-m",
+                "pip",
+                "--isolated",
+                "install",
+                "--disable-pip-version-check",
+                "--no-deps",
+            ]
+            find_links = subprocess.run(
+                [
+                    *common,
+                    "--no-index",
+                    "--find-links",
+                    os.fspath(index_dir / "index.html"),
+                    "--target",
+                    os.fspath(root / "find-links-install"),
+                    "rocm-sdk-core==10.1.0+asan.20260807",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(find_links.returncode, 0, find_links.stderr)
+
+            simple = subprocess.run(
+                [
+                    *common,
+                    "--index-url",
+                    (index_dir / "simple").as_uri() + "/",
+                    "--target",
+                    os.fspath(root / "simple-install"),
+                    "rocm-sdk-core==10.1.0+asan.20260807",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(simple.returncode, 0, simple.stderr)
+
+    def test_cli_stage_and_verify_complete_set(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            packages = root / "packages" / "dist"
+            for project in PHASE1_PROJECTS - {"rocm"}:
+                _write_wheel(packages, project)
+            _write_sdist(packages, "rocm")
+
+            self.assertEqual(
+                main(
+                    [
+                        "stage",
+                        "--input-dir",
+                        os.fspath(packages.parent),
+                        "--output-root",
+                        os.fspath(root / "local"),
+                        "--require-phase1-set",
+                    ]
+                ),
+                0,
+            )
+            self.assertEqual(
+                main(
+                    [
+                        "verify",
+                        "--output-root",
+                        os.fspath(root / "local"),
+                        "--require-phase1-set",
+                    ]
+                ),
+                0,
+            )
+
+    def test_stages_find_links_simple_index_and_manifest(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            packages = root / "packages" / "dist"
+            output = root / "local"
+            wheel = _write_wheel(packages, "rocm-sdk-core")
+
+            index_dir = stage_index(packages.parent, output)
+
+            staged_wheel = index_dir / wheel.name
+            self.assertEqual(staged_wheel.read_bytes(), wheel.read_bytes())
+
+            find_links = (index_dir / "index.html").read_text(encoding="utf-8")
+            self.assertIn(wheel.name.replace("+", "%2B"), find_links)
+
+            simple_root = (index_dir / "simple" / "index.html").read_text(
+                encoding="utf-8"
+            )
+            self.assertIn('href="./rocm-sdk-core/"', simple_root)
+
+            project_index = (
+                index_dir / "simple" / "rocm-sdk-core" / "index.html"
+            ).read_text(encoding="utf-8")
+            self.assertIn("../../rocm_sdk_core-10.1.0%2Basan.20260807", project_index)
+            self.assertIn("#sha256=", project_index)
+
+            manifest = json.loads(
+                (index_dir / "index-manifest.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(manifest["index_kind"], "local-only")
+            self.assertEqual(manifest["relative_path"], "whl-asan/gfx942-all")
+            self.assertEqual(manifest["package_count"], 1)
+            self.assertEqual(manifest["packages"][0]["project"], "rocm-sdk-core")
+            self.assertEqual(verify_index(output), index_dir)
+
+    def test_rejects_non_asan_version(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            _write_wheel(root / "packages", "rocm-sdk-core", "10.1.0")
+
+            with self.assertRaisesRegex(ValueError, "expected prefix"):
+                stage_index(root / "packages", root / "local")
+
+    def test_refuses_different_wheel_with_same_filename(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            packages = root / "packages"
+            _write_wheel(packages, "rocm-sdk-core", marker="first")
+            stage_index(packages, root / "local")
+            _write_wheel(packages, "rocm-sdk-core", marker="second")
+
+            with self.assertRaisesRegex(FileExistsError, "Refusing to overwrite"):
+                stage_index(packages, root / "local")
+
+    def test_requires_complete_phase1_project_set_when_requested(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            packages = root / "packages"
+            _write_wheel(packages, "rocm-sdk-core")
+
+            with self.assertRaisesRegex(ValueError, "missing required Phase 1"):
+                stage_index(
+                    packages,
+                    root / "local",
+                    require_phase1_set=True,
+                )
+
+            for project in PHASE1_PROJECTS - {"rocm-sdk-core", "rocm"}:
+                _write_wheel(packages, project)
+            _write_sdist(packages, "rocm")
+            index_dir = stage_index(
+                packages,
+                root / "complete",
+                require_phase1_set=True,
+            )
+            self.assertEqual(
+                len(list(index_dir.glob("*.whl"))), len(PHASE1_PROJECTS) - 1
+            )
+            self.assertEqual(len(list(index_dir.glob("*.tar.gz"))), 1)
+
+    def test_phase1_set_requires_rocm_selector_as_sdist(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            packages = root / "packages"
+            for project in PHASE1_PROJECTS:
+                _write_wheel(packages, project)
+
+            with self.assertRaisesRegex(ValueError, "rocm requires a sdist"):
+                stage_index(
+                    packages,
+                    root / "local",
+                    require_phase1_set=True,
+                )
+
+    def test_verify_detects_tampered_wheel(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            wheel = _write_wheel(root / "packages", "rocm-sdk-core")
+            index_dir = stage_index(root / "packages", root / "local")
+            (index_dir / wheel.name).write_bytes(b"tampered")
+
+            with self.assertRaises(ValueError):
+                verify_index(root / "local")
+
+    def test_rejects_mixed_asan_build_versions(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            packages = root / "packages"
+            _write_wheel(packages, "rocm-sdk-core")
+            _write_wheel(
+                packages,
+                "rocm-sdk-devel",
+                "10.1.0+asan.20260808",
+            )
+
+            with self.assertRaisesRegex(ValueError, "exactly one package version"):
+                stage_index(packages, root / "local")
+
+    def test_rejects_unsafe_family_name(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            _write_wheel(root / "packages", "rocm-sdk-core")
+            with self.assertRaisesRegex(ValueError, "Invalid family"):
+                stage_index(root / "packages", root / "local", family="../escape")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/build_tools/tests/asan_python_packaging_test.py
+++ b/build_tools/tests/asan_python_packaging_test.py
@@ -1,0 +1,259 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+import argparse
+import os
+from pathlib import Path
+import sys
+import tempfile
+import types
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
+
+from _therock_utils.artifacts import ArtifactCatalog
+from build_python_packages import (
+    _rpath_resolves_directory,
+    find_asan_runtime_rpath,
+    resolve_package_version,
+    validate_asan_runtime_resolution,
+)
+
+
+class AsanVersionResolutionTest(unittest.TestCase):
+    def test_version_defaults_to_artifact_nightly_date(self):
+        args = argparse.Namespace(asan=True, asan_build_id=None, version="")
+        manifest = {
+            "rocm_version": "10.1.0",
+            "rocm_package_version": "10.1.0a20260807",
+        }
+
+        self.assertEqual(
+            resolve_package_version(args, manifest),
+            "10.1.0+asan.20260807",
+        )
+
+    def test_explicit_asan_version_must_match_artifact_base(self):
+        args = argparse.Namespace(
+            asan=True,
+            asan_build_id=None,
+            version="7.15.0+asan.20260807",
+        )
+        with self.assertRaisesRegex(ValueError, r"10\.1\.0\+asan"):
+            resolve_package_version(args, {"rocm_version": "10.1.0"})
+
+    def test_build_id_requires_asan_mode(self):
+        args = argparse.Namespace(
+            asan=False,
+            asan_build_id="20260807",
+            version="10.1.0",
+        )
+        with self.assertRaisesRegex(ValueError, "requires --asan"):
+            resolve_package_version(args, {"rocm_version": "10.1.0"})
+
+
+class AsanRuntimeDiscoveryTest(unittest.TestCase):
+    def test_finds_clang_resource_directory(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact_dir = Path(temp_dir)
+            artifact = artifact_dir / "base_lib_generic"
+            stage = artifact / "base" / "aux-overlay" / "stage"
+            runtime = (
+                stage
+                / "lib"
+                / "llvm"
+                / "lib"
+                / "clang"
+                / "23"
+                / "lib"
+                / "linux"
+                / "libclang_rt.asan-x86_64.so"
+            )
+            runtime.parent.mkdir(parents=True)
+            runtime.touch()
+            (artifact / "artifact_manifest.txt").write_text("base/aux-overlay/stage\n")
+
+            self.assertEqual(
+                find_asan_runtime_rpath(ArtifactCatalog(artifact_dir)),
+                "lib/llvm/lib/clang/23/lib/linux",
+            )
+
+    def test_missing_runtime_is_rejected(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with self.assertRaisesRegex(RuntimeError, "no shared Clang ASAN"):
+                find_asan_runtime_rpath(ArtifactCatalog(Path(temp_dir)))
+
+
+class AsanRpathValidationTest(unittest.TestCase):
+    def test_origin_rpath_resolves_cross_wheel_runtime(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            binary = root / "_rocm_sdk_libraries" / "lib" / "libfoo.so"
+            runtime_dir = (
+                root
+                / "_rocm_sdk_core"
+                / "lib"
+                / "llvm"
+                / "lib"
+                / "clang"
+                / "23"
+                / "lib"
+                / "linux"
+            )
+
+            self.assertTrue(
+                _rpath_resolves_directory(
+                    binary_path=binary,
+                    rpaths=[
+                        "$ORIGIN/../../_rocm_sdk_core/"
+                        "lib/llvm/lib/clang/23/lib/linux"
+                    ],
+                    expected_dir=runtime_dir,
+                )
+            )
+
+    def test_origin_rpath_resolves_separate_wheel_staging_directories(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            profiler_platform = root / "rocm-profiler" / "platform"
+            core_platform = root / "rocm-sdk-core" / "platform"
+            binary = profiler_platform / "_rocm_profiler" / "bin" / "rocprof"
+            runtime_dir = (
+                core_platform
+                / "_rocm_sdk_core"
+                / "lib"
+                / "llvm"
+                / "lib"
+                / "clang"
+                / "23"
+                / "lib"
+                / "linux"
+            )
+
+            self.assertTrue(
+                _rpath_resolves_directory(
+                    binary_path=binary,
+                    rpaths=[
+                        "$ORIGIN/../../_rocm_sdk_core/"
+                        "lib/llvm/lib/clang/23/lib/linux"
+                    ],
+                    expected_dir=runtime_dir,
+                    binary_platform_root=profiler_platform,
+                    expected_platform_root=core_platform,
+                )
+            )
+
+    def test_validator_projects_separate_wheels_into_site_packages(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            core_platform = root / "rocm-sdk-core" / "platform"
+            core_dir = core_platform / "_rocm_sdk_core"
+            profiler_platform = root / "rocm-profiler" / "platform"
+            profiler_dir = profiler_platform / "_rocm_profiler"
+            runtime_rpath = "lib/llvm/lib/clang/23/lib/linux"
+            runtime_dir = core_dir / runtime_rpath
+            runtime_dir.mkdir(parents=True)
+            (runtime_dir / "libclang_rt.asan-x86_64.so").touch()
+
+            binary = profiler_dir / "bin" / "rocprof"
+            binary.parent.mkdir(parents=True)
+            binary.touch()
+            package = types.SimpleNamespace(
+                platform_dir=profiler_dir,
+                files=types.SimpleNamespace(
+                    materialized_relpaths={"bin/rocprof": (None, binary)}
+                ),
+            )
+            core = types.SimpleNamespace(platform_dir=core_dir)
+
+            with mock.patch(
+                "build_python_packages._elf_dynamic_info",
+                return_value=(
+                    ["libclang_rt.asan-x86_64.so"],
+                    [
+                        "$ORIGIN/../../_rocm_sdk_core/"
+                        "lib/llvm/lib/clang/23/lib/linux"
+                    ],
+                ),
+            ):
+                validate_asan_runtime_resolution(
+                    core=core,
+                    packages=[package],
+                    runtime_rpath=runtime_rpath,
+                    require_instrumented=True,
+                )
+
+    def test_validator_accepts_resolvable_instrumented_elf(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            core_dir = root / "_rocm_sdk_core"
+            runtime_rpath = "lib/llvm/lib/clang/23/lib/linux"
+            runtime_dir = core_dir / runtime_rpath
+            runtime_dir.mkdir(parents=True)
+            (runtime_dir / "libclang_rt.asan-x86_64.so").touch()
+
+            binary = root / "_rocm_sdk_libraries" / "lib" / "libfoo.so"
+            binary.parent.mkdir(parents=True)
+            binary.touch()
+            package = types.SimpleNamespace(
+                platform_dir=root / "_rocm_sdk_libraries",
+                files=types.SimpleNamespace(
+                    materialized_relpaths={"lib/libfoo.so": (None, binary)}
+                )
+            )
+            core = types.SimpleNamespace(platform_dir=core_dir)
+            dynamic_info = (
+                ["libclang_rt.asan-x86_64.so"],
+                ["$ORIGIN/../../_rocm_sdk_core/" "lib/llvm/lib/clang/23/lib/linux"],
+            )
+
+            with mock.patch(
+                "build_python_packages._elf_dynamic_info",
+                return_value=dynamic_info,
+            ):
+                validate_asan_runtime_resolution(
+                    core=core,
+                    packages=[package],
+                    runtime_rpath=runtime_rpath,
+                    require_instrumented=True,
+                )
+
+    def test_validator_rejects_unresolved_instrumented_elf(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            core_dir = root / "_rocm_sdk_core"
+            runtime_rpath = "lib/llvm/lib/clang/23/lib/linux"
+            runtime_dir = core_dir / runtime_rpath
+            runtime_dir.mkdir(parents=True)
+            (runtime_dir / "libclang_rt.asan-x86_64.so").touch()
+
+            binary = root / "_rocm_sdk_libraries" / "lib" / "libfoo.so"
+            binary.parent.mkdir(parents=True)
+            binary.touch()
+            package = types.SimpleNamespace(
+                platform_dir=root / "_rocm_sdk_libraries",
+                files=types.SimpleNamespace(
+                    materialized_relpaths={"lib/libfoo.so": (None, binary)}
+                )
+            )
+            core = types.SimpleNamespace(platform_dir=core_dir)
+
+            with mock.patch(
+                "build_python_packages._elf_dynamic_info",
+                return_value=(
+                    ["libclang_rt.asan-x86_64.so"],
+                    ["$ORIGIN/llvm/lib/clang/23/lib/linux"],
+                ),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "cannot resolve"):
+                    validate_asan_runtime_resolution(
+                        core=core,
+                        packages=[package],
+                        runtime_rpath=runtime_rpath,
+                        require_instrumented=True,
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/build_tools/tests/compute_rocm_package_version_test.py
+++ b/build_tools/tests/compute_rocm_package_version_test.py
@@ -17,6 +17,47 @@ import compute_rocm_package_version
 
 
 class DetermineVersionTest(unittest.TestCase):
+    def test_asan_version_uses_isolated_local_version(self):
+        version = compute_rocm_package_version.compute_version(
+            release_type="asan",
+            override_base_version="10.1.0",
+            asan_build_id="20260807",
+        )
+        self.assertEqual(version, "10.1.0+asan.20260807")
+
+    def test_asan_build_id_is_normalized(self):
+        version = compute_rocm_package_version.compute_version(
+            release_type="asan",
+            override_base_version="10.1.0",
+            asan_build_id="RUN_31-137",
+        )
+        self.assertEqual(version, "10.1.0+asan.run.31.137")
+
+    def test_asan_build_id_rejects_non_local_version_characters(self):
+        with self.assertRaisesRegex(ValueError, "ASAN build ID"):
+            compute_rocm_package_version.compute_version(
+                release_type="asan",
+                override_base_version="10.1.0",
+                asan_build_id="../../release",
+            )
+
+    def test_asan_version_is_wheel_only(self):
+        with self.assertRaisesRegex(ValueError, "only supported for wheels"):
+            compute_rocm_package_version.compute_version(
+                package_type="deb",
+                release_type="asan",
+                override_base_version="10.1.0",
+                asan_build_id="20260807",
+            )
+
+    def test_asan_build_id_requires_asan_release_type(self):
+        with self.assertRaisesRegex(ValueError, "requires release_type='asan'"):
+            compute_rocm_package_version.compute_version(
+                release_type="nightly",
+                override_base_version="10.1.0",
+                asan_build_id="20260807",
+            )
+
     def test_ci_version_uses_dev_version_shape(self):
         version = compute_rocm_package_version.compute_version(
             release_type="ci",
@@ -388,6 +429,32 @@ class MainFunctionMultiplePackageTypesTest(unittest.TestCase):
             self.assertIn("rocm_rpm_package_version", captured_outputs)
         finally:
             compute_rocm_package_version.gha_set_output = original_gha_set_output
+
+    def test_asan_cli_emits_wheel_output_only(self):
+        captured_outputs = {}
+        original_gha_set_output = compute_rocm_package_version.gha_set_output
+
+        def mock_gha_set_output(outputs):
+            captured_outputs.update(outputs)
+
+        compute_rocm_package_version.gha_set_output = mock_gha_set_output
+        try:
+            compute_rocm_package_version.main(
+                [
+                    "--release-type",
+                    "asan",
+                    "--asan-build-id",
+                    "20260807",
+                    "--override-base-version",
+                    "10.1.0",
+                ]
+            )
+        finally:
+            compute_rocm_package_version.gha_set_output = original_gha_set_output
+
+        self.assertEqual(
+            captured_outputs, {"rocm_package_version": "10.1.0+asan.20260807"}
+        )
 
 
 if __name__ == "__main__":

--- a/docs/packaging/local_asan_index.md
+++ b/docs/packaging/local_asan_index.md
@@ -1,0 +1,95 @@
+# Local ASan Python Package Index
+
+Phase 1 ASan packages can be staged and installed without publishing them to
+S3 or any other network service. The local layout mirrors the proposed
+per-family publication tree:
+
+```text
+<output-root>/
+└── whl-asan/
+    └── gfx942-all/
+        ├── index.html
+        ├── index-manifest.json
+        ├── rocm-10.1.0+asan.<build-id>.tar.gz
+        ├── rocm_sdk_*.whl
+        └── simple/
+            ├── index.html
+            └── <normalized-project>/index.html
+```
+
+The top-level `index.html` is a flat `pip --find-links` index generated with
+TheRock's existing local index utility. The `simple/` subtree is a PEP 503
+repository with SHA-256 fragments. `index-manifest.json` records the same
+hashes and package metadata for offline verification.
+
+## Stage packages
+
+First build ASan packages into a local package directory. Then stage them into
+the isolated index:
+
+```bash
+python build_tools/packaging/python/stage_local_asan_index.py stage \
+  --input-dir /path/to/packages \
+  --output-root /path/to/phase1-local \
+  --require-phase1-set
+```
+
+If `/path/to/packages/dist` exists, it is used automatically. Otherwise the
+tool reads packages directly from `/path/to/packages`. By default, it accepts
+only package metadata versions beginning with `10.1.0+asan.` and stages them
+under `whl-asan/gfx942-all`.
+
+`--require-phase1-set` verifies that the local index contains:
+
+- the `rocm` selector sdist;
+- `rocm-sdk-core`;
+- `rocm-sdk-libraries`;
+- `rocm-sdk-device-gfx942`;
+- `rocm-sdk-devel`.
+
+The tool refuses to overwrite an existing package with different contents. Use
+a new output root for a different build ID rather than mixing builds.
+
+## Verify and install offline
+
+Verify every package against the manifest before installation:
+
+```bash
+python build_tools/packaging/python/stage_local_asan_index.py verify \
+  --output-root /path/to/phase1-local \
+  --require-phase1-set
+```
+
+Install from the flat local index with network package lookup disabled:
+
+The single-target selector exposes the generic `device` extra, which is pinned
+to `rocm-sdk-device-gfx942`. Per-target extras such as `device-gfx942` are only
+generated for multi-target selectors.
+
+```bash
+INDEX=/path/to/phase1-local/whl-asan/gfx942-all
+python -m venv /path/to/asan-venv
+source /path/to/asan-venv/bin/activate
+python -m pip install --no-index --find-links="$INDEX/index.html" --pre \
+  "rocm[libraries,devel,device]"
+```
+
+Or exercise the PEP 503 tree directly:
+
+```bash
+python -m pip install --index-url="file://$INDEX/simple/" --pre \
+  "rocm[libraries,devel,device]"
+```
+
+Run the installed SDK checks under the ASan environment described in
+[`sanitizers.md`](../development/sanitizers.md):
+
+```bash
+export HSA_XNACK=1
+export ASAN_OPTIONS=detect_leaks=0:abort_on_error=1:print_stacktrace=1
+python -m rocm_sdk path --root
+rocm-sdk test
+```
+
+The staging command only uses local filesystem operations. It does not import
+TheRock's storage backends, choose a bucket, or expose an upload mode.

--- a/docs/packaging/python_packaging.md
+++ b/docs/packaging/python_packaging.md
@@ -125,6 +125,46 @@ objects fail to load at install time. See
 [environment_setup_guide.md#patchelf](../environment_setup_guide.md#patchelf)
 for supported install paths.
 
+#### Local ASAN wheels
+
+An ASAN artifact build must be packaged with `--asan`. This gives every ROCm
+wheel a non-release, PEP 440 local version such as
+`10.1.0+asan.20260807`, packages the shared Clang ASAN runtime in
+`rocm-sdk-core`, and validates that ASAN-linked ELFs in the split wheels can
+resolve that runtime through a relative RPATH.
+
+```bash
+python ./build_tools/build_python_packages.py \
+    --artifact-dir=/path/to/asan/build/artifacts \
+    --dest-dir=/path/to/local/rocm-asan-wheels \
+    --linux-amdgpu-families=gfx94X-dcgpu \
+    --asan
+```
+
+The default ASAN build ID is derived from `rocm_package_version` in the source
+artifact's `therock_manifest.json` (for example, `20260807` from
+`10.1.0a20260807`). Use `--asan-build-id=<id>` to select a different local
+identifier. An explicit `--version` is accepted only when it has the matching
+artifact base and canonical `<base>+asan.<build-id>` shape; this prevents an
+ASAN artifact set from being mislabeled as a release wheel.
+
+The kpack split is unchanged. For a gfx942 artifact set, the local output under
+`/path/to/local/rocm-asan-wheels/dist` includes:
+
+```text
+rocm-10.1.0+asan.20260807.tar.gz
+rocm_sdk_core-10.1.0+asan.20260807-*.whl
+rocm_sdk_libraries-10.1.0+asan.20260807-*.whl
+rocm_sdk_device_gfx942-10.1.0+asan.20260807-*.whl
+rocm_sdk_devel-10.1.0+asan.20260807-*.whl
+```
+
+`build_python_packages.py` only writes local files. It does not upload or
+promote packages. Also note that it consumes TheRock's structured `artifacts/`
+directory, not an already-flattened `therock-dist-*.tar.gz` SDK archive.
+See [Local ASan Python Package Index](local_asan_index.md) to stage the result
+under an isolated `whl-asan/gfx942-all/` tree and install it offline.
+
 ### Building from CI Artifacts
 
 You can also build packages from artifacts uploaded by CI workflows:


### PR DESCRIPTION
Stack: **1 of 2**. Phase 2 is stacked on this commit in **ROCm/TheRock#7313**.

## Summary

Add the integrated Phase 1 path for producing a coherent local ROCm ASAN Python package set from TheRock's structured artifacts:

- add an explicit wheel-only ASAN version mode and derive the build identity from artifact metadata;
- discover and package one shared Clang ASAN runtime in `rocm-sdk-core`;
- inject origin-relative cross-wheel runtime paths and validate the merged installation layout before building wheels;
- reject release-labelled, mismatched, incomplete, or unresolved ASAN package sets;
- stage a local-only flat/PEP 503 index with SHA-256 fragments and a verified manifest; and
- document the structured-artifact, runtime, versioning, and local-index contracts.

The build path has no upload or publication action.

## Why this is a draft

This preserves the complete validated prototype for review, but several policy and hardening decisions should be resolved before merge:

- choose the final version policy (`10.1.0+asan.<id>`, prerelease-preserving spelling, or an explicit workflow-supplied version);
- split/generalize the ASAN-specific local-index implementation into reusable manifest and PEP 503 layers;
- separate the generic cross-wheel ELF resolver from the ASAN policy; and
- add the remaining malformed-archive, multiple-runtime, prerelease-manifest, and legacy non-kpack cases described in the execution review.

## Real-input evidence

The prototype was exercised from TheRock `6b6cd74cf7825b2ed3d4795f8fee801e3150d248` with the `linux-release-asan` preset, a pinned manylinux image, and `gfx942:xnack+` artifacts.

- produced selector, profiler, core, libraries, device, and devel packages at `10.1.0+asan.20260807`;
- inspected 175 ELF candidates and found 82 ASAN-linked ELFs, including HIP and HSA, with zero unresolved shared-runtime dependencies;
- static wheel/package validation passed, including ZIP/CRC, exact pins, kpack content, and shared-runtime resolution;
- clean offline installation, `rocm-sdk init`, SDK-root lookup, and 26 of 27 SDK tests passed;
- the remaining GPU initialization test reproduced the documented pre-fix null-PC compiler-rt failure, so the runtime result is evidence rather than a production acceptance pass.

No generated wheels, indexes, hashes, reports, build trees, or machine-local orchestration files are included.

## Tests

```text
76 focused tests passed:
- compute_rocm_package_version_test
- asan_python_packaging_test
- stage_local_asan_index_test
- generate_local_index_test

python -m py_compile: pass
git diff --check: pass
```

## Follow-up acceptance

- ROCm/llvm-project#3827 supplies the late-HSA compiler-rt fix needed for strict runtime acceptance.
- Rebuild the Phase 1 core wheel with that runtime and require strict gfx942 validation before publication.
- Publication/promotion remains a separate authenticated workflow and is intentionally out of scope here.
