### PR TITLE
Fix/skip unit tests that were failing locally on Windows

### DIFF
--- a/build_tools/github_actions/tests/stage_reuse_decision_test.py
+++ b/build_tools/github_actions/tests/stage_reuse_decision_test.py
@@ -105,22 +105,18 @@ def _selector(baseline):
 
 class ModeParsingTest(unittest.TestCase):
     def test_default_is_dry_run(self):
-        import os
-
-        os.environ.pop("STAGE_REUSE_MODE", None)
-        self.assertEqual(StageReuseMode.from_environ(), StageReuseMode.DRY_RUN)
+        with patch.dict(os.environ):
+            os.environ.pop("STAGE_REUSE_MODE", None)
+            self.assertEqual(StageReuseMode.from_environ(), StageReuseMode.DRY_RUN)
 
     def test_explicit_modes(self):
-        import os
-
         for value, expected in [
             ("dry-run", StageReuseMode.DRY_RUN),
             ("reuse-stage", StageReuseMode.REUSE_STAGE),
             ("garbage", StageReuseMode.DRY_RUN),
         ]:
-            os.environ["STAGE_REUSE_MODE"] = value
-            self.assertEqual(StageReuseMode.from_environ(), expected)
-        os.environ.pop("STAGE_REUSE_MODE", None)
+            with patch.dict(os.environ, {"STAGE_REUSE_MODE": value}):
+                self.assertEqual(StageReuseMode.from_environ(), expected)
 
 
 class AvailabilityGateTest(unittest.TestCase):
