### PR TITLE
CI: fix workflow_dispatch runner fallback for PyTorch wheel _ci builds + tolerate newer ninja

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels_ci.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels_ci.yml
@@ -106,6 +106,14 @@ on:
           - sccache
           - ccache
         default: sccache
+      build_runs_on:
+        description: >-
+          Build runner label. On workflow_dispatch, default to the self-hosted
+          ROCm Linux pool so runs land on a runner with sccache/mirror access;
+          otherwise the runs-on expression falls back to 'ubuntu-24.04', which
+          cannot complete a full PyTorch build.
+        type: string
+        default: "aws-linux-scale-rocm-prod"
 
 permissions:
   contents: read

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
@@ -259,7 +259,14 @@ jobs:
         run: |
           choco source disable -n=chocolatey
           choco source add -n=internal -s http://nexus-service.nexus-ns.svc.cluster.local:8081/repository/choco-group/ --priority=1
-          choco install --no-progress -y ninja --version 1.13.1
+          # Some runner images already ship a newer ninja; choco install of the
+          # pinned version then fails with "a newer version is already
+          # installed". Only install when ninja is missing.
+          if command -v ninja >/dev/null 2>&1; then
+            printf '%s\n' "ninja already installed: $(ninja --version)"
+          else
+            choco install --no-progress -y ninja --version 1.13.1
+          fi
 
       # Build a fixed version of libuv from source, no matter the pytorch ref.
       # gloo requires >= 1.26; v1.47.0 matches upstream's source build.

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels_ci.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels_ci.yml
@@ -105,6 +105,14 @@ on:
           - sccache
           - ccache
         default: sccache
+      build_runs_on:
+        description: >-
+          Build runner label. On workflow_dispatch, default to the self-hosted
+          ROCm Windows pool so runs land on a runner with sccache/mirror access;
+          otherwise the runs-on expression falls back to 'windows-2022', which
+          cannot resolve the internal package mirror.
+        type: string
+        default: "aws-windows-scale-rocm-prod-mix"
 
 permissions:
   contents: read


### PR DESCRIPTION
JIRA ID : ROCM-29365

## Summary

Fix `workflow_dispatch` of the PyTorch wheel builds so manually-dispatched runs land on the self-hosted ROCm build fleet instead of a GitHub-hosted fallback runner, plus tolerate a preinstalled newer ninja on Windows runners. These were both hit while doing pre-merge validation of PyTorch fixes via direct `workflow_dispatch` (e.g. the ROCM-29365 torchaudio hipify fix, and the release/2.14 carry-forward branch).

1. **`_ci` workflows fell back to GitHub-hosted runners on dispatch.** `multi_arch_build_portable_linux_pytorch_wheels_ci.yml` and `multi_arch_build_windows_pytorch_wheels_ci.yml` defined `build_runs_on` only under `workflow_call`. On `workflow_dispatch`, `inputs.build_runs_on` was empty and the `runs-on` expression `github.repository_owner == 'ROCm' && inputs.build_runs_on || '<hosted>'` fell back to a GitHub-hosted `ubuntu-24.04` / `windows-2022` runner. Those runners can't reach the sccache bucket or the internal package mirror, so a full PyTorch build can't complete within the 6h job limit. Added `build_runs_on` to the `workflow_dispatch` inputs (defaults `aws-linux-scale-rocm-prod` / `aws-windows-scale-rocm-prod-mix`), matching the non-`ci` workflows.

2. **Tolerate a preinstalled newer ninja on Windows.** `Install requirements` pinned `choco install ninja --version 1.13.1`; current Windows runner images already ship a newer ninja, so choco exits 1 with "a newer version is already installed". Only install the pinned version when ninja is missing.

## Why

Direct `workflow_dispatch` of these workflows is the intended path for pre-merge validation of a PyTorch ref. On today's images a bare dispatch fails before/within the build: the `_ci` variants land on a GitHub-hosted runner (Linux `_ci` dispatch ran on `ubuntu-24.04` and timed out at 6h), and the ninja pin fails on runners that already ship a newer ninja. Confirmed by a green Windows dev build during ROCM-29365 validation: https://github.com/ROCm/TheRock/actions/runs/31667526330

## Notes

The Windows non-`ci` `build_runs_on` dispatch input that an earlier revision of this PR added has since landed on `main` independently; this PR now drops that duplicate (keeping `main`'s) and instead fixes the two `_ci` variants that still had the fallback, plus keeps the ninja tolerance change.

## Test plan

- [x] Windows dev build succeeds via `workflow_dispatch` on the self-hosted pool (torch + torchaudio + torchvision): run 31667526330.
- [ ] Dispatched Linux `_ci` run lands on `aws-linux-scale-rocm-prod` (not `ubuntu-24.04`).
- [ ] Dispatched Windows `_ci` run lands on `aws-windows-scale-rocm-prod-mix` (not `windows-2022`).
- [ ] Windows build passes `Install requirements` with a preinstalled newer ninja.
