### PR TITLE
feat(fetch_sources): authenticate GitHub clones via GITHUB_CLONE_TOKEN

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
@@ -153,8 +153,18 @@ jobs:
             --output-dir="${BUILD_DIR}" \
             --bootstrap
 
+      - name: Generate clone token
+        id: clone-token
+        uses: actions/create-github-app-token@df432ceeac20ab8f7f8cc7a0e70e0c83f3eb6ff3 # v2.0.6
+        with:
+          app-id: ${{ secrets.ROCM_CLONE_APP_ID }}
+          private-key: ${{ secrets.ROCM_CLONE_APP_PRIVATE_KEY }}
+          owner: ROCm
+
       - name: Fetch sources
         timeout-minutes: 30
+        env:
+          GITHUB_CLONE_TOKEN: ${{ steps.clone-token.outputs.token }}
         run: ./build_tools/fetch_sources.py --stage ${STAGE_NAME} --jobs 12 --depth 1 ${EXTERNAL_FETCH_SOURCES_ARGS}
 
       - name: Get stage configuration

--- a/.github/workflows/multi_arch_build_windows_artifacts.yml
+++ b/.github/workflows/multi_arch_build_windows_artifacts.yml
@@ -181,8 +181,18 @@ jobs:
             --output-dir="${BUILD_DIR}" \
             --bootstrap
 
+      - name: Generate clone token
+        id: clone-token
+        uses: actions/create-github-app-token@df432ceeac20ab8f7f8cc7a0e70e0c83f3eb6ff3 # v2.0.6
+        with:
+          app-id: ${{ secrets.ROCM_CLONE_APP_ID }}
+          private-key: ${{ secrets.ROCM_CLONE_APP_PRIVATE_KEY }}
+          owner: ROCm
+
       - name: Fetch sources
         timeout-minutes: 30
+        env:
+          GITHUB_CLONE_TOKEN: ${{ steps.clone-token.outputs.token }}
         run: python build_tools/fetch_sources.py --stage ${STAGE_NAME} --jobs 12 --depth 1 ${EXTERNAL_FETCH_SOURCES_ARGS}
 
       - name: Get stage configuration

--- a/.github/workflows/multi_arch_build_wsl_rocdxg_artifacts.yml
+++ b/.github/workflows/multi_arch_build_wsl_rocdxg_artifacts.yml
@@ -151,8 +151,18 @@ jobs:
         with:
           version: "3.62.0"
 
+      - name: Generate clone token
+        id: clone-token
+        uses: actions/create-github-app-token@df432ceeac20ab8f7f8cc7a0e70e0c83f3eb6ff3 # v2.0.6
+        with:
+          app-id: ${{ secrets.ROCM_CLONE_APP_ID }}
+          private-key: ${{ secrets.ROCM_CLONE_APP_PRIVATE_KEY }}
+          owner: ROCm
+
       - name: Fetch sources
         timeout-minutes: 30
+        env:
+          GITHUB_CLONE_TOKEN: ${{ steps.clone-token.outputs.token }}
         run: python build_tools/fetch_sources.py --stage ${STAGE_NAME} --jobs 12 --depth 1 ${EXTERNAL_FETCH_SOURCES_ARGS}
 
       - name: Set up WSL with Ubuntu

--- a/.github/workflows/test_consumer_graph_drift.yml
+++ b/.github/workflows/test_consumer_graph_drift.yml
@@ -36,8 +36,18 @@ jobs:
       - name: Install Python deps
         run: pip install -r requirements.txt
 
+      - name: Generate clone token
+        id: clone-token
+        uses: actions/create-github-app-token@df432ceeac20ab8f7f8cc7a0e70e0c83f3eb6ff3 # v2.0.6
+        with:
+          app-id: ${{ secrets.ROCM_CLONE_APP_ID }}
+          private-key: ${{ secrets.ROCM_CLONE_APP_PRIVATE_KEY }}
+          owner: ROCm
+
       - name: Fetch sources
         # All subproject sources must be present for the graph to be complete.
+        env:
+          GITHUB_CLONE_TOKEN: ${{ steps.clone-token.outputs.token }}
         run: python3 ./build_tools/fetch_sources.py --jobs 12 --depth 1
 
       - name: Configure (emits the consumer graph)

--- a/build_tools/fetch_sources.py
+++ b/build_tools/fetch_sources.py
@@ -45,6 +45,30 @@ def is_windows() -> bool:
     return platform.system() == "Windows"
 
 
+def _configure_github_clone_token() -> None:
+    """Configure git to authenticate GitHub clones using GITHUB_CLONE_TOKEN.
+
+    When set, injects the token into all https://github.com/ URLs via
+    git's url.insteadOf mechanism. This allows fetch_sources.py to clone
+    private and rate-limited ROCm org repos without hitting anonymous
+    GitHub API throttling limits.
+    """
+    token = os.environ.get("GITHUB_CLONE_TOKEN")
+    if not token:
+        return
+    subprocess.run(
+        [
+            "git",
+            "config",
+            "--global",
+            f"url.https://x-access-token:{token}@github.com/.insteadOf",
+            "https://github.com/",
+        ],
+        check=True,
+    )
+    log("Configured git to use GITHUB_CLONE_TOKEN for github.com clones.")
+
+
 def log(*args, **kwargs):
     print(*args, **kwargs)
     sys.stdout.flush()