@@ -272,39 +268,38 @@ class DefaultBaselineSelectorTest(unittest.TestCase):
     an empty ordered_commit_shas window while current_commit_sha is set."""
 
     def _run_with_env(self, env, fake_history, fake_select):
-        import os
-
-        old_env = {k: os.environ.get(k) for k in env}
-        os.environ.update({k: v for k, v in env.items() if v is not None})
+        test_env = {
+            "GITHUB_REPOSITORY": "ROCm/TheRock",
+            "THEROCK_REPOSITORY": "ROCm/TheRock",
+        }
         for k, v in env.items():
             if v is None:
-                os.environ.pop(k, None)
+                test_env.pop(k, None)
+            else:
+                test_env[k] = v
 
-        import baseline_runs
-        import github_actions_api
-
-        orig_select = baseline_runs.select_baseline_run
-        orig_hist = getattr(github_actions_api, "gha_query_recent_branch_commits", None)
         captured = {}
 
         def _capturing_select(**kwargs):
             captured.update(kwargs)
             return fake_select
 
-        baseline_runs.select_baseline_run = _capturing_select
-        github_actions_api.gha_query_recent_branch_commits = fake_history
-        try:
+        with (
+            patch.dict(os.environ, test_env, clear=True),
+            patch.object(
+                srd.baseline_runs,
+                "select_baseline_run",
+                new=_capturing_select,
+            ),
+            patch.object(
+                srd.github_actions_api,
+                "gha_query_recent_branch_commits",
+                new=fake_history,
+            ),
+        ):
             selector = srd._default_baseline_selector(platform="linux")
             result = selector([("base", "generic")])
-        finally:
-            baseline_runs.select_baseline_run = orig_select
-            if orig_hist is not None:
-                github_actions_api.gha_query_recent_branch_commits = orig_hist
-            for k, v in old_env.items():
-                if v is None:
-                    os.environ.pop(k, None)
-                else:
-                    os.environ[k] = v
+
         return captured, result
 
     def test_history_is_fetched_and_threaded(self):

--- a/build_tools/tests/build_prod_wheels_version_test.py
+++ b/build_tools/tests/build_prod_wheels_version_test.py
@@ -15,7 +15,7 @@ sys.path.insert(
     0, os.fspath(Path(__file__).parent.parent.parent / "external-builds" / "pytorch")
 )
 
-from build_prod_wheels import compute_build_version, get_source_commit_short
+from build_prod_wheels import compute_build_version
 
 
 class ComputeBuildVersionTest(unittest.TestCase):
@@ -42,25 +42,6 @@ class ComputeBuildVersionTest(unittest.TestCase):
         with mock.patch("build_prod_wheels.get_source_commit_short", return_value=""):
             version = compute_build_version(self.source_dir, "+rocm7.10.0", "dev")
         self.assertEqual(version, "2.12.0a0+rocm7.10.0")
-
-
-class GetSourceCommitShortTest(unittest.TestCase):
-    def test_reads_short_commit_from_git_repo(self):
-        with tempfile.TemporaryDirectory() as temp_dir:
-            repo = Path(temp_dir)
-            subprocess.check_call(["git", "init"], cwd=repo)
-            subprocess.check_call(
-                ["git", "config", "user.email", "test@example.com"], cwd=repo
-            )
-            subprocess.check_call(["git", "config", "user.name", "Test User"], cwd=repo)
-            (repo / "version.txt").write_text("2.12.0a0\n")
-            subprocess.check_call(["git", "add", "version.txt"], cwd=repo)
-            subprocess.check_call(
-                ["git", "-c", "commit.gpgSign=false", "commit", "-m", "init"],
-                cwd=repo,
-            )
-            commit = get_source_commit_short(repo, length=8)
-            self.assertEqual(len(commit), 8)
 
 
 if __name__ == "__main__":

--- a/build_tools/tests/build_prod_wheels_version_test.py
+++ b/build_tools/tests/build_prod_wheels_version_test.py
@@ -55,7 +55,10 @@ class GetSourceCommitShortTest(unittest.TestCase):
             subprocess.check_call(["git", "config", "user.name", "Test User"], cwd=repo)
             (repo / "version.txt").write_text("2.12.0a0\n")
             subprocess.check_call(["git", "add", "version.txt"], cwd=repo)
-            subprocess.check_call(["git", "commit", "-m", "init"], cwd=repo)
+            subprocess.check_call(
+                ["git", "-c", "commit.gpgSign=false", "commit", "-m", "init"],
+                cwd=repo,
+            )
             commit = get_source_commit_short(repo, length=8)
             self.assertEqual(len(commit), 8)
 

--- a/build_tools/tests/configure_stage_test.py
+++ b/build_tools/tests/configure_stage_test.py
@@ -117,6 +117,10 @@ class ManifestValidationTest(unittest.TestCase):
                 f"Invalid feature '{feature}' for subproject '{subproject}'",
             )
 
+    @unittest.skipIf(
+        sys.platform == "win32",
+        "manifest verification requires a Linux CMake configuration",
+    )
     def test_artifact_subprojects_matches_cmake(self):
         """Verify artifact_subprojects.json matches what CMake generates."""
         repo_root = Path(__file__).parent.parent.parent

--- a/build_tools/tests/os_util_test.py
+++ b/build_tools/tests/os_util_test.py
@@ -116,6 +116,8 @@ class RmtreeWithRetryTest(unittest.TestCase):
             finally:
                 holder.terminate()
                 holder.wait()
+                if target.exists():
+                    rmtree_with_retry(target)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Related issues:
* https://github.com/ROCm/TheRock/issues/6930
* https://github.com/ROCm/TheRock/issues/6927

## Technical Details

Tests should isolate themselves from the environment
* Environment variables set by GitHub Actions like `GITHUB_REPOSITORY`
* Local git configuration settings (such as requiring commit signing for `git commit` operations)
* If a test only runs when certain conditions are met (such as having submodules initialized), it should take care that it passes outside of CI on a variety of systems, since CI might not run those tests

Tests should also cover _meaningful_ logic, not just commands ourside of our control like `git rev-parse --short`.

## Test Plan

```
pytest build_tools/github_actions/tests/ build_tools/tests/ -vv --durations=20
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
