### PR TITLE
Add hipfile to Linux library preload list

### DIFF
--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -170,11 +170,6 @@ LINUX_LIBRARY_PRELOADS = [
     "amd_comgr",
     "amd_smi",
     "amdhip64",
-    "rocprofiler-sdk",  # Linux only: needed by torch since kineto uses rocprofiler-sdk.
-    "rocprofiler-sdk-roctx",  # Linux only for the moment.
-    # TODO: Remove roctracer64 and roctx64 once fully switched to rocprofiler-sdk.
-    "roctracer64",  # Linux only for the moment.
-    "roctx64",  # Linux only for the moment.
     "hiprtc",
     "hipblas",
     "hipfft",
@@ -182,13 +177,19 @@ LINUX_LIBRARY_PRELOADS = [
     "hipsparse",
     "hipsparselt",
     "hipsolver",
-    "rccl",  # Linux only for the moment.
     "hipblaslt",
     "miopen",
     "hipdnn",
     "rocm_sysdeps_liblzma",
     "rocm-openblas",
     "rocm_smi64",
+    # Linux only.
+    "rocprofiler-sdk",  # Needed by torch since kineto uses rocprofiler-sdk.
+    "rocprofiler-sdk-roctx",
+    # TODO: Remove roctracer64 and roctx64 once fully switched to rocprofiler-sdk.
+    "roctracer64",
+    "roctx64",
+    "rccl",
     "hipfile",
 ]
 

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -189,6 +189,7 @@ LINUX_LIBRARY_PRELOADS = [
     "rocm_sysdeps_liblzma",
     "rocm-openblas",
     "rocm_smi64",
+    "hipfile",
 ]
 
 # List of library preloads for Windows to generate into _rocm_init.py


### PR DESCRIPTION
Issue link: https://github.com/ROCm/TheRock/issues/7329

## Motivation

Nightly PyTorch smoke tests fail and are blocked on Linux ROCm arches (observed on gfx1153) at `import torch` with:

`[ERROR] Failed to retrieve GPU info: ERROR:libhipfile.so.0: cannot open shared object file: No such file or directory
`
This started with the `10.1.0a20260811` nightly and is deterministic (not flaky) —`import torch` never succeeds, so it also masks any real underlying test failures.

Failing CI jobs (rockrel run 31452759725, torch nightly, gfx1153):
- py 3.12: https://github.com/ROCm/rockrel/actions/runs/31452759725/job/93678340937
- py 3.10: https://github.com/ROCm/rockrel/actions/runs/31452759725/job/93677958469
- py 3.13: https://github.com/ROCm/rockrel/actions/runs/31452759725/job/93678622649

<!-- GitHub issue: add tracking issue link here if one exists -->

## Technical Details

Upstream PyTorch PR pytorch/pytorch#191069 ("[ROCm] Enable hipFile", commit `4c5b5ab032f2a4f3c7807925ea92fffa457423c2`, in nightly source since ~Aug 8) added `hip::hipfile` to `TORCH_PYTHON_LINK_LIBRARIES`. As a result `libtorch_python.so` now carries `NEEDED libhipfile.so.0`.

In wheel installs, torch resolves its ROCm deps via the preload list we generate into `torch/_rocm_init.py` (loaded RTLD_GLOBAL on `import torch`), because torch's RUNPATH points at build-only paths. `libhipfile.so.0` does ship in the `rocm-sdk-core` wheel, but `hipfile` was never added to `LINUX_LIBRARY_PRELOADS`, so it is never preloaded and `import torch` fails to load it.

This PR adds `"hipfile"` to `LINUX_LIBRARY_PRELOADS` in `external-builds/pytorch/build_prod_wheels.py`. `hipfile` is already declared as a core `LibraryEntry` in the rocm_sdk `_dist_info.py`, so the shortname resolves. Windows is unaffected (hipFile is Linux-only), so `WINDOWS_LIBRARY_PRELOADS` is left unchanged.

## Test Plan

- Confirm `torch/_rocm_init.py` includes `'hipfile'` in `preload_shortnames`.
- Recommended before merge: nightly gfx1153 PyTorch smoke test against this branch.

## Test Result

Validated locally in a ROCm container with the TheRock `rocm-sdk` wheels:
  - Without fix: `ctypes.CDLL('libhipfile.so.0')` fails with `cannot open shared object file` (the CI error).
  - With the fix's preload (`initialize_process(preload_shortnames=[...,'hipfile'])`): `libhipfile.so.0` loads from rocm-sdk-core and resolves.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
