### PR TITLE
external-builds/pytorch: add a torch-only ROCm ASAN build mode

### DIFF
--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -23,8 +23,14 @@ Example
 import argparse
 import functools
 import json
+import os
 from pathlib import Path
+from pathlib import PurePosixPath
+import re
 import sys
+
+from elftools.common.exceptions import ELFError
+from elftools.elf.elffile import ELFFile
 
 from _therock_utils.artifacts import ArtifactCatalog, ArtifactName
 from _therock_utils.cmake_amdgpu_targets import amdgpu_family_map, expand_families
@@ -64,6 +70,209 @@ def load_therock_manifest(artifact_dir: Path) -> dict:
             f"Is base_lib_generic present in {artifact_dir}?"
         )
     return json.loads(manifest_path.read_text())
+
+
+def _asan_build_id_from_manifest(manifest: dict) -> str | None:
+    """Derive a stable build ID from a nightly artifact manifest."""
+    package_version = manifest.get("rocm_package_version", "")
+    match = re.search(r"(?:a|rc)(\d{8,})$", package_version)
+    return match.group(1) if match else None
+
+
+def resolve_package_version(args: argparse.Namespace, manifest: dict) -> str:
+    """Resolve the package version, enforcing ASAN/release isolation."""
+    import compute_rocm_package_version
+
+    is_asan = getattr(args, "asan", False)
+    asan_build_id = getattr(args, "asan_build_id", None)
+    version = getattr(args, "version", "")
+
+    if asan_build_id and not is_asan:
+        raise ValueError("--asan-build-id requires --asan")
+
+    if not is_asan:
+        if version:
+            return version
+        print("::: Version not specified, choosing a default")
+        resolved = compute_rocm_package_version.compute_version(
+            custom_version_suffix=".dev0"
+        )
+        print(f"::: Version defaulting to {resolved}")
+        return resolved
+
+    base_version = manifest.get("rocm_version")
+    if not base_version:
+        raise ValueError(
+            "ASAN packaging requires rocm_version in therock_manifest.json"
+        )
+
+    if version:
+        expected = re.compile(
+            rf"^{re.escape(base_version)}\+asan\.[a-z0-9]+(?:\.[a-z0-9]+)*$"
+        )
+        if not expected.fullmatch(version):
+            raise ValueError(
+                "--asan requires a canonical ASAN wheel version matching "
+                f"{base_version}+asan.<build-id>; got {version!r}"
+            )
+        return version
+
+    if asan_build_id is None:
+        asan_build_id = _asan_build_id_from_manifest(manifest)
+    resolved = compute_rocm_package_version.compute_version(
+        release_type="asan",
+        override_base_version=base_version,
+        asan_build_id=asan_build_id,
+    )
+    print(f"::: ASAN wheel version defaulting to {resolved}")
+    return resolved
+
+
+def find_asan_runtime_rpath(artifacts: ArtifactCatalog) -> str:
+    """Find the Clang ASAN runtime directory in staged artifacts."""
+    runtime_dirs: set[str] = set()
+    for relpath, entry in artifacts.pm.matches():
+        relpath = PurePosixPath(relpath)
+        if entry.is_file() and relpath.match(
+            "lib/llvm/lib/clang/*/lib/linux/libclang_rt.asan-*.so"
+        ):
+            runtime_dirs.add(relpath.parent.as_posix())
+
+    if not runtime_dirs:
+        raise RuntimeError(
+            "--asan was requested but no shared Clang ASAN runtime was found "
+            "in the input artifacts"
+        )
+    if len(runtime_dirs) != 1:
+        raise RuntimeError(
+            "ASAN artifacts contain multiple Clang runtime directories: "
+            + ", ".join(sorted(runtime_dirs))
+        )
+    return runtime_dirs.pop()
+
+
+def _elf_dynamic_info(path: Path) -> tuple[list[str], list[str]] | None:
+    """Return an ELF's NEEDED entries and RPATH/RUNPATH entries."""
+    try:
+        with path.open("rb") as stream:
+            elf = ELFFile(stream)
+            dynamic = elf.get_section_by_name(".dynamic")
+            if dynamic is None:
+                return ([], [])
+            needed: list[str] = []
+            rpaths: list[str] = []
+            for tag in dynamic.iter_tags():
+                if tag.entry.d_tag == "DT_NEEDED":
+                    needed.append(tag.needed)
+                elif tag.entry.d_tag == "DT_RPATH":
+                    rpaths.extend(tag.rpath.split(":"))
+                elif tag.entry.d_tag == "DT_RUNPATH":
+                    rpaths.extend(tag.runpath.split(":"))
+            return needed, rpaths
+    except (ELFError, OSError, ValueError):
+        return None
+
+
+def _rpath_resolves_directory(
+    *,
+    binary_path: Path,
+    rpaths: list[str],
+    expected_dir: Path,
+    binary_platform_root: Path | None = None,
+    expected_platform_root: Path | None = None,
+) -> bool:
+    """Checks an ELF RPATH against its directory in the installed wheel set.
+
+    Package staging directories are isolated from each other, but the contents
+    of every package's ``platform/`` directory are merged into one
+    site-packages directory when the wheels are installed. When platform roots
+    are supplied, project both paths into that common layout before resolving
+    ``$ORIGIN``. Omitting them retains the direct filesystem check used for
+    paths that are already in a merged layout.
+    """
+    if (binary_platform_root is None) != (expected_platform_root is None):
+        raise ValueError(
+            "binary_platform_root and expected_platform_root must be supplied together"
+        )
+
+    if binary_platform_root is not None and expected_platform_root is not None:
+        install_root = Path("/site-packages")
+        try:
+            binary_path = install_root / binary_path.resolve().relative_to(
+                binary_platform_root.resolve()
+            )
+            expected_dir = install_root / expected_dir.resolve().relative_to(
+                expected_platform_root.resolve()
+            )
+        except ValueError:
+            return False
+
+    expected_dir = expected_dir.resolve()
+    for rpath in rpaths:
+        for origin_syntax in ("$ORIGIN", "${ORIGIN}"):
+            if not rpath.startswith(origin_syntax):
+                continue
+            relative = rpath[len(origin_syntax) :].lstrip("/")
+            candidate = Path(os.path.normpath(binary_path.parent / relative))
+            if candidate.resolve() == expected_dir:
+                return True
+    return False
+
+
+def validate_asan_runtime_resolution(
+    *,
+    core: PopulatedDistPackage,
+    packages: list[PopulatedDistPackage],
+    runtime_rpath: str,
+    require_instrumented: bool,
+) -> None:
+    """Validate that packaged ASAN-linked ELFs resolve the core runtime."""
+    runtime_dir = core.platform_dir / runtime_rpath
+    runtimes = sorted(runtime_dir.glob("libclang_rt.asan-*.so"))
+    if not runtimes:
+        raise RuntimeError(
+            f"ASAN runtime was not packaged in rocm-sdk-core at {runtime_dir}"
+        )
+
+    instrumented_count = 0
+    unresolved: list[Path] = []
+    for package in packages:
+        for _, path in package.files.materialized_relpaths.values():
+            if not path.is_file():
+                continue
+            dynamic_info = _elf_dynamic_info(path)
+            if dynamic_info is None:
+                continue
+            needed, rpaths = dynamic_info
+            if not any(name.startswith("libclang_rt.asan-") for name in needed):
+                continue
+            instrumented_count += 1
+            if not _rpath_resolves_directory(
+                binary_path=path,
+                rpaths=rpaths,
+                expected_dir=runtime_dir,
+                binary_platform_root=package.platform_dir.parent,
+                expected_platform_root=core.platform_dir.parent,
+            ):
+                unresolved.append(path)
+
+    if unresolved:
+        paths = "\n  ".join(str(path) for path in unresolved[:20])
+        extra = (
+            "" if len(unresolved) <= 20 else f"\n  ... ({len(unresolved) - 20} more)"
+        )
+        raise RuntimeError(
+            "ASAN-linked packaged ELFs cannot resolve the rocm-sdk-core "
+            f"runtime directory:\n  {paths}{extra}"
+        )
+    if require_instrumented and not instrumented_count:
+        raise RuntimeError(
+            "--asan was requested but no packaged ELF links the shared ASAN runtime"
+        )
+    print(
+        "::: ASAN RPATH validation passed: "
+        f"{instrumented_count} instrumented ELF(s), runtime {runtime_rpath}"
+    )
 
 
 def ensure_profiler_library_symlinks(profiler: PopulatedDistPackage) -> None:
