### PR TITLE
fix(package): update rocpd & roctx python versions to include 3.14

### DIFF
--- a/.github/workflows/build_portable_linux_python_packages.yml
+++ b/.github/workflows/build_portable_linux_python_packages.yml
@@ -103,7 +103,7 @@ jobs:
     permissions:
       id-token: write
     container:
-      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:a382085df3ba2419b58aa9051350883a0d0b732a4bc0a4ef60458f8161bb08c6
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64:users-yhui-update-manylinux-sha
     outputs:
       package_find_links_url: ${{ steps.upload.outputs.package_find_links_url }}
       kpack_split: ${{ steps.upload.outputs.kpack_split }}

--- a/.github/workflows/manifest-diff.yml
+++ b/.github/workflows/manifest-diff.yml
@@ -84,7 +84,7 @@ jobs:
       id-token: write
       contents: read
     container:
-      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:a382085df3ba2419b58aa9051350883a0d0b732a4bc0a4ef60458f8161bb08c6
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64:users-yhui-update-manylinux-sha
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
@@ -84,7 +84,7 @@ jobs:
       contents: read
       id-token: write
     container:
-      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:a382085df3ba2419b58aa9051350883a0d0b732a4bc0a4ef60458f8161bb08c6
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64:users-yhui-update-manylinux-sha
     env:
       QUARTZ_REPORTING_WORKFLOW: multi_arch_build_portable_linux_artifacts.yml
       QUARTZ_WORKFLOW_POSTFIX: "- build ROCm artifacts"

--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -187,7 +187,7 @@ jobs:
       id-token: write
       contents: read
     container:
-      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:a382085df3ba2419b58aa9051350883a0d0b732a4bc0a4ef60458f8161bb08c6
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64:users-yhui-update-manylinux-sha
     env:
       PACKAGE_DIST_DIR: ${{ github.workspace }}/output/packages/dist
       optional_build_prod_arguments: ""

--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels_ci.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels_ci.yml
@@ -120,7 +120,7 @@ jobs:
       id-token: write
       contents: read
     container:
-      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:a382085df3ba2419b58aa9051350883a0d0b732a4bc0a4ef60458f8161bb08c6
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64:users-yhui-update-manylinux-sha
     env:
       PACKAGE_DIST_DIR: ${{ github.workspace }}/output/packages/dist
       RELEASE_TYPE: ci

--- a/.github/workflows/multi_arch_build_wsl_rocdxg_artifacts.yml
+++ b/.github/workflows/multi_arch_build_wsl_rocdxg_artifacts.yml
@@ -72,7 +72,7 @@ jobs:
       RELEASE_TYPE: ${{ inputs.release_type }}
       THEROCK_HOST_WORKSPACE: ${{ github.workspace }}
       EXTERNAL_FETCH_SOURCES_ARGS: ${{ inputs.external_repo_config != '' && fromJSON(inputs.external_repo_config).fetch_sources_args || '' }}
-      MANYLINUX_IMAGE: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:a382085df3ba2419b58aa9051350883a0d0b732a4bc0a4ef60458f8161bb08c6
+      MANYLINUX_IMAGE: ghcr.io/rocm/therock_build_manylinux_x86_64:users-yhui-update-manylinux-sha
       # Clean, space-free mount target for the Windows SDK shared include dir
       # inside the container. Avoids the raw "(x86)" path segment that /bin/sh
       # misparses during nested subproject configure.

--- a/build_tools/github_actions/manylinux_config.py
+++ b/build_tools/github_actions/manylinux_config.py
@@ -17,7 +17,8 @@ DIST_PYTHON_EXECUTABLES = (
     "/opt/python/cp310-cp310/bin/python;"
     "/opt/python/cp311-cp311/bin/python;"
     "/opt/python/cp312-cp312/bin/python;"
-    "/opt/python/cp313-cp313/bin/python"
+    "/opt/python/cp313-cp313/bin/python;"
+    "/opt/python-shared/cp314-cp314/bin/python3"
 )
 
 # Python executables with shared libpython, for embedded Python builds (rocgdb)

--- a/build_tools/github_actions/manylinux_config.py
+++ b/build_tools/github_actions/manylinux_config.py
@@ -18,7 +18,7 @@ DIST_PYTHON_EXECUTABLES = (
     "/opt/python/cp311-cp311/bin/python;"
     "/opt/python/cp312-cp312/bin/python;"
     "/opt/python/cp313-cp313/bin/python;"
-    "/opt/python-shared/cp314-cp314/bin/python3"
+    "/opt/python/cp314-cp314/bin/python"
 )
 
 # Python executables with shared libpython, for embedded Python builds (rocgdb)

