### PR TITLE
[docs] Refresh build instructions for python/pytorch packages

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -390,6 +390,9 @@ jobs:
             -e rocm-systems/python/rocm-bootstrap \
             -e rocm-systems/shared/kpack
 
+      # TODO(https://github.com/ROCm/TheRock/issues/5656): Integrate this
+      # rocm_kpack.tools.split_python_wheels flow into build_prod_wheels.py and
+      # document the standalone developer workflow.
       - name: Split fat wheels (torch + torchvision)
         run: |
           # The splitter writes the host wheel under the same filename as

--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -111,9 +111,9 @@ on:
         type: string
         default: "3.12"
       pytorch_git_ref:
-        description: PyTorch ref to checkout (for example, "release/2.12").
+        description: PyTorch ref to checkout (for example, "release/2.13").
         type: string
-        default: "release/2.12"
+        default: "release/2.13"
       pytorch_gitrepo_origin:
         description: >-
           Optional PyTorch git origin override (for example, a fork URL for

--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels_ci.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels_ci.yml
@@ -291,6 +291,9 @@ jobs:
             -e rocm-systems/python/rocm-bootstrap \
             -e rocm-systems/shared/kpack
 
+      # TODO(https://github.com/ROCm/TheRock/issues/5656): Integrate this
+      # rocm_kpack.tools.split_python_wheels flow into build_prod_wheels.py and
+      # document the standalone developer workflow.
       - name: Split PyTorch fat wheel
         if: ${{ inputs.kpack_split == 'true' }}
         run: |

--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels_ci.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels_ci.yml
@@ -30,7 +30,7 @@ on:
       pytorch_git_ref:
         description: PyTorch ref to checkout (typically "release/X.Y")
         type: string
-        default: "release/2.11"
+        default: "release/2.13"
       rocm_package_find_links_url:
         description: URL for pip --find-links to install ROCm packages (flat page; use this OR rocm_package_index_url)
         type: string
@@ -85,7 +85,7 @@ on:
       pytorch_git_ref:
         description: PyTorch ref to checkout (typically "release/X.Y")
         type: string
-        default: "release/2.11"
+        default: "release/2.13"
       rocm_package_find_links_url:
         description: URL for pip --find-links to install ROCm packages (flat page; use this OR rocm_package_index_url)
         type: string

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
@@ -405,6 +405,9 @@ jobs:
             -e rocm-systems/python/rocm-bootstrap \
             -e rocm-systems/shared/kpack
 
+      # TODO(https://github.com/ROCm/TheRock/issues/5656): Integrate this
+      # rocm_kpack.tools.split_python_wheels flow into build_prod_wheels.py and
+      # document the standalone developer workflow.
       - name: Split fat wheels (torch + torchvision)
         run: |
           DIST_DIR="$(cygpath -u "${{ env.PACKAGE_DIST_DIR }}")"

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
@@ -105,9 +105,9 @@ on:
         type: string
         default: "3.12"
       pytorch_git_ref:
-        description: PyTorch ref to checkout (for example, "release/2.12").
+        description: PyTorch ref to checkout (for example, "release/2.13").
         type: string
-        default: "release/2.12"
+        default: "release/2.13"
       pytorch_gitrepo_origin:
         description: >-
           Optional PyTorch git origin override (for example, a fork URL for

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels_ci.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels_ci.yml
@@ -320,6 +320,9 @@ jobs:
             -e rocm-systems/python/rocm-bootstrap \
             -e rocm-systems/shared/kpack
 
+      # TODO(https://github.com/ROCm/TheRock/issues/5656): Integrate this
+      # rocm_kpack.tools.split_python_wheels flow into build_prod_wheels.py and
+      # document the standalone developer workflow.
       - name: Split PyTorch fat wheel
         if: ${{ inputs.kpack_split == 'true' }}
         run: |

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels_ci.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels_ci.yml
@@ -29,7 +29,7 @@ on:
       pytorch_git_ref:
         description: PyTorch ref to checkout (typically "release/X.Y")
         type: string
-        default: "release/2.11"
+        default: "release/2.13"
       rocm_package_find_links_url:
         description: URL for pip --find-links to install ROCm packages (flat page; use this OR rocm_package_index_url)
         type: string
@@ -84,7 +84,7 @@ on:
       pytorch_git_ref:
         description: PyTorch ref to checkout (typically "release/X.Y")
         type: string
-        default: "release/2.11"
+        default: "release/2.13"
       rocm_package_find_links_url:
         description: URL for pip --find-links to install ROCm packages (flat page; use this OR rocm_package_index_url)
         type: string

--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -30,9 +30,9 @@ on:
         required: true
         type: string
       pytorch_git_ref:
-        description: PyTorch ref to checkout test sources from. (e.g. "nightly", or "release/2.7")
+        description: PyTorch ref to checkout test sources from. (e.g. "nightly", or "release/2.13")
         type: string
-        default: "release/2.7"
+        default: "release/2.13"
       device_query:
         description: >-
           GPU candidate-set selection (--device-query, stage 1). "unique": one
@@ -72,7 +72,7 @@ on:
         type: string
       pytorch_git_ref:
         type: string
-        default: "release/2.7"
+        default: "release/2.13"
       device_query:
         description: >-
           --device-query. "unique": one device per architecture; "all": every

--- a/.github/workflows/test_pytorch_wheels_full.yml
+++ b/.github/workflows/test_pytorch_wheels_full.yml
@@ -34,7 +34,7 @@ on:
         required: true
         type: string
       pytorch_git_ref:
-        description: PyTorch ref to checkout test sources from. (e.g. "nightly", or "release/2.9")
+        description: PyTorch ref to checkout test sources from. (e.g. "nightly", or "release/2.13")
         type: string
         default: "nightly"
       pytorch_git_repo:

--- a/build_tools/fetch_artifacts.py
+++ b/build_tools/fetch_artifacts.py
@@ -8,18 +8,20 @@
 The install_rocm_from_artifacts.py script builds on top of this script to both
 download artifacts then unpack them into a usable install directory.
 
-Example usage (using https://github.com/ROCm/TheRock/actions/runs/15685736080):
+Example usage (find run IDs at https://github.com/ROCm/TheRock/actions):
   pip install boto3
+  RUN_ID="<replace-with-run-id>"
   python build_tools/fetch_artifacts.py \
-    --run-id 15685736080 --artifact-group gfx110X-all --output-dir ~/.therock/artifacts_15685736080
+    --run-id ${RUN_ID} --output-dir ~/.therock/artifacts_${RUN_ID}
 
-Download all artifacts for all GPU architectures:
+Download artifacts for selected individual GPU targets:
   python build_tools/fetch_artifacts.py \
-    --run-id 15685736080 --output-dir ~/.therock/artifacts_15685736080
+    --run-id ${RUN_ID} --amdgpu-targets gfx942,gfx1100 \
+    --output-dir ~/.therock/artifacts_${RUN_ID}
 
 Include/exclude regular expressions can be given to control what is downloaded:
   python build_tools/fetch_artifacts.py \
-    --run-id 15685736080 --artifact-group gfx110X-all --output-dir ~/.therock/artifacts_15685736080 \
+    --run-id ${RUN_ID} --output-dir ~/.therock/artifacts_${RUN_ID} \
     amd-llvm base 'core-(hip|runtime)' sysdeps \
     --exclude _dbg_
 

--- a/docs/packaging/python_packaging.md
+++ b/docs/packaging/python_packaging.md
@@ -13,7 +13,8 @@ We generate the following types of packages:
 - Selector package: The `rocm` package is built as an sdist so that it is
   evaluated at the point of install, allowing it to perform some selection logic
   to detect dependencies and needs. Most other packages are installed by
-  asking to install extras of this one (i.e. `rocm[libraries]`, etc).
+  asking to install extras of this one (i.e.
+  `rocm[libraries,device-gfx942]`, etc).
   - The `rocm` package provides the `rocm-sdk` tool.
   - The `rocm` package uses the `import rocm_sdk` Python namespace as we do
     not want a barename `rocm`.
@@ -23,15 +24,13 @@ We generate the following types of packages:
   symlinks (instead, only SONAME libraries are included, and any executable
   symlinks are emitted by dynamically compiling an executable that can execle
   a relative binary).
-- Device packages: When kpack artifact splitting is enabled
-  (`KPACK_SPLIT_ARTIFACTS` flag in `therock_manifest.json`), per-ISA device
-  wheels (`rocm-sdk-device-{target}`) are produced alongside an arch-neutral
-  `rocm-sdk-libraries` host wheel. Device wheels contain `.kpack` archives
-  and kernel databases (Tensile `.co`/`.dat`, MIOpen `.kdb`/`.db.txt`, etc.)
-  that overlay into the `rocm-sdk-libraries` platform directory in
-  site-packages. Each device wheel declares `Requires-Dist` on the matching
-  version of `rocm-sdk-libraries`. Users install only the device wheels for
-  their GPU target(s).
+- Device packages: Per-ISA device wheels (`rocm-sdk-device-{target}`) are
+  produced alongside an arch-neutral `rocm-sdk-libraries` host wheel. Device
+  wheels contain `.kpack` archives and kernel databases (Tensile `.co`/`.dat`,
+  MIOpen `.kdb`/`.db.txt`, etc.) that overlay into the `rocm-sdk-libraries`
+  platform directory in site-packages. Each device wheel declares
+  `Requires-Dist` on the matching version of `rocm-sdk-libraries`. Users install
+  only the device wheels for their GPU target(s).
 - Devel package: The `rocm-sdk-devel` package is the catch-all for everything.
   For any file already populated in a runtime package, it will include it as
   a relative symlink in the tarball. During extraction, file symlinks are
@@ -42,30 +41,26 @@ We generate the following types of packages:
   file. The installed package is extended in response to requesting a path to it
   via the `rocm-sdk` tool.
 
-### Legacy vs kpack-split packaging modes
+### Kpack-split packaging
 
-The packaging pipeline supports two modes, selected automatically based on the
-`KPACK_SPLIT_ARTIFACTS` flag in the build's `therock_manifest.json`:
+All current builds enable `KPACK_SPLIT_ARTIFACTS` by default. The
+`rocm-sdk-libraries` host wheel is architecture neutral and device code is
+distributed in `rocm-sdk-device-{target}` wheels, one per GFX ISA target. The
+devel package is also architecture neutral and excludes test binaries, which
+require device code to run. The packaging tools detect this layout from the
+flag in the build's `therock_manifest.json`. Support for older manifests is
+retained temporarily in the implementation but is not part of the current
+release flow; see [issue 3340](https://github.com/ROCm/TheRock/issues/3340).
 
-- **Legacy mode** (flag absent or false): Runtime packages can be target neutral
-  or target specific. Target specific packages like `rocm-sdk-libraries-{family}`
-  are suffixed with their target family and contain both host code and embedded
-  device code.
-- **Kpack-split mode** (flag true): The `rocm-sdk-libraries` host wheel is
-  arch-neutral (no family suffix, no device code). Device code is distributed
-  via separate `rocm-sdk-device-{target}` wheels, one per GFX ISA target.
-  The devel package is also arch-neutral and excludes test binaries (which
-  require device code to run).
-
-In kpack-split mode the arch-neutral `rocm-sdk-devel` tree does not itself contain
-per-ISA device files. Each installed `rocm-sdk-device-{target}` wheel ships a
-manifest, and `rocm-sdk init` - which also runs on the first use of a devel tool
-such as `hipcc` - hardlinks that wheel's device files from `rocm-sdk-libraries`
-into the devel tree, recording them in the device wheel's `RECORD` so
-`pip uninstall` removes them. Because the compiler trampolines only trigger this
-on the first expansion, after installing or removing a `rocm-sdk-device-*` wheel
-in an already-initialized environment, re-run `rocm-sdk init` or `rocm-sdk test`
-to refresh the device files in the devel tree.
+The arch-neutral `rocm-sdk-devel` tree does not itself contain per-ISA device
+files. Each installed `rocm-sdk-device-{target}` wheel ships a manifest, and
+`rocm-sdk init` - which also runs on the first use of a devel tool such as
+`hipcc` - hardlinks that wheel's device files from `rocm-sdk-libraries` into the
+devel tree, recording them in the device wheel's `RECORD` so `pip uninstall`
+removes them. Because the compiler trampolines only trigger this on the first
+expansion, after installing or removing a `rocm-sdk-device-*` wheel in an
+already-initialized environment, re-run `rocm-sdk init` or `rocm-sdk test` to
+refresh the device files in the devel tree.
 
 It is expected that all packages are installed in the same site-lib, as they use
 relative symlinks and RPATHs that cross the top-level package boundary. The
@@ -85,9 +80,10 @@ including a commit hash). You can also set an explicit fixed version with the
 [`build_tools/compute_rocm_package_version.py`](/build_tools/compute_rocm_package_version.py).
 and the [versioning documentation](versioning.md) for more version formats.
 
-### Build Target Family Selection
+### Package Target Selection
 
-The target GPU family used when building packages is determined in the following order:
+The GPU target selected by the `rocm` meta package is determined in the following
+order:
 
 1. `ROCM_SDK_TARGET_FAMILY` environment variable, if set.
 1. Dynamically discovered target family on the system.
@@ -97,9 +93,10 @@ For CI builds on CPU-only machines, this will typically fall through to (3).
 For developer machines with GPUs, the dynamic detection in (2) should suffice,
 but can be overridden by setting (1).
 
-In case of multiple GPU architectures present, the dynamically discovered target family
-defaults to the first available family, in which case it might be necessary to set the
-`ROCM_SDK_TARGET_FAMILY` environment variable.
+If multiple GPU architectures are present, dynamic detection defaults to the
+first available target. Set the `ROCM_SDK_TARGET_FAMILY` environment variable to
+override that choice. The environment variable retains its historical name but
+accepts an individual GFX ISA target such as `gfx942`.
 
 ### Building from Local Artifacts
 
@@ -131,14 +128,14 @@ You can also build packages from artifacts uploaded by CI workflows:
 
 ```bash
 # 1. Fetch artifacts from a CI run (find run IDs at github.com/ROCm/TheRock/actions)
-RUN_ID=21440027240
-ARTIFACT_GROUP=gfx110X-all
+RUN_ID="<replace-with-run-id>"
 ARTIFACTS_DIR=${HOME}/therock/${RUN_ID}/artifacts
 PACKAGES_DIR=${HOME}/therock/${RUN_ID}/packages
 
+# Fetch the complete platform artifact set. Package construction requires the
+# generic host artifacts and every device target recorded in the build manifest.
 python ./build_tools/fetch_artifacts.py \
     --run-id=${RUN_ID} \
-    --artifact-group=${ARTIFACT_GROUP} \
     --output-dir=${ARTIFACTS_DIR}
 
 # 2. Build Python packages from the fetched artifacts
@@ -147,41 +144,24 @@ python ./build_tools/build_python_packages.py \
     --dest-dir=${PACKAGES_DIR}
 
 # 3. Check the packages that were built
-ls ${PACKAGES_DIR}
-# rocm_sdk_core-7.12.0.dev0-py3-none-win_amd64.whl
-# rocm_sdk_devel-7.12.0.dev0-py3-none-win_amd64.whl
-# rocm_sdk_libraries_gfx110x_all-7.12.0.dev0-py3-none-win_amd64.whl
-# rocm-7.12.0.dev0.tar.gz
-```
-
-For kpack-split builds, use `artifact_manager.py` with `--amdgpu-targets` to
-fetch per-ISA artifacts:
-
-```bash
-python ./build_tools/artifact_manager.py fetch --stage all \
-    --output-dir=${ARTIFACTS_DIR} \
-    --run-id=${RUN_ID} --platform linux \
-    --amdgpu-families "gfx94X-dcgpu;gfx120X-all" \
-    --amdgpu-targets "gfx942,gfx1100,gfx1101,gfx1102,gfx1103,gfx1151,gfx1200,gfx1201"
-
-python ./build_tools/build_python_packages.py \
-    --artifact-dir=${ARTIFACTS_DIR}/artifacts \
-    --dest-dir=${PACKAGES_DIR}
-
-# Kpack-split output:
-# rocm_sdk_core-*.whl, rocm_sdk_libraries-*.whl (arch-neutral),
+ls ${PACKAGES_DIR}/dist
+# rocm_sdk_core-*.whl
+# rocm_sdk_libraries-*.whl
 # rocm_sdk_device_gfx942-*.whl, rocm_sdk_device_gfx1100-*.whl, ...
+# rocm_sdk_devel-*.whl
+# rocm-*.tar.gz
 ```
 
 ### Installing Locally Built Packages
 
 To install locally built packages, you can use the
 [`-f, --find-links`](https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-f)
-option:
+option. Replace `device-gfx942` with the target for your GPU, or use
+`device-all` to install every device wheel:
 
 ```bash
 python -m venv .venv && source .venv/bin/activate
-pip install rocm[libraries,devel] --pre \
+pip install "rocm[libraries,devel,device-gfx942]" --pre \
     --find-links=${PACKAGES_DIR}/dist
 
 # Run sanity tests to verify the installation
@@ -198,7 +178,7 @@ python ./third-party/indexer/indexer.py ${PACKAGES_DIR}/dist \
 
 # Install using --find-links
 python -m venv .venv && source .venv/bin/activate
-pip install rocm[libraries,devel] --pre \
+pip install "rocm[libraries,devel,device-gfx942]" --pre \
     --find-links=${PACKAGES_DIR}/dist/index.html
 ```
 
@@ -276,8 +256,8 @@ Instead:
 - Runtime dependencies are resolved using RPATH.
 
 > [!NOTE]
-> The `rocm` meta package requires device-family-specific components
-> (e.g. `gfx94X-dcgpu`). If these are not available in the selected
+> The `rocm` meta package requires a device wheel for the selected GFX ISA target
+> (for example, `rocm-sdk-device-gfx942`). If it is not available in the selected
 > package index, installation may be incomplete.
 
 ## Using Packages from Frameworks
@@ -290,9 +270,9 @@ subset (including runtime, HIP, system libraries and critical path math
 libraries), this is a process of installing the development packages like:
 
 ```bash
-# See RELEASES.md for exact arch specific incantations, --index-url
+# See RELEASES.md for exact target-specific incantations, --index-url
 # combinations, etc.
-pip install rocm[libraries,devel]
+pip install "rocm[libraries,devel,device-gfx942]"
 ```
 
 Then build your framework by setting appropriate CMake settings or environment

--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -172,11 +172,19 @@ Now note the gfx target you want to build for and then...
 [advanced build instructions](#advanced-build-instructions) for ways to
 mix/match build steps.
 
+> [!WARNING]
+> Pass `--pytorch-rocm-arch` with the gfx target for your development system,
+> such as `--pytorch-rocm-arch gfx1100`. If this option is omitted, the build
+> uses every target reported by the multi-arch `rocm-sdk` packages (currently
+> more than 20 targets). Compiling PyTorch for all of them can take over two
+> hours, compared with roughly 30–60 minutes for a single target.
+
 - On Linux:
 
   ```bash
   python build_prod_wheels.py build \
-    --install-rocm --index-url https://rocm.nightlies.amd.com/v2/gfx110X-all/ \
+    --install-rocm --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+    --pytorch-rocm-arch gfx1100 \
     --output-dir $HOME/tmp/pyout
   ```
 
@@ -184,7 +192,8 @@ mix/match build steps.
 
   ```batch
   python build_prod_wheels.py build ^
-    --install-rocm --index-url https://rocm.nightlies.amd.com/v2/gfx110X-all/ ^
+    --install-rocm --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ ^
+    --pytorch-rocm-arch gfx1100 ^
     --pytorch-dir C:/b/pytorch ^
     --pytorch-audio-dir C:/b/audio ^
     --pytorch-vision-dir C:/b/vision ^
@@ -319,7 +328,7 @@ The `rocm[libraries,devel]` packages can be installed in multiple ways:
 
   ```bash
   build_prod_wheels.py
-      --index-url https://rocm.nightlies.amd.com/v2/gfx110X-all/ \
+      --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
       install-rocm
   ```
 
@@ -328,7 +337,7 @@ The `rocm[libraries,devel]` packages can be installed in multiple ways:
   ```bash
   # From therock-nightly-python
   python -m pip install \
-    --index-url https://rocm.nightlies.amd.com/v2/gfx110X-all/ \
+    --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
     rocm[libraries,devel]
 
   # OR from therock-dev-python
@@ -497,7 +506,7 @@ a manifest for the release branch and check out from that manifest:
 python build_tools/github_actions/generate_pytorch_source_manifest.py \
   --rocm-version 7.13.0a20260501 \
   --output external-builds/pytorch/pytorch_manifest.json \
-  --pytorch-git-refs release/2.12
+  --pytorch-git-refs release/2.13
 
 python external-builds/pytorch/checkout_from_manifest.py \
   --manifest external-builds/pytorch/pytorch_manifest.json \
@@ -516,7 +525,7 @@ which can then be read by the checkout script.
 > ```bash
 > python pytorch_torch_repo.py checkout \
 >   --gitrepo-origin https://github.com/ROCm/pytorch.git \
->   --repo-hashtag release/2.12
+>   --repo-hashtag release/2.13
 > python pytorch_audio_repo.py checkout --require-related-commit
 > python pytorch_vision_repo.py checkout --require-related-commit
 > python pytorch_triton_repo.py checkout
@@ -530,13 +539,13 @@ which can then be read by the checkout script.
 python build_tools/github_actions/generate_pytorch_source_manifest.py \
     --rocm-version 7.13.0a20260501 \
     --output external-builds/pytorch/pytorch_manifest.json \
-    --pytorch-git-refs "release/2.11"
+    --pytorch-git-refs "release/2.13"
 
 # Multiple versions (computed filenames in a directory):
 python build_tools/github_actions/generate_pytorch_source_manifest.py \
     --rocm-version 7.13.0a20260501 \
     --manifest-dir external-builds/pytorch/manifests/ \
-    --pytorch-git-refs "release/2.11 release/2.12 nightly"
+    --pytorch-git-refs "release/2.11 release/2.12 release/2.13 nightly"
 
 # The target platform defaults to the current host. Pass it explicitly when
 # generating a manifest for another platform:
@@ -544,13 +553,13 @@ python build_tools/github_actions/generate_pytorch_source_manifest.py \
     --rocm-version 7.13.0a20260501 \
     --platform windows \
     --output manifest.json \
-    --pytorch-git-refs "release/2.11"
+    --pytorch-git-refs "release/2.13"
 
 # Only pytorch (skip audio/vision/triton/apex):
 python build_tools/github_actions/generate_pytorch_source_manifest.py \
     --rocm-version 7.13.0a20260501 \
     --output external-builds/pytorch/manifest.json \
-    --pytorch-git-refs "release/2.11" \
+    --pytorch-git-refs "release/2.13" \
     --projects pytorch
 ```
 

--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -378,7 +378,27 @@ use `device-all` when the environment must support every published target.
     --dest-dir=build/packages
   ```
 
-### Bundling PyTorch and ROCm together into a "fat wheel"
+### Splitting multi-architecture PyTorch wheels
+
+`build_prod_wheels.py` produces unsplit multi-target PyTorch wheels containing
+PyTorch device code for every target in `--pytorch-rocm-arch`. Before
+publishing, the TheRock CI/CD workflows use
+`rocm_kpack.tools.split_python_wheels` to replace the unsplit `torch` and
+`torchvision` wheels with architecture-neutral host wheels and per-ISA
+`amd-torch-device-*` and `amd-torchvision-device-*` wheels.
+
+This post-processing is not yet integrated into `build_prod_wheels.py`, and the
+kpack packages it requires are not yet published. See the current implementation
+in the following workflows:
+
+- [Portable Linux PyTorch wheels](/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml)
+- [Windows PyTorch wheels](/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml)
+
+Follow [issue 5656](https://github.com/ROCm/TheRock/issues/5656) for publishing
+the required packages, integrating wheel splitting into the build scripts, and
+documenting a supported standalone developer workflow.
+
+### Bundling ROCm libraries into a PyTorch "fat wheel"
 
 By default, Python wheels produced by the PyTorch build do not include ROCm
 binaries. Instead, they expect those binaries to come from the

--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -107,8 +107,8 @@ detailed instructions. That information is summarized here.
 
 ### Prerequisites and setup
 
-You will need a supported Python version (3.10+) on a system which we build the
-`rocm[libraries,devel]` packages for. See the
+You will need a supported Python version (3.10+) on a system for which we build
+the `rocm[libraries,devel,device-*]` packages. See the
 [`RELEASES.md`: Installing releases using pip](../../RELEASES.md#installing-releases-using-pip)
 and [Python Packaging](../../docs/packaging/python_packaging.md) documentation
 for more background on these `rocm` packages.
@@ -184,6 +184,7 @@ mix/match build steps.
   ```bash
   python build_prod_wheels.py build \
     --install-rocm --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+    --rocm-extras device-gfx1100 \
     --pytorch-rocm-arch gfx1100 \
     --output-dir $HOME/tmp/pyout
   ```
@@ -193,6 +194,7 @@ mix/match build steps.
   ```batch
   python build_prod_wheels.py build ^
     --install-rocm --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ ^
+    --rocm-extras device-gfx1100 ^
     --pytorch-rocm-arch gfx1100 ^
     --pytorch-dir C:/b/pytorch ^
     --pytorch-audio-dir C:/b/audio ^
@@ -320,7 +322,9 @@ per-target device wheels were promoted independently. See the discussion on
 
 ### Other ways to install the rocm packages
 
-The `rocm[libraries,devel]` packages can be installed in multiple ways:
+The `rocm[libraries,devel,device-*]` packages can be installed in multiple ways.
+The examples use `device-gfx942`; replace it with the target for your GPU, or
+use `device-all` when the environment must support every published target.
 
 - (As above) during the `build_prod_wheels.py build` subcommand
 
@@ -329,6 +333,7 @@ The `rocm[libraries,devel]` packages can be installed in multiple ways:
   ```bash
   build_prod_wheels.py
       --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+      --rocm-extras device-gfx942 \
       install-rocm
   ```
 
@@ -338,30 +343,28 @@ The `rocm[libraries,devel]` packages can be installed in multiple ways:
   # From therock-nightly-python
   python -m pip install \
     --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
-    rocm[libraries,devel]
+    "rocm[libraries,devel,device-gfx942]"
 
   # OR from therock-dev-python
   python -m pip install \
-    --index-url https://rocm.devreleases.amd.com/v2/gfx110X-all/ \
-    rocm[libraries,devel]
+    --index-url https://rocm.devreleases.amd.com/whl-multi-arch/ \
+    "rocm[libraries,devel,device-gfx942]"
   ```
 
-- Building the rocm Python packages from artifacts fetched from a CI run:
-
-  <!-- TODO: teach scripts to look up latest stable run and mkdir themselves -->
+- Building the rocm Python packages from artifacts fetched from a CI run. Fetch
+  the complete artifact set: package construction needs the generic host
+  artifacts and every per-ISA device artifact recorded in the build manifest.
 
   ```bash
   # From the repository root
-  mkdir $HOME/.therock/17123441166
-  mkdir $HOME/.therock/17123441166/artifacts
+  RUN_ID="<replace-with-run-id>"
   python ./build_tools/fetch_artifacts.py \
-    --run-id=17123441166 \
-    --target=gfx110X-all \
-    --output-dir=$HOME/.therock/17123441166/artifacts
+    --run-id=${RUN_ID} \
+    --output-dir=${HOME}/.therock/${RUN_ID}/artifacts
 
   python ./build_tools/build_python_packages.py \
-    --artifact-dir=$HOME/.therock/17123441166/artifacts \
-    --dest-dir=$HOME/.therock/17123441166/packages
+    --artifact-dir=${HOME}/.therock/${RUN_ID}/artifacts \
+    --dest-dir=${HOME}/.therock/${RUN_ID}/packages
   ```
 
 - Building the rocm Python packages from artifacts built from source:
@@ -379,10 +382,10 @@ The `rocm[libraries,devel]` packages can be installed in multiple ways:
 
 By default, Python wheels produced by the PyTorch build do not include ROCm
 binaries. Instead, they expect those binaries to come from the
-`rocm[libraries,devel]` packages. A "fat wheel" bundles the ROCm binaries into
-the same wheel archive to produce a standalone install including both PyTorch
-and ROCm, with all necessary patches to shared library / DLL loading for out of
-the box operation.
+`rocm[libraries,devel,device-*]` packages. A "fat wheel" bundles the ROCm
+binaries into the same wheel archive to produce a standalone install including
+both PyTorch and ROCm, with all necessary patches to shared library / DLL loading
+for out of the box operation.
 
 To produce such a fat wheel, see
 [`windows_patch_fat_wheel.py`](./windows_patch_fat_wheel.py) and a future

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -60,7 +60,7 @@ to the build sub-command (useful for docker invocations).
 # For therock-nightly-python
 build_prod_wheels.py \
     install-rocm \
-    --index-url https://rocm.nightlies.amd.com/v2/gfx110X-all/
+    --index-url https://rocm.nightlies.amd.com/whl-multi-arch/
 
 # For therock-dev-python (unstable but useful for testing outside of prod)
 build_prod_wheels.py \
@@ -130,7 +130,8 @@ versions):
     build \
         --install-rocm \
         --pip-cache-dir /therock/output/pip_cache \
-        --index-url https://rocm.nightlies.amd.com/v2/gfx110X-all/ \
+        --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+        --pytorch-rocm-arch gfx942 \
         --clean \
         --output-dir /therock/output/cp312/wheels
 ```

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -43,15 +43,17 @@ python pytorch_vision_repo.py checkout --checkout-dir C:/b/vision
 
 2. Install rocm wheels:
 
-You must have the `rocm[libraries,devel]` packages installed. The `install-rocm`
-command gives a one-stop to fetch the latest nightlies from the CI or elsewhere.
-Below we are using nightly rocm-sdk packages from the CI bucket. See `RELEASES.md`
-for further options. Specific versions can be specified via `--rocm-sdk-version`
-and `--no-pre` (to disable searching for pre-release candidates). The installed
-version will be printed and subsequently will be embedded into torch builds as
-a dependency. Such an arrangement is a head-on-head build (i.e. torch head on top
-of ROCm head). Other arrangements are possible by passing pinned versions, official
-repositories, etc.
+You must have the `rocm[libraries,devel]` packages installed to build PyTorch.
+To run or test the resulting wheels, also install the device extra matching the
+GPU target you plan to build for, or use `device-all` to install every published
+target. The `install-rocm` command gives a one-stop to fetch these packages from
+the latest nightlies or elsewhere. Below we are using nightly rocm-sdk packages
+from the CI bucket. See `RELEASES.md` for further options. Specific versions can
+be specified via `--rocm-sdk-version` and `--no-pre` (to disable searching for
+pre-release candidates). The installed version will be printed and subsequently
+will be embedded into torch builds as a dependency. Such an arrangement is a
+head-on-head build (i.e. torch head on top of ROCm head). Other arrangements are
+possible by passing pinned versions, official repositories, etc.
 
 You can also install in the same invocation as build by passing `--install-rocm`
 to the build sub-command (useful for docker invocations).
@@ -60,12 +62,14 @@ to the build sub-command (useful for docker invocations).
 # For therock-nightly-python
 build_prod_wheels.py \
     install-rocm \
-    --index-url https://rocm.nightlies.amd.com/whl-multi-arch/
+    --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+    --rocm-extras device-gfx942
 
 # For therock-dev-python (unstable but useful for testing outside of prod)
 build_prod_wheels.py \
     install-rocm \
-    --index-url https://rocm.devreleases.amd.com/v2/gfx110X-all/
+    --index-url https://rocm.devreleases.amd.com/whl-multi-arch/ \
+    --rocm-extras device-gfx942
 ```
 
 3. Build torch, torchaudio and torchvision for one or more gfx architectures.
@@ -131,6 +135,7 @@ versions):
         --install-rocm \
         --pip-cache-dir /therock/output/pip_cache \
         --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+        --rocm-extras device-gfx942 \
         --pytorch-rocm-arch gfx942 \
         --clean \
         --output-dir /therock/output/cp312/wheels


### PR DESCRIPTION
## Motivation

Key changes:
* Switch to recommending multi-arch indexes and install instructions (see https://github.com/ROCm/TheRock/issues/3340)
  * Recommend `--pytorch-rocm-arch` for local builds to significantly speed them up
* Switch workflow defaults from `release/2.7` branch (no longer supported) to `release/2.13` branch (latest stable)
* Start to document kpack split tooling as it applies to pytorch (see https://github.com/ROCm/TheRock/issues/5656)

## Technical Details

Changes here were generated by Codex and reviewed manually. I did *not* individually test all commands.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
