### PR TITLE
[testing] Optimize build_tools/tests/artifact_descriptor_overlap_test.py

### DIFF
--- a/build_tools/tests/artifact_descriptor_overlap_test.py
+++ b/build_tools/tests/artifact_descriptor_overlap_test.py
@@ -12,8 +12,12 @@ both `artifact-rocprofiler-sdk.toml` and `artifact-aqlprofile-tests.toml`
 included `profiler/aqlprofile/stage`, causing concurrent extraction to race
 (and fail with "file exists" errors) on overlapping files.
 
-This test loads the real artifact-*.toml descriptors from the source tree and
-checks that each stage directory (basedir) belongs to exactly one descriptor.
+This test loads TheRock-owned artifact-*.toml descriptors and checks that each
+stage directory (basedir) belongs to exactly one descriptor. Descriptor
+discovery uses ``git ls-files`` so it does not recursively scan generated build
+trees, caches, or the contents of submodules. Both tracked files and non-ignored
+untracked files are included, so a newly created descriptor is checked before
+it is staged.
 
 Limitations (cases this test does NOT catch):
   - Two artifacts with *different* basedirs whose installed files collide
@@ -25,11 +29,40 @@ Limitations (cases this test does NOT catch):
     enforcement. Catching this requires inspecting actual build output.
 """
 
+import subprocess
 import tomllib
 import unittest
 from pathlib import Path
 
 THEROCK_DIR = Path(__file__).resolve().parent.parent.parent
+
+
+def get_descriptor_paths() -> list[Path]:
+    """Find TheRock-owned descriptors without crawling the whole workspace.
+
+    Using a directory allow-list would need updating whenever descriptors move
+    into a new source area, while a deny-list could easily miss a new generated
+    or external tree. Git already knows the relevant boundary: ``--cached``
+    lists files tracked by this repository (not files inside submodules), and
+    ``--others --exclude-standard`` adds new, non-ignored files while excluding
+    ignored build outputs and caches.
+    """
+    result = subprocess.run(
+        [
+            "git",
+            "ls-files",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+            "--",
+            ":(glob)**/artifact-*.toml",
+        ],
+        cwd=THEROCK_DIR,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [THEROCK_DIR / relpath for relpath in result.stdout.splitlines()]
 
 
 def get_basedirs(descriptor_path: Path) -> set[str]:
@@ -67,7 +100,7 @@ class ArtifactDescriptorOverlapTest(unittest.TestCase):
         seen: dict[str, Path] = {}
         errors: list[str] = []
 
-        descriptors = sorted(THEROCK_DIR.rglob("artifact-*.toml"))
+        descriptors = sorted(get_descriptor_paths())
         self.assertGreater(
             len(descriptors),
             0,


### PR DESCRIPTION
## Motivation

* Follow-up to https://github.com/ROCm/TheRock/issues/6752

This unit test was taking ~7 seconds locally since it ran `rglob()` across the entire source directory, including nested build directories and submodules. Now it takes ~0.05s by only scanning files visible to git.

The test still fails as expected if https://github.com/ROCm/TheRock/pull/3698 is reverted:

```diff
(.venv) λ git diff
diff --git a/profiler/artifact-rocprofiler-sdk.toml b/profiler/artifact-rocprofiler-sdk.toml
index a38ec8198..05a1f8af3 100644
--- a/profiler/artifact-rocprofiler-sdk.toml
+++ b/profiler/artifact-rocprofiler-sdk.toml
@@ -1,3 +1,14 @@
+# aqlprofile
+[components.dbg."profiler/aqlprofile/stage"]
+[components.dev."profiler/aqlprofile/stage"]
+[components.doc."profiler/aqlprofile/stage"]
+[components.lib."profiler/aqlprofile/stage"]
+[components.run."profiler/aqlprofile/stage"]
+[components.test."profiler/aqlprofile/stage"]
+include = [
+  "share/hsa-amd-aqlprofile/**",
+]
+
```

```python
pytest build_tools/tests/artifact_descriptor_overlap_test.py -vv --durations=20
...
            )
E           AssertionError: Duplicate basedirs across artifact descriptors will cause extraction collisions (see https://github.com/ROCm/TheRock/issues/3758):
E             - basedir 'profiler/aqlprofile/stage' claimed by both profiler\artifact-aqlprofile.toml and profiler\artifact-rocprofiler-sdk.toml

build_tools\tests\artifact_descriptor_overlap_test.py:122: AssertionError
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
