### PR TITLE
fix(packaging): correct the install harness GPG key import

### DIFF
--- a/build_tools/packaging/linux/native_linux_package_install_test.py
+++ b/build_tools/packaging/linux/native_linux_package_install_test.py
@@ -28,7 +28,7 @@ Test modes (--test-type):
   actual install. Requires --packages-dir.
 
 Path and repo name are overridable via environment variables: ROCM_REPO_NAME (repo id used for
-APT list, Zypper/Yum repo file and section), ROCM_APT_KEYRING_DIR, ROCM_APT_SOURCES_LIST,
+APT list, Zypper/Yum repo file and section), ROCM_APT_SOURCES_LIST,
 ROCM_APT_KEYRING_FILE, ROCM_ZYPP_REPOS_DIR, ROCM_YUM_REPOS_DIR,
 ROCM_RDHC_REL_PATH (relative path from install prefix to rdhc binary).
 
@@ -158,11 +158,16 @@ def _env(key: str, default: str) -> str:
 # ROCM_REPO_NAME: logical repo name used for APT list, Zypper/Yum repo file and section id
 # ROCM_APT_*, ROCM_ZYPP_*, ROCM_YUM_*, ROCM_RDHC_REL_PATH
 REPO_NAME = _env("ROCM_REPO_NAME", "rocm-test")
-APT_KEYRING_DIR = _env("ROCM_APT_KEYRING_DIR", "/etc/apt/keyrings")
 APT_SOURCES_LIST = _env(
     "ROCM_APT_SOURCES_LIST", f"/etc/apt/sources.list.d/{REPO_NAME}.list"
 )
-APT_KEYRING_FILE = _env("ROCM_APT_KEYRING_FILE", "/etc/apt/keyrings/rocm.gpg")
+# Derived from REPO_NAME like APT_SOURCES_LIST above, and deliberately not
+# /etc/apt/keyrings/rocm.gpg. No package owns that path, but the current
+# documented amdgpu package manager steps set the signing key up there
+# ("wget .../rocm.gpg.key | gpg --dearmor | sudo tee /etc/apt/keyrings/rocm.gpg")
+# and point signed-by= at it. This harness writes its keyring the same way, so
+# sharing the path would overwrite the key a host is already using.
+APT_KEYRING_FILE = _env("ROCM_APT_KEYRING_FILE", f"/etc/apt/keyrings/{REPO_NAME}.gpg")
 ZYPP_REPOS_DIR = _env("ROCM_ZYPP_REPOS_DIR", "/etc/zypp/repos.d")
 YUM_REPOS_DIR = _env("ROCM_YUM_REPOS_DIR", "/etc/yum.repos.d")
 VERIFY_KEY_COMPONENTS = [
@@ -440,9 +445,14 @@ class NativeLinuxPackageInstallTest:
         print(f"\nGPG Key URL: {self.gpg_key_url}")
 
         if self.package_type == "deb":
-            # For DEB, import GPG key using pipeline approach
-            keyring_dir = Path(APT_KEYRING_DIR)
-            keyring_file = keyring_dir / "rocm.gpg"
+            # Write to the same path the sources entry pins with signed-by=.
+            # These were separate expressions that happened to agree, so any
+            # change to one silently broke apt's ability to find the keyring.
+            # PurePosixPath, not Path: these are paths on the target Linux
+            # filesystem handed to mkdir(1), tee(1) and chmod(1). Path follows
+            # the local flavour, so on Windows it renders "\etc\apt\keyrings".
+            keyring_file = PurePosixPath(APT_KEYRING_FILE)
+            keyring_dir = keyring_file.parent
 
             try:
                 # Create keyring directory
@@ -456,20 +466,31 @@ class NativeLinuxPackageInstallTest:
                 )
                 print(f"[PASS] Created keyring directory: {keyring_dir}")
 
-                # Download, dearmor, and write GPG key using pipeline
-                # wget URL -O - | gpg --dearmor | sudo tee keyring_file > /dev/null
+                # Download, dearmor and write the key as three list-form calls
+                # rather than one shell pipeline: the URL and the keyring path
+                # are both configurable, and interpolating them into a shell
+                # string makes them command injection vectors.
                 print(f"\nDownloading and importing GPG key from {self.gpg_key_url}...")