@@ -718,6 +742,7 @@ def get_submodule_revision(submodule_path: str) -> str:
 
 
 def main(argv):
+    _configure_github_clone_token()
     parser = argparse.ArgumentParser(
         prog="fetch_sources",
         description="Fetch sources for TheRock build. Use --stage for stage-aware "

--- a/build_tools/tests/fetch_sources_mirror_test.py
+++ b/build_tools/tests/fetch_sources_mirror_test.py
@@ -22,6 +22,7 @@ from fetch_sources import (
     get_enabled_sources,
     parse_source_set_args,
     resolve_reference_dir,
+    _configure_github_clone_token,
     _resolve_mirror_path,
     _fetch_one_external_git_source,
     _update_one_submodule,
@@ -390,6 +391,38 @@ class FetchExternalGitSourceTest(unittest.TestCase):
         self.assertEqual(
             commands[2], ["git", "checkout", "--detach", self.source.commit]
         )
+
+
+class ConfigureGithubCloneTokenTest(unittest.TestCase):
+    """Tests for _configure_github_clone_token."""
+
+    @mock.patch("subprocess.run")
+    @mock.patch.dict(os.environ, {"GITHUB_CLONE_TOKEN": "ghs_testtoken123"}, clear=False)
+    def test_configures_git_when_token_set(self, mock_run):
+        _configure_github_clone_token()
+        mock_run.assert_called_once_with(
+            [
+                "git",
+                "config",
+                "--global",
+                "url.https://x-access-token:ghs_testtoken123@github.com/.insteadOf",
+                "https://github.com/",
+            ],
+            check=True,
+        )
+
+    @mock.patch("subprocess.run")
+    @mock.patch.dict(os.environ, {}, clear=False)
+    def test_no_op_when_token_not_set(self, mock_run):
+        os.environ.pop("GITHUB_CLONE_TOKEN", None)
+        _configure_github_clone_token()
+        mock_run.assert_not_called()
+
+    @mock.patch("subprocess.run")
+    @mock.patch.dict(os.environ, {"GITHUB_CLONE_TOKEN": ""}, clear=False)
+    def test_no_op_when_token_empty(self, mock_run):
+        _configure_github_clone_token()
+        mock_run.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Addresses intermittent `Fetch sources` timeouts caused by GitHub server-side throttling of anonymous git clone traffic from many concurrent CI runners (#7170, ROCm/TheRock-Infra#602).

When hundreds of runners simultaneously clone large repos like `compiler/amd-llvm` (ROCm/llvm-project), GitHub rate-limits unauthenticated requests, causing clones that normally take 2.5 minutes to stall past the 30-minute timeout.

**Solution:** Use a GitHub App installation token to authenticate all `fetch_sources.py` git clone operations. Authenticated requests get significantly higher rate limits and dedicated throughput from GitHub.

## Changes

### `build_tools/fetch_sources.py`
- Added `_configure_github_clone_token()`: reads `GITHUB_CLONE_TOKEN` env var and configures `git url.insteadOf` to inject the token for all `https://github.com/` clones
- Called at the top of `main()` — no-ops silently if env var is not set (safe for local dev and forks)

### Workflows (4 files)
Added a `Generate clone token` step immediately before `Fetch sources` in every workflow that calls `fetch_sources.py`:
- `multi_arch_build_portable_linux_artifacts.yml`
- `multi_arch_build_windows_artifacts.yml`
- `multi_arch_build_wsl_rocdxg_artifacts.yml`
- `test_consumer_graph_drift.yml`

Uses `actions/create-github-app-token` with two org secrets:
- `ROCM_CLONE_APP_ID`
- `ROCM_CLONE_APP_PRIVATE_KEY`

### Tests
- Added `ConfigureGithubCloneTokenTest` to `build_tools/tests/fetch_sources_mirror_test.py`
  - Token set → git config called with correct args
  - Token not set → no-op
  - Token empty string → no-op

## Prerequisites

A GitHub App must be created and installed on the ROCm org with:
- **Permission:** `Contents: Read` on all repositories
- **Org secrets set:** `ROCM_CLONE_APP_ID`, `ROCM_CLONE_APP_PRIVATE_KEY`

## Test plan
- [ ] GitHub App created with `Contents: Read` org-wide
- [ ] `ROCM_CLONE_APP_ID` and `ROCM_CLONE_APP_PRIVATE_KEY` set as ROCm org secrets
- [ ] CI run on this PR shows `Generate clone token` step succeeding
- [ ] `Fetch sources` completes consistently without throttling delays
- [ ] Local `fetch_sources.py` runs (without `GITHUB_CLONE_TOKEN` set) are unaffected

Closes #7170

🤖 Generated with [Claude Code](https://claude.com/claude-code)