### PR TITLE
[pre-commit] Add lychee markdown link checker at the manual stage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,6 +50,16 @@ repos:
     - id: actionlint
       args: [-shellcheck=, -ignore, 'label ".+" is unknown']
 
+- repo: https://github.com/lycheeverse/lychee.git
+  rev: lychee-v0.24.2
+  hooks:
+    - id: lychee
+      stages: [manual]
+      args:
+        - --offline
+        - --root-dir
+        - .
+
 - repo: local
   hooks:
   - id: forbidden-paths

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -295,7 +295,14 @@ pre-commit run --all-files
 
 # Install the git hook.
 pre-commit install
+
+# Run the markdown link checker (manual stage, not run on commit).
+pre-commit run --hook-stage manual --all-files lychee
 ```
+
+The `lychee` hook checks that repo-relative markdown links resolve to files that
+exist. It is confined to the `manual` stage because it downloads a `lychee`
+binary on first run, which the other hooks do not need.
 
 #### Requesting a code review
 

--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -196,7 +196,7 @@ mix/match build steps.
 ### Prerequisites
 
 On Linux we run automated tests under our
-[`no_rocm_image_ubuntu24_04.Dockerfile`](dockerfiles/no_rocm_image_ubuntu24_04.Dockerfile)
+[`no_rocm_image_ubuntu24_04.Dockerfile`](/dockerfiles/no_rocm_image_ubuntu24_04.Dockerfile)
 container (also
 [documented in `dockerfiles/README.md`](/dockerfiles/README.md#no_rocm_image_dockerfile)).
 Docker is optional for developers and users. If you want to use our test image,


### PR DESCRIPTION
## Motivation

Follow-up to #7294, where the request was for an off-the-shelf markdown link
checker rather than fixing broken links one instance at a time.

## Technical Details

Three changes:

1. `.pre-commit-config.yaml` — the `lychee` block exactly as written in
   [#7294](https://github.com/ROCm/TheRock/pull/7294#issuecomment-5273975886),
   plus `stages: [manual]`.
2. `external-builds/pytorch/README.md:199` — one leading `/`. The sibling link
   two lines below at `:201` already has it.
3. `CONTRIBUTING.md` — the manual invocation, added to the existing
   `#### pre-commit checks` example block.

**No `exclude` is needed.** `.pre-commit-config.yaml:4` already carries a global
`exclude: "third_party/"`, which covers `build_tools/third_party/`. That is the
whole of the 3-vs-4 discrepancy: my 4 came from running the `lychee` binary
directly over the tree, which applies no pre-commit file filtering; the 3 came
through `pre-commit`, which does. My earlier claim that the `implib` link "needs
an exclude or the hook stays red" was wrong.

### Why `stages: [manual]`

Because two of the three links it reports cannot be fixed here — open pull
requests rewrite both lines — so at the default stage the existing
`.github/workflows/pre-commit.yml` job would fail on every PR until they land.

| Link | Open PR covering that line | Status |
| --- | --- | --- |
| `docs/development/README.md:24` | #7253, hunk `@@ -17,11 +17,11 @@` deletes that exact line | left alone |
| `docs/development/workflow_outputs.md:305` | #4685, hunk `@@ -295,15 +295,15 @@` rewrites that exact line | left alone |
| `external-builds/pytorch/README.md:199` | none of the 8 open PRs on the file; nearest hunks are #5439 `190-195` and #7313 `180-185` | fixed here |

Hunk ranges are from each PR's combined diff against its own merge base. The
scan covered all 481 open PRs.

### What `stages: [manual]` actually does

It skips the binary install, not the hook repo clone. Each row is a fresh
`PRE_COMMIT_HOME`:

| Command | hook repo cloned | `lychee` binary installed | hook runs |
| --- | --- | --- | --- |
| `pre-commit install-hooks` | yes, 7.4 MB | no | no |
| `pre-commit run` | yes, 7.4 MB | no | no |
| `pre-commit run --all-files` | yes, 7.4 MB | no | no |
| `pre-commit run --hook-stage manual --all-files` | yes | yes, 31 MB total, 109 s | yes |
| *without* `stages: [manual]`, `pre-commit run --all-files` | yes | yes, 31 MB total, 121 s | yes |

So the `cargo` step you had to approve is skipped on commit and in CI; the
7.4 MB `git clone` of `lycheeverse/lychee` still happens on any first
`pre-commit` invocation, including `install-hooks`.

Separately: the `lychee` hook id bootstrapped fine here on a clean cache — it
fetches `cargo-binstall` and a prebuilt binary, no pre-existing `cargo` needed.
My earlier report that it failed to bootstrap was a network restriction on my
side, not the hook.

## Test Plan

`pre-commit` 4.6.2, Python 3.12.10, Windows 11, at `47947a1`. Each run used an
isolated `PRE_COMMIT_HOME`. Linux and macOS were **not** exercised.

## Test Result

Default stage, whole config, whole tree — what CI runs. `lychee` is absent from
the list, and the run is green:

```
$ pre-commit run --all-files
Trim Trailing Whitespace..................................................Passed
Fix End of Files..........................................................Passed
Check Yaml................................................................Passed
Check JSON................................................................Passed
Check for merge conflicts.................................................Passed
Check for added large files...............................................Passed
Mixed line ending.........................................................Passed
black.....................................................................Passed
clang-format..............................................................Passed
mdformat..................................................................Passed
No-tabs checker...........................................................Passed
Lint GitHub Actions workflow files........................................Passed
Forbid secrets, certificates, keys, and executables...(no files to check)Skipped
Enforce *_test.py naming for build_tools tests........(no files to check)Skipped
exit=0
```

Manual stage, after the `external-builds/pytorch/README.md` fix — 3 errors down
to 2, and the OK count moves 506 → 507:

```
$ pre-commit run --hook-stage manual --all-files lychee
Issues found in 2 inputs. Find details below.

[docs/development/README.md]:
[ERROR] .../docs/development/test_runner_info.md (at 24:3) | File not found.
[docs/development/workflow_outputs.md]:
[ERROR] .../build_tools/github_actions/upload_pytorch_manifest.py (at 305:3) | File not found.

🔍 2238 Total 🔗 1196 Unique ✅ 507 OK 🚫 2 Errors 👻 1729 Excluded
🔍 269 Total 🔗 241 Unique ✅ 55 OK 🚫 0 Errors 👻 214 Excluded
```

The `third_party` A/B, deleting only line 4 of `.pre-commit-config.yaml` and
changing nothing else:

```
# line 4 present (as shipped) — 3 errors, implib is not even an input
🔍 2238 Total 🔗 1197 Unique ✅ 506 OK 🚫 3 Errors 👻 1729 Excluded

# line 4 deleted — the 4th error appears
[build_tools/third_party/implib/doc/ReduceLibraryInterface.md]:
[ERROR] .../build_tools/third_party/implib/doc/tests/multilib/run.sh (at 32:138) | File not found.
🔍 1177 Total 🔗 596 Unique ✅ 107 OK 🚫 1 Error 👻 1069 Excluded
```

If you want the class actually gated rather than merely available, the existing
`pre-commit` job takes it in three lines — but only once the two links above are
resolved, since it would be red until then:

```yaml
      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
        with:
          extra_args: --hook-stage manual --all-files lychee
```

Happy to send that as a follow-up after #7253 lands.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