-                pipeline_cmd = (
-                    f"wget -q -O - {self.gpg_key_url} | "
-                    f"gpg --dearmor | "
-                    f"sudo tee {keyring_file} > /dev/null"
-                )
-
-                subprocess.run(
-                    pipeline_cmd,
-                    shell=True,
+                armored = subprocess.run(
+                    ["wget", "-q", "-O", "-", self.gpg_key_url],
                     check=True,
                     stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    timeout=GPG_KEY_TIMEOUT_SEC,
+                ).stdout
+                dearmored = subprocess.run(
+                    ["gpg", "--dearmor"],
+                    input=armored,
+                    check=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    timeout=GPG_KEY_TIMEOUT_SEC,
+                ).stdout
+                subprocess.run(
+                    ["sudo", "tee", str(keyring_file)],
+                    input=dearmored,
+                    check=True,
+                    stdout=subprocess.DEVNULL,
                     stderr=subprocess.PIPE,
                     timeout=GPG_KEY_TIMEOUT_SEC,
                 )
@@ -488,6 +509,13 @@ class NativeLinuxPackageInstallTest:
                 print(f"[FAIL] Failed to setup GPG key: {e}")
                 if e.stderr:
                     print(f"Error output: {e.stderr.decode()}")
+                return False
+            except subprocess.TimeoutExpired as e:
+                # TimeoutExpired is a SubprocessError, not an OSError or a
+                # CalledProcessError, so neither handler around it catches one.
+                # Without this the whole run dies on a slow mirror instead of
+                # reporting a failed key import like every other failure here.
+                print(f"[FAIL] Timed out setting up GPG key: {e}")
                 return False
             except OSError as e:
                 print(f"[FAIL] Error setting up GPG key: {e}")
@@ -522,7 +550,9 @@ class NativeLinuxPackageInstallTest:
 
         if self.gpg_key_url:
             # Use GPG key verification (arch=amd64 matches ROCm Ubuntu install docs)
-            apt_keyring = Path(APT_KEYRING_FILE)
+            # PurePosixPath for the same reason: this lands in signed-by= inside
+            # a sources file on the target, not on the machine running the test.
+            apt_keyring = PurePosixPath(APT_KEYRING_FILE)
             repo_entry = f"deb [arch=amd64 signed-by={apt_keyring}] {self.repo_url} stable main\n"
         else:
             # No GPG check (trusted=yes; arch=amd64 matches install_rocm_packages.sh)

--- a/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
+++ b/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
@@ -104,6 +104,111 @@ class EnvHelperTest(unittest.TestCase):
             )
 
 
