### PR TITLE
fix(tests): preload the ASAN runtime for host-asan builds

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -29,7 +29,10 @@ TODO(#2200): clarify AMD GPU family selection
 
 import copy
 import os
+import platform
 import random
+import shlex
+import subprocess
 import sys
 from pathlib import Path
 
@@ -76,6 +79,41 @@ def is_asan():
     """Determines if this is an ASAN build using BUILD_VARIANT env var."""
     BUILD_VARIANT = os.getenv("BUILD_VARIANT", "")
     return BUILD_VARIANT == "asan"
+
+
+def is_asan_instrumented():
+    """Determines if this build's host libraries carry ASAN instrumentation.
+
+    Unlike is_asan(), this covers the host-asan variant as well. Use it for
+    anything that has to cope with instrumented host libraries; use is_asan()
+    only to gate behavior specific to full (host + device) ASAN.
+    """
+    BUILD_VARIANT = os.getenv("BUILD_VARIANT", "")
+    return BUILD_VARIANT in ("asan", "host-asan")
+
+
+def get_asan_lib_path(bin_dir):
+    """Resolves the ASAN runtime shared library shipped with the build's clang.
+
+    Executables that are not themselves linked against the runtime must preload
+    this, otherwise loading an instrumented ROCm library pulls the runtime in
+    too late and it aborts with "ASan runtime does not come first in initial
+    library list".
+    """
+    arch = platform.machine()
+    clang_path = str(Path(bin_dir).parent / "lib" / "llvm" / "bin" / "clang++")
+    asan_lib = f"libclang_rt.asan-{arch}.so"
+    cmd = [clang_path, f"-print-file-name={asan_lib}"]
+    _log(f"++ Exec [{clang_path}]$ {shlex.join(cmd)}")
+    result = subprocess.run(cmd, check=True, text=True, capture_output=True)
+    # Clang echoes the bare filename back when it cannot resolve it.
+    resolved = result.stdout.strip()
+    if not resolved or resolved == asan_lib or not Path(resolved).is_file():
+        raise FileNotFoundError(
+            f"Could not locate ASan runtime '{asan_lib}' via {clang_path} "
+            f"(got: '{resolved}')"
+        )
+    return str(Path(resolved).resolve())
 
 
 def select_weighted_label(labels_config: list[dict], context_name: str) -> str:

--- a/build_tools/github_actions/test_executable_scripts/test_hipfile.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipfile.py
@@ -19,7 +19,6 @@
 # packaged unit suite.
 
 import logging
-import platform
 import shlex
 import subprocess
 import sys
@@ -32,9 +31,9 @@ THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 
-# Importing is_asan from amdgpu_family_matrix.py
+# Importing ASAN helpers from amdgpu_family_matrix.py
 sys.path.append(str(THEROCK_DIR / "build_tools" / "github_actions"))
-from amdgpu_family_matrix import is_asan
+from amdgpu_family_matrix import get_asan_lib_path, is_asan_instrumented
 
 if THEROCK_BIN_DIR is None:
     logging.error("env(THEROCK_BIN_DIR) is not set. Set it before running tests.")
@@ -48,25 +47,9 @@ if not HIPFILE_TEST_DIR.is_dir():
     raise SystemExit(1)
 
 
-def get_asan_lib_path():
-    arch = platform.machine()
-    clang_path = str(Path(THEROCK_BIN_DIR).parent / "lib" / "llvm" / "bin" / "clang++")
-    asan_lib = f"libclang_rt.asan-{arch}.so"
-    cmd = [clang_path, f"-print-file-name={asan_lib}"]
-    logging.info(f"++ Exec [{clang_path}]$ {shlex.join(cmd)}")
-    result = subprocess.run(cmd, check=True, text=True, capture_output=True)
-    resolved = result.stdout.strip()
-    if not resolved or resolved == asan_lib or not Path(resolved).is_file():
-        raise FileNotFoundError(
-            f"Could not locate ASan runtime '{asan_lib}' via {clang_path} "
-            f"(got: '{resolved}')"
-        )
-    return str(Path(resolved).resolve())
-
-
 env = os.environ.copy()
-if is_asan():
-    asan_lib = get_asan_lib_path()
+if is_asan_instrumented():
+    asan_lib = get_asan_lib_path(THEROCK_BIN_DIR)
     existing_preload = env.get("LD_PRELOAD", "")
     env["LD_PRELOAD"] = (
         f"{existing_preload}:{asan_lib}" if existing_preload else asan_lib

--- a/build_tools/github_actions/test_executable_scripts/test_hiptests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiptests.py
@@ -24,9 +24,9 @@ TEST_TYPE = os.getenv("TEST_TYPE", "standard")
 os_type = platform.system().lower()
 CATCH_TESTS_PATH = str(Path(THEROCK_BIN_DIR).parent / "share" / "hip" / "catch_tests")
 
-# Importing is_asan from amdgpu_family_matrix.py
+# Importing ASAN helpers from amdgpu_family_matrix.py
 sys.path.append(str(THEROCK_DIR / "build_tools" / "github_actions"))
-from amdgpu_family_matrix import is_asan
+from amdgpu_family_matrix import get_asan_lib_path, is_asan_instrumented
 
 env = os.environ.copy()
 
@@ -109,20 +109,6 @@ GENERIC_TEST_TO_IGNORE = [
 ]
 
 
-def get_asan_lib_path():
-    arch = platform.machine()
-    CLANG_PATH = str(Path(THEROCK_BIN_DIR).parent / "lib" / "llvm" / "bin" / "clang++")
-    cmd = [f"{CLANG_PATH}", f"--print-file-name=libclang_rt.asan-{arch}.so"]
-    logging.info(f"++ Exec [{CLANG_PATH}]$ {shlex.join(cmd)}")
-    result = subprocess.run(
-        cmd,
-        check=True,
-        text=True,
-        capture_output=True,
-    )
-    return result.stdout.strip()
-
-
 def copy_dlls_exe_path():
     if platform.system() == "Windows":
         # hip and comgr dlls need to be copied to the same folder as exectuable
@@ -163,8 +149,8 @@ def setup_env(env):
         else:
             env["LD_LIBRARY_PATH"] = HIP_LIB_PATH
         # For ASAN mode, we preload it for test count query and test running
-        if is_asan():
-            env["LD_PRELOAD"] = get_asan_lib_path()
+        if is_asan_instrumented():
+            env["LD_PRELOAD"] = get_asan_lib_path(THEROCK_BIN_DIR)
             env["HSA_XNACK"] = "1"
             # Increase stack size of clr threads
             env["CQ_THREAD_STACK_SIZE"] = "8388608"
@@ -180,7 +166,7 @@ def setup_env(env):
 
 def execute_tests(env):
     # Allow for more time in ASAN mode to run the tests.
-    timeout = 1500 if is_asan() else 600
+    timeout = 1500 if is_asan_instrumented() else 600
     cmd = [
         "ctest",
         "--tests-information",

--- a/build_tools/github_actions/tests/amdgpu_family_matrix_test.py
+++ b/build_tools/github_actions/tests/amdgpu_family_matrix_test.py
@@ -20,7 +20,10 @@ if "CI_CONFIG_PATH" in os.environ:
 import amdgpu_family_matrix
 from amdgpu_family_matrix import (
     get_all_families_for_trigger_types,
+    get_asan_lib_path,
     get_build_runner_labels,
+    is_asan,
+    is_asan_instrumented,
     load_external_runner_config,
 )
 
@@ -275,6 +278,64 @@ class TestExternalConfig(unittest.TestCase):
         # Non-runner keys should come from local definitions
         self.assertEqual(result["gfx94x"]["linux"]["family"], "gfx94X-dcgpu")
         self.assertIn("asan", result["gfx94x"]["linux"]["build_variants"])
+
+
+class AsanHelpersTest(unittest.TestCase):
+    def test_is_asan_only_matches_full_asan(self):
+        """is_asan() gates full (host + device) ASAN behavior only."""
+        for variant, expected in [
+            ("asan", True),
+            ("host-asan", False),
+            ("release", False),
+            ("tsan", False),
+            ("", False),
+        ]:
+            with mock.patch.dict(os.environ, {"BUILD_VARIANT": variant}):
+                self.assertEqual(is_asan(), expected, f"BUILD_VARIANT={variant}")
+
+    def test_is_asan_instrumented_covers_host_asan(self):
+        """Host libraries are instrumented under both ASAN variants."""
+        for variant, expected in [
+            ("asan", True),
+            ("host-asan", True),
+            ("release", False),
+            ("tsan", False),
+            ("", False),
+        ]:
+            with mock.patch.dict(os.environ, {"BUILD_VARIANT": variant}):
+                self.assertEqual(
+                    is_asan_instrumented(), expected, f"BUILD_VARIANT={variant}"
+                )
+
+    def test_is_asan_instrumented_without_build_variant_set(self):
+        """A missing BUILD_VARIANT must not be treated as an ASAN build."""
+        with mock.patch.dict(os.environ, clear=False) as _:
+            os.environ.pop("BUILD_VARIANT", None)
+            self.assertFalse(is_asan_instrumented())
+
+    def test_get_asan_lib_path_returns_resolved_runtime(self):
+        with mock.patch.object(amdgpu_family_matrix.subprocess, "run") as fake_run:
+            fake_run.return_value = mock.Mock(stdout=f"{__file__}\n")
+            self.assertEqual(get_asan_lib_path("/rocm/bin"), str(Path(__file__)))
+        # The runtime is looked up via the clang shipped alongside the build.
+        cmd = fake_run.call_args[0][0]
+        self.assertTrue(cmd[0].endswith(os.path.join("lib", "llvm", "bin", "clang++")))
+        self.assertTrue(cmd[1].startswith("-print-file-name=libclang_rt.asan-"))
+
+    def test_get_asan_lib_path_raises_when_unresolved(self):
+        """Clang echoes the bare filename back when it cannot resolve it."""
+        with mock.patch.object(amdgpu_family_matrix.subprocess, "run") as fake_run:
+            fake_run.return_value = mock.Mock(
+                stdout=f"libclang_rt.asan-{amdgpu_family_matrix.platform.machine()}.so\n"
+            )
+            with self.assertRaises(FileNotFoundError):
+                get_asan_lib_path("/rocm/bin")
+
+    def test_get_asan_lib_path_raises_on_missing_file(self):
+        with mock.patch.object(amdgpu_family_matrix.subprocess, "run") as fake_run:
+            fake_run.return_value = mock.Mock(stdout="/nonexistent/libclang_rt.so\n")
+            with self.assertRaises(FileNotFoundError):
+                get_asan_lib_path("/rocm/bin")
 
 
 if __name__ == "__main__":

--- a/tests/test_rocm_sanity.py
+++ b/tests/test_rocm_sanity.py
@@ -20,19 +20,19 @@ THEROCK_BIN_DIR = Path(os.getenv("THEROCK_BIN_DIR")).resolve()
 
 AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
 
-# Importing is_asan from amdgpu_family_matrix.py
+# Importing ASAN helpers from amdgpu_family_matrix.py
 sys.path.append(str(THIS_DIR.parent / "build_tools" / "github_actions"))
-from amdgpu_family_matrix import is_asan
+from amdgpu_family_matrix import get_asan_lib_path, is_asan, is_asan_instrumented
 
 
 def is_windows():
     return "windows" == platform.system().lower()
 
 
-def run_command(command: list[str], cwd=None):
+def run_command(command: list[str], cwd=None, env=None):
     logger.info(f"++ Run [{cwd}]$ {shlex.join(command)}")
     process = subprocess.run(
-        command, capture_output=True, cwd=cwd, shell=is_windows(), text=True
+        command, capture_output=True, cwd=cwd, env=env, shell=is_windows(), text=True
     )
     if process.returncode != 0:
         logger.error(f"Command failed!")
@@ -149,7 +149,17 @@ class TestROCmSanity:
         # Running and checking the executable
         platform_executable_prefix = "./" if not is_windows() else ""
         hip_check_executable = f"{platform_executable_prefix}hip_check"
-        process = run_command([hip_check_executable], cwd=str(THEROCK_BIN_DIR))
+        # hip_check is deliberately compiled without -fsanitize=address, so it
+        # needs the runtime preloaded to link against instrumented ROCm
+        # libraries. Instrumenting it instead would pull in device-side
+        # instrumentation that the host-asan variant exists to avoid.
+        env = None
+        if is_asan_instrumented():
+            env = {
+                **os.environ,
+                "LD_PRELOAD": get_asan_lib_path(THEROCK_BIN_DIR),
+            }
+        process = run_command([hip_check_executable], cwd=str(THEROCK_BIN_DIR), env=env)
         check.equal(process.returncode, 0)
         check.greater(
             os.path.getsize(str(THEROCK_BIN_DIR / hip_check_executable_file)), 0


### PR DESCRIPTION
## Problem

The test-side ASAN handling in `build_tools/` and `tests/` is gated on `is_asan()`:

```python
def is_asan():
    BUILD_VARIANT = os.getenv("BUILD_VARIANT", "")
    return BUILD_VARIANT == "asan"
```

The `host-asan` variant sets `BUILD_VARIANT=host-asan`, so every one of those gates is silently inert on it. Executables that are not themselves linked against the ASAN runtime then abort as soon as they load an instrumented ROCm library:

```
==931==ASan runtime does not come first in initial library list; you should
either link runtime to your application or manually preload it with LD_PRELOAD.
```

Observed live on [ROCm/rocm-systems#10088](https://github.com/ROCm/rocm-systems/pull/10088), where `test_hip_printf` failed this way and, because sanity gates the component tests, `hip-tests` and `rocrtst` never ran at all.

This has not shown up before because nothing had actually run these tests under ASAN: ASAN runs on rocm-systems PRs all resolve to `Linux::skip` without an opt-in label, and the full-ASAN release workflow has no sanity job.

## Change

- Add `is_asan_instrumented()`, true for both `asan` and `host-asan`, and use it for the handling that exists to cope with instrumented **host** libraries.
- `is_asan()` keeps its current meaning, so gates specific to full host+device ASAN are untouched. That matters for the rocminfo skip for #3312 in particular: those tests **pass** under `host-asan`, and broadening `is_asan()` outright would have started skipping them and quietly lost coverage.
- `test_hip_printf` compiles `hip_check` without `-fsanitize=address` and then runs it, so it needs the same preload. Compiling it with the sanitizer instead would pull in device-side instrumentation, which is precisely what the `host-asan` variant exists to avoid.
- The runtime lookup was already duplicated in `test_hiptests.py` and `test_hipfile.py`; both now share one implementation instead of this adding a third copy.

Deliberately **not** changed: the `is_asan()` gates in `test_rocblas.py`, `test_hipblas.py`, `test_hipblaslt.py` and `test_rocprofiler_sdk.py`. Those select test exclusions and tuning rather than coping with instrumented libraries, so whether they should apply to `host-asan` is a separate judgement, and none of those components are in the host-ASAN presubmit scope.

## Testing

- `763 passed, 2 failed` in `build_tools/github_actions/tests/`, against a `757 passed, 2 failed` baseline on `main`. The 2 failures are pre-existing in `stage_reuse_decision_test.py` and unrelated.
- 6 new unit tests covering both helpers, including that `is_asan()` still does **not** match `host-asan`.
- Live validation is pending on [ROCm/rocm-systems#10088](https://github.com/ROCm/rocm-systems/pull/10088), which carries this commit alongside #7311 so the full sanity -> hip-tests -> rocrtst path can be exercised.

## Related

Unblocks the runtime-only host-ASAN presubmit in #7311 / #7202, but stands on its own: any ASAN test run on the `host-asan` variant hits this today.

Made with [Cursor](https://cursor.com)