### PR TITLE
[testing] Automate skipping CI for test/filter only changes

### DIFF
--- a/build_tools/github_actions/configure_ci_path_filters.py
+++ b/build_tools/github_actions/configure_ci_path_filters.py
@@ -227,6 +227,10 @@ _SKIPPABLE_PATH_PATTERNS = [
     # This directory contains a collection of AI skills and other developer
     # utilities. It includes some Python scripts, none of which affect CI.
     "skills/*",
+    # This module runs in the lightweight setup job before build jobs are
+    # enabled. Its behavior is covered by unit tests, while running the full
+    # ROCm build would not provide additional validation of the path filters.
+    "build_tools/github_actions/configure_ci_path_filters.py",
     # Unit-test-only directories exercised by .github/workflows/unit_tests.yml.
     # Keep these in sync with the pytest invocations in that workflow and the
     # testpaths in pyproject.toml files. These are intentionally explicit

--- a/build_tools/github_actions/configure_ci_path_filters.py
+++ b/build_tools/github_actions/configure_ci_path_filters.py
@@ -227,6 +227,17 @@ _SKIPPABLE_PATH_PATTERNS = [
     # This directory contains a collection of AI skills and other developer
     # utilities. It includes some Python scripts, none of which affect CI.
     "skills/*",
+    # Unit-test-only directories exercised by .github/workflows/unit_tests.yml.
+    # Keep these in sync with the pytest invocations in that workflow and the
+    # testpaths in pyproject.toml files. These are intentionally explicit
+    # directory roots: other test paths exercise built ROCm packages in CI.
+    "build_tools/tests/*",
+    "build_tools/github_actions/tests/*",
+    "build_tools/packaging/linux/tests/*",
+    "build_tools/packaging/python/tests/*",
+    "build_tools/third_party/s3_management/tests/*",
+    "build_tools/scan_tools/github_actions/tests/*",
+    "test_tools/tests/*",
 ]
 
 # GitHub workflow files that are used by CI workflows. Changes to any of

--- a/build_tools/github_actions/tests/configure_ci_path_filters_test.py
+++ b/build_tools/github_actions/tests/configure_ci_path_filters_test.py
@@ -83,6 +83,10 @@ class ConfigureCIPathFiltersTest(unittest.TestCase):
             with self.subTest(path=path):
                 self.assertFalse(is_ci_run_required([path]))
 
+    def test_dont_run_ci_for_path_filter_only_changes(self):
+        paths = ["build_tools/github_actions/configure_ci_path_filters.py"]
+        self.assertFalse(is_ci_run_required(paths))
+
     def test_run_ci_for_tests_exercising_built_packages(self):
         integration_test_paths = [
             # Tests for ROCm subprojects.

--- a/build_tools/github_actions/tests/configure_ci_path_filters_test.py
+++ b/build_tools/github_actions/tests/configure_ci_path_filters_test.py
@@ -67,6 +67,46 @@ class ConfigureCIPathFiltersTest(unittest.TestCase):
         run_ci = is_ci_run_required(paths)
         self.assertTrue(run_ci)
 
+    def test_dont_run_ci_for_unit_test_only_changes(self):
+        # These directories are exercised separately by unit_tests.yml.
+        unit_test_paths = [
+            "build_tools/tests/example_test.py",
+            "build_tools/github_actions/tests/example_test.py",
+            "build_tools/packaging/linux/tests/example_test.py",
+            "build_tools/packaging/python/tests/example_test.py",
+            "build_tools/third_party/s3_management/tests/example_test.py",
+            "build_tools/scan_tools/github_actions/tests/example_test.py",
+            "test_tools/tests/example_test.py",
+        ]
+
+        for path in unit_test_paths:
+            with self.subTest(path=path):
+                self.assertFalse(is_ci_run_required([path]))
+
+    def test_run_ci_for_tests_exercising_built_packages(self):
+        integration_test_paths = [
+            # Tests for ROCm subprojects.
+            "build_tools/github_actions/test_executable_scripts/test_example.py",
+            # Install tests for packages (run on CI after building packages)
+            "build_tools/packaging/python/templates/example_test.py",
+            "build_tools/packaging/linux/example_test.py",
+            # Integration tests for ROCm (run on CI after building artifacts)
+            "tests/test_rocm_sanity.py",
+        ]
+
+        for path in integration_test_paths:
+            with self.subTest(path=path):
+                self.assertTrue(is_ci_run_required([path]))
+
+    def test_run_ci_for_source_and_unit_test_changes(self):
+        # Exclusions for skipping unit tests do not take priority over
+        # inclusions for modifying script files.
+        paths = [
+            "build_tools/build_tarballs.py",
+            "build_tools/tests/build_tarballs_test.py",
+        ]
+        self.assertTrue(is_ci_run_required(paths))
+
     @patch("configure_ci_path_filters.subprocess.run")
     def test_missing_base_sha_is_fetched_before_diffing(self, mock_run):
         base_sha = "f5c168058a7ceaa0f179cc36784b491a11a3adc7"


### PR DESCRIPTION
## Motivation

* Part of https://github.com/ROCm/TheRock/issues/6927

Changes to unit tests for script files have no impact on CI and can skip automatically. PRs can still add the `ci:skip` label (see https://github.com/ROCm/TheRock/blob/main/docs/development/ci_behavior_manipulation.md#pull-request), but this will also skip the CI workflow on `push` events to help reduce load on CI build/test runners.

I feel that changes to path filters can also skip CI (while changes to the `build_tools/github_actions/configure_multi_arch_ci.py` script itself should still always run CI).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