+class ConfiguredPathsTest(unittest.TestCase):
+    """Tests for the module-level on-disk paths.
+
+    The paths are module constants resolved from the environment at import
+    time, and ROCM_REPO_NAME / ROCM_APT_KEYRING_FILE are documented overrides.
+    These tests are about the shipped defaults, so they re-import the module
+    with those variables cleared rather than reading whatever the ambient shell
+    happens to export.
+    """
+
+    def setUp(self):
+        # Load a private copy under its own name rather than reloading the
+        # shared instance: the @patch.object decorators elsewhere in this file
+        # bind to the class object that exists at class-definition time, and
+        # reloading swaps it out from under them.
+        with patch.dict(os.environ, {}, clear=False):
+            for name in ("ROCM_REPO_NAME", "ROCM_APT_KEYRING_FILE"):
+                os.environ.pop(name, None)
+            spec = importlib.util.spec_from_file_location(
+                "native_linux_package_install_test__default_paths", _module_path
+            )
+            self.mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(self.mod)
+
+    def test_apt_keyring_does_not_collide_with_the_driver_keyring(self):
+        # The harness writes this file with 'sudo tee'. No package owns
+        # /etc/apt/keyrings/rocm.gpg, but the current documented amdgpu package
+        # manager steps set the signing key up there and point signed-by= at it,
+        # so writing to the same path would clobber a key the host is using.
+        #
+        # Compare whole paths rather than searching for a substring: several
+        # candidate names contain "rocm.gpg" as a substring, so a containment
+        # check would pass even for a name that still collides.
+        self.assertNotEqual(self.mod.APT_KEYRING_FILE, "/etc/apt/keyrings/rocm.gpg")
+
+    def test_no_keyring_dir_constant_remains(self):
+        # APT_KEYRING_DIR used to hold the directory that setup_gpg_key() wrote
+        # into, and the module docstring advertised ROCM_APT_KEYRING_DIR as an
+        # override. The directory is now derived from APT_KEYRING_FILE, so
+        # bringing the constant back would give the harness two ways to say
+        # where the keyring lives and let them drift apart again. Setting the
+        # env var would also look like it worked while doing nothing.
+        self.assertFalse(hasattr(self.mod, "APT_KEYRING_DIR"))
+
+    def test_apt_keyring_is_derived_from_repo_name(self):
+        # Matches the sibling APT_SOURCES_LIST, which is also REPO_NAME-derived,
+        # so the harness's files stay grouped under one recognizable name.
+        self.assertEqual(
+            self.mod.APT_KEYRING_FILE,
+            f"/etc/apt/keyrings/{self.mod.REPO_NAME}.gpg",
+        )
+
+    def test_gpg_import_writes_the_path_the_sources_entry_pins(self):
+        # setup_gpg_key() writes the keyring and the sources entry pins it with
+        # signed-by=. These were two separate expressions that happened to
+        # agree, so renaming the constant silently pointed apt at a keyring
+        # that was never created. Assert they are the same path.
+        written = self._written_keyring_path()
+        self.assertEqual(written, self.mod.APT_KEYRING_FILE)
+
+    def _written_keyring_path(self):
+        """Run setup_gpg_key() with subprocess stubbed; return the tee target."""
+        runner = self.mod.NativeLinuxPackageInstallTest(
+            os_profile="ubuntu2404",
+            repo_url="https://example.com/repo",
+            release_type="prerelease",
+            gpg_key_url="https://example.com/rocm.gpg",
+        )
+        with patch.object(self.mod.subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(stdout=b"key")
+            with _suppress_script_output():
+                self.assertTrue(runner.setup_gpg_key())
+        tee_calls = [
+            c.args[0]
+            for c in mock_run.call_args_list
+            if c.args and c.args[0][:2] == ["sudo", "tee"]
+        ]
+        self.assertEqual(len(tee_calls), 1, f"expected one tee call, got {tee_calls}")
+        return tee_calls[0][2]
+
+    def test_gpg_import_uses_no_shell(self):
+        # The URL and the keyring path are both configurable; interpolating
+        # them into a shell string makes them injection vectors.
+        runner = self.mod.NativeLinuxPackageInstallTest(
+            os_profile="ubuntu2404",
+            repo_url="https://example.com/repo",
+            release_type="prerelease",
+            gpg_key_url="https://example.com/rocm.gpg",
+        )
+        with patch.object(self.mod.subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(stdout=b"key")
+            with _suppress_script_output():
+                self.assertTrue(runner.setup_gpg_key())
+        # Assert the import actually ran. The checks below live inside a loop
+        # over the recorded calls, so without this they pass trivially if a
+        # future change makes the deb branch return before running anything.
+        self.assertTrue(mock_run.call_args_list, "setup_gpg_key ran no commands")
+        for call in mock_run.call_args_list:
+            self.assertNotIn("shell", call.kwargs)
+            # Guard args before indexing: a call written as run(args=[...])
+            # has empty .args and would raise IndexError instead of failing.
+            self.assertTrue(call.args, f"expected a positional argv, got {call}")
+            self.assertIsInstance(call.args[0], list)
+
+
 class NormalizeTestTypeTest(unittest.TestCase):
     """Tests for _normalize_test_type()."""
 
@@ -1401,15 +1506,32 @@ class SetupGpgKeyTest(unittest.TestCase):
 
     @patch("native_linux_package_install_test.subprocess.run")
     def test_returns_true_for_deb_when_mock_succeeds(self, mock_run):
-        # Test that for DEB with gpg_key_url, setup_gpg_key returns True when mkdir, pipeline, and chmod succeed.
-        mock_run.return_value = MagicMock(returncode=0)
+        # Test that for DEB with gpg_key_url, setup_gpg_key returns True when
+        # every step of the key import succeeds.
+        mock_run.return_value = MagicMock(returncode=0, stdout=b"key")
         t = native_linux_package_install_test.NativeLinuxPackageInstallTest(
             repo_url="https://example.com",
             os_profile="ubuntu2404",
             gpg_key_url="https://example.com/rocm.gpg",
         )
         self.assertTrue(t.setup_gpg_key())
-        self.assertEqual(mock_run.call_count, 3)  # mkdir, pipeline, chmod
+        # Assert the sequence rather than a bare count: the download and
+        # dearmor steps are separate list-form calls (they were one shell
+        # pipeline), and a count alone gives no signal about what changed.
+        #
+        # Compare two tokens, not one. Three of the five commands run under
+        # sudo, so matching on argv[0] alone cannot tell tee from chmod and
+        # would pass even if the keyring were written by the wrong tool.
+        self.assertEqual(
+            [c.args[0][:2] for c in mock_run.call_args_list],
+            [
+                ["sudo", "mkdir"],
+                ["wget", "-q"],
+                ["gpg", "--dearmor"],
+                ["sudo", "tee"],
+                ["sudo", "chmod"],
+            ],
+        )
 
     @patch("native_linux_package_install_test.subprocess.run")
     def test_returns_false_for_deb_when_subprocess_fails(self, mock_run):
@@ -1424,6 +1546,64 @@ class SetupGpgKeyTest(unittest.TestCase):
             os_profile="ubuntu2404",
             gpg_key_url="https://example.com/rocm.gpg",
         )
+        self.assertFalse(t.setup_gpg_key())
+
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_returns_false_when_the_downloaded_body_is_not_a_key(self, mock_run):
+        # The download succeeds but returns something that isn't a key, which
+        # is what a server serving an HTML error page with HTTP 200 gives you.
+        # 'gpg --dearmor' exits 2 on anything that isn't OpenPGP data.
+        #
+        # This is the case the old implementation got wrong. It ran the import
+        # as one shell pipeline, and a pipeline exits with the status of its
+        # LAST command, so check=True only ever validated 'tee'. gpg failed,
+        # tee still wrote an empty keyring and exited 0, and the harness
+        # printed success and returned True. apt then failed much later with an
+        # opaque signature error, nowhere near the actual fault.
+        import subprocess
+
+        def fail_on_dearmor(argv, **kwargs):
+            if argv[:2] == ["gpg", "--dearmor"]:
+                # Model what subprocess actually does, rather than raising
+                # unconditionally. Raising regardless of `check` would make
+                # this test pass even if the production code stopped checking
+                # the dearmor step, which is precisely the bug it guards.
+                if not kwargs.get("check"):
+                    return MagicMock(returncode=2, stdout=b"")
+                raise subprocess.CalledProcessError(
+                    2, argv, stderr=b"gpg: no valid OpenPGP data found."
+                )
+            return MagicMock(returncode=0, stdout=b"<html>404</html>")
+
+        mock_run.side_effect = fail_on_dearmor
+        t = native_linux_package_install_test.NativeLinuxPackageInstallTest(
+            repo_url="https://example.com",
+            os_profile="ubuntu2404",
+            gpg_key_url="https://example.com/rocm.gpg",
+        )
+
+        self.assertFalse(t.setup_gpg_key())
+        # The keyring must not be written at all. Reporting the failure is only
+        # half of it; an empty file left behind would still break apt.
+        self.assertNotIn(
+            ["sudo", "tee"], [c.args[0][:2] for c in mock_run.call_args_list]
+        )
+
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_returns_false_when_a_step_times_out(self, mock_run):
+        # TimeoutExpired is a SubprocessError. It is neither an OSError nor a
+        # CalledProcessError, so it matches neither of the other handlers and
+        # used to propagate out of setup_gpg_key and abort the run, instead of
+        # being reported as a failed key import.
+        import subprocess
+
+        mock_run.side_effect = subprocess.TimeoutExpired("wget", 60)
+        t = native_linux_package_install_test.NativeLinuxPackageInstallTest(
+            repo_url="https://example.com",
+            os_profile="ubuntu2404",
+            gpg_key_url="https://example.com/rocm.gpg",
+        )
+
         self.assertFalse(t.setup_gpg_key())
 
 


### PR DESCRIPTION
## Motivation

`native_linux_package_install_test.py` is an existing install test that CI runs today. It downloads a repository signing key and saves it to disk so apt can check package signatures. Three things are wrong with how it does that, and all of them predate the `amdrocm-repo` work.

**The import could fail and still report success.** The key was fetched with a single `shell=True` pipeline. A pipeline reports the exit status of its last command, so `check=True` was only ever checking `tee`. If the download returned something that wasn't a key, `gpg --dearmor` failed, `tee` wrote an empty keyring anyway, and the harness printed `[PASS]` and returned `True`. The run then failed much later on a signature error that gave no hint where it came from. This isn't a corner case. `gpg --dearmor` exits 2 on an empty body or on an HTML error page served with a 200, which is a normal thing for a server to return.

**The documented `ROCM_APT_KEYRING_FILE` override didn't work.** Only the `signed-by=` line used it. The code that writes the key built its own path and hardcoded `rocm.gpg`, so setting the variable saved the key in one place and told apt to look in another. `apt update` then failed with "The repository is not signed".

**The default path clashes with AMD's install instructions.** Those instructions put the ROCm signing key at `/etc/apt/keyrings/rocm.gpg`, and the harness writes over it with `sudo tee`. This doesn't happen in CI, which runs in throwaway containers, but it does on the VMs and workstations the script is also meant to run on.

Split out of #7276 because it changes existing code and doesn't depend on the new `amdrocm-repo` feature.

Contributes to #6986.

## Technical Details

**The shell pipeline is gone.** The import now runs as three `subprocess.run` calls, one each for `wget`, `gpg --dearmor` and `sudo tee`. Each takes its arguments as a list and sets `check=True`, so a failure stops the import there instead of leaving an empty keyring behind. The URL and the keyring path are no longer interpolated into a shell string, so neither can be used for injection.

**The keyring path comes from one constant.** `setup_gpg_key()` takes both the file and its parent directory from `APT_KEYRING_FILE`. That fixes the override, and it lets the default move to `/etc/apt/keyrings/{REPO_NAME}.gpg`, the way `APT_SOURCES_LIST` already works. The rename only works because of that. On its own it would have written to `rocm.gpg` while telling apt to check `rocm-test.gpg`. `APT_KEYRING_DIR` goes too, along with its docstring entry, since nothing reads it any more and nothing in the repo sets it.

**Paths are `PurePosixPath`.** These are paths on the target Linux filesystem, handed to `mkdir`, `tee` and `chmod`. `Path` follows the local flavour and renders `\etc\apt\keyrings` on Windows, which fails the `windows-2022` job.

**A timeout now returns `False`.** `subprocess.TimeoutExpired` is a `SubprocessError`, so neither the `CalledProcessError` nor the `OSError` handler caught it and a timeout killed the run instead of reporting a failed import. That was already true, but splitting the pipeline takes the timed calls in that block from two to four. Each carries `GPG_KEY_TIMEOUT_SEC` of 60, so fetch, dearmor and write together can take up to 180 seconds.

**The file runs in CI, but these lines don't.** Every change sits behind `if self.gpg_key_url:` (`:543`, `:551`, `:763`), which covers both `setup_gpg_key()` call sites, and neither caller passes a key URL. `test_native_linux_packages_install.yml:227` wires `GPG_KEY_URL` from an input (`:17`, `:62`, `:151`) nobody sets, and `multi_arch_build_native_linux_packages.yml:138` runs `--test-type simulate`, which skips repository setup.

## Test Plan

- **Unit tests.** Five new cases in `ConfiguredPathsTest`: the default doesn't collide with `/etc/apt/keyrings/rocm.gpg`, it derives from `REPO_NAME`, `APT_KEYRING_DIR` is gone, the write target matches what `signed-by=` pins, and no call uses a shell. Two new cases in `SetupGpgKeyTest` for the bad body and the timeout, plus the existing sequence check tightened to compare two argv tokens instead of one.
- **End to end against a signed repo.** Build a real GPG-signed apt repository in a container, serve it over localhost, and drive the genuine `setup_deb_repository()`, which runs a real `apt update`. Run the same scenarios against `main` to confirm each one fails there.
- **Full suite.** `pytest build_tools/` in the CI container against a freshly measured `origin/main` baseline, comparing failure names rather than counts.
- **Negative controls.** For every new assertion, break the code it covers, confirm the test fails, then restore.
- **Lint.** `pre-commit` over the changed files.

## Test Result

| Check | Result |
|---|---|
| Unit tests | Pass. 125 in the module, including the 7 new cases. |
| End to end against a signed repo | Pass, 12/12. The same suite scores 6/12 on `main`. |
| Full suite | **No new failures.** 9 failed / 1761 passed against 9 failed / 1754 on `main`. Identical failure names. |
| Negative controls | Pass. Six, each failing only the test it targets. |
| Lint | Pass. |

The six checks `main` fails are exactly the ones this fixes. It overwrites `/etc/apt/keyrings/rocm.gpg`, ignores the `ROCM_APT_KEYRING_FILE` override, and reports success on a body that isn't a key while leaving an empty keyring behind. The override case is the sharpest. There, `apt update` exits 100 with "The repository is not signed", so `main` doesn't just misplace the key, it breaks apt in a plain container.

The nine pre-existing failures are in `compute_rocm_package_version_test.py`, `jax_install_scripts_test.py` and `stage_reuse_decision_test.py`, none of which this touches.

**Not covered.** `PurePosixPath` can't be exercised on Linux. `Unit Tests :: windows-2022` covers it and passed on #7276 with this same code. The timeout is covered by unit test rather than end to end, since `GPG_KEY_TIMEOUT_SEC` is 60 and isn't overridable.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