@@ -189,6 +398,7 @@ def validate_required_dist_packages(
 
 def run(args: argparse.Namespace):
     manifest = load_therock_manifest(args.artifact_dir)
+    args.version = resolve_package_version(args, manifest)
     kpack_split = manifest.get("flags", {}).get("KPACK_SPLIT_ARTIFACTS", False)
     if kpack_split:
         print("::: Detected KPACK_SPLIT_ARTIFACTS — producing host + device wheels")
@@ -215,6 +425,11 @@ def run(args: argparse.Namespace):
         windows_targets = expand_families(args.windows_amdgpu_families, family_map)
 
     artifacts = ArtifactCatalog(args.artifact_dir)
+    asan_runtime_rpath = (
+        find_asan_runtime_rpath(artifacts) if getattr(args, "asan", False) else None
+    )
+    if asan_runtime_rpath:
+        print(f"::: ASAN runtime detected at {asan_runtime_rpath}")
     validate_kpack_split_target_completeness(
         kpack_split=kpack_split,
         artifact_dir=args.artifact_dir,
@@ -237,6 +452,8 @@ def run(args: argparse.Namespace):
     core = PopulatedDistPackage(params, logical_name="core")
     core.rpath_dep(core, "lib/llvm/lib")
     core.rpath_dep(core, "lib/rocm_sysdeps/lib")
+    if asan_runtime_rpath:
+        core.rpath_dep(core, asan_runtime_rpath)
     core.populate_runtime_files(
         params.filter_artifacts(
             core_artifact_filter,
@@ -266,6 +483,8 @@ def run(args: argparse.Namespace):
         profiler.rpath_dep(core, "lib")
         profiler.rpath_dep(core, "lib/llvm/lib")
         profiler.rpath_dep(core, "lib/rocm_sysdeps/lib")
+        if asan_runtime_rpath:
+            profiler.rpath_dep(core, asan_runtime_rpath)
         profiler.populate_runtime_files(profiler_artifacts)
         ensure_profiler_library_symlinks(profiler)
 
@@ -295,9 +514,9 @@ def run(args: argparse.Namespace):
         )
 
     if kpack_split:
-        _run_kpack_split(args, params, core)
+        _run_kpack_split(args, params, core, asan_runtime_rpath)
     else:
-        _run_legacy(args, params, core)
+        _run_legacy(args, params, core, asan_runtime_rpath)
 
     if args.build_packages:
         validate_required_dist_packages(
@@ -315,7 +534,10 @@ def run(args: argparse.Namespace):
 
 
 def _run_kpack_split(
-    args: argparse.Namespace, params: Parameters, core: PopulatedDistPackage
+    args: argparse.Namespace,
+    params: Parameters,
+    core: PopulatedDistPackage,
+    asan_runtime_rpath: str | None,
 ):
     """Kpack-split mode: arch-neutral host libraries + per-ISA device wheels."""
 
@@ -326,6 +548,8 @@ def _run_kpack_split(
     lib.rpath_dep(core, "lib/host-math/lib")
     # rpp needs libomp, which ships in core under lib/llvm/lib.
     lib.rpath_dep(core, "lib/llvm/lib")
+    if asan_runtime_rpath:
+        lib.rpath_dep(core, asan_runtime_rpath)
     lib.populate_runtime_files(
         params.filter_artifacts(
             filter=functools.partial(libraries_artifact_filter, "generic"),
@@ -335,6 +559,13 @@ def _run_kpack_split(
     # Build core + libraries wheels. The rocm, rocm-sdk-devel, and
     # rocm-sdk-device staging dirs do not exist yet, so the default scan
     # in build_packages will not accidentally include them.
+    if asan_runtime_rpath:
+        validate_asan_runtime_resolution(
+            core=core,
+            packages=list(params.populated_packages),
+            runtime_rpath=asan_runtime_rpath,
+            require_instrumented=True,
+        )
     if args.build_packages:
         build_packages(args.dest_dir, wheel_compression=args.wheel_compression)
 
@@ -348,11 +579,20 @@ def _run_kpack_split(
         dev = PopulatedDistPackage(params, logical_name="device", target_family=target)
         dev.rpath_dep(core, "lib")
         dev.rpath_dep(core, "lib/rocm_sysdeps/lib")
+        if asan_runtime_rpath:
+            dev.rpath_dep(core, asan_runtime_rpath)
         dev.populate_device_files(
             params.filter_artifacts(
                 filter=functools.partial(device_artifact_filter, target),
             )
         )
+        if asan_runtime_rpath:
+            validate_asan_runtime_resolution(
+                core=core,
+                packages=[dev],
+                runtime_rpath=asan_runtime_rpath,
+                require_instrumented=False,
+            )
         if args.build_packages:
             build_packages(
                 args.dest_dir,
@@ -402,7 +642,10 @@ def _run_kpack_split(
 
 
 def _run_legacy(
-    args: argparse.Namespace, params: Parameters, core: PopulatedDistPackage
+    args: argparse.Namespace,
+    params: Parameters,
+    core: PopulatedDistPackage,
+    asan_runtime_rpath: str | None,
 ):
     """Legacy mode: per-family libraries wheels with embedded device code."""
 
@@ -416,6 +659,8 @@ def _run_legacy(
         lib.rpath_dep(core, "lib/host-math/lib")
         # rpp needs libomp, which ships in core under lib/llvm/lib.
         lib.rpath_dep(core, "lib/llvm/lib")
+        if asan_runtime_rpath:
+            lib.rpath_dep(core, asan_runtime_rpath)
         lib.populate_runtime_files(
             params.filter_artifacts(
                 filter=functools.partial(libraries_artifact_filter, target_family),
@@ -430,6 +675,13 @@ def _run_legacy(
     # Build non-devel, non-meta wheels first — the rocm and rocm-sdk-devel
     # staging dirs do not exist yet, so the default scan in build_packages
     # will not accidentally include them.
+    if asan_runtime_rpath:
+        validate_asan_runtime_resolution(
+            core=core,
+            packages=list(params.populated_packages),
+            runtime_rpath=asan_runtime_rpath,
+            require_instrumented=True,
+        )
     if args.build_packages:
         build_packages(args.dest_dir, wheel_compression=args.wheel_compression)
 
@@ -647,6 +899,23 @@ def main(argv: list[str]):
         help="Package versions (defaults to an automatic dev version)",
     )
     p.add_argument(
+        "--asan",
+        default=False,
+        action="store_true",
+        help=(
+            "Build locally versioned ASAN wheels, require the shared Clang "
+            "ASAN runtime, and validate cross-wheel runtime RPATHs"
+        ),
+    )
+    p.add_argument(
+        "--asan-build-id",
+        default=None,
+        help=(
+            "Build identifier for --asan (defaults to the source artifact's "
+            "nightly date, then today's date)"
+        ),
+    )
+    p.add_argument(
         "--version-suffix",
         default="",
         help="Version suffix to append to package names on disk",
@@ -686,18 +955,6 @@ def main(argv: list[str]):
         ),
     )
     args = p.parse_args(argv)
-
-    if not args.version:
-        print(f"::: Version not specified, choosing a default")
-        import compute_rocm_package_version
-
-        # Generate a default version like `7.10.0.dev0`.
-        # This is a simple and predictable version, compared to using
-        # `release_type="dev"`, which appends the git commit hash.
-        args.version = compute_rocm_package_version.compute_version(
-            custom_version_suffix=".dev0"
-        )
-        print(f"::: Version defaulting to {args.version}")
 
     run(args)
 

--- a/build_tools/compute_rocm_package_version.py
+++ b/build_tools/compute_rocm_package_version.py
@@ -34,6 +34,9 @@ Sample usage:
 
   python compute_rocm_package_version.py --release-type=nightly --override-base-version=7.99.0
   # 7.99.0a20251021
+
+  python compute_rocm_package_version.py --release-type=asan --asan-build-id=20260807
+  # rocm_package_version=10.1.0+asan.20260807
 """
 
 import argparse
@@ -41,6 +44,7 @@ from datetime import datetime
 from pathlib import Path
 import json
 import os
+import re
 import subprocess
 import sys
 
@@ -105,6 +109,28 @@ def get_current_date():
     return datetime.today().strftime("%Y%m%d")
 
 
+def normalize_asan_build_id(build_id: str | None) -> str:
+    """Return a PEP 440 local-version-safe ASAN build identifier.
+
+    ASAN wheels are intentionally isolated from release wheels with a local
+    version of the form ``+asan.<build-id>``. Dots, hyphens and underscores
+    are equivalent separators under PEP 440, so normalize all of them to dots
+    to keep filenames and dependency pins deterministic.
+    """
+    if build_id is None:
+        return get_current_date()
+
+    build_id = build_id.strip()
+    if not build_id:
+        raise ValueError("ASAN build ID must not be empty")
+    if not re.fullmatch(r"[A-Za-z0-9]+(?:[._-][A-Za-z0-9]+)*", build_id):
+        raise ValueError(
+            "ASAN build ID must contain only alphanumeric components separated "
+            "by '.', '-' or '_'"
+        )
+    return re.sub(r"[._-]+", ".", build_id).lower()
+
+
 def compute_version(
     package_type: str = "wheel",
     release_type: str | None = None,
@@ -112,21 +138,28 @@ def compute_version(
     prerelease_version: str | None = None,
     override_base_version: str | None = None,
     override_git_sha: str | None = None,
+    asan_build_id: str | None = None,
 ) -> str:
     """Compute package version based on package type and release type.
 
     Args:
         package_type: Type of package ("wheel", "deb", or "rpm")
-        release_type: Release type ("ci", "dev", "nightly", "prerelease", or "release")
+        release_type: Release type ("asan", "ci", "dev", "nightly",
+            "prerelease", or "release")
         custom_version_suffix: Custom suffix to override automatic suffix
         prerelease_version: Prerelease version number
         override_base_version: Override the base version from version.json
         override_git_sha: Explicit git SHA override, forwarded to get_git_sha().
             See get_git_sha() for details on when this is needed.
+        asan_build_id: Optional ASAN wheel build identifier. Defaults to the
+            current date and is only valid with ``release_type="asan"``.
 
     Returns:
         Computed version string appropriate for the package type
     """
+    if asan_build_id is not None and release_type != "asan":
+        raise ValueError("asan_build_id requires release_type='asan'")
+
     if override_base_version:
         base_version = override_base_version
     else:
@@ -140,6 +173,8 @@ def compute_version(
             # Trust the custom suffix to satisfy the general rules:
             # https://packaging.python.org/en/latest/specifications/version-specifiers/
             version_suffix = custom_version_suffix
+        elif release_type == "asan":
+            version_suffix = f"+asan.{normalize_asan_build_id(asan_build_id)}"
         elif release_type in ("ci", "dev"):
             # Construct a dev release version:
             # https://packaging.python.org/en/latest/specifications/version-specifiers/#developmental-releases
@@ -167,6 +202,8 @@ def compute_version(
 
     # Handle native packages (deb/rpm)
     else:  # package_type in ["deb", "rpm"]
+        if release_type == "asan":
+            raise ValueError("ASAN package versions are only supported for wheels")
         if custom_version_suffix:
             # Custom suffix uses the provided value
             version_suffix_str = f"{custom_version_suffix}"
@@ -216,10 +253,11 @@ def main(argv):
     release_type_group.add_argument(
         "--release-type",
         type=str,
-        choices=["ci", "dev", "nightly", "prerelease", "release"],
+        choices=["asan", "ci", "dev", "nightly", "prerelease", "release"],
         help=(
             "The type of package version to produce. "
-            "'ci' uses dev-style versions; 'release' is only valid for deb/rpm."
+            "'ci' uses dev-style versions; 'asan' is wheel-only; "
+            "'release' is only valid for deb/rpm."
         ),
     )
     release_type_group.add_argument(
@@ -246,6 +284,14 @@ def main(argv):
         help="Explicit git SHA to embed in the version instead of auto-detecting",
     )
 
+    parser.add_argument(
+        "--asan-build-id",
+        help=(
+            "Build identifier for --release-type=asan (defaults to YYYYMMDD). "
+            "The wheel version is <base>+asan.<build-id>."
+        ),
+    )
+
     args = parser.parse_args(argv)
 
     # Validation
@@ -259,9 +305,17 @@ def main(argv):
             "--prerelease-version is required when release type is 'prerelease'"
         )
 
-    # Compute versions for all three package types: wheel, deb, and rpm
+    if args.release_type != "asan" and args.asan_build_id:
+        parser.error("--asan-build-id requires --release-type=asan")
+
+    # ASAN packaging is deliberately wheel-only. Native package production is
+    # a separate release pipeline and must not accidentally consume this local
+    # version scheme.
     outputs = {}
-    for pkg_type in ["wheel", "deb", "rpm"]:
+    package_types = (
+        ["wheel"] if args.release_type == "asan" else ["wheel", "deb", "rpm"]
+    )
+    for pkg_type in package_types:
         version = compute_version(
             package_type=pkg_type,
             release_type=args.release_type,
@@ -269,6 +323,7 @@ def main(argv):
             prerelease_version=args.prerelease_version,
             override_base_version=args.override_base_version,
             override_git_sha=args.override_git_sha,
+            asan_build_id=args.asan_build_id,
         )
 
         # Set appropriate output variable based on package type

--- a/build_tools/linux_portable_build.py
+++ b/build_tools/linux_portable_build.py
@@ -69,6 +69,7 @@ def do_build(args: argparse.Namespace, *, rest_args: list[str]):
     # Pass through environment variables that control build behavior.
     # These are set by CI workflows to enable features like build profiling.
     passthrough_env_vars = [
+        "CMAKE_BUILD_PARALLEL_LEVEL",
         "EXTRA_C_COMPILER_LAUNCHER",
         "EXTRA_CXX_COMPILER_LAUNCHER",
         "THEROCK_BUILD_PROF_LOG_DIR",

--- a/build_tools/packaging/python/stage_local_asan_index.py
+++ b/build_tools/packaging/python/stage_local_asan_index.py
@@ -1,0 +1,500 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Stage ASan Python packages in a strictly local package index.
+
+The output layout intentionally mirrors the proposed ASan publication prefix::
+
+    <output-root>/whl-asan/gfx942-all/
+      *.whl
+      *.tar.gz
+      index.html
+      index-manifest.json
+      simple/
+        index.html
+        <normalized-project>/index.html
+
+``index.html`` is suitable for ``pip --find-links``. The ``simple`` subtree is
+a PEP 503-style repository suitable for ``pip --index-url``. This tool only
+accepts filesystem paths and has no upload or network code.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict, dataclass
+from email.parser import BytesParser
+from html import escape
+import hashlib
+import json
+from pathlib import Path, PurePosixPath
+import re
+import shutil
+import sys
+import tarfile
+import tempfile
+from urllib.parse import quote
+import zipfile
+
+from generate_local_index import generate_simple_index
+
+
+DEFAULT_FAMILY = "gfx942-all"
+DEFAULT_VERSION_PREFIX = "10.1.0+asan."
+PHASE1_PROJECTS = frozenset(
+    {
+        "rocm",
+        "rocm-sdk-core",
+        "rocm-sdk-libraries",
+        "rocm-sdk-device-gfx942",
+        "rocm-sdk-devel",
+    }
+)
+PHASE1_ARTIFACT_TYPES = {
+    project: "sdist" if project == "rocm" else "wheel" for project in PHASE1_PROJECTS
+}
+_FAMILY_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+@dataclass(frozen=True)
+class PackageRecord:
+    filename: str
+    artifact_type: str
+    project: str
+    normalized_project: str
+    version: str
+    sha256: str
+    size: int
+
+
+def normalize_project_name(name: str) -> str:
+    """Normalize a Python distribution name as specified by PEP 503."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _read_sdist_metadata(path: Path) -> bytes:
+    """Read the authoritative top-level PKG-INFO from an sdist.
+
+    Setuptools sdists can also contain a generated ``*.egg-info/PKG-INFO``.
+    The root ``<sdist-root>/PKG-INFO`` is authoritative. Auxiliary copies are
+    accepted only when their normalized contents agree with it.
+    """
+    try:
+        with tarfile.open(path, "r:gz") as sdist:
+            metadata_files = sorted(
+                (
+                    member
+                    for member in sdist.getmembers()
+                    if member.isfile() and member.name.endswith("/PKG-INFO")
+                ),
+                key=lambda member: member.name,
+            )
+            canonical_files = [
+                member
+                for member in metadata_files
+                if len(PurePosixPath(member.name).parts) == 2
+                and PurePosixPath(member.name).parts[0] not in {"", ".", "..", "/"}
+            ]
+            if len(canonical_files) != 1:
+                raise ValueError(
+                    f"Expected exactly one top-level <sdist-root>/PKG-INFO in "
+                    f"{path}, found {len(canonical_files)}"
+                )
+
+            canonical_file = sdist.extractfile(canonical_files[0])
+            if canonical_file is None:
+                raise ValueError(f"Cannot read PKG-INFO in {path}")
+            canonical_bytes = canonical_file.read()
+            normalized_canonical = canonical_bytes.replace(b"\r\n", b"\n").rstrip(
+                b"\n"
+            )
+
+            for member in metadata_files:
+                if member is canonical_files[0]:
+                    continue
+                metadata_file = sdist.extractfile(member)
+                if metadata_file is None:
+                    raise ValueError(f"Cannot read {member.name} in {path}")
+                nested_bytes = metadata_file.read()
+                normalized_nested = nested_bytes.replace(b"\r\n", b"\n").rstrip(
+                    b"\n"
+                )
+                if normalized_nested != normalized_canonical:
+                    raise ValueError(
+                        f"Auxiliary PKG-INFO {member.name} disagrees with "
+                        f"{canonical_files[0].name} in {path}"
+                    )
+            return canonical_bytes
+    except tarfile.TarError as exc:
+        raise ValueError(f"Invalid sdist archive: {path}") from exc
+
+
+def inspect_package(path: Path, version_prefix: str) -> PackageRecord:
+    """Read and validate identity from wheel METADATA or sdist PKG-INFO."""
+    if not path.is_file():
+        raise ValueError(f"Not a package file: {path}")
+
+    if path.suffix == ".whl":
+        artifact_type = "wheel"
+        try:
+            with zipfile.ZipFile(path) as wheel:
+                metadata_files = [
+                    name
+                    for name in wheel.namelist()
+                    if name.endswith(".dist-info/METADATA")
+                ]
+                if len(metadata_files) != 1:
+                    raise ValueError(
+                        f"Expected exactly one .dist-info/METADATA in {path}, "
+                        f"found {len(metadata_files)}"
+                    )
+                metadata_bytes = wheel.read(metadata_files[0])
+        except zipfile.BadZipFile as exc:
+            raise ValueError(f"Invalid wheel archive: {path}") from exc
+    elif path.name.endswith(".tar.gz"):
+        artifact_type = "sdist"
+        metadata_bytes = _read_sdist_metadata(path)
+    else:
+        raise ValueError(f"Unsupported package file: {path}")
+
+    metadata = BytesParser().parsebytes(metadata_bytes)
+
+    project = metadata.get("Name")
+    version = metadata.get("Version")
+    if not project or not version:
+        raise ValueError(f"Package metadata lacks Name or Version: {path}")
+    if not version.lower().startswith(version_prefix.lower()):
+        raise ValueError(
+            f"Package {path.name} has version {version!r}; expected prefix "
+            f"{version_prefix!r}"
+        )
+
+    return PackageRecord(
+        filename=path.name,
+        artifact_type=artifact_type,
+        project=project,
+        normalized_project=normalize_project_name(project),
+        version=version,
+        sha256=sha256_file(path),
+        size=path.stat().st_size,
+    )
+
+
+def _write_text_atomic(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        mode="w", encoding="utf-8", dir=path.parent, delete=False
+    ) as temp:
+        temp.write(content)
+        temp_path = Path(temp.name)
+    temp_path.replace(path)
+
+
+def _html_page(title: str, links: list[tuple[str, str]]) -> str:
+    lines = [
+        "<!DOCTYPE html>",
+        "<html>",
+        "<head>",
+        '  <meta charset="utf-8">',
+        f"  <title>{escape(title)}</title>",
+        "</head>",
+        "<body>",
+        f"  <h1>{escape(title)}</h1>",
+    ]
+    lines.extend(
+        f'  <a href="{escape(href, quote=True)}">{escape(label)}</a><br>'
+        for href, label in links
+    )
+    lines.extend(["</body>", "</html>", ""])
+    return "\n".join(lines)
+
+
+def _write_indexes(
+    index_dir: Path, family: str, records: list[PackageRecord]
+) -> None:
+    """Write flat find-links and PEP 503 indexes for staged packages."""
+    generate_simple_index(
+        output_path=index_dir / "index.html",
+        local_files=[index_dir / record.filename for record in records],
+        title=f"ROCm 10.1 ASan Python Packages - {family}",
+    )
+
+    by_project: dict[str, list[PackageRecord]] = {}
+    for record in records:
+        by_project.setdefault(record.normalized_project, []).append(record)
+
+    simple_dir = index_dir / "simple"
+    root_links = [(f"./{quote(project)}/", project) for project in sorted(by_project)]
+    _write_text_atomic(
+        simple_dir / "index.html", _html_page("Simple index", root_links)
+    )
+
+    for project, project_records in sorted(by_project.items()):
+        links = [
+            (
+                f"../../{quote(record.filename)}#sha256={record.sha256}",
+                record.filename,
+            )
+            for record in sorted(project_records, key=lambda item: item.filename)
+        ]
+        _write_text_atomic(
+            simple_dir / project / "index.html",
+            _html_page(f"Links for {project}", links),
+        )
+
+
+def _write_manifest(index_dir: Path, family: str, records: list[PackageRecord]) -> None:
+    manifest = {
+        "schema_version": 1,
+        "index_kind": "local-only",
+        "relative_path": f"whl-asan/{family}",
+        "package_count": len(records),
+        "packages": [asdict(record) for record in records],
+    }
+    _write_text_atomic(
+        index_dir / "index-manifest.json",
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+    )
+
+
+def _validate_family(family: str) -> None:
+    if not _FAMILY_RE.fullmatch(family) or family in {".", ".."}:
+        raise ValueError(f"Invalid family name: {family!r}")
+
+
+def _validate_phase1_set(records: list[PackageRecord]) -> None:
+    found_projects = {record.normalized_project for record in records}
+    missing = sorted(PHASE1_PROJECTS - found_projects)
+    if missing:
+        raise ValueError(
+            "Local index is missing required Phase 1 projects: " + ", ".join(missing)
+        )
+    for project, artifact_type in PHASE1_ARTIFACT_TYPES.items():
+        if not any(
+            record.normalized_project == project
+            and record.artifact_type == artifact_type
+            for record in records
+        ):
+            raise ValueError(
+                f"Phase 1 project {project} requires a {artifact_type} artifact"
+            )
+
+
+def _validate_consistent_versions(records: list[PackageRecord]) -> None:
+    versions = sorted({record.version for record in records})
+    if len(versions) != 1:
+        raise ValueError(
+            "Local index must contain exactly one package version; found: "
+            + ", ".join(versions)
+        )
+
+
+def stage_index(
+    input_dir: Path,
+    output_root: Path,
+    *,
+    family: str = DEFAULT_FAMILY,
+    version_prefix: str = DEFAULT_VERSION_PREFIX,
+    require_phase1_set: bool = False,
+) -> Path:
+    """Validate and copy packages into a local ``whl-asan`` index."""
+    _validate_family(family)
+    input_dir = input_dir.resolve()
+    if not input_dir.is_dir():
+        raise FileNotFoundError(f"Input directory does not exist: {input_dir}")
+    wheel_dir = input_dir / "dist" if (input_dir / "dist").is_dir() else input_dir
+    source_packages = sorted(
+        path
+        for pattern in ("*.whl", "*.tar.gz")
+        for path in wheel_dir.glob(pattern)
+        if path.is_file()
+    )
+    if not source_packages:
+        raise FileNotFoundError(f"No wheel or sdist files found in {wheel_dir}")
+
+    source_records = {
+        package.name: inspect_package(package, version_prefix)
+        for package in source_packages
+    }
+    index_dir = output_root.resolve() / "whl-asan" / family
+    index_dir.mkdir(parents=True, exist_ok=True)
+
+    # Never silently replace a differently-built package with the same filename.
+    for source in source_packages:
+        destination = index_dir / source.name
+        if (
+            destination.exists()
+            and sha256_file(destination) != source_records[source.name].sha256
+        ):
+            raise FileExistsError(
+                "Refusing to overwrite package with different contents: "
+                f"{destination}"
+            )
+
+    for source in source_packages:
+        destination = index_dir / source.name
+        if not destination.exists():
+            shutil.copy2(source, destination)
+
+    staged_packages = sorted(
+        path
+        for pattern in ("*.whl", "*.tar.gz")
+        for path in index_dir.glob(pattern)
+    )
+    records = [
+        inspect_package(package, version_prefix) for package in staged_packages
+    ]
+    records.sort(key=lambda item: (item.normalized_project, item.filename))
+    _validate_consistent_versions(records)
+
+    if require_phase1_set:
+        _validate_phase1_set(records)
+
+    _write_indexes(index_dir, family, records)
+    _write_manifest(index_dir, family, records)
+    return index_dir
+
+
+def verify_index(
+    output_root: Path,
+    *,
+    family: str = DEFAULT_FAMILY,
+    version_prefix: str = DEFAULT_VERSION_PREFIX,
+    require_phase1_set: bool = False,
+) -> Path:
+    """Verify wheel hashes, metadata, completeness, and generated indexes."""
+    _validate_family(family)
+    index_dir = output_root.resolve() / "whl-asan" / family
+    manifest_path = index_dir / "index-manifest.json"
+    if not manifest_path.is_file():
+        raise FileNotFoundError(f"Manifest not found: {manifest_path}")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if manifest.get("index_kind") != "local-only":
+        raise ValueError(f"Unexpected index kind in {manifest_path}")
+    if manifest.get("relative_path") != f"whl-asan/{family}":
+        raise ValueError(f"Unexpected index path in {manifest_path}")
+
+    expected = {item["filename"]: item for item in manifest.get("packages", [])}
+    actual_names = {
+        path.name
+        for pattern in ("*.whl", "*.tar.gz")
+        for path in index_dir.glob(pattern)
+    }
+    if actual_names != set(expected):
+        raise ValueError(
+            "Staged packages differ from manifest: "
+            f"expected={sorted(expected)}, actual={sorted(actual_names)}"
+        )
+
+    records = []
+    for filename in sorted(expected):
+        record = inspect_package(index_dir / filename, version_prefix)
+        if asdict(record) != expected[filename]:
+            raise ValueError(f"Package does not match manifest: {filename}")
+        records.append(record)
+
+    _validate_consistent_versions(records)
+    if require_phase1_set:
+        _validate_phase1_set(records)
+
+    required_indexes = [index_dir / "index.html", index_dir / "simple" / "index.html"]
+    required_indexes.extend(
+        index_dir / "simple" / record.normalized_project / "index.html"
+        for record in records
+    )
+    missing_indexes = sorted(
+        str(path) for path in required_indexes if not path.is_file()
+    )
+    if missing_indexes:
+        raise FileNotFoundError("Missing index files: " + ", ".join(missing_indexes))
+
+    flat_index = (index_dir / "index.html").read_text(encoding="utf-8")
+    simple_root = (index_dir / "simple" / "index.html").read_text(
+        encoding="utf-8"
+    )
+    for record in records:
+        if f'./{quote(record.filename)}' not in flat_index:
+            raise ValueError(
+                f"Package missing from find-links index: {record.filename}"
+            )
+        if f'./{quote(record.normalized_project)}/' not in simple_root:
+            raise ValueError(
+                f"Project missing from simple index: {record.normalized_project}"
+            )
+        project_index = (
+            index_dir / "simple" / record.normalized_project / "index.html"
+        ).read_text(encoding="utf-8")
+        expected_link = (
+            f"../../{quote(record.filename)}#sha256={record.sha256}"
+        )
+        if expected_link not in project_index:
+            raise ValueError(
+                f"Package missing from project index: {record.filename}"
+            )
+    return index_dir
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    stage = subparsers.add_parser(
+        "stage", help="Validate, copy, and index wheels and sdists"
+    )
+    stage.add_argument("--input-dir", type=Path, required=True)
+    stage.add_argument("--output-root", type=Path, required=True)
+
+    verify = subparsers.add_parser("verify", help="Verify an existing local index")
+    verify.add_argument("--output-root", type=Path, required=True)
+
+    for command in (stage, verify):
+        command.add_argument("--family", default=DEFAULT_FAMILY)
+        command.add_argument("--version-prefix", default=DEFAULT_VERSION_PREFIX)
+        command.add_argument(
+            "--require-phase1-set",
+            action="store_true",
+            help=(
+                "Require the rocm selector sdist plus core, libraries, gfx942 "
+                "device, and devel wheels"
+            ),
+        )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        if args.command == "stage":
+            index_dir = stage_index(
+                args.input_dir,
+                args.output_root,
+                family=args.family,
+                version_prefix=args.version_prefix,
+                require_phase1_set=args.require_phase1_set,
+            )
+        else:
+            index_dir = verify_index(
+                args.output_root,
+                family=args.family,
+                version_prefix=args.version_prefix,
+                require_phase1_set=args.require_phase1_set,
+            )
+    except (FileExistsError, FileNotFoundError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    print(index_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/build_tools/packaging/tests/stage_local_asan_index_test.py
+++ b/build_tools/packaging/tests/stage_local_asan_index_test.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the strictly local ASan wheel index."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tarfile
+import tempfile
+import unittest
+import zipfile
+from io import BytesIO
+
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent / "python"))
+
+from stage_local_asan_index import (  # noqa: E402
+    PHASE1_PROJECTS,
+    main,
+    normalize_project_name,
+    stage_index,
+    verify_index,
+)
+
+
+def _wheel_filename(project: str, version: str) -> str:
+    distribution = project.replace("-", "_")
+    return f"{distribution}-{version}-py3-none-any.whl"
+
+
+def _write_wheel(
+    directory: Path,
+    project: str,
+    version: str = "10.1.0+asan.20260807",
+    *,
+    marker: str = "",
+) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / _wheel_filename(project, version)
+    dist_info = f"{project.replace('-', '_')}-{version}.dist-info"
+    with zipfile.ZipFile(path, "w") as wheel:
+        wheel.writestr(
+            f"{dist_info}/METADATA",
+            "Metadata-Version: 2.1\n"
+            f"Name: {project}\n"
+            f"Version: {version}\n\n{marker}",
+        )
+        wheel.writestr(
+            f"{dist_info}/WHEEL",
+            "Wheel-Version: 1.0\nTag: py3-none-any\n",
+        )
+        wheel.writestr(f"{dist_info}/RECORD", "")
+    return path
+
+
+def _write_sdist(
+    directory: Path,
+    project: str,
+    version: str = "10.1.0+asan.20260807",
+    *,
+    nested_metadata: bytes | None = None,
+) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"{project}-{version}.tar.gz"
+    package_root = f"{project}-{version}"
+    metadata = (
+        "Metadata-Version: 2.1\n"
+        f"Name: {project}\n"
+        f"Version: {version}\n"
+    ).encode()
+    info = tarfile.TarInfo(f"{package_root}/PKG-INFO")
+    info.size = len(metadata)
+    with tarfile.open(path, "w:gz") as sdist:
+        sdist.addfile(info, BytesIO(metadata))
+        nested_info = tarfile.TarInfo(
+            f"{package_root}/src/{project}.egg-info/PKG-INFO"
+        )
+        nested_payload = metadata if nested_metadata is None else nested_metadata
+        nested_info.size = len(nested_payload)
+        sdist.addfile(nested_info, BytesIO(nested_payload))
+    return path
+
+
+class TestProjectNormalization(unittest.TestCase):
+    def test_pep503_normalization(self):
+        self.assertEqual(normalize_project_name("ROCm_SDK.Device"), "rocm-sdk-device")
+
+
+class TestStageLocalAsanIndex(unittest.TestCase):
+    def test_accepts_matching_setuptools_egg_info_metadata(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            sdist = _write_sdist(root / "packages", "rocm")
+
+            index_dir = stage_index(root / "packages", root / "local")
+
+            self.assertTrue((index_dir / sdist.name).is_file())
+
+    def test_rejects_disagreeing_setuptools_egg_info_metadata(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            _write_sdist(
+                root / "packages",
+                "rocm",
+                nested_metadata=(
+                    b"Metadata-Version: 2.1\n"
+                    b"Name: rocm\n"
+                    b"Version: 10.1.0+asan.different\n"
+                ),
+            )
+
+            with self.assertRaisesRegex(ValueError, "disagrees with"):
+                stage_index(root / "packages", root / "local")
+
+    def test_rejects_multiple_top_level_metadata_candidates(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            packages = root / "packages"
+            packages.mkdir()
+            path = packages / "rocm-10.1.0+asan.20260807.tar.gz"
+            metadata = (
+                b"Metadata-Version: 2.1\n"
+                b"Name: rocm\n"
+                b"Version: 10.1.0+asan.20260807\n"
+            )
+            with tarfile.open(path, "w:gz") as sdist:
+                for package_root in ("rocm-first", "rocm-second"):
+                    info = tarfile.TarInfo(f"{package_root}/PKG-INFO")
+                    info.size = len(metadata)
+                    sdist.addfile(info, BytesIO(metadata))
+
+            with self.assertRaisesRegex(ValueError, "top-level.*found 2"):
+                stage_index(packages, root / "local")
+
+    def test_pip_resolves_flat_and_simple_indexes_without_network(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            _write_wheel(root / "packages", "rocm-sdk-core")
+            index_dir = stage_index(root / "packages", root / "local")
+
+            common = [
+                sys.executable,
+                "-m",
+                "pip",
+                "--isolated",
+                "install",
+                "--disable-pip-version-check",
+                "--no-deps",
+            ]
+            find_links = subprocess.run(
+                [
+                    *common,
+                    "--no-index",
+                    "--find-links",
+                    os.fspath(index_dir / "index.html"),
+                    "--target",
+                    os.fspath(root / "find-links-install"),
+                    "rocm-sdk-core==10.1.0+asan.20260807",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(find_links.returncode, 0, find_links.stderr)
+
+            simple = subprocess.run(
+                [
+                    *common,
+                    "--index-url",
+                    (index_dir / "simple").as_uri() + "/",
+                    "--target",
+                    os.fspath(root / "simple-install"),
+                    "rocm-sdk-core==10.1.0+asan.20260807",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(simple.returncode, 0, simple.stderr)
+
+    def test_cli_stage_and_verify_complete_set(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            packages = root / "packages" / "dist"
+            for project in PHASE1_PROJECTS - {"rocm"}:
+                _write_wheel(packages, project)
+            _write_sdist(packages, "rocm")
+
+            self.assertEqual(
+                main(
+                    [
+                        "stage",
+                        "--input-dir",
+                        os.fspath(packages.parent),
+                        "--output-root",
+                        os.fspath(root / "local"),
+                        "--require-phase1-set",
+                    ]
+                ),
+                0,
+            )
+            self.assertEqual(
+                main(
+                    [
+                        "verify",
+                        "--output-root",
+                        os.fspath(root / "local"),
+                        "--require-phase1-set",
+                    ]
+                ),
+                0,
+            )
+
+    def test_stages_find_links_simple_index_and_manifest(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            packages = root / "packages" / "dist"
+            output = root / "local"
+            wheel = _write_wheel(packages, "rocm-sdk-core")
+
+            index_dir = stage_index(packages.parent, output)
+
+            staged_wheel = index_dir / wheel.name
+            self.assertEqual(staged_wheel.read_bytes(), wheel.read_bytes())
+
+            find_links = (index_dir / "index.html").read_text(encoding="utf-8")
+            self.assertIn(wheel.name.replace("+", "%2B"), find_links)
+
+            simple_root = (index_dir / "simple" / "index.html").read_text(
+                encoding="utf-8"
+            )
+            self.assertIn('href="./rocm-sdk-core/"', simple_root)
+
+            project_index = (
+                index_dir / "simple" / "rocm-sdk-core" / "index.html"
+            ).read_text(encoding="utf-8")
+            self.assertIn("../../rocm_sdk_core-10.1.0%2Basan.20260807", project_index)
+            self.assertIn("#sha256=", project_index)
+
+            manifest = json.loads(
+                (index_dir / "index-manifest.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(manifest["index_kind"], "local-only")
+            self.assertEqual(manifest["relative_path"], "whl-asan/gfx942-all")
+            self.assertEqual(manifest["package_count"], 1)
+            self.assertEqual(manifest["packages"][0]["project"], "rocm-sdk-core")
+            self.assertEqual(verify_index(output), index_dir)
+
+    def test_rejects_non_asan_version(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            _write_wheel(root / "packages", "rocm-sdk-core", "10.1.0")
+
+            with self.assertRaisesRegex(ValueError, "expected prefix"):
+                stage_index(root / "packages", root / "local")
+
+    def test_refuses_different_wheel_with_same_filename(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            packages = root / "packages"
+            _write_wheel(packages, "rocm-sdk-core", marker="first")
+            stage_index(packages, root / "local")
+            _write_wheel(packages, "rocm-sdk-core", marker="second")
+
+            with self.assertRaisesRegex(FileExistsError, "Refusing to overwrite"):
+                stage_index(packages, root / "local")
+
+    def test_requires_complete_phase1_project_set_when_requested(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            packages = root / "packages"
+            _write_wheel(packages, "rocm-sdk-core")
+
+            with self.assertRaisesRegex(ValueError, "missing required Phase 1"):
+                stage_index(
+                    packages,
+                    root / "local",
+                    require_phase1_set=True,
+                )
+
+            for project in PHASE1_PROJECTS - {"rocm-sdk-core", "rocm"}:
+                _write_wheel(packages, project)
+            _write_sdist(packages, "rocm")
+            index_dir = stage_index(
+                packages,
+                root / "complete",
+                require_phase1_set=True,
+            )
+            self.assertEqual(
+                len(list(index_dir.glob("*.whl"))), len(PHASE1_PROJECTS) - 1
+            )
+            self.assertEqual(len(list(index_dir.glob("*.tar.gz"))), 1)
+
+    def test_phase1_set_requires_rocm_selector_as_sdist(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            packages = root / "packages"
+            for project in PHASE1_PROJECTS:
+                _write_wheel(packages, project)
+
+            with self.assertRaisesRegex(ValueError, "rocm requires a sdist"):
+                stage_index(
+                    packages,
+                    root / "local",
+                    require_phase1_set=True,
+                )
+
+    def test_verify_detects_tampered_wheel(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            wheel = _write_wheel(root / "packages", "rocm-sdk-core")
+            index_dir = stage_index(root / "packages", root / "local")
+            (index_dir / wheel.name).write_bytes(b"tampered")
+
+            with self.assertRaises(ValueError):
+                verify_index(root / "local")
+
+    def test_rejects_mixed_asan_build_versions(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            packages = root / "packages"
+            _write_wheel(packages, "rocm-sdk-core")
+            _write_wheel(
+                packages,
+                "rocm-sdk-devel",
+                "10.1.0+asan.20260808",
+            )
+
+            with self.assertRaisesRegex(ValueError, "exactly one package version"):
+                stage_index(packages, root / "local")
+
+    def test_rejects_unsafe_family_name(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            _write_wheel(root / "packages", "rocm-sdk-core")
+            with self.assertRaisesRegex(ValueError, "Invalid family"):
+                stage_index(root / "packages", root / "local", family="../escape")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/build_tools/tests/asan_python_packaging_test.py
+++ b/build_tools/tests/asan_python_packaging_test.py
@@ -1,0 +1,259 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+import argparse
+import os
+from pathlib import Path
+import sys
+import tempfile
+import types
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
+
+from _therock_utils.artifacts import ArtifactCatalog
+from build_python_packages import (
+    _rpath_resolves_directory,
+    find_asan_runtime_rpath,
+    resolve_package_version,
+    validate_asan_runtime_resolution,
+)
+
+
+class AsanVersionResolutionTest(unittest.TestCase):
+    def test_version_defaults_to_artifact_nightly_date(self):
+        args = argparse.Namespace(asan=True, asan_build_id=None, version="")
+        manifest = {
+            "rocm_version": "10.1.0",
+            "rocm_package_version": "10.1.0a20260807",
+        }
+
+        self.assertEqual(
+            resolve_package_version(args, manifest),
+            "10.1.0+asan.20260807",
+        )
+
+    def test_explicit_asan_version_must_match_artifact_base(self):
+        args = argparse.Namespace(
+            asan=True,
+            asan_build_id=None,
+            version="7.15.0+asan.20260807",
+        )
+        with self.assertRaisesRegex(ValueError, r"10\.1\.0\+asan"):
+            resolve_package_version(args, {"rocm_version": "10.1.0"})
+
+    def test_build_id_requires_asan_mode(self):
+        args = argparse.Namespace(
+            asan=False,
+            asan_build_id="20260807",
+            version="10.1.0",
+        )
+        with self.assertRaisesRegex(ValueError, "requires --asan"):
+            resolve_package_version(args, {"rocm_version": "10.1.0"})
+
+
+class AsanRuntimeDiscoveryTest(unittest.TestCase):
+    def test_finds_clang_resource_directory(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact_dir = Path(temp_dir)
+            artifact = artifact_dir / "base_lib_generic"
+            stage = artifact / "base" / "aux-overlay" / "stage"
+            runtime = (
+                stage
+                / "lib"
+                / "llvm"
+                / "lib"
+                / "clang"
+                / "23"
+                / "lib"
+                / "linux"
+                / "libclang_rt.asan-x86_64.so"
+            )
+            runtime.parent.mkdir(parents=True)
+            runtime.touch()
+            (artifact / "artifact_manifest.txt").write_text("base/aux-overlay/stage\n")
+
+            self.assertEqual(
+                find_asan_runtime_rpath(ArtifactCatalog(artifact_dir)),
+                "lib/llvm/lib/clang/23/lib/linux",
+            )
+
+    def test_missing_runtime_is_rejected(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with self.assertRaisesRegex(RuntimeError, "no shared Clang ASAN"):
+                find_asan_runtime_rpath(ArtifactCatalog(Path(temp_dir)))
+
+
+class AsanRpathValidationTest(unittest.TestCase):
+    def test_origin_rpath_resolves_cross_wheel_runtime(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            binary = root / "_rocm_sdk_libraries" / "lib" / "libfoo.so"
+            runtime_dir = (
+                root
+                / "_rocm_sdk_core"
+                / "lib"
+                / "llvm"
+                / "lib"
+                / "clang"
+                / "23"
+                / "lib"
+                / "linux"
+            )
+
+            self.assertTrue(
+                _rpath_resolves_directory(
+                    binary_path=binary,
+                    rpaths=[
+                        "$ORIGIN/../../_rocm_sdk_core/"
+                        "lib/llvm/lib/clang/23/lib/linux"
+                    ],
+                    expected_dir=runtime_dir,
+                )
+            )
+
+    def test_origin_rpath_resolves_separate_wheel_staging_directories(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            profiler_platform = root / "rocm-profiler" / "platform"
+            core_platform = root / "rocm-sdk-core" / "platform"
+            binary = profiler_platform / "_rocm_profiler" / "bin" / "rocprof"
+            runtime_dir = (
+                core_platform
+                / "_rocm_sdk_core"
+                / "lib"
+                / "llvm"
+                / "lib"
+                / "clang"
+                / "23"
+                / "lib"
+                / "linux"
+            )
+
+            self.assertTrue(
+                _rpath_resolves_directory(
+                    binary_path=binary,
+                    rpaths=[
+                        "$ORIGIN/../../_rocm_sdk_core/"
+                        "lib/llvm/lib/clang/23/lib/linux"
+                    ],
+                    expected_dir=runtime_dir,
+                    binary_platform_root=profiler_platform,
+                    expected_platform_root=core_platform,
+                )
+            )
+
+    def test_validator_projects_separate_wheels_into_site_packages(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            core_platform = root / "rocm-sdk-core" / "platform"
+            core_dir = core_platform / "_rocm_sdk_core"
+            profiler_platform = root / "rocm-profiler" / "platform"
+            profiler_dir = profiler_platform / "_rocm_profiler"
+            runtime_rpath = "lib/llvm/lib/clang/23/lib/linux"
+            runtime_dir = core_dir / runtime_rpath
+            runtime_dir.mkdir(parents=True)
+            (runtime_dir / "libclang_rt.asan-x86_64.so").touch()
+
+            binary = profiler_dir / "bin" / "rocprof"
+            binary.parent.mkdir(parents=True)
+            binary.touch()
+            package = types.SimpleNamespace(
+                platform_dir=profiler_dir,
+                files=types.SimpleNamespace(
+                    materialized_relpaths={"bin/rocprof": (None, binary)}
+                ),
+            )
+            core = types.SimpleNamespace(platform_dir=core_dir)
+
+            with mock.patch(
+                "build_python_packages._elf_dynamic_info",
+                return_value=(
+                    ["libclang_rt.asan-x86_64.so"],
+                    [
+                        "$ORIGIN/../../_rocm_sdk_core/"
+                        "lib/llvm/lib/clang/23/lib/linux"
+                    ],
+                ),
+            ):
+                validate_asan_runtime_resolution(
+                    core=core,
+                    packages=[package],
+                    runtime_rpath=runtime_rpath,
+                    require_instrumented=True,
+                )
+
+    def test_validator_accepts_resolvable_instrumented_elf(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            core_dir = root / "_rocm_sdk_core"
+            runtime_rpath = "lib/llvm/lib/clang/23/lib/linux"
+            runtime_dir = core_dir / runtime_rpath
+            runtime_dir.mkdir(parents=True)
+            (runtime_dir / "libclang_rt.asan-x86_64.so").touch()
+
+            binary = root / "_rocm_sdk_libraries" / "lib" / "libfoo.so"
+            binary.parent.mkdir(parents=True)
+            binary.touch()
+            package = types.SimpleNamespace(
+                platform_dir=root / "_rocm_sdk_libraries",
+                files=types.SimpleNamespace(
+                    materialized_relpaths={"lib/libfoo.so": (None, binary)}
+                )
+            )
+            core = types.SimpleNamespace(platform_dir=core_dir)
+            dynamic_info = (
+                ["libclang_rt.asan-x86_64.so"],
+                ["$ORIGIN/../../_rocm_sdk_core/" "lib/llvm/lib/clang/23/lib/linux"],
+            )
+
+            with mock.patch(
+                "build_python_packages._elf_dynamic_info",
+                return_value=dynamic_info,
+            ):
+                validate_asan_runtime_resolution(
+                    core=core,
+                    packages=[package],
+                    runtime_rpath=runtime_rpath,
+                    require_instrumented=True,
+                )
+
+    def test_validator_rejects_unresolved_instrumented_elf(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            core_dir = root / "_rocm_sdk_core"
+            runtime_rpath = "lib/llvm/lib/clang/23/lib/linux"
+            runtime_dir = core_dir / runtime_rpath
+            runtime_dir.mkdir(parents=True)
+            (runtime_dir / "libclang_rt.asan-x86_64.so").touch()
+
+            binary = root / "_rocm_sdk_libraries" / "lib" / "libfoo.so"
+            binary.parent.mkdir(parents=True)
+            binary.touch()
+            package = types.SimpleNamespace(
+                platform_dir=root / "_rocm_sdk_libraries",
+                files=types.SimpleNamespace(
+                    materialized_relpaths={"lib/libfoo.so": (None, binary)}
+                )
+            )
+            core = types.SimpleNamespace(platform_dir=core_dir)
+
+            with mock.patch(
+                "build_python_packages._elf_dynamic_info",
+                return_value=(
+                    ["libclang_rt.asan-x86_64.so"],
+                    ["$ORIGIN/llvm/lib/clang/23/lib/linux"],
+                ),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "cannot resolve"):
+                    validate_asan_runtime_resolution(
+                        core=core,
+                        packages=[package],
+                        runtime_rpath=runtime_rpath,
+                        require_instrumented=True,
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/build_tools/tests/compute_rocm_package_version_test.py
+++ b/build_tools/tests/compute_rocm_package_version_test.py
@@ -17,6 +17,47 @@ import compute_rocm_package_version
 
 
 class DetermineVersionTest(unittest.TestCase):
+    def test_asan_version_uses_isolated_local_version(self):
+        version = compute_rocm_package_version.compute_version(
+            release_type="asan",
+            override_base_version="10.1.0",
+            asan_build_id="20260807",
+        )
+        self.assertEqual(version, "10.1.0+asan.20260807")
+
+    def test_asan_build_id_is_normalized(self):
+        version = compute_rocm_package_version.compute_version(
+            release_type="asan",
+            override_base_version="10.1.0",
+            asan_build_id="RUN_31-137",
+        )
+        self.assertEqual(version, "10.1.0+asan.run.31.137")
+
+    def test_asan_build_id_rejects_non_local_version_characters(self):
+        with self.assertRaisesRegex(ValueError, "ASAN build ID"):
+            compute_rocm_package_version.compute_version(
+                release_type="asan",
+                override_base_version="10.1.0",
+                asan_build_id="../../release",
+            )
+
+    def test_asan_version_is_wheel_only(self):
+        with self.assertRaisesRegex(ValueError, "only supported for wheels"):
+            compute_rocm_package_version.compute_version(
+                package_type="deb",
+                release_type="asan",
+                override_base_version="10.1.0",
+                asan_build_id="20260807",
+            )
+
+    def test_asan_build_id_requires_asan_release_type(self):
+        with self.assertRaisesRegex(ValueError, "requires release_type='asan'"):
+            compute_rocm_package_version.compute_version(
+                release_type="nightly",
+                override_base_version="10.1.0",
+                asan_build_id="20260807",
+            )
+
     def test_ci_version_uses_dev_version_shape(self):
         version = compute_rocm_package_version.compute_version(
             release_type="ci",
@@ -388,6 +429,32 @@ class MainFunctionMultiplePackageTypesTest(unittest.TestCase):
             self.assertIn("rocm_rpm_package_version", captured_outputs)
         finally:
             compute_rocm_package_version.gha_set_output = original_gha_set_output
+
+    def test_asan_cli_emits_wheel_output_only(self):
+        captured_outputs = {}
+        original_gha_set_output = compute_rocm_package_version.gha_set_output
+
+        def mock_gha_set_output(outputs):
+            captured_outputs.update(outputs)
+
+        compute_rocm_package_version.gha_set_output = mock_gha_set_output
+        try:
+            compute_rocm_package_version.main(
+                [
+                    "--release-type",
+                    "asan",
+                    "--asan-build-id",
+                    "20260807",
+                    "--override-base-version",
+                    "10.1.0",
+                ]
+            )
+        finally:
+            compute_rocm_package_version.gha_set_output = original_gha_set_output
+
+        self.assertEqual(
+            captured_outputs, {"rocm_package_version": "10.1.0+asan.20260807"}
+        )
 
 
 if __name__ == "__main__":

--- a/docs/packaging/local_asan_index.md
+++ b/docs/packaging/local_asan_index.md
@@ -1,0 +1,95 @@
+# Local ASan Python Package Index
+
+Phase 1 ASan packages can be staged and installed without publishing them to
+S3 or any other network service. The local layout mirrors the proposed
+per-family publication tree:
+
+```text
+<output-root>/
+└── whl-asan/
+    └── gfx942-all/
+        ├── index.html
+        ├── index-manifest.json
+        ├── rocm-10.1.0+asan.<build-id>.tar.gz
+        ├── rocm_sdk_*.whl
+        └── simple/
+            ├── index.html
+            └── <normalized-project>/index.html
+```
+
+The top-level `index.html` is a flat `pip --find-links` index generated with
+TheRock's existing local index utility. The `simple/` subtree is a PEP 503
+repository with SHA-256 fragments. `index-manifest.json` records the same
+hashes and package metadata for offline verification.
+
+## Stage packages
+
+First build ASan packages into a local package directory. Then stage them into
+the isolated index:
+
+```bash
+python build_tools/packaging/python/stage_local_asan_index.py stage \
+  --input-dir /path/to/packages \
+  --output-root /path/to/phase1-local \
+  --require-phase1-set
+```
+
+If `/path/to/packages/dist` exists, it is used automatically. Otherwise the
+tool reads packages directly from `/path/to/packages`. By default, it accepts
+only package metadata versions beginning with `10.1.0+asan.` and stages them
+under `whl-asan/gfx942-all`.
+
+`--require-phase1-set` verifies that the local index contains:
+
+- the `rocm` selector sdist;
+- `rocm-sdk-core`;
+- `rocm-sdk-libraries`;
+- `rocm-sdk-device-gfx942`;
+- `rocm-sdk-devel`.
+
+The tool refuses to overwrite an existing package with different contents. Use
+a new output root for a different build ID rather than mixing builds.
+
+## Verify and install offline
+
+Verify every package against the manifest before installation:
+
+```bash
+python build_tools/packaging/python/stage_local_asan_index.py verify \
+  --output-root /path/to/phase1-local \
+  --require-phase1-set
+```
+
+Install from the flat local index with network package lookup disabled:
+
+The single-target selector exposes the generic `device` extra, which is pinned
+to `rocm-sdk-device-gfx942`. Per-target extras such as `device-gfx942` are only
+generated for multi-target selectors.
+
+```bash
+INDEX=/path/to/phase1-local/whl-asan/gfx942-all
+python -m venv /path/to/asan-venv
+source /path/to/asan-venv/bin/activate
+python -m pip install --no-index --find-links="$INDEX/index.html" --pre \
+  "rocm[libraries,devel,device]"
+```
+
+Or exercise the PEP 503 tree directly:
+
+```bash
+python -m pip install --index-url="file://$INDEX/simple/" --pre \
+  "rocm[libraries,devel,device]"
+```
+
+Run the installed SDK checks under the ASan environment described in
+[`sanitizers.md`](../development/sanitizers.md):
+
+```bash
+export HSA_XNACK=1
+export ASAN_OPTIONS=detect_leaks=0:abort_on_error=1:print_stacktrace=1
+python -m rocm_sdk path --root
+rocm-sdk test
+```
+
+The staging command only uses local filesystem operations. It does not import
+TheRock's storage backends, choose a bucket, or expose an upload mode.

--- a/docs/packaging/python_packaging.md
+++ b/docs/packaging/python_packaging.md
@@ -125,6 +125,46 @@ objects fail to load at install time. See
 [environment_setup_guide.md#patchelf](../environment_setup_guide.md#patchelf)
 for supported install paths.
 
+#### Local ASAN wheels
+
+An ASAN artifact build must be packaged with `--asan`. This gives every ROCm
+wheel a non-release, PEP 440 local version such as
+`10.1.0+asan.20260807`, packages the shared Clang ASAN runtime in
+`rocm-sdk-core`, and validates that ASAN-linked ELFs in the split wheels can
+resolve that runtime through a relative RPATH.
+
+```bash
+python ./build_tools/build_python_packages.py \
+    --artifact-dir=/path/to/asan/build/artifacts \
+    --dest-dir=/path/to/local/rocm-asan-wheels \
+    --linux-amdgpu-families=gfx94X-dcgpu \
+    --asan
+```
+
+The default ASAN build ID is derived from `rocm_package_version` in the source
+artifact's `therock_manifest.json` (for example, `20260807` from
+`10.1.0a20260807`). Use `--asan-build-id=<id>` to select a different local
+identifier. An explicit `--version` is accepted only when it has the matching
+artifact base and canonical `<base>+asan.<build-id>` shape; this prevents an
+ASAN artifact set from being mislabeled as a release wheel.
+
+The kpack split is unchanged. For a gfx942 artifact set, the local output under
+`/path/to/local/rocm-asan-wheels/dist` includes:
+
+```text
+rocm-10.1.0+asan.20260807.tar.gz
+rocm_sdk_core-10.1.0+asan.20260807-*.whl
+rocm_sdk_libraries-10.1.0+asan.20260807-*.whl
+rocm_sdk_device_gfx942-10.1.0+asan.20260807-*.whl
+rocm_sdk_devel-10.1.0+asan.20260807-*.whl
+```
+
+`build_python_packages.py` only writes local files. It does not upload or
+promote packages. Also note that it consumes TheRock's structured `artifacts/`
+directory, not an already-flattened `therock-dist-*.tar.gz` SDK archive.
+See [Local ASan Python Package Index](local_asan_index.md) to stage the result
+under an isolated `whl-asan/gfx942-all/` tree and install it offline.
+
 ### Building from CI Artifacts
 
 You can also build packages from artifacts uploaded by CI workflows:

--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -180,6 +180,67 @@ mix/match build steps.
     --output-dir $HOME/tmp/pyout
   ```
 
+### Local ROCm 10.1 ASAN torch wheel
+
+Phase 2 has a deliberately isolated `--asan` mode for a torch-only
+`gfx942:xnack+` build. It consumes the local index produced by Phase 1 and
+passes `--no-index` to pip, so release ROCm packages cannot be selected as a
+fallback. The single-target selector's `device` extra is added automatically
+and must resolve `rocm-sdk-device-gfx942`.
+
+The Phase 1 index contains only ROCm artifacts, so prepare the current Python
+environment with the selector sdist's build dependencies before running the
+offline install:
+
+```bash
+python -m pip install 'setuptools>=70.2' wheel
+```
+
+ASAN mode verifies these packages and passes `--no-build-isolation` to pip;
+the offline ROCm install therefore does not try to resolve setuptools from the
+local ROCm-only index.
+
+```bash
+python build_prod_wheels.py build \
+  --asan \
+  --install-rocm \
+  --find-links /path/to/local-index/whl-asan/gfx942-all/index.html \
+  --pytorch-rocm-arch gfx942:xnack+ \
+  --pytorch-dir /path/to/ROCm/pytorch \
+  --no-build-triton \
+  --no-build-pytorch-audio \
+  --no-build-pytorch-vision \
+  --no-build-apex \
+  --output-dir /path/to/local-output
+```
+
+Before compiling, the mode verifies the Phase 1 manifest, its coherent
+`10.1.x+asan.<build-id>` package version, the installed SDK version, ROCm
+Clang executables, device bitcode, and the shared Clang ASAN runtime. It then
+exports `USE_ASAN=1`, ROCm Clang as both the conventional and CMake compilers,
+`gfx942:xnack+`, `HIP_DEVICE_LIB_PATH`, frame-pointer/linker flags, and a
+build-time ASAN runtime path. It also appends
+`-DCMAKE_CXX_SCAN_FOR_MODULES=OFF` to any caller-provided `CMAKE_ARGS`: CMake
+4.4 otherwise requests `clang-scan-deps`, which is not included in the Phase 1
+ROCm devel wheel. The torch version is derived as
+`<torch-base>+rocm10.1.asan.<build-id>`; a conflicting explicit suffix is
+rejected.
+
+After installing the finished wheel, the import sanity subprocess alone
+preloads the shared ASAN runtime discovered from ROCm Clang. The preload is not
+applied to pip, CMake, Ninja, compilers, or release-mode sanity checks.
+
+No separate Triton wheel is built. Flash and memory-efficient attention remain
+enabled by default through PyTorch's prebuilt AOTriton `+asan` path. The
+ROCm/pytorch source must contain the ROCm 10.1/HIP 7.16 compatibility mapping
+for those artifacts (the Phase 0 validated source was commit
+`dcf02e51371deb3050899643462349c1941e8979`). Use
+`--no-enable-pytorch-flash-attention` only as a diagnostic fallback.
+
+This command only writes the requested local output directory. It does not
+publish or upload wheels. Allow enough free space for the roughly 26 GiB SDK
+installation plus the PyTorch checkout, build tree, and finished wheel.
+
 - On Windows:
 
   ```batch

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -140,9 +140,11 @@ inline system deps into the audio and vision wheels as needed.
 """
 
 import argparse
+from importlib import metadata
 import json
 import os
 from pathlib import Path
+from packaging.specifiers import SpecifierSet
 from packaging.version import parse
 import platform
 import shutil
@@ -191,6 +193,22 @@ LINUX_LIBRARY_PRELOADS = [
     "rocm_smi64",
 ]
 
+ASAN_SUPPORTED_ROCM = (10, 1)
+ASAN_SUPPORTED_ARCH = "gfx942:xnack+"
+ASAN_DEFAULT_OPTIONS = "detect_leaks=0:abort_on_error=1:print_stacktrace=1"
+ASAN_CMAKE_ARGS = ("-DCMAKE_CXX_SCAN_FOR_MODULES=OFF",)
+ASAN_REQUIRED_LOCAL_PACKAGES = {
+    "rocm",
+    "rocm-sdk-core",
+    "rocm-sdk-devel",
+    "rocm-sdk-device-gfx942",
+    "rocm-sdk-libraries",
+}
+ASAN_BOOTSTRAP_REQUIREMENTS = {
+    "setuptools": SpecifierSet(">=70.2"),
+    "wheel": SpecifierSet(""),
+}
+
 # List of library preloads for Windows to generate into _rocm_init.py
 WINDOWS_LIBRARY_PRELOADS = [
     "amd_comgr",
@@ -221,12 +239,23 @@ def run_command(args: list[str | Path], cwd: Path, env: dict[str, str] | None = 
     subprocess.check_call(args, cwd=str(cwd), env=full_env)
 
 
-def capture(args: list[str | Path], cwd: Path) -> str:
+def capture(
+    args: list[str | Path],
+    cwd: Path,
+    env: dict[str, str] | None = None,
+) -> str:
     args = [str(arg) for arg in args]
     print(f"++ Capture [{cwd}]$ {shlex.join(args)}")
+    full_env = dict(os.environ)
+    if env:
+        full_env.update(env)
     try:
         return subprocess.check_output(
-            args, cwd=str(cwd), stderr=subprocess.STDOUT, text=True
+            args,
+            cwd=str(cwd),
+            env=full_env,
+            stderr=subprocess.STDOUT,
+            text=True,
         ).strip()
     except subprocess.CalledProcessError as e:
         print(f"Error capturing output: {e}")
@@ -286,6 +315,134 @@ def get_version_suffix_for_installed_rocm_package() -> str:
     version_suffix = f"+{base_name}{str(parsed_version).replace('+','-')}"
     print(f"Version suffix is: {version_suffix}")
     return version_suffix
+
+
+def validate_asan_rocm_version(rocm_version: str) -> None:
+    """Reject a release or incompatible ROCm SDK before an ASAN build."""
+    parsed_version = parse(rocm_version)
+    if tuple(parsed_version.release[:2]) != ASAN_SUPPORTED_ROCM:
+        raise RuntimeError(
+            "--asan currently requires a ROCm 10.1 SDK; "
+            f"found {rocm_version!r}"
+        )
+    local_parts = (parsed_version.local or "").split(".")
+    if not local_parts or local_parts[0] != "asan" or len(local_parts) < 2:
+        raise RuntimeError(
+            "--asan requires a uniquely labelled ROCm ASAN SDK version "
+            f"(expected 10.1.x+asan.<build-id>, found {rocm_version!r})"
+        )
+
+
+def get_asan_version_suffix(rocm_version: str) -> str:
+    """Derive a collision-resistant torch local version from an ASAN SDK."""
+    validate_asan_rocm_version(rocm_version)
+    parsed_version = parse(rocm_version)
+    major, minor = parsed_version.release[:2]
+    return f"+rocm{major}.{minor}.{parsed_version.local}"
+
+
+def resolve_asan_version_suffix(
+    rocm_version: str, explicit_suffix: str | None
+) -> str:
+    expected_suffix = get_asan_version_suffix(rocm_version)
+    if explicit_suffix and explicit_suffix != expected_suffix:
+        raise RuntimeError(
+            "--asan refuses an explicit torch version suffix that could "
+            "collide with or misidentify the SDK: "
+            f"expected {expected_suffix!r}, found {explicit_suffix!r}"
+        )
+    return expected_suffix
+
+
+def validate_local_asan_index(find_links: str) -> str:
+    """Validate the Phase 1 local index and return its coherent SDK version."""
+    index_path = Path(find_links).expanduser()
+    index_dir = index_path.parent if index_path.name == "index.html" else index_path
+    manifest_path = index_dir / "index-manifest.json"
+    if not index_dir.is_dir() or not manifest_path.is_file():
+        raise ValueError(
+            "--asan --install-rocm requires a local Phase 1 index directory "
+            "(or its index.html) containing index-manifest.json; "
+            f"not found at {index_dir}"
+        )
+
+    try:
+        manifest = json.loads(manifest_path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"Invalid local ASAN index manifest {manifest_path}: {exc}")
+    if manifest.get("index_kind") != "local-only":
+        raise ValueError(
+            f"ASAN index manifest must declare index_kind='local-only': {manifest_path}"
+        )
+    if manifest.get("relative_path") != "whl-asan/gfx942-all":
+        raise ValueError(
+            "ASAN index must be the gfx942 family index at "
+            f"whl-asan/gfx942-all: {manifest_path}"
+        )
+
+    packages = manifest.get("packages")
+    if not isinstance(packages, list):
+        raise ValueError(f"ASAN index manifest has no package list: {manifest_path}")
+    for package in packages:
+        if not isinstance(package, dict):
+            raise ValueError(
+                f"ASAN index manifest contains a malformed package: {manifest_path}"
+            )
+        filename = package.get("filename")
+        if (
+            not isinstance(filename, str)
+            or Path(filename).name != filename
+            or not (index_dir / filename).is_file()
+        ):
+            raise ValueError(
+                f"ASAN index package file is missing or invalid: {filename!r}"
+            )
+        declared_size = package.get("size")
+        if (
+            declared_size is not None
+            and (index_dir / filename).stat().st_size != declared_size
+        ):
+            raise ValueError(
+                f"ASAN index package size does not match its manifest: {filename}"
+            )
+    projects = {package.get("normalized_project") for package in packages}
+    missing = sorted(ASAN_REQUIRED_LOCAL_PACKAGES - projects)
+    if missing:
+        raise ValueError(
+            f"ASAN index is missing required packages {missing}: {manifest_path}"
+        )
+    versions = {package.get("version") for package in packages}
+    if len(versions) != 1 or None in versions:
+        raise ValueError(
+            f"ASAN index packages do not have one coherent version: {manifest_path}"
+        )
+    version = versions.pop()
+    if not isinstance(version, str):
+        raise ValueError(f"ASAN index contains an invalid version: {version!r}")
+    validate_asan_rocm_version(version)
+    return version
+
+
+def validate_asan_bootstrap_requirements() -> None:
+    """Ensure the environment can build the local selector without isolation."""
+    missing = []
+    for distribution, requirement in ASAN_BOOTSTRAP_REQUIREMENTS.items():
+        try:
+            installed_version = metadata.version(distribution)
+        except metadata.PackageNotFoundError:
+            missing.append(f"{distribution}{requirement}")
+            continue
+        if requirement and not requirement.contains(
+            installed_version, prereleases=True
+        ):
+            missing.append(f"{distribution}{requirement} (found {installed_version})")
+    if missing:
+        raise RuntimeError(
+            "--asan local installation uses --no-build-isolation and requires "
+            "bootstrap build dependencies in the current environment: "
+            f"{', '.join(missing)}. Install them first with: "
+            "python -m pip install 'setuptools>=70.2' wheel"
+        )
 
 
 def get_source_commit_short(source_dir: Path, length: int = 8) -> str:
@@ -552,14 +709,87 @@ def validate_build_args(
         and args.pytorch_dir is not None
         and not is_windows
         and not args.build_triton
+        and not args.asan
     ):
         parser.error(
             "--enable-pytorch-flash-attention on Linux requires Triton; "
             "specify --triton-dir or disable Flash Attention"
         )
 
+    if not args.asan:
+        return
+    if is_windows:
+        parser.error("--asan is supported only on Linux x86_64")
+    if platform.machine().lower() not in ("x86_64", "amd64"):
+        parser.error("--asan is supported only on Linux x86_64")
+    if args.pytorch_dir is None:
+        parser.error("--asan requires a PyTorch checkout via --pytorch-dir")
+
+    unsupported_builds = [
+        option
+        for enabled, option in (
+            (args.build_triton, "--build-triton"),
+            (args.build_pytorch_audio, "--build-pytorch-audio"),
+            (args.build_pytorch_vision, "--build-pytorch-vision"),
+            (args.build_apex, "--build-apex"),
+        )
+        if enabled
+    ]
+    if unsupported_builds:
+        parser.error(
+            "--asan Phase 2 builds torch only; disable " + ", ".join(unsupported_builds)
+        )
+    asan_extras = {
+        extra.strip() for extra in args.rocm_extras.split(",") if extra.strip()
+    }
+    if asan_extras - {"device"}:
+        parser.error(
+            "--asan only supports the gfx942 single-target 'device' extra; "
+            f"found {sorted(asan_extras)}"
+        )
+
+    requested_arch = args.pytorch_rocm_arch or os.environ.get("PYTORCH_ROCM_ARCH")
+    if requested_arch is None:
+        requested_arch = ASAN_SUPPORTED_ARCH
+    if requested_arch.replace(",", ";") != ASAN_SUPPORTED_ARCH:
+        parser.error(
+            f"--asan Phase 2 requires --pytorch-rocm-arch {ASAN_SUPPORTED_ARCH}; "
+            f"found {requested_arch!r}"
+        )
+    args.pytorch_rocm_arch = ASAN_SUPPORTED_ARCH
+
+    if args.index_url:
+        parser.error(
+            "--asan local mode does not accept --index-url; use the Phase 1 "
+            "index with --find-links to prevent mixing release packages"
+        )
+    if args.install_rocm:
+        if not args.find_links:
+            parser.error(
+                "--asan --install-rocm requires --find-links pointing to the "
+                "local Phase 1 whl-asan/gfx942-all index"
+            )
+        try:
+            index_version = validate_local_asan_index(args.find_links)
+            requested_versions = SpecifierSet(args.rocm_sdk_version)
+        except (ValueError, RuntimeError) as exc:
+            parser.error(str(exc))
+        if not requested_versions.contains(index_version, prereleases=True):
+            parser.error(
+                f"--rocm-sdk-version {args.rocm_sdk_version!r} excludes local "
+                f"ASAN SDK {index_version}"
+            )
+        # Install an exact coherent set even when the caller used the default
+        # broad selector. This prevents a future local index addition from
+        # silently changing the toolchain used by a retry.
+        args.rocm_sdk_version = f"=={index_version}"
+        args.asan_index_version = index_version
+
 
 def do_install_rocm(args: argparse.Namespace):
+    if getattr(args, "asan", False):
+        validate_asan_bootstrap_requirements()
+
     # Because the rocm package caches current GPU selection and such, we
     # always purge it to ensure a clean rebuild.
     #
@@ -585,6 +815,13 @@ def do_install_rocm(args: argparse.Namespace):
         "install",
         "--force-reinstall",
     ]
+    if getattr(args, "asan", False) or getattr(args, "no_index", False):
+        pip_args.append("--no-index")
+    if getattr(args, "asan", False):
+        # The local Phase 1 index intentionally contains only the ROCm package
+        # set, not generic build dependencies. Reuse the explicitly prepared
+        # environment when pip builds the selector sdist.
+        pip_args.append("--no-build-isolation")
     if args.pre:
         pip_args.extend(["--pre"])
     if args.index_url:
@@ -594,10 +831,19 @@ def do_install_rocm(args: argparse.Namespace):
     if args.pip_cache_dir:
         pip_args.extend(["--cache-dir", str(args.pip_cache_dir)])
     rocm_sdk_version = args.rocm_sdk_version if args.rocm_sdk_version else ""
-    extras = "libraries,devel"
-    if args.rocm_extras:
-        extras += f",{args.rocm_extras}"
-    pip_args.extend([f"rocm[{extras}]{rocm_sdk_version}"])
+    extras = ["libraries", "devel"]
+    requested_extras = [
+        extra.strip() for extra in args.rocm_extras.split(",") if extra.strip()
+    ]
+    if getattr(args, "asan", False):
+        # A single-target selector exposes `device`, which resolves to the
+        # gfx942 KPACK wheel. `device-gfx942` is only a multi-target extra.
+        requested_extras.append("device")
+    extras.extend(requested_extras)
+    # Preserve order while avoiding `device,device` when an orchestrator makes
+    # the automatic ASAN choice explicit.
+    extras = list(dict.fromkeys(extras))
+    pip_args.extend([f"rocm[{','.join(extras)}]{rocm_sdk_version}"])
     run_command(pip_args, cwd=Path.cwd())
     print(f"Installed version: {get_rocm_sdk_version()}")
 
@@ -625,6 +871,7 @@ def _setup_common_build_env(
     pytorch_rocm_arch: str,
     triton_dir: Path | None,
     is_windows: bool,
+    asan: bool = False,
 ) -> dict[str, str]:
     """Construct the common environment dict shared by all wheel builds."""
     env: dict[str, str] = {
@@ -669,7 +916,7 @@ def _setup_common_build_env(
                 "CXX": str((llvm_dir / "clang-cl.exe").resolve()),
             }
         )
-    else:
+    elif not asan:
         env.update(
             {
                 # Workaround GCC12 compiler flags.
@@ -711,6 +958,117 @@ def _setup_common_build_env(
         env["OpenBLAS_LIB_NAME"] = "rocm-openblas"
 
     return env
+
+
+def _setup_asan_build_env(rocm_dir: Path, pytorch_rocm_arch: str) -> dict[str, str]:
+    """Validate the ROCm Clang/ASAN payload and construct ASAN build settings."""
+    if is_windows or platform.machine().lower() not in ("x86_64", "amd64"):
+        raise RuntimeError("--asan is supported only on Linux x86_64")
+    if pytorch_rocm_arch != ASAN_SUPPORTED_ARCH:
+        raise RuntimeError(
+            f"--asan requires PYTORCH_ROCM_ARCH={ASAN_SUPPORTED_ARCH}; "
+            f"found {pytorch_rocm_arch!r}"
+        )
+
+    llvm_bin = rocm_dir / "lib" / "llvm" / "bin"
+    clang = llvm_bin / "clang"
+    clangxx = llvm_bin / "clang++"
+    for compiler in (clang, clangxx):
+        if not compiler.is_file() or not os.access(compiler, os.X_OK):
+            raise RuntimeError(
+                f"--asan requires the executable ROCm compiler {compiler}"
+            )
+
+    hip_device_lib_path = rocm_dir / "lib" / "llvm" / "amdgcn" / "bitcode"
+    if not hip_device_lib_path.is_dir() or not any(
+        hip_device_lib_path.glob("*.bc")
+    ):
+        raise RuntimeError(
+            "--asan requires ROCm device bitcode under "
+            f"{hip_device_lib_path}"
+        )
+
+    runtime_name = f"libclang_rt.asan-{platform.machine().lower()}.so"
+    runtime_text = capture(
+        [clangxx, f"-print-file-name={runtime_name}"], cwd=rocm_dir
+    )
+    runtime_path = Path(runtime_text)
+    if (
+        not runtime_text
+        or runtime_text == runtime_name
+        or not runtime_path.is_absolute()
+        or not runtime_path.is_file()
+    ):
+        raise RuntimeError(
+            "ROCm clang++ did not resolve its shared ASAN runtime: "
+            f"expected {runtime_name}, got {runtime_text!r}"
+        )
+    try:
+        runtime_path.resolve().relative_to(rocm_dir.resolve())
+    except ValueError:
+        # Some Linux venvs materialize the same wheel under both `lib` and
+        # `lib64`. The rocm-sdk root can be the lib64 copy while clang reports
+        # its resource dir through the equivalent lib copy. Accept only when
+        # the reported suffix also exists below this exact SDK payload root.
+        try:
+            payload_index = len(runtime_path.parts) - 1 - list(
+                reversed(runtime_path.parts)
+            ).index(rocm_dir.name)
+            payload_relative = Path(*runtime_path.parts[payload_index + 1 :])
+        except ValueError:
+            payload_relative = Path()
+        if (
+            payload_relative.parts[:4] != ("lib", "llvm", "lib", "clang")
+            or not (rocm_dir / payload_relative).is_file()
+        ):
+            raise RuntimeError(
+                "ROCm clang++ resolved ASAN outside the installed ROCm SDK, "
+                f"which could mix sanitizer runtimes: {runtime_path}"
+            )
+
+    inherited_ld_library_path = os.environ.get("LD_LIBRARY_PATH", "")
+    ld_library_parts = [str(runtime_path.parent), str(rocm_dir / "lib")]
+    if inherited_ld_library_path:
+        ld_library_parts.append(inherited_ld_library_path)
+    inherited_path = os.environ.get("PATH", "")
+    path_parts = [str(llvm_bin)]
+    if inherited_path:
+        path_parts.append(inherited_path)
+    inherited_cmake_args = os.environ.get("CMAKE_ARGS", "")
+    asan_cmake_args = " ".join(ASAN_CMAKE_ARGS)
+    cmake_args = (
+        f"{inherited_cmake_args} {asan_cmake_args}"
+        if inherited_cmake_args
+        else asan_cmake_args
+    )
+
+    return {
+        "USE_ASAN": "1",
+        "USE_ROCM": "1",
+        "USE_CUDA": "0",
+        "USE_NINJA": "1",
+        "CC": str(clang),
+        "CXX": str(clangxx),
+        "CMAKE_C_COMPILER": str(clang),
+        "CMAKE_CXX_COMPILER": str(clangxx),
+        "PYTORCH_ROCM_ARCH": pytorch_rocm_arch,
+        "HIP_DEVICE_LIB_PATH": str(hip_device_lib_path),
+        "ASAN_OPTIONS": os.environ.get("ASAN_OPTIONS", ASAN_DEFAULT_OPTIONS),
+        "CFLAGS": "-fno-omit-frame-pointer ",
+        "CXXFLAGS": "-fno-omit-frame-pointer ",
+        "LDFLAGS": "-shared-libasan ",
+        "LD_LIBRARY_PATH": os.path.pathsep.join(ld_library_parts),
+        "PATH": os.path.pathsep.join(path_parts),
+        # scikit-build-core forwards CMAKE_ARGS to its configure invocation.
+        # CMake 4.4 otherwise enables C++20 dependency scanning automatically
+        # and requires clang-scan-deps, which is intentionally absent from the
+        # Phase 1 ROCm devel wheel.
+        "CMAKE_ARGS": cmake_args,
+        # Private hand-off to do_build. It is removed before the environment is
+        # passed to any build subprocess and used only for the post-build import
+        # probe's LD_PRELOAD.
+        "_THEROCK_ASAN_RUNTIME_PATH": str(runtime_path),
+    }
 
 
 def _do_build_wheels_core(
@@ -763,9 +1121,6 @@ def do_build(args: argparse.Namespace):
     if args.install_rocm:
         do_install_rocm(args)
 
-    if not args.version_suffix:
-        args.version_suffix = get_version_suffix_for_installed_rocm_package()
-
     triton_dir: Path | None = args.triton_dir
     pytorch_dir: Path | None = args.pytorch_dir
     pytorch_audio_dir: Path | None = args.pytorch_audio_dir
@@ -773,6 +1128,19 @@ def do_build(args: argparse.Namespace):
     apex_dir: Path | None = args.apex_dir
 
     rocm_sdk_version = get_rocm_sdk_version()
+    if args.asan:
+        validate_asan_rocm_version(rocm_sdk_version)
+        args.version_suffix = resolve_asan_version_suffix(
+            rocm_sdk_version, args.version_suffix
+        )
+        index_version = getattr(args, "asan_index_version", None)
+        if index_version and index_version != rocm_sdk_version:
+            raise RuntimeError(
+                f"Installed ROCm SDK {rocm_sdk_version} does not match local "
+                f"ASAN index {index_version}"
+            )
+    elif not args.version_suffix:
+        args.version_suffix = get_version_suffix_for_installed_rocm_package()
     cmake_prefix = get_rocm_path("cmake")
     bin_dir = get_rocm_path("bin")
     rocm_dir = get_rocm_path("root")
@@ -807,9 +1175,22 @@ def do_build(args: argparse.Namespace):
     pytorch_rocm_arch = pytorch_rocm_arch.replace(",", ";")
 
     env = _setup_common_build_env(
-        cmake_prefix, bin_dir, rocm_dir, pytorch_rocm_arch, triton_dir, is_windows
+        cmake_prefix,
+        bin_dir,
+        rocm_dir,
+        pytorch_rocm_arch,
+        triton_dir,
+        is_windows,
+        asan=args.asan,
     )
     print(f"  PATH = {env['PATH']}")
+    if args.asan:
+        asan_env = _setup_asan_build_env(rocm_dir, pytorch_rocm_arch)
+        args.asan_runtime_path = Path(asan_env.pop("_THEROCK_ASAN_RUNTIME_PATH"))
+        # ROCm/TheRock#7210 provides the generic option and post-build archive
+        # gate. ASAN builds always opt into that portable RPATH contract.
+        args.pytorch_portable_rpath = True
+        env.update(asan_env)
 
     if args.use_ccache:
         if not shutil.which("ccache"):
@@ -1077,6 +1458,92 @@ def copy_libuv_to_torch_lib(pytorch_dir: Path):
     shutil.copy2(uv_dll, target_lib)
 
 
+def resolve_pytorch_flash_attention(
+    args: argparse.Namespace,
+    env: dict[str, str],
+    triton_requirement: str | None,
+) -> bool:
+    """Resolve Flash Attention without conflating Triton and AOTriton."""
+    if args.asan:
+        # Phase 2 does not build a separate Triton wheel. PyTorch's AOTriton
+        # CMake integration selects its prebuilt +asan runtime/images when
+        # USE_ASAN=1. Keep that proven gfx942 path enabled by default while
+        # retaining an explicit opt-out for diagnostics.
+        use_flash_attention = args.enable_pytorch_flash_attention is not False
+        print(
+            "ASAN AOTriton Flash Attention behavior: "
+            f"{'enabled' if use_flash_attention else 'disabled'}"
+        )
+        return use_flash_attention
+    if args.enable_pytorch_flash_attention is not None:
+        use_flash_attention = args.enable_pytorch_flash_attention
+        print(f"Flash Attention explicitly set to: {use_flash_attention}")
+        return use_flash_attention
+    if not is_windows and not triton_requirement:
+        print("Disabling Flash Attention on Linux since triton is not built")
+        return False
+
+    # Enable aotriton by default if supported. AOTriton supports a subset of
+    # GPU architectures. When at least one target arch is supported, let its
+    # build system filter to supported targets. When none are supported its
+    # configure step fails on the empty target list.
+    aotriton_supported_arch_prefixes = (
+        "gfx90a",
+        "gfx942",
+        "gfx950",
+        "gfx11",
+        "gfx12",
+    )
+    rocm_arch_list = env.get("PYTORCH_ROCM_ARCH", "").split(";")
+    has_aotriton_supported_arch = any(
+        arch.startswith(aotriton_supported_arch_prefixes) for arch in rocm_arch_list
+    )
+    print(
+        f"Flash Attention default behavior: {has_aotriton_supported_arch}\n"
+        f"  (has_aotriton_supported_arch: {has_aotriton_supported_arch})"
+    )
+    return has_aotriton_supported_arch
+
+
+def get_pytorch_sanity_env(
+    args: argparse.Namespace, build_env: dict[str, str]
+) -> dict[str, str] | None:
+    """Return environment overrides for the post-install torch import only."""
+    if not args.asan:
+        return None
+    runtime_path = Path(args.asan_runtime_path)
+    if not runtime_path.is_file():
+        raise RuntimeError(
+            f"Validated ASAN runtime disappeared before torch sanity check: {runtime_path}"
+        )
+    inherited_preload = os.environ.get("LD_PRELOAD", "")
+    preload_parts = [str(runtime_path)]
+    if inherited_preload:
+        preload_parts.append(inherited_preload)
+    sanity_env = {"LD_PRELOAD": os.path.pathsep.join(preload_parts)}
+    # Keep ASAN's no-leak policy and the validated SDK library search path
+    # scoped to the same subprocess. In particular, do not LD_PRELOAD the
+    # sanitizer into pip, CMake, Ninja, or compiler processes.
+    for env_name in ("ASAN_OPTIONS", "LD_LIBRARY_PATH"):
+        if env_name in build_env:
+            sanity_env[env_name] = build_env[env_name]
+    return sanity_env
+
+
+def sanity_check_installed_pytorch(
+    args: argparse.Namespace, build_env: dict[str, str]
+) -> None:
+    print("+++ Sanity checking installed torch (unavailable is okay on CPU machines):")
+    sanity_check_output = capture(
+        [sys.executable, "-c", "import torch; print(torch.cuda.is_available())"],
+        cwd=tempfile.gettempdir(),
+        env=get_pytorch_sanity_env(args, build_env),
+    )
+    if not sanity_check_output:
+        raise RuntimeError("torch package sanity check failed (see output above)")
+    print(f"Sanity check output:\n{sanity_check_output}")
+
+
 def do_build_pytorch(
     args: argparse.Namespace,
     pytorch_dir: Path,
@@ -1090,8 +1557,8 @@ def do_build_pytorch(
     )
     print(f"  Using PYTORCH_BUILD_VERSION: {pytorch_build_version}")
 
-    env["USE_ROCM"] = "ON"
-    env["USE_CUDA"] = "OFF"
+    env["USE_ROCM"] = "1" if args.asan else "ON"
+    env["USE_CUDA"] = "0" if args.asan else "OFF"
     env["USE_MPI"] = "OFF"
     env["USE_NUMA"] = "OFF"
     env["PYTORCH_BUILD_VERSION"] = pytorch_build_version
@@ -1111,42 +1578,11 @@ def do_build_pytorch(
     # Add the _rocm_init.py file.
     (pytorch_dir / "torch" / "_rocm_init.py").write_text(get_rocm_init_contents(args))
 
-    # Enable/disable flash attention.
-    if args.enable_pytorch_flash_attention is not None:
-        use_flash_attention = args.enable_pytorch_flash_attention
-        print(f"Flash Attention explicitly set to: {use_flash_attention}")
-        # Note: this may fail if aotriton is not supported, see below.
-    elif not is_windows and not triton_requirement:
-        print(f"Disabling Flash Attention on Linux since triton is not built")
-        use_flash_attention = False
-    else:
-        # Enable aotriton by default if supported.
-        # aotriton supports a subset of GPU architectures. When *at least* one
-        # target arch is supported let aotriton's build system (gpu_targets.py)
-        # filter to just the supported ones. The runtime (check_gpu in
-        # sdp_utils.cpp) gracefully falls back to math/CK backends on
-        # unsupported GPUs. We only disable flash attention when *no* target
-        # arch is supported — otherwise aotriton's configure step fails on the
-        # empty target list (https://github.com/ROCm/aotriton/issues/169).
-        #
-        # These prefixes match what aotriton's gpu_targets.py recognizes.
-        # See also the image list in pytorch/cmake/External/aotriton.cmake.
-        AOTRITON_SUPPORTED_ARCH_PREFIXES = (
-            "gfx90a",
-            "gfx942",
-            "gfx950",
-            "gfx11",
-            "gfx12",
-        )
-        rocm_arch_list = env.get("PYTORCH_ROCM_ARCH", "").split(";")
-        has_aotriton_supported_arch = any(
-            arch.startswith(AOTRITON_SUPPORTED_ARCH_PREFIXES) for arch in rocm_arch_list
-        )
-        use_flash_attention = has_aotriton_supported_arch
-        print(
-            f"Flash Attention default behavior: {use_flash_attention}\n"
-            f"  (has_aotriton_supported_arch: {has_aotriton_supported_arch})"
-        )
+    # Enable/disable Flash Attention. ASAN uses prebuilt AOTriton +asan
+    # artifacts and intentionally has no separate Triton wheel dependency.
+    use_flash_attention = resolve_pytorch_flash_attention(
+        args, env, triton_requirement
+    )
     # Finally update the environment with the resolved setting.
     env.update(
         {
@@ -1296,15 +1732,7 @@ def do_build_pytorch(
         [sys.executable, "-m", "pip", "install", built_wheel], cwd=tempfile.gettempdir()
     )
 
-    print("+++ Sanity checking installed torch (unavailable is okay on CPU machines):")
-    sanity_check_output = capture(
-        [sys.executable, "-c", "import torch; print(torch.cuda.is_available())"],
-        cwd=tempfile.gettempdir(),
-    )
-    if not sanity_check_output:
-        raise RuntimeError("torch package sanity check failed (see output above)")
-    else:
-        print(f"Sanity check output:\n{sanity_check_output}")
+    sanity_check_installed_pytorch(args, env)
 
 
 def do_build_pytorch_audio(
@@ -1426,6 +1854,12 @@ def main(argv: list[str]):
             help="URL or path for pip --find-links (flat package index).",
         )
         p.add_argument("--pip-cache-dir", type=Path, help="Pip cache dir")
+        p.add_argument(
+            "--no-index",
+            action="store_true",
+            default=False,
+            help="Pass --no-index to pip. This is automatic in --asan mode.",
+        )
         # Note that we default to >1.0 because at the time of writing, we had
         # 0.1.0 release placeholder packages out on pypi and we don't want them
         # taking priority.
@@ -1464,6 +1898,14 @@ def main(argv: list[str]):
         "--install-rocm",
         action=argparse.BooleanOptionalAction,
         help="Install rocm-sdk before building",
+    )
+    build_p.add_argument(
+        "--asan",
+        action="store_true",
+        default=False,
+        help="Build a ROCm 10.1 gfx942:xnack+ torch ASAN wheel from the local "
+        "Phase 1 SDK index. Enables ROCm Clang and strict SDK/runtime preflight; "
+        "Triton, sibling wheels, and remote package indexes are excluded.",
     )
     build_p.add_argument(
         "--output-dir",

--- a/external-builds/pytorch/test_build_prod_wheels.py
+++ b/external-builds/pytorch/test_build_prod_wheels.py
@@ -1,0 +1,348 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+import argparse
+import json
+import os
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.fspath(Path(__file__).parent))
+
+import build_prod_wheels as bpw
+
+
+class AsanVersionTest(unittest.TestCase):
+    def test_rocm_10_1_asan_suffix_is_unique(self):
+        self.assertEqual(
+            bpw.get_asan_version_suffix("10.1.0+asan.20260807"),
+            "+rocm10.1.asan.20260807",
+        )
+
+    def test_release_sdk_is_rejected(self):
+        with self.assertRaisesRegex(RuntimeError, "uniquely labelled"):
+            bpw.validate_asan_rocm_version("10.1.0")
+
+    def test_old_branch_version_is_rejected(self):
+        with self.assertRaisesRegex(RuntimeError, "ROCm 10.1"):
+            bpw.validate_asan_rocm_version("7.15.0+asan.20260807")
+
+    def test_conflicting_explicit_suffix_is_rejected(self):
+        with self.assertRaisesRegex(RuntimeError, "collide"):
+            bpw.resolve_asan_version_suffix(
+                "10.1.0+asan.20260807", "+rocm10.1"
+            )
+
+
+class LocalAsanIndexTest(unittest.TestCase):
+    def _write_manifest(self, root: Path, *, version="10.1.0+asan.20260807"):
+        index = root / "whl-asan" / "gfx942-all"
+        index.mkdir(parents=True)
+        packages = []
+        for project in sorted(bpw.ASAN_REQUIRED_LOCAL_PACKAGES):
+            filename = f"{project}-{version}.pkg"
+            (index / filename).touch()
+            packages.append(
+                {
+                    "normalized_project": project,
+                    "version": version,
+                    "filename": filename,
+                    "size": 0,
+                }
+            )
+        (index / "index-manifest.json").write_text(
+            json.dumps(
+                {
+                    "index_kind": "local-only",
+                    "relative_path": "whl-asan/gfx942-all",
+                    "packages": packages,
+                }
+            )
+        )
+        (index / "index.html").touch()
+        return index
+
+    def test_accepts_phase1_directory_or_index_page(self):
+        with tempfile.TemporaryDirectory() as td:
+            index = self._write_manifest(Path(td))
+            expected = "10.1.0+asan.20260807"
+            self.assertEqual(bpw.validate_local_asan_index(str(index)), expected)
+            self.assertEqual(
+                bpw.validate_local_asan_index(str(index / "index.html")), expected
+            )
+
+    def test_rejects_incomplete_package_set(self):
+        with tempfile.TemporaryDirectory() as td:
+            index = self._write_manifest(Path(td))
+            manifest_path = index / "index-manifest.json"
+            manifest = json.loads(manifest_path.read_text())
+            manifest["packages"].pop()
+            manifest_path.write_text(json.dumps(manifest))
+            with self.assertRaisesRegex(ValueError, "missing required packages"):
+                bpw.validate_local_asan_index(str(index))
+
+    def test_build_validation_pins_local_version_and_defaults_arch(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            index = self._write_manifest(root)
+            pytorch_dir = root / "pytorch"
+            pytorch_dir.mkdir()
+            args = self._build_args(pytorch_dir, index)
+            parser = argparse.ArgumentParser()
+
+            bpw.validate_build_args(parser, args)
+
+            self.assertEqual(args.pytorch_rocm_arch, "gfx942:xnack+")
+            self.assertEqual(args.rocm_sdk_version, "==10.1.0+asan.20260807")
+            self.assertEqual(args.asan_index_version, "10.1.0+asan.20260807")
+
+    def test_build_validation_rejects_remote_index(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            index = self._write_manifest(root)
+            pytorch_dir = root / "pytorch"
+            pytorch_dir.mkdir()
+            args = self._build_args(pytorch_dir, index)
+            args.index_url = "https://example.invalid/simple"
+            with self.assertRaises(SystemExit):
+                bpw.validate_build_args(argparse.ArgumentParser(), args)
+
+    @staticmethod
+    def _build_args(pytorch_dir: Path, index: Path):
+        return argparse.Namespace(
+            asan=True,
+            pytorch_dir=pytorch_dir,
+            triton_dir=None,
+            pytorch_audio_dir=None,
+            pytorch_vision_dir=None,
+            apex_dir=None,
+            build_triton=False,
+            build_pytorch_audio=False,
+            build_pytorch_vision=False,
+            build_apex=False,
+            enable_pytorch_flash_attention=None,
+            rocm_extras="",
+            pytorch_rocm_arch=None,
+            index_url=None,
+            install_rocm=True,
+            find_links=str(index),
+            rocm_sdk_version=">1.0",
+        )
+
+
+class AsanEnvironmentTest(unittest.TestCase):
+    def _make_sdk(self, root: Path):
+        llvm_bin = root / "lib" / "llvm" / "bin"
+        llvm_bin.mkdir(parents=True)
+        for name in ("clang", "clang++"):
+            compiler = llvm_bin / name
+            compiler.touch()
+            compiler.chmod(0o755)
+        bitcode = root / "lib" / "llvm" / "amdgcn" / "bitcode"
+        bitcode.mkdir(parents=True)
+        (bitcode / "ocml.bc").touch()
+        runtime = (
+            root
+            / "lib"
+            / "llvm"
+            / "lib"
+            / "clang"
+            / "23"
+            / "lib"
+            / "linux"
+            / "libclang_rt.asan-x86_64.so"
+        )
+        runtime.parent.mkdir(parents=True)
+        runtime.touch()
+        return runtime
+
+    def test_asan_env_uses_rocm_clang_and_shared_runtime(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            runtime = self._make_sdk(root)
+            with mock.patch.object(bpw, "capture", return_value=str(runtime)):
+                env = bpw._setup_asan_build_env(root, "gfx942:xnack+")
+
+            self.assertEqual(env["USE_ASAN"], "1")
+            self.assertEqual(env["USE_ROCM"], "1")
+            self.assertEqual(env["USE_CUDA"], "0")
+            self.assertEqual(env["CC"], str(root / "lib/llvm/bin/clang"))
+            self.assertEqual(env["CXX"], str(root / "lib/llvm/bin/clang++"))
+            self.assertEqual(env["CMAKE_C_COMPILER"], env["CC"])
+            self.assertEqual(env["CMAKE_CXX_COMPILER"], env["CXX"])
+            self.assertEqual(env["PYTORCH_ROCM_ARCH"], "gfx942:xnack+")
+            self.assertIn("-fno-omit-frame-pointer", env["CXXFLAGS"])
+            self.assertNotIn("maybe-uninitialized", env["CXXFLAGS"])
+            self.assertIn("-shared-libasan", env["LDFLAGS"])
+            self.assertTrue(env["LD_LIBRARY_PATH"].startswith(str(runtime.parent)))
+            self.assertEqual(
+                env["CMAKE_ARGS"],
+                "-DCMAKE_CXX_SCAN_FOR_MODULES=OFF",
+            )
+
+    def test_asan_cmake_args_preserve_caller_arguments(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            runtime = self._make_sdk(root)
+            caller_args = "-DFOO=ON -DQUOTED='value with spaces'"
+            with mock.patch.object(
+                bpw, "capture", return_value=str(runtime)
+            ), mock.patch.dict(os.environ, {"CMAKE_ARGS": caller_args}):
+                env = bpw._setup_asan_build_env(root, "gfx942:xnack+")
+
+            self.assertEqual(
+                env["CMAKE_ARGS"],
+                caller_args + " -DCMAKE_CXX_SCAN_FOR_MODULES=OFF",
+            )
+
+    def test_runtime_outside_sdk_is_rejected(self):
+        with tempfile.TemporaryDirectory() as sdk_td, tempfile.TemporaryDirectory(
+        ) as rt_td:
+            root = Path(sdk_td)
+            self._make_sdk(root)
+            runtime = Path(rt_td) / "libclang_rt.asan-x86_64.so"
+            runtime.touch()
+            with mock.patch.object(bpw, "capture", return_value=str(runtime)):
+                with self.assertRaisesRegex(RuntimeError, "outside"):
+                    bpw._setup_asan_build_env(root, "gfx942:xnack+")
+
+    def test_common_asan_env_omits_gcc_warning_flags(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            env = bpw._setup_common_build_env(
+                root / "cmake",
+                root / "bin",
+                root,
+                "gfx942:xnack+",
+                None,
+                False,
+                asan=True,
+            )
+            self.assertNotIn("CXXFLAGS", env)
+            self.assertNotIn("CPPFLAGS", env)
+
+    def test_common_release_env_preserves_gcc_warning_flags(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            env = bpw._setup_common_build_env(
+                root / "cmake", root / "bin", root, "gfx942", None, False
+            )
+            self.assertIn("maybe-uninitialized", env["CXXFLAGS"])
+            self.assertIn("maybe-uninitialized", env["CPPFLAGS"])
+            self.assertNotIn("CMAKE_ARGS", env)
+
+
+class AsanInstallAndFeatureTest(unittest.TestCase):
+    def test_bootstrap_requires_modern_setuptools_and_wheel(self):
+        versions = {"setuptools": "69.0", "wheel": "0.45.1"}
+        with mock.patch.object(
+            bpw.metadata, "version", side_effect=lambda name: versions[name]
+        ):
+            with self.assertRaisesRegex(RuntimeError, "setuptools>=70.2"):
+                bpw.validate_asan_bootstrap_requirements()
+
+    def test_bootstrap_accepts_preinstalled_build_dependencies(self):
+        versions = {"setuptools": "75.0", "wheel": "0.45.1"}
+        with mock.patch.object(
+            bpw.metadata, "version", side_effect=lambda name: versions[name]
+        ):
+            bpw.validate_asan_bootstrap_requirements()
+
+    def test_install_is_offline_and_includes_single_target_device(self):
+        args = argparse.Namespace(
+            asan=True,
+            pip_cache_dir=None,
+            pre=True,
+            index_url=None,
+            find_links="/local/whl-asan/gfx942-all/index.html",
+            rocm_sdk_version="==10.1.0+asan.20260807",
+            rocm_extras="device",
+            no_index=True,
+        )
+        with mock.patch.object(bpw, "run_command") as run, mock.patch.object(
+            bpw, "get_rocm_sdk_version", return_value="10.1.0+asan.20260807"
+        ), mock.patch.object(bpw, "validate_asan_bootstrap_requirements"):
+            bpw.do_install_rocm(args)
+        install_command = next(
+            call.args[0] for call in run.call_args_list if "install" in call.args[0]
+        )
+        self.assertIn("--no-index", install_command)
+        self.assertIn("--no-build-isolation", install_command)
+        self.assertIn("--find-links", install_command)
+        self.assertIn(
+            "rocm[libraries,devel,device]==10.1.0+asan.20260807", install_command
+        )
+
+    def test_release_install_preserves_index_and_extras_behavior(self):
+        args = argparse.Namespace(
+            asan=False,
+            no_index=False,
+            pip_cache_dir=None,
+            pre=True,
+            index_url="https://example.invalid/simple",
+            find_links=None,
+            rocm_sdk_version=">1.0",
+            rocm_extras="",
+        )
+        with mock.patch.object(bpw, "run_command") as run, mock.patch.object(
+            bpw, "get_rocm_sdk_version", return_value="10.1.0"
+        ):
+            bpw.do_install_rocm(args)
+        install_command = next(
+            call.args[0] for call in run.call_args_list if "install" in call.args[0]
+        )
+        self.assertNotIn("--no-index", install_command)
+        self.assertNotIn("--no-build-isolation", install_command)
+        self.assertIn("--index-url", install_command)
+        self.assertIn("rocm[libraries,devel]>1.0", install_command)
+
+    def test_asan_defaults_to_prebuilt_aotriton_without_triton_wheel(self):
+        args = argparse.Namespace(asan=True, enable_pytorch_flash_attention=None)
+        self.assertTrue(
+            bpw.resolve_pytorch_flash_attention(
+                args, {"PYTORCH_ROCM_ARCH": "gfx942:xnack+"}, None
+            )
+        )
+        args.enable_pytorch_flash_attention = False
+        self.assertFalse(
+            bpw.resolve_pytorch_flash_attention(
+                args, {"PYTORCH_ROCM_ARCH": "gfx942:xnack+"}, None
+            )
+        )
+
+    def test_asan_sanity_preloads_validated_runtime_only_for_capture(self):
+        with tempfile.TemporaryDirectory() as td:
+            runtime = Path(td) / "libclang_rt.asan-x86_64.so"
+            runtime.touch()
+            args = argparse.Namespace(asan=True, asan_runtime_path=runtime)
+            build_env = {
+                "ASAN_OPTIONS": "detect_leaks=0:abort_on_error=1",
+                "LD_LIBRARY_PATH": "/rocm/lib",
+            }
+            with mock.patch.dict(
+                os.environ, {"LD_PRELOAD": "/existing/preload.so"}
+            ), mock.patch.object(bpw, "capture", return_value="False") as capture:
+                bpw.sanity_check_installed_pytorch(args, build_env)
+
+            sanity_env = capture.call_args.kwargs["env"]
+            self.assertEqual(
+                sanity_env["LD_PRELOAD"],
+                f"{runtime}{os.path.pathsep}/existing/preload.so",
+            )
+            self.assertEqual(sanity_env["ASAN_OPTIONS"], build_env["ASAN_OPTIONS"])
+            self.assertEqual(
+                sanity_env["LD_LIBRARY_PATH"], build_env["LD_LIBRARY_PATH"]
+            )
+
+    def test_release_sanity_does_not_set_preload(self):
+        args = argparse.Namespace(asan=False)
+        with mock.patch.object(bpw, "capture", return_value="False") as capture:
+            bpw.sanity_check_installed_pytorch(args, {})
+        self.assertIsNone(capture.call_args.kwargs["env"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stack: **2 of 2**, after **ROCm/TheRock#7312**.

For the Phase 2-only review diff, compare [`draft/asan-wheels-phase1-rocm...draft/asan-wheels-phase2-pytorch`](https://github.com/sa-faizal/TheRock/compare/draft/asan-wheels-phase1-rocm...draft/asan-wheels-phase2-pytorch).

## Summary

Add the integrated Phase 2 production-builder mode for a torch-only ROCm ASAN wheel built from the isolated Phase 1 package set:

- validate the local manifest, exact coherent ROCm ASAN version, bootstrap frontend, and single `gfx942:xnack+` target;
- install the SDK offline with `--no-index`, `--no-build-isolation`, exact versioning, and the selector's `device` extra;
- select packaged ROCm Clang, bitcode, and the shared ASAN runtime and configure shared-ASAN/frame-pointer flags;
- disable CMake's optional module scanner while preserving caller `CMAKE_ARGS`;
- derive a collision-resistant Torch suffix from the selected ROCm candidate;
- keep the prebuilt ASAN AOTriton path enabled without building a separate Triton wheel; and
- scope `LD_PRELOAD` to the post-install Torch sanity subprocess only.

ASAN mode opts into the generic portable-RPATH contract from ROCm/TheRock#7210; its parser/archive-gate implementation is deliberately not duplicated here.

## Why this is a draft

- the reusable builder still contains pilot policy for ROCm 10.1 and `gfx942:xnack+` that should move into workflow configuration;
- the final fat wheel must be rebuilt after the compiler-rt and portable-RPATH dependencies land;
- the independent kpack PEP 376 RECORD correction in `ROCm/rocm-systems` must land before the final split; and
- strict offline GPU validation must replace the historical diagnostic baseline before publication.

## Real-input evidence

The prototype consumed the Phase 1 `10.1.0+asan.20260807` index and a HIPified PyTorch checkout based on `dcf02e51371deb3050899643462349c1941e8979`.

- the full 3,830-edge Torch build completed and produced a 643 MiB fat wheel;
- the isolated import sanity check reported `2.14.0a0+rocm10.1.asan.20260807`;
- corrected split host/device wheels passed ZIP CRC, full PEP 376 RECORD, reciprocal pin, kpack, and ASAN-linkage validation;
- clean CPython 3.12 offline installation and plain Torch import passed;
- the GPU smoke reached the known pre-fix compiler-rt null-PC initialization failure, so the preserved artifacts are diagnostic evidence, not publishable outputs.

No local runner, wheel, dependency wheelhouse, generated AOTriton images, PyTorch HIPIFY output, submodule pointer, or validation artifact is included.

## Tests

```text
20 focused ASAN production-builder tests passed
python -m py_compile: pass
git diff --check: pass
```

The three portable-RPATH tests from the integrated prototype were excluded because ROCm/TheRock#7210 owns that implementation and its focused coverage.

## Dependencies and final acceptance

- ROCm/TheRock#7312 — coherent ROCm ASAN package/index input
- ROCm/TheRock#7210 — portable Torch RPATH activation and archive gate
- ROCm/pytorch#3549 — portable PyTorch CMake RPATH policy
- ROCm/llvm-project#3827 — late-HSA compiler-rt initialization fix
- independent `ROCm/rocm-systems` kpack RECORD fix

After those dependencies land, rebuild rather than patch the preserved wheels and require zero absolute RPATH/RUNPATH components, strict offline installation, successful gfx942 tensor execution (`1240.0`), and zero downgraded ASAN findings.
