### PR TITLE
Float Stable Torch ROCm Dependency Pins

### DIFF
--- a/build_tools/packaging/promote_packages.py
+++ b/build_tools/packaging/promote_packages.py
@@ -348,6 +348,31 @@ def rewrite_metadata_rocm_line(
     return requires_match.group("prefix") + requires_match.group("name") + tail
 
 
+_CHECK_VERSION_RE = re.compile(
+    r"(?P<prefix>\bcheck_version\s*=\s*['\"])(?P<version>[^'\"]+)(?P<suffix>['\"])"
+)
+
+
+def rewrite_rocm_init_check_version(
+    line: str, old_rocm_version: str, new_rocm_version: str
+) -> str:
+    """Rewrite torch _rocm_init.py stable checks to ROCm major/minor wildcard."""
+    rewritten = line.replace(old_rocm_version, new_rocm_version)
+    check_version_match = _CHECK_VERSION_RE.search(rewritten)
+    if check_version_match is None:
+        return rewritten
+    if check_version_match.group("version") != new_rocm_version:
+        return rewritten
+    minor_spec = stable_minor_spec(new_rocm_version)
+    if minor_spec is None:
+        return rewritten
+    return (
+        rewritten[: check_version_match.start("version")]
+        + minor_spec
+        + rewritten[check_version_match.end("version") :]
+    )
+
+
 def update_metadata_rocm_requires_dist(
     new_dir_path: pathlib.Path,
     package_name_no_version: str,
@@ -1009,6 +1034,19 @@ def wheel_change_extra_files(
     with fileinput.input(files=files_to_change, encoding="utf-8", inplace=True) as f:
         for line in f:
             print(line.replace(old_rocm_version, new_rocm_version), end="")
+
+    if float_rocm_dependency_patch and "torch" == package_name_no_version:
+        rocm_init_path = new_dir_path / package_name_no_version / "_rocm_init.py"
+        with fileinput.input(
+            files=[rocm_init_path], encoding="utf-8", inplace=True
+        ) as f:
+            for line in f:
+                print(
+                    rewrite_rocm_init_check_version(
+                        line, old_rocm_version, new_rocm_version
+                    ),
+                    end="",
+                )
 
     print("    ...done")
 

--- a/build_tools/packaging/promote_packages.py
+++ b/build_tools/packaging/promote_packages.py
@@ -347,7 +347,8 @@ def rewrite_metadata_rocm_line(
         tail,
         count=1,
     )
-    return requires_match.group("prefix") + requires_match.group("name") + tail
+    tail_start, tail_end = requires_match.span("tail")
+    return rewritten[:tail_start] + tail + rewritten[tail_end:]
 
 
 def rewrite_rocm_init_check_version(
@@ -369,7 +370,7 @@ def update_metadata_rocm_requires_dist(
     *,
     float_rocm_dependency_patch: bool = False,
 ) -> None:
-    """Update Requires-Dist lines in METADATA that reference rocm, leaving others unchanged."""
+    """Update ROCm references in METADATA Summary and Requires-Dist fields."""
     metadata_path = (
         new_dir_path / f"{package_name_no_version}-{old_version}.dist-info" / "METADATA"
     )
@@ -394,7 +395,7 @@ def update_metadata_rocm_requires_dist(
                         ),
                         end="",
                     )
-                elif line.startswith("Requires-Dist"):
+                elif line.startswith("Requires-Dist") and "rocm" in lower_line:
                     print(
                         rewrite_metadata_rocm_line(
                             line,
@@ -981,12 +982,13 @@ def wheel_change_extra_files(
     if JAX_ROCM_PACKAGE_PATTERN.match(package_name_no_version):
         return
 
+    files_to_float: list[pathlib.Path] = []
+
     # rocm packages needing extra handling
     if new_dir_path.name.startswith("rocm"):
         files_to_change = [
             new_dir_path / package_name_no_version / "_dist_info.py",
         ]
-        files_to_float = []
 
         if new_dir_path.name.startswith("rocm_sdk_core"):
             files_to_change.append(
@@ -1004,14 +1006,10 @@ def wheel_change_extra_files(
         files_to_float = [
             new_dir_path / package_name_no_version / "_rocm_init.py",
         ]
-        if not float_rocm_dependency_patch:
-            files_to_change.extend(files_to_float)
-            files_to_float = []
     elif "apex" in package_name_no_version:
         files_to_change = [
             new_dir_path / package_name_no_version / "git_version_info_installed.py",
         ]
-        files_to_float = []
     else:
         # we have multiple packages that have a version.py that needs updating
         need_change_version_py = ["torchaudio", "torchvision", "jaxlib"]
@@ -1019,7 +1017,6 @@ def wheel_change_extra_files(
             files_to_change = [
                 new_dir_path / package_name_no_version / "version.py",
             ]
-            files_to_float = []
         else:
             # no additional (rocm-specific) files needed to be changed that contain the version
             # currently applying to: triton
@@ -1028,12 +1025,16 @@ def wheel_change_extra_files(
     def rewrite_exact(line: str) -> str:
         return line.replace(old_rocm_version, new_rocm_version)
 
-    def rewrite_rocm_init(line: str) -> str:
+    def rewrite_float_version(line: str) -> str:
         return rewrite_rocm_init_check_version(line, old_rocm_version, new_rocm_version)
+
+    if not float_rocm_dependency_patch:
+        files_to_change.extend(files_to_float)
+        files_to_float = []
 
     rewrite_groups = [
         (files_to_change, rewrite_exact),
-        (files_to_float, rewrite_rocm_init),
+        (files_to_float, rewrite_float_version),
     ]
     for files, rewrite_line in rewrite_groups:
         if not files:

--- a/build_tools/packaging/promote_packages.py
+++ b/build_tools/packaging/promote_packages.py
@@ -24,11 +24,11 @@ Common workflows:
 Other combinations are mechanically possible but not typical.
 
 When promoting torch-family wheels to a stable release, ROCm package
-dependencies in METADATA are rewritten to a patch-floating stable minor
-specifier (for example `rocm-sdk-core==7.13.*`). The torch wheel identity itself
-remains exact (for example `torch-2.8.0+rocm7.13.0-...whl`) so the artifact
-records the ROCm version it was built against, while allowing ROCm patch
-updates that do not require rebuilding torch.
+dependencies in METADATA are rewritten to a forward patch-compatible specifier
+(for example `rocm-sdk-core~=7.13.0`). The torch wheel identity itself remains
+exact (for example `torch-2.8.0+rocm7.13.0-...whl`) so the artifact records the
+ROCm version it was built against, while allowing later ROCm patch updates that
+do not require rebuilding torch.
 
 The keep-list pass (--multi-arch-targets) is independent of version promotion: it
 runs whenever --multi-arch-targets is supplied, alongside any version rewrite. To
@@ -291,6 +291,18 @@ def stable_minor_spec(version_str: str) -> str | None:
     return f"{version.release[0]}.{version.release[1]}.*"
 
 
+def stable_patch_compatible_spec(version_str: str) -> str | None:
+    """Return a forward patch-compatible specifier like `~=7.13.1`, or None."""
+    version = Version(version_str)
+    if version.is_prerelease or version.is_devrelease or version.local is not None:
+        return None
+    if len(version.release) < 3:
+        raise ValueError(
+            f"Stable version {version_str!r} must include major, minor, and patch"
+        )
+    return f"~={version}"
+
+
 _REQUIRES_DIST_NAME_RE = re.compile(
     r"^(?P<prefix>Requires-Dist:\s*)(?P<name>[A-Za-z0-9_.-]+)(?P<tail>.*)$"
 )
@@ -307,7 +319,9 @@ def rewrite_metadata_rocm_line(
 
     Summary lines and non-floating requirements use exact replacement. When
     `float_rocm_dependency_patch` is set, only existing exact `==<stable version>`
-    pins on ROCm dependency names are converted to `==X.Y.*`.
+    pins on ROCm dependency names are converted to `~=X.Y.Z`. This allows later
+    patches on the same minor line without permitting a downgrade below the
+    version against which the wheel was built.
     """
     rewritten = line.replace(old_rocm_version, new_rocm_version)
     if not float_rocm_dependency_patch or not rewritten.startswith("Requires-Dist"):
@@ -334,16 +348,17 @@ def rewrite_metadata_rocm_line(
 
     exact_version = specifier.version
     try:
-        minor_spec = stable_minor_spec(exact_version)
+        compatible_spec = stable_patch_compatible_spec(exact_version)
     except InvalidVersion:
         return rewritten
-    if minor_spec is None:
+    if compatible_spec is None:
         return rewritten
 
+    compatible_version = compatible_spec.removeprefix("~=")
     tail = requires_match.group("tail")
     tail = re.sub(
-        rf"(?P<operator>==\s*){re.escape(exact_version)}(?P<boundary>\b)",
-        rf"\g<operator>{minor_spec}\g<boundary>",
+        rf"==(?P<space>\s*){re.escape(exact_version)}(?P<boundary>\b)",
+        rf"~=\g<space>{compatible_version}\g<boundary>",
         tail,
         count=1,
     )
@@ -982,6 +997,8 @@ def wheel_change_extra_files(
     if JAX_ROCM_PACKAGE_PATTERN.match(package_name_no_version):
         return
 
+    # If more files need specialized rewrites, replace the parallel file groups
+    # below with (path, rewrite function) pairs so the dispatch stays explicit.
     files_to_float: list[pathlib.Path] = []
 
     # rocm packages needing extra handling

--- a/build_tools/packaging/promote_packages.py
+++ b/build_tools/packaging/promote_packages.py
@@ -23,6 +23,13 @@ Common workflows:
   - a  -> rc                 e.g. 7.13.0a20260501 -> 7.13.0rc1
 Other combinations are mechanically possible but not typical.
 
+When promoting torch-family wheels to a stable release, ROCm package
+dependencies in METADATA are rewritten to a patch-floating stable minor
+specifier (for example `rocm-sdk-core==7.13.*`). The torch wheel identity itself
+remains exact (for example `torch-2.8.0+rocm7.13.0-...whl`) so the artifact
+records the ROCm version it was built against, while allowing ROCm patch
+updates that do not require rebuilding torch.
+
 The keep-list pass (--multi-arch-targets) is independent of version promotion: it
 runs whenever --multi-arch-targets is supplied, alongside any version rewrite. To
 run ONLY the keep-list pass and leave the version untouched, use
@@ -84,7 +91,9 @@ import sys
 import tarfile
 import tempfile
 
-from packaging.version import Version
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.utils import canonicalize_name
+from packaging.version import InvalidVersion, Version
 from pkginfo import Wheel
 
 # Need dynamic load as change_wheel_version needs to be imported via parent directory
@@ -239,12 +248,114 @@ For tar.gz., the version is extract from <.tar.gz>/PKG-INFO file.
     return args
 
 
+def is_torch_package_name(package_name: str) -> bool:
+    """Return True for torch-family packages eligible for ROCm dep floating."""
+    normalized = canonicalize_name(package_name)
+    return normalized in {
+        "torch",
+        "torchvision",
+        "torchaudio",
+        "triton",
+        "apex",
+    } or normalized.startswith(
+        (
+            "amd-torch-device-",
+            "amd-torchvision-device-",
+        )
+    )
+
+
+def is_floating_rocm_dependency_name(package_name: str) -> bool:
+    """Return True for ROCm package deps that may float in torch metadata.
+
+    `rocm-bootstrap` intentionally stays out of this set. It is not part of the
+    stable ROCm SDK dependency line that should float at patch level.
+    """
+    normalized = canonicalize_name(package_name)
+    return (
+        normalized == "rocm"
+        or normalized.startswith("rocm-sdk-")
+        or normalized == "rocm-profiler"
+    )
+
+
+def stable_minor_spec(version_str: str) -> str | None:
+    """Return a stable patch-floating specifier like `7.13.*`, or None."""
+    version = Version(version_str)
+    if version.is_prerelease or version.is_devrelease or version.local is not None:
+        return None
+    if len(version.release) < 2:
+        raise ValueError(f"Stable version {version_str!r} must include major and minor")
+    return f"{version.release[0]}.{version.release[1]}.*"
+
+
+_REQUIRES_DIST_NAME_RE = re.compile(
+    r"^(?P<prefix>Requires-Dist:\s*)(?P<name>[A-Za-z0-9_.-]+)(?P<tail>.*)$"
+)
+
+
+def rewrite_metadata_rocm_line(
+    line: str,
+    old_rocm_version: str,
+    new_rocm_version: str,
+    *,
+    float_rocm_dependency_patch: bool,
+) -> str:
+    """Rewrite one METADATA line for ROCm version promotion.
+
+    Summary lines and non-floating requirements use exact replacement. When
+    `float_rocm_dependency_patch` is set, only existing exact `==<stable version>`
+    pins on ROCm dependency names are converted to `==X.Y.*`.
+    """
+    rewritten = line.replace(old_rocm_version, new_rocm_version)
+    if not float_rocm_dependency_patch or not rewritten.startswith("Requires-Dist"):
+        return rewritten
+
+    requires_match = _REQUIRES_DIST_NAME_RE.match(rewritten)
+    if not requires_match:
+        raise ValueError(f"Malformed Requires-Dist line: {line!r}")
+    requirement_text = requires_match.group("name") + requires_match.group("tail")
+    try:
+        requirement = Requirement(requirement_text)
+    except InvalidRequirement as e:
+        raise ValueError(f"Malformed Requires-Dist requirement: {line!r}") from e
+
+    if not is_floating_rocm_dependency_name(requirement.name):
+        return rewritten
+
+    specifiers = list(requirement.specifier)
+    if len(specifiers) != 1:
+        return rewritten
+    specifier = specifiers[0]
+    if specifier.operator != "==" or "*" in specifier.version:
+        return rewritten
+
+    exact_version = specifier.version
+    try:
+        minor_spec = stable_minor_spec(exact_version)
+    except InvalidVersion:
+        return rewritten
+    if minor_spec is None:
+        return rewritten
+
+    tail = requires_match.group("tail")
+    tail = re.sub(
+        rf"(?P<operator>==\s*){re.escape(exact_version)}(?P<boundary>\b)",
+        rf"\g<operator>{minor_spec}\g<boundary>",
+        tail,
+        count=1,
+    )
+    return requires_match.group("prefix") + requires_match.group("name") + tail
+
+
 def update_metadata_rocm_requires_dist(
     new_dir_path: pathlib.Path,
     package_name_no_version: str,
     old_version: str,
     old_rocm_version: str,
     new_rocm_version: str,
+    *,
+    float_rocm_dependency_patch: bool = False,
 ) -> None:
     """Update Requires-Dist lines in METADATA that reference rocm, leaving others unchanged."""
     metadata_path = (
@@ -261,9 +372,25 @@ def update_metadata_rocm_requires_dist(
                 if line.startswith("Summary:") and (
                     "TheRock" in line or "rocm" in line
                 ):
-                    print(line.replace(old_rocm_version, new_rocm_version), end="")
-                elif line.startswith("Requires-Dist") and "rocm" in line:
-                    print(line.replace(old_rocm_version, new_rocm_version), end="")
+                    print(
+                        rewrite_metadata_rocm_line(
+                            line,
+                            old_rocm_version,
+                            new_rocm_version,
+                            float_rocm_dependency_patch=False,
+                        ),
+                        end="",
+                    )
+                elif line.startswith("Requires-Dist"):
+                    print(
+                        rewrite_metadata_rocm_line(
+                            line,
+                            old_rocm_version,
+                            new_rocm_version,
+                            float_rocm_dependency_patch=float_rocm_dependency_patch,
+                        ),
+                        end="",
+                    )
                 else:
                     print(line, end="")
 
@@ -779,6 +906,7 @@ def wheel_change_extra_files(
     old_version: Version,
     new_version: Version,
     multi_arch_targets: list[str] | None = None,
+    dest_version: str = "release",
 ) -> None:
     # Always run the keep-list pass when archs are requested; do this *before*
     # version rewrites so the version replacement sees a consistent file
@@ -815,6 +943,9 @@ def wheel_change_extra_files(
         if "rocm" not in str(new_version)
         else str(new_version).split("+rocm")[-1]
     )
+    float_rocm_dependency_patch = dest_version == "release" and is_torch_package_name(
+        package_name_no_version
+    )
 
     print("    Changing ROCm-specific files that contain the version")
 
@@ -826,6 +957,7 @@ def wheel_change_extra_files(
         old_version,
         old_rocm_version,
         new_rocm_version,
+        float_rocm_dependency_patch=float_rocm_dependency_patch,
     )
     # Per-arch device wheels (amd_torch_device_gfx, amd_torchvision_device_gfx,
     # rocm_sdk_device_gfx) carry no package-specific files that reference the
@@ -898,7 +1030,9 @@ def promote_wheel(
     # Bound callback matching change_wheel_version's expected signature:
     #   callback(new_dir_path: Path, old_version: Version, new_version: Version) -> None
     callback = functools.partial(
-        wheel_change_extra_files, multi_arch_targets=multi_arch_targets
+        wheel_change_extra_files,
+        multi_arch_targets=multi_arch_targets,
+        dest_version=dest_version,
     )
 
     if skip_version_promotion:

--- a/build_tools/packaging/promote_packages.py
+++ b/build_tools/packaging/promote_packages.py
@@ -251,6 +251,8 @@ For tar.gz., the version is extract from <.tar.gz>/PKG-INFO file.
 def is_torch_package_name(package_name: str) -> bool:
     """Return True for torch-family packages eligible for ROCm dep floating."""
     normalized = canonicalize_name(package_name)
+    # Keep apex and triton in this policy set; this is a no-op until they have
+    # ROCm-specific Requires-Dist dependencies.
     return normalized in {
         "torch",
         "torchvision",
@@ -348,29 +350,14 @@ def rewrite_metadata_rocm_line(
     return requires_match.group("prefix") + requires_match.group("name") + tail
 
 
-_CHECK_VERSION_RE = re.compile(
-    r"(?P<prefix>\bcheck_version\s*=\s*['\"])(?P<version>[^'\"]+)(?P<suffix>['\"])"
-)
-
-
 def rewrite_rocm_init_check_version(
     line: str, old_rocm_version: str, new_rocm_version: str
 ) -> str:
-    """Rewrite torch _rocm_init.py stable checks to ROCm major/minor wildcard."""
-    rewritten = line.replace(old_rocm_version, new_rocm_version)
-    check_version_match = _CHECK_VERSION_RE.search(rewritten)
-    if check_version_match is None:
-        return rewritten
-    if check_version_match.group("version") != new_rocm_version:
-        return rewritten
+    """Rewrite torch _rocm_init.py stable check to a ROCm major/minor wildcard."""
     minor_spec = stable_minor_spec(new_rocm_version)
     if minor_spec is None:
-        return rewritten
-    return (
-        rewritten[: check_version_match.start("version")]
-        + minor_spec
-        + rewritten[check_version_match.end("version") :]
-    )
+        return line.replace(old_rocm_version, new_rocm_version)
+    return line.replace(old_rocm_version, minor_spec)
 
 
 def update_metadata_rocm_requires_dist(
@@ -394,8 +381,9 @@ def update_metadata_rocm_requires_dist(
             inplace=True,
         ) as f:
             for line in f:
+                lower_line = line.casefold()
                 if line.startswith("Summary:") and (
-                    "TheRock" in line or "rocm" in line
+                    "therock" in lower_line or "rocm" in lower_line
                 ):
                     print(
                         rewrite_metadata_rocm_line(
@@ -930,8 +918,8 @@ def wheel_change_extra_files(
     new_dir_path: pathlib.Path,
     old_version: Version,
     new_version: Version,
+    dest_version: str,
     multi_arch_targets: list[str] | None = None,
-    dest_version: str = "release",
 ) -> None:
     # Always run the keep-list pass when archs are requested; do this *before*
     # version rewrites so the version replacement sees a consistent file
@@ -998,6 +986,7 @@ def wheel_change_extra_files(
         files_to_change = [
             new_dir_path / package_name_no_version / "_dist_info.py",
         ]
+        files_to_float = []
 
         if new_dir_path.name.startswith("rocm_sdk_core"):
             files_to_change.append(
@@ -1010,13 +999,19 @@ def wheel_change_extra_files(
     # only torch and NOT triton, torchaudio, torchvision
     elif "torch" == package_name_no_version:
         files_to_change = [
-            new_dir_path / package_name_no_version / "_rocm_init.py",
             new_dir_path / package_name_no_version / "version.py",
         ]
+        files_to_float = [
+            new_dir_path / package_name_no_version / "_rocm_init.py",
+        ]
+        if not float_rocm_dependency_patch:
+            files_to_change.extend(files_to_float)
+            files_to_float = []
     elif "apex" in package_name_no_version:
         files_to_change = [
             new_dir_path / package_name_no_version / "git_version_info_installed.py",
         ]
+        files_to_float = []
     else:
         # we have multiple packages that have a version.py that needs updating
         need_change_version_py = ["torchaudio", "torchvision", "jaxlib"]
@@ -1024,29 +1019,30 @@ def wheel_change_extra_files(
             files_to_change = [
                 new_dir_path / package_name_no_version / "version.py",
             ]
+            files_to_float = []
         else:
             # no additional (rocm-specific) files needed to be changed that contain the version
             # currently applying to: triton
             return
 
-    for f in files_to_change:
-        print(f"      {f}")
-    with fileinput.input(files=files_to_change, encoding="utf-8", inplace=True) as f:
-        for line in f:
-            print(line.replace(old_rocm_version, new_rocm_version), end="")
+    def rewrite_exact(line: str) -> str:
+        return line.replace(old_rocm_version, new_rocm_version)
 
-    if float_rocm_dependency_patch and "torch" == package_name_no_version:
-        rocm_init_path = new_dir_path / package_name_no_version / "_rocm_init.py"
-        with fileinput.input(
-            files=[rocm_init_path], encoding="utf-8", inplace=True
-        ) as f:
+    def rewrite_rocm_init(line: str) -> str:
+        return rewrite_rocm_init_check_version(line, old_rocm_version, new_rocm_version)
+
+    rewrite_groups = [
+        (files_to_change, rewrite_exact),
+        (files_to_float, rewrite_rocm_init),
+    ]
+    for files, rewrite_line in rewrite_groups:
+        if not files:
+            continue
+        for f in files:
+            print(f"      {f}")
+        with fileinput.input(files=files, encoding="utf-8", inplace=True) as f:
             for line in f:
-                print(
-                    rewrite_rocm_init_check_version(
-                        line, old_rocm_version, new_rocm_version
-                    ),
-                    end="",
-                )
+                print(rewrite_line(line), end="")
 
     print("    ...done")
 

--- a/build_tools/packaging/tests/promote_keep_list_test.py
+++ b/build_tools/packaging/tests/promote_keep_list_test.py
@@ -21,6 +21,7 @@ import unittest
 from pathlib import Path
 
 from packaging.metadata import Metadata
+from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
@@ -289,12 +290,12 @@ class ApplyKeepListToMetadataTest(unittest.TestCase):
             )
         self.assertIn("Requires-Dist: rocm-bootstrap", result)
         self.assertIn(
-            "Requires-Dist: rocm[libraries]==7.13.*\n"
-            "Requires-Dist: rocm-sdk-core==7.13.*\n",
+            "Requires-Dist: rocm[libraries]~=7.13.0\n"
+            "Requires-Dist: rocm-sdk-core~=7.13.0\n",
             result,
         )
         self.assertIn(
-            'Requires-Dist: ROCm-SDK-Core == 7.13.*; extra == "core"',
+            'Requires-Dist: ROCm-SDK-Core ~= 7.13.0; extra == "core"',
             result,
         )
         self.assertIn(
@@ -303,6 +304,16 @@ class ApplyKeepListToMetadataTest(unittest.TestCase):
         )
         self.assertNotIn("rocm-sdk-core==7.13.0\n", result)
         Metadata.from_email(result, validate=True)
+
+    def test_stable_patch_compatible_spec_rejects_earlier_patch(self):
+        specifier_text = ptf.stable_patch_compatible_spec("7.13.1")
+        self.assertEqual(specifier_text, "~=7.13.1")
+        assert specifier_text is not None
+        specifier = SpecifierSet(specifier_text)
+        self.assertNotIn(Version("7.13.0"), specifier)
+        self.assertIn(Version("7.13.1"), specifier)
+        self.assertIn(Version("7.13.2"), specifier)
+        self.assertNotIn(Version("7.14.0"), specifier)
 
     def test_non_rocm_dependency_is_not_rewritten(self):
         body = """\

--- a/build_tools/packaging/tests/promote_keep_list_test.py
+++ b/build_tools/packaging/tests/promote_keep_list_test.py
@@ -20,6 +20,7 @@ import textwrap
 import unittest
 from pathlib import Path
 
+from packaging.metadata import Metadata
 from packaging.version import Version
 
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
@@ -244,6 +245,7 @@ class ApplyKeepListToMetadataTest(unittest.TestCase):
             .replace(
                 "Requires-Dist: rocm-bootstrap\n",
                 "Requires-Dist: rocm-bootstrap\n"
+                "Requires-Dist: rocm[libraries]==7.13.0a20260505\n"
                 "Requires-Dist: rocm-sdk-core==7.13.0a20260505\n",
                 1,
             )
@@ -286,7 +288,11 @@ class ApplyKeepListToMetadataTest(unittest.TestCase):
                 (torch_dir / "version.py").read_text(encoding="utf-8"),
             )
         self.assertIn("Requires-Dist: rocm-bootstrap", result)
-        self.assertIn("Requires-Dist: rocm-sdk-core==7.13.*", result)
+        self.assertIn(
+            "Requires-Dist: rocm[libraries]==7.13.*\n"
+            "Requires-Dist: rocm-sdk-core==7.13.*\n",
+            result,
+        )
         self.assertIn(
             'Requires-Dist: ROCm-SDK-Core == 7.13.*; extra == "core"',
             result,
@@ -296,6 +302,24 @@ class ApplyKeepListToMetadataTest(unittest.TestCase):
             result,
         )
         self.assertNotIn("rocm-sdk-core==7.13.0\n", result)
+        Metadata.from_email(result, validate=True)
+
+    def test_non_rocm_dependency_is_not_rewritten(self):
+        body = """\
+Metadata-Version: 2.2
+Name: torch
+Version: 2.8.0+rocm7.13.0
+Requires-Dist: unrelated==7.13.0a20260505
+"""
+        result = self._apply_version_rewrite(
+            body,
+            "torch",
+            "2.8.0+rocm7.13.0",
+            "7.13.0a20260505",
+            "7.13.0",
+            float_rocm_dependency_patch=True,
+        )
+        self.assertEqual(result, textwrap.dedent(body))
 
     def test_compound_rocm_dependency_specifier_does_not_float(self):
         body = """\

--- a/build_tools/packaging/tests/promote_keep_list_test.py
+++ b/build_tools/packaging/tests/promote_keep_list_test.py
@@ -20,6 +20,8 @@ import textwrap
 import unittest
 from pathlib import Path
 
+from packaging.version import Version
+
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 import promote_packages as ptf
 
@@ -252,14 +254,37 @@ class ApplyKeepListToMetadataTest(unittest.TestCase):
                 1,
             )
         )
-        result = self._apply_version_rewrite(
-            body,
-            "torch",
-            "2.8.0+rocm7.13.0",
-            "7.13.0a20260505",
-            "7.13.0",
-            float_rocm_dependency_patch=True,
-        )
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "torch-2.8.0+rocm7.13.0"
+            torch_dir = root / "torch"
+            dist_info = root / "torch-2.8.0+rocm7.13.0a20260505.dist-info"
+            torch_dir.mkdir(parents=True)
+            dist_info.mkdir()
+            (torch_dir / "_rocm_init.py").write_text(
+                "check_version='7.13.0a20260505')\n", encoding="utf-8"
+            )
+            (torch_dir / "version.py").write_text(
+                "__version__ = '2.8.0+rocm7.13.0a20260505'\n",
+                encoding="utf-8",
+            )
+            (dist_info / "METADATA").write_text(body, encoding="utf-8")
+
+            ptf.wheel_change_extra_files(
+                root,
+                Version("2.8.0+rocm7.13.0a20260505"),
+                Version("2.8.0+rocm7.13.0"),
+                dest_version="release",
+            )
+
+            result = (dist_info / "METADATA").read_text(encoding="utf-8")
+            self.assertIn(
+                "check_version='7.13.*'",
+                (torch_dir / "_rocm_init.py").read_text(encoding="utf-8"),
+            )
+            self.assertIn(
+                "__version__ = '2.8.0+rocm7.13.0'",
+                (torch_dir / "version.py").read_text(encoding="utf-8"),
+            )
         self.assertIn("Requires-Dist: rocm-bootstrap", result)
         self.assertIn("Requires-Dist: rocm-sdk-core==7.13.*", result)
         self.assertIn(
@@ -327,6 +352,14 @@ Requires-Dist: rocm-sdk-core==7.13.0a20260505
         )
         self.assertIn("Requires-Dist: rocm-sdk-core==7.13.0rc1", result)
         self.assertNotIn("==7.13.*", result)
+        self.assertEqual(
+            ptf.rewrite_rocm_init_check_version(
+                "check_version='7.13.0a20260505')\n",
+                "7.13.0a20260505",
+                "7.13.0rc1",
+            ),
+            "check_version='7.13.0rc1')\n",
+        )
 
     def test_rocm_package_dependency_stays_exact_when_floating_disabled(self):
         result = self._apply_version_rewrite(

--- a/build_tools/packaging/tests/promote_keep_list_test.py
+++ b/build_tools/packaging/tests/promote_keep_list_test.py
@@ -159,6 +159,32 @@ class ApplyKeepListToMetadataTest(unittest.TestCase):
         finally:
             path.unlink()
 
+    def _apply_version_rewrite(
+        self,
+        body: str,
+        package_name: str,
+        old_version: str,
+        old_rocm_version: str,
+        new_rocm_version: str,
+        *,
+        float_rocm_dependency_patch: bool,
+    ) -> str:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            dist_info = root / f"{package_name}-{old_version}.dist-info"
+            dist_info.mkdir()
+            metadata = dist_info / "METADATA"
+            metadata.write_text(textwrap.dedent(body), encoding="utf-8")
+            ptf.update_metadata_rocm_requires_dist(
+                root,
+                package_name,
+                old_version,
+                old_rocm_version,
+                new_rocm_version,
+                float_rocm_dependency_patch=float_rocm_dependency_patch,
+            )
+            return metadata.read_text(encoding="utf-8")
+
     def test_drops_non_kept_extras_and_requires(self):
         # Torch body: multi-arch with no bare `extra == "device"` line — pure
         # drop, no repoint.
@@ -209,6 +235,110 @@ class ApplyKeepListToMetadataTest(unittest.TestCase):
             self.assertIn("no overlap", str(cm.exception))
         finally:
             path.unlink()
+
+    def test_stable_torch_rocm_dependency_floats_patch(self):
+        body = (
+            get_multi_arch_metadata_torch_archs_body()
+            .replace(
+                "Requires-Dist: rocm-bootstrap\n",
+                "Requires-Dist: rocm-bootstrap\n"
+                "Requires-Dist: rocm-sdk-core==7.13.0a20260505\n",
+                1,
+            )
+            .replace(
+                "Requires-Dist: rocm-sdk-core==7.13.0a20260505\n",
+                "Requires-Dist: rocm-sdk-core==7.13.0a20260505\n"
+                'Requires-Dist: ROCm-SDK-Core == 7.13.0a20260505; extra == "core"\n',
+                1,
+            )
+        )
+        result = self._apply_version_rewrite(
+            body,
+            "torch",
+            "2.8.0+rocm7.13.0",
+            "7.13.0a20260505",
+            "7.13.0",
+            float_rocm_dependency_patch=True,
+        )
+        self.assertIn("Requires-Dist: rocm-bootstrap", result)
+        self.assertIn("Requires-Dist: rocm-sdk-core==7.13.*", result)
+        self.assertIn(
+            'Requires-Dist: ROCm-SDK-Core == 7.13.*; extra == "core"',
+            result,
+        )
+        self.assertIn(
+            'Requires-Dist: amd-torch-device-gfx1010 == 2.8.0+rocm7.13.0; extra == "device-gfx1010"',
+            result,
+        )
+        self.assertNotIn("rocm-sdk-core==7.13.0\n", result)
+
+    def test_compound_rocm_dependency_specifier_does_not_float(self):
+        body = """\
+Metadata-Version: 2.2
+Name: torch
+Version: 2.8.0+rocm7.13.0
+Requires-Dist: rocm-sdk-core==7.13.0a20260505,!=7.13.0.post1
+"""
+        result = self._apply_version_rewrite(
+            body,
+            "torch",
+            "2.8.0+rocm7.13.0",
+            "7.13.0a20260505",
+            "7.13.0",
+            float_rocm_dependency_patch=True,
+        )
+        self.assertIn(
+            "Requires-Dist: rocm-sdk-core==7.13.0,!=7.13.0.post1",
+            result,
+        )
+        self.assertNotIn("==7.13.*", result)
+
+    def test_malformed_requires_dist_raises_when_floating_enabled(self):
+        body = """\
+Metadata-Version: 2.2
+Name: torch
+Version: 2.8.0+rocm7.13.0
+Requires-Dist: rocm-sdk-core (==7.13.0
+"""
+        with self.assertRaises(ValueError):
+            self._apply_version_rewrite(
+                body,
+                "torch",
+                "2.8.0+rocm7.13.0",
+                "7.13.0a20260505",
+                "7.13.0",
+                float_rocm_dependency_patch=True,
+            )
+
+    def test_torch_rocm_dependency_stays_exact_for_prerelease_promotion(self):
+        body = """\
+Metadata-Version: 2.2
+Name: torch
+Version: 2.8.0+rocm7.13.0rc1
+Requires-Dist: rocm-sdk-core==7.13.0a20260505
+"""
+        result = self._apply_version_rewrite(
+            body,
+            "torch",
+            "2.8.0+rocm7.13.0rc1",
+            "7.13.0a20260505",
+            "7.13.0rc1",
+            float_rocm_dependency_patch=True,
+        )
+        self.assertIn("Requires-Dist: rocm-sdk-core==7.13.0rc1", result)
+        self.assertNotIn("==7.13.*", result)
+
+    def test_rocm_package_dependency_stays_exact_when_floating_disabled(self):
+        result = self._apply_version_rewrite(
+            get_multi_arch_metadata_archs_body(),
+            "rocm",
+            "7.13.0",
+            "7.13.0a20260505",
+            "7.13.0",
+            float_rocm_dependency_patch=False,
+        )
+        self.assertIn("Requires-Dist: rocm-sdk-core==7.13.0", result)
+        self.assertNotIn("==7.13.*", result)
 
 
 class ApplyKeepListToRequiresTxtTest(unittest.TestCase):


### PR DESCRIPTION
## Motivation

Torch wheels currently strictly pin their corresponding ROCm dependencies. This is desirable for development and nightly builds as well as prereleases, but is unnecessarily restrictive for stable releases.

Stable Torch wheels should be able to use later ROCm patch releases on the same major and minor version. For example, a wheel built against ROCm 7.14.0 should allow upgrading to ROCm 7.14.1 without requiring a new Torch package, while a wheel built against ROCm 7.14.1 should not allow downgrading to ROCm 7.14.0.

Closes #7345

## Technical Details

Stable torch wheels keep their exact `+rocmX.Y.Z` artifact identity while their ROCm package dependencies accept later patch releases on the same minor line.

Existing exact stable ROCm `Requires-Dist` pins in Torch-family metadata are changed from `==X.Y.Z` to the PEP 440 compatible-release specifier `~=X.Y.Z`. This is equivalent to `>=X.Y.Z, ==X.Y.*`, allowing later patches without permitting a downgrade below the ROCm version against which the wheel was built.

ROCm package wheels, prerelease promotions, compound specifiers, `rocm-bootstrap`, and Torch-to-Torch dependencies remain exact.
 
The generated `_rocm_init.py` runtime check uses `X.Y.*`. The runtime API supports glob patterns rather than PEP 440 specifiers, so it verifies same-minor compatibility while the package metadata enforces the forward-only lower bound.


## Test Plan

- python build_tools/packaging/tests/promote_keep_list_test.py
- python -m py_compile build_tools/packaging/promote_packages.py \ build_tools/packaging/tests/promote_keep_list_test.py

## Test Result

- Passed: promote_keep_list_test.py (34 tests)
- Passed: py_compile

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.

Generated with Codex