--- a/build_tools/linux_portable_build.py
+++ b/build_tools/linux_portable_build.py
@@ -145,7 +145,7 @@ def main(argv: list[str]):
     p.add_argument("--docker", default="docker", help="Docker or podman binary")
     p.add_argument(
         "--image",
-        default="ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:a382085df3ba2419b58aa9051350883a0d0b732a4bc0a4ef60458f8161bb08c6",
+        default="ghcr.io/rocm/therock_build_manylinux_x86_64:users-yhui-update-manylinux-sha",
         help="Build docker image",
     )
     p.add_argument(

--- a/external-builds/uccl/build_prod_wheels.py
+++ b/external-builds/uccl/build_prod_wheels.py
@@ -127,7 +127,7 @@ def main(argv: list[str]):
 
     p.add_argument(
         "--image",
-        default="ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:a382085df3ba2419b58aa9051350883a0d0b732a4bc0a4ef60458f8161bb08c6",
+        default="ghcr.io/rocm/therock_build_manylinux_x86_64:users-yhui-update-manylinux-sha",
         help="Base docker image for UCCL's build",
     )
     p.add_argument(

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -99,9 +99,10 @@ if(THEROCK_ENABLE_ROCPROFV3)
   else()
     message(STATUS "Detected Python versions for rocprofiler-sdk python bindings: ${_detected_python_versions}")
     message(STATUS "Python executables: ${_detected_python_executables}")
-    # Join all detected Python versions into a single string separated by semicolons.
+    # Join all detected Python versions/executables into semicolon-separated strings.
     # This is a workaround because therock_cmake_subproject_declare does not support passing lists directly.
     list(JOIN _detected_python_versions "\;" _detected_python_versions_str)
+    list(JOIN _detected_python_executables "\;" _detected_python_executables_str)
   endif()
 
   therock_cmake_subproject_declare(rocprofiler-sdk
@@ -122,6 +123,7 @@ if(THEROCK_ENABLE_ROCPROFV3)
       -DROCM_PATH="${THEROCK_BINARY_DIR}/dist/rocm"
       -DROCPROFILER_BUILD_YAML_CPP=OFF
       -DROCPROFILER_PYTHON_VERSIONS:STRING="${_detected_python_versions_str}"
+      -DROCPROFILER_PYTHON_EXECUTABLES:STRING="${_detected_python_executables_str}"
     CMAKE_INCLUDES
       therock_explicit_finders.cmake
     IGNORE_PACKAGES


### PR DESCRIPTION

## Motivation

In ROCm 7.14 whl and tarballs, rocpd and roctx need to support multiple python versions.  Looks like it's been limited to 3.10-3.13.  When users installed onto Ubuntu 26.04 where the default python version is 3.14, they get an error:

```rocpd --help
Traceback (most recent call last):
  File "/opt/venv/lib/python3.14/site-packages/_rocm_sdk_devel/bin/rocpd", line 74, in <module>
    main()
    ~~~~^^
  File "/opt/venv/lib/python3.14/site-packages/_rocm_sdk_devel/bin/rocpd", line 46, in main
    raise ImportError(
    ...<5 lines>...
    )
ImportError: rocpd not supported for Python version 3.14 (sys.executable='/opt/venv/bin/python3').
rocpd supported python versions: 3.10, 3.11, 3.12, 3.13
```

## Technical Details

Digging into TheRock build, it looks like the python versions used are defined in `DIST_PYTHON_EXECUTABLES`.  However, the manylinux image SHA TheRock is using is slightly old, and only has up to 3.13 in /opt/python.  

To add 3.14, we would need to:
1) Update the manylinux image SHA to something newer, and then update `DIST_PYTHON_EXECUTABLES` or
2) Just use the `/opt/python-shared/cp314-cp314/bin/python3` that rocgdb is using

Opting for 2, to minimize changes. 
We may need an additional rocprofiler-sdk change to make the python 3.14 discoverable since CMake is old in manylinux image.  https://github.com/ROCm/rocm-systems/pull/10198

Addresses ISSUE ID https://github.com/ROCm/TheRock/issues/7398

## Test Plan

Check the build artifacts to see if python3.14 is now usable with rocpd.  There was discussion to add rocpd tests to TheRock, but there are additional issues that need to be resolved, before those tests can be added.  

## Test Result

rocpd should be usable with python 3.14

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
