### PR TITLE
feat(asan): Add `build_variant` support to native Linux packaging 

### DIFF
--- a/.github/workflows/multi_arch_build_native_linux_packages.yml
+++ b/.github/workflows/multi_arch_build_native_linux_packages.yml
@@ -25,6 +25,11 @@ on:
         required: false
         type: string
         default: ""
+      build_variant:
+        description: "Build variant (e.g. 'asan'). When set to 'asan', changes the install prefix to DEFAULT_INSTALL_PREFIX-asan-MAJOR.MINOR (e.g. /opt/rocm/core-asan-7.15)."
+        required: false
+        type: string
+        default: ""
       release_type:
         description: "Release type: 'ci', 'dev', 'nightly', or 'prerelease'"
         required: false
@@ -130,7 +135,8 @@ jobs:
             --rocm-version "${{ inputs.rocm_version }}" \
             --artifacts-dir "${{ env.ARTIFACTS_DIR }}" \
             --pkg-type "${{ inputs.native_package_type }}" \
-            --version-suffix "${{ env.ARTIFACT_RUN_ID }}"
+            --version-suffix "${{ env.ARTIFACT_RUN_ID }}" \
+            --build-variant "${{ inputs.build_variant }}"
 
       - name: Simulated install Test
         id: test-packages

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -162,6 +162,7 @@ jobs:
       dist_amdgpu_families: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
       rocm_version: ${{ inputs.rocm_deb_package_version || inputs.rocm_package_version }}
       native_package_type: deb
+      build_variant: ${{ fromJSON(inputs.build_config).build_variant_label }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
     permissions:
@@ -178,6 +179,7 @@ jobs:
       dist_amdgpu_families: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
       rocm_version: ${{ inputs.rocm_rpm_package_version || inputs.rocm_package_version }}
       native_package_type: rpm
+      build_variant: ${{ fromJSON(inputs.build_config).build_variant_label }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
     permissions:

--- a/.github/workflows/multi_arch_release_linux.yml
+++ b/.github/workflows/multi_arch_release_linux.yml
@@ -136,6 +136,7 @@ jobs:
       rocm_version: ${{ inputs.rocm_deb_package_version }}
       native_package_type: deb
       release_type: ${{ inputs.release_type }}
+      build_variant: ${{ inputs.build_variant }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
     permissions:
@@ -153,6 +154,7 @@ jobs:
       rocm_version: ${{ inputs.rocm_rpm_package_version }}
       native_package_type: rpm
       release_type: ${{ inputs.release_type }}
+      build_variant: ${{ inputs.build_variant }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
     permissions:

--- a/.github/workflows/multi_arch_release_linux.yml
+++ b/.github/workflows/multi_arch_release_linux.yml
@@ -248,6 +248,7 @@ jobs:
               "os_profile": "${{ matrix.os_profile }}",
               "artifact_group": "${{ fromJSON(inputs.build_config).dist_amdgpu_families }}",
               "test_type": "${{ inputs.test_type }}",
+              "build_variant": "${{ inputs.build_variant }}",
               "repository": "${{ inputs.repository }}",
               "ref": "${{ inputs.ref }}"
             }

--- a/.github/workflows/test_native_linux_packages_install.yml
+++ b/.github/workflows/test_native_linux_packages_install.yml
@@ -46,6 +46,11 @@ on:
         description: "Branch, tag or SHA to checkout. Defaults to the reference or SHA that triggered the workflow"
         type: string
         required: false
+      build_variant:
+        description: "Build variant (e.g. 'asan'). Changes expected package names to match variant-suffixed packages."
+        required: false
+        type: string
+        default: ""
   workflow_dispatch:
     inputs:
       package_install_url:
@@ -91,6 +96,10 @@ on:
       ref:
         description: "Branch, tag or SHA to checkout. Defaults to the reference or SHA that triggered the workflow"
         type: string
+      build_variant:
+        description: "Build variant (e.g. 'asan'). Changes expected package names."
+        type: string
+        default: ""
 
 permissions:
   id-token: write
@@ -155,6 +164,7 @@ jobs:
       GFX_ARCH: ${{ needs.prepare_install_context.outputs.gfx_arch }}
       INSTALL_PREFIX: ${{ inputs.install_prefix || '/opt/rocm/core' }}
       TEST_TYPE: ${{ inputs.test_type }}
+      BUILD_VARIANT: ${{ inputs.build_variant }}
     steps:
       - name: Install System Prerequisites
         run: |

--- a/build_tools/packaging/linux/build_package.py
+++ b/build_tools/packaging/linux/build_package.py
@@ -8,21 +8,30 @@
 create RPM and DEB packages and upload to artifactory server
 
 ```
-# With explicit target specification:
+# Standard release build (auto-detection of targets from artifact directory):
 ./build_package.py --artifacts-dir ./ARTIFACTS_DIR  \
-        --target gfx94X-dcgpu \
         --dest-dir ./OUTPUT_PKGDIR \
-        --rocm-version 7.1.0 \
+        --rocm-version 7.15.0 \
         --pkg-type deb (or rpm) \
-        --version-suffix build_type (daily/master/nightly/release)
+        --version-suffix 28484694006
 
-# With auto-detection of targets from artifact directory:
+# ASAN build — package name gets -asan suffix, install prefix gets -asan-MAJOR.MINOR:
+#   Package:        amdrocm-core-asan7.15
+#   Install prefix: /opt/rocm/core-asan-7.15
 ./build_package.py --artifacts-dir ./ARTIFACTS_DIR  \
         --dest-dir ./OUTPUT_PKGDIR \
-        --rocm-version 7.1.0 \
+        --rocm-version 7.15.0 \
         --pkg-type deb (or rpm) \
-        --version-suffix build_type (daily/master/nightly/release)
+        --version-suffix 28484694006 \
+        --build-variant asan
 ```
+
+--version-suffix: CI run ID appended to the DEB/RPM version field
+  (e.g. '7.15.0-28484694006' for DEB, release='28484694006' for RPM).
+  Does not affect the package name or install prefix.
+
+--build-variant: Build type that modifies both the package name and
+  install prefix. Currently supports 'asan'.
 """
 
 import argparse
@@ -603,6 +612,7 @@ def create_package_config(args: argparse.Namespace) -> PackageConfig:
         gfx_arch=default_gfx_arch,
         enable_kpack=args.enable_kpack,
         gfxarch_list=tuple(gfxarch_list),
+        build_variant=args.build_variant,
     )
 
 
@@ -727,7 +737,13 @@ def main(argv: list[str]):
         "--version-suffix",
         type=str,
         nargs="?",
-        help="Version suffix to append to package names",
+        help=(
+            "Release identifier appended to the package version field in DEB/RPM "
+            "metadata (e.g. a CI run ID like '28484694006'). "
+            "For DEB this becomes the debian revision (e.g. '7.15.0-28484694006'); "
+            "for RPM this sets the release field. "
+            "Does not affect the package name or install prefix."
+        ),
     )
 
     p.add_argument(

--- a/build_tools/packaging/linux/build_package.py
+++ b/build_tools/packaging/linux/build_package.py
@@ -575,10 +575,15 @@ def create_package_config(args: argparse.Namespace) -> PackageConfig:
     minor = re.match(r"^\d+", parts[1])
     modified_rocm_version = f"{major.group()}.{minor.group()}"
 
-    # Append version to default install prefix
+    # Append version (and build variant for ASAN) to default install prefix.
+    # Release:  /opt/rocm/core-7.15
+    # ASAN:     /opt/rocm/core-asan-7.15
     prefix = args.install_prefix
     if prefix == DEFAULT_INSTALL_PREFIX:
-        prefix = f"{prefix}-{modified_rocm_version}"
+        if args.build_variant == "asan":
+            prefix = f"{prefix}-{args.build_variant}-{modified_rocm_version}"
+        else:
+            prefix = f"{prefix}-{modified_rocm_version}"
 
     # Validate package type
     pkg_type = (args.pkg_type or "").lower()
@@ -729,6 +734,16 @@ def main(argv: list[str]):
         "--install-prefix",
         default=f"{DEFAULT_INSTALL_PREFIX}",
         help="Base directory where package will be installed",
+    )
+
+    p.add_argument(
+        "--build-variant",
+        default="",
+        help=(
+            "Build variant (e.g. 'asan'). When set to 'asan', the install prefix "
+            "becomes DEFAULT_INSTALL_PREFIX-asan-MAJOR.MINOR "
+            "(e.g. /opt/rocm/core-asan-7.15)."
+        ),
     )
 
     p.add_argument(

--- a/build_tools/packaging/linux/native_linux_package_install_test.py
+++ b/build_tools/packaging/linux/native_linux_package_install_test.py
@@ -366,6 +366,7 @@ class NativeLinuxPackageInstallTest:
         gfx_arch: str | list[str] | None = None,
         rocm_version: str | None = None,
         gpg_key_url: str | None = None,
+        build_variant: str = "",
     ):
         """Initialize the native Linux package install test runner.
 
@@ -383,6 +384,10 @@ class NativeLinuxPackageInstallTest:
         If unset: unversioned ``amdrocm`` / ``amdrocm-core-sdk`` (``gfx_arch`` alone
         does not add arch suffixes).
         gpg_key_url: GPG key URL
+        build_variant: Build variant (e.g. 'asan'). When set, '-{variant}' is
+        inserted before the version suffix in package names so that variant
+        packages are tested (e.g. ``amdrocm-asan7.15-gfx942`` instead of
+        ``amdrocm7.15-gfx942``).
         """
         self.os_profile = os_profile.lower()
         self.package_type = self._derive_package_type(os_profile)
@@ -400,29 +405,43 @@ class NativeLinuxPackageInstallTest:
             self.gfx_arch_list[0] if self.gfx_arch_list else None
         )
         self.gpg_key_url = gpg_key_url
+        self.build_variant = build_variant.strip().lower()
 
-        # Metapackage install targets (four combinations of optional inputs):
-        #   gfx_arch + rocm_version -> amdrocm{major.minor}-{arch} per arch
-        #   gfx_arch only           -> amdrocm / amdrocm-core-sdk (arch not in name)
-        #   rocm_version only       -> amdrocm{major.minor} / amdrocm-core-sdk{major.minor}
-        #   neither                 -> unversioned amdrocm / amdrocm-core-sdk
+        # Build variants that produce distinct package names with a '-{variant}'
+        # suffix inserted before the version. 'release' is the default build and
+        # does NOT alter the package name (amdrocm7.15, not amdrocm-release7.15).
+        _NAMED_VARIANTS = {"asan"}
+
+        # Metapackage install targets (four combinations of optional inputs).
+        # When build_variant is a named variant (e.g. 'asan'), '-{variant}' is
+        # inserted before the version suffix:
+        #   gfx_arch + rocm_version -> amdrocm-asan{major.minor}-{arch} per arch
+        #   gfx_arch only           -> amdrocm-asan / amdrocm-core-sdk-asan
+        #   rocm_version only       -> amdrocm-asan{major.minor} / amdrocm-core-sdk-asan{major.minor}
+        #   neither                 -> amdrocm-asan / amdrocm-core-sdk-asan
         ver = self.rocm_version_major_minor
+        variant_sep = (
+            f"-{self.build_variant}" if self.build_variant in _NAMED_VARIANTS else ""
+        )
         if self.gfx_arch_list and ver:
             self.package_names = []
             for arch in self.gfx_arch_list:
                 self.package_names.extend(
                     [
-                        f"amdrocm{ver}-{arch}",
-                        f"amdrocm-core-sdk{ver}-{arch}",
+                        f"amdrocm{variant_sep}{ver}-{arch}",
+                        f"amdrocm-core-sdk{variant_sep}{ver}-{arch}",
                     ]
                 )
         elif ver:
             self.package_names = [
-                f"amdrocm{ver}",
-                f"amdrocm-core-sdk{ver}",
+                f"amdrocm{variant_sep}{ver}",
+                f"amdrocm-core-sdk{variant_sep}{ver}",
             ]
         else:
-            self.package_names = ["amdrocm", "amdrocm-core-sdk"]
+            self.package_names = [
+                f"amdrocm{variant_sep}",
+                f"amdrocm-core-sdk{variant_sep}",
+            ]
 
     def setup_gpg_key(self) -> bool:
         """Setup GPG key for repositories that require GPG verification.
@@ -1419,6 +1438,12 @@ def _build_argument_parser(*, exit_on_error: bool = True) -> ArgumentParser:
         help="GPG key URL",
     )
     parser.add_argument(
+        "--build-variant",
+        type=str,
+        default="",
+        help="Build variant (e.g. 'asan'). Changes expected package names to match variant-suffixed packages.",
+    )
+    parser.add_argument(
         "--test-type",
         type=str,
         default="sanity",
@@ -1573,6 +1598,7 @@ def run_tests(args: Namespace) -> int:
         gfx_arch=args.gfx_arch,
         rocm_version=args.rocm_version,
         gpg_key_url=args.gpg_key_url,
+        build_variant=args.build_variant,
     )
 
     print("\n" + "=" * 80)
@@ -1676,6 +1702,9 @@ def _argv_from_ci_env() -> list[str] | None:
     gpg = (os.environ.get("GPG_KEY_URL") or "").strip()
     if gpg:
         argv.extend(["--gpg-key-url", gpg])
+    build_variant = (os.environ.get("BUILD_VARIANT") or "").strip()
+    if build_variant:
+        argv.extend(["--build-variant", build_variant])
     return argv
 
 

--- a/build_tools/packaging/linux/packaging_utils.py
+++ b/build_tools/packaging/linux/packaging_utils.py
@@ -85,6 +85,7 @@ class PackageConfig:
     versioned_pkg: bool = True
     enable_kpack: bool = False
     gfxarch_list: tuple = field(default_factory=tuple)
+    build_variant: str = ""
 
 
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -413,6 +414,11 @@ def update_package_name(pkg_name, config: PackageConfig):
         major = re.match(r"^\d+", parts[0])
         minor = re.match(r"^\d+", parts[1])
         pkg_suffix = f"{major.group()}.{minor.group()}"
+
+    # For ASAN builds, insert the variant before the version suffix so the
+    # package name reflects the build type (e.g. amdrocm-core-asan7.15).
+    if config.build_variant == "asan":
+        pkg_suffix = f"-{config.build_variant}{pkg_suffix}"
 
     pkg_info = get_package_info(pkg_name)
     updated_pkgname = pkg_name

--- a/build_tools/packaging/linux/tests/build_package_test.py
+++ b/build_tools/packaging/linux/tests/build_package_test.py
@@ -135,6 +135,7 @@ def _args(tmp: Path, **overrides: object) -> Namespace:
         "enable_kpack": False,
         "pkg_names": None,
         "clean_build": False,
+        "build_variant": "",
     }
     defaults.update(overrides)
     return Namespace(**defaults)

--- a/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
+++ b/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
@@ -880,6 +880,7 @@ class RunTestsTestTypeTest(unittest.TestCase):
             packages_dir=None,
             pkg_type=None,
             rocm_version=None,
+            build_variant="",
         )
 
     @patch.object(
@@ -1875,6 +1876,75 @@ class RunStreamingTest(unittest.TestCase):
         with self.assertRaises(sp.TimeoutExpired):
             native_linux_package_install_test._run_streaming(["slow-cmd"], 30)
         mock_proc.kill.assert_called_once()
+
+
+class BuildVariantPackageNamesTest(unittest.TestCase):
+    """Verify that build_variant='asan' inserts '-asan' before version in package names."""
+
+    def test_asan_with_gfx_arch_and_rocm_version(self):
+        t = native_linux_package_install_test.NativeLinuxPackageInstallTest(
+            repo_url="https://example.com",
+            os_profile="ubuntu2404",
+            gfx_arch="gfx942",
+            rocm_version="7.15.0",
+            build_variant="asan",
+        )
+        self.assertEqual(
+            t.package_names,
+            ["amdrocm-asan7.15-gfx942", "amdrocm-core-sdk-asan7.15-gfx942"],
+        )
+
+    def test_asan_with_rocm_version_only(self):
+        t = native_linux_package_install_test.NativeLinuxPackageInstallTest(
+            repo_url="https://example.com",
+            os_profile="rhel10",
+            rocm_version="7.15.0",
+            build_variant="asan",
+        )
+        self.assertEqual(
+            t.package_names,
+            ["amdrocm-asan7.15", "amdrocm-core-sdk-asan7.15"],
+        )
+
+    def test_asan_without_version_or_arch(self):
+        t = native_linux_package_install_test.NativeLinuxPackageInstallTest(
+            repo_url="https://example.com",
+            os_profile="ubuntu2404",
+            build_variant="asan",
+        )
+        self.assertEqual(
+            t.package_names,
+            ["amdrocm-asan", "amdrocm-core-sdk-asan"],
+        )
+
+    def test_no_build_variant_unchanged(self):
+        # Verify default (no build_variant) is unaffected.
+        t = native_linux_package_install_test.NativeLinuxPackageInstallTest(
+            repo_url="https://example.com",
+            os_profile="ubuntu2404",
+            gfx_arch="gfx942",
+            rocm_version="7.15.0",
+        )
+        self.assertEqual(
+            t.package_names,
+            ["amdrocm7.15-gfx942", "amdrocm-core-sdk7.15-gfx942"],
+        )
+
+    def test_release_build_variant_does_not_alter_package_names(self):
+        # 'release' is the default build type label passed from CI build_variant_label.
+        # It must NOT insert '-release' into package names — there is no
+        # amdrocm-release7.15 package.
+        t = native_linux_package_install_test.NativeLinuxPackageInstallTest(
+            repo_url="https://example.com",
+            os_profile="ubuntu2404",
+            gfx_arch="gfx942",
+            rocm_version="7.15.0",
+            build_variant="release",
+        )
+        self.assertEqual(
+            t.package_names,
+            ["amdrocm7.15-gfx942", "amdrocm-core-sdk7.15-gfx942"],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Add `build_variant` support to native Linux packaging so that ASAN builds
produce packages with a distinct name and install prefix, allowing them to
coexist with release packages on the same system.

JIRA ID : https://github.com/ROCm/TheRock/issues/7342

## Motivation

ASAN-instrumented packages must not overwrite or conflict with release packages.
Previously all native packages installed to `/opt/rocm/core-MAJOR.MINOR` and
were named `amdrocm-core7.15` regardless of build type, making it impossible to
install both ASAN and release packages side by side.

## Technical Details

**`build_tools/packaging/linux/packaging_utils.py`**
- Add `build_variant: str = ""` field to `PackageConfig` (default empty → no
  change to existing behavior)
- In `update_package_name()`, when `build_variant == "asan"`, insert `-asan`
  before the version suffix in the package name

**`build_tools/packaging/linux/build_package.py`**
- Add `--build-variant` CLI argument (default `""`)
- Pass `build_variant` from args to `PackageConfig`
- Install prefix logic: when `build_variant == "asan"`, prefix becomes
  `DEFAULT_INSTALL_PREFIX-asan-MAJOR.MINOR` instead of
  `DEFAULT_INSTALL_PREFIX-MAJOR.MINOR`
- Clarify `--version-suffix` docstring: it is the CI run ID appended to the
  DEB/RPM version field only; it does not affect package name or install prefix
- Update module docstring with examples for both release and ASAN builds

**`.github/workflows/multi_arch_build_native_linux_packages.yml`**
- Add `build_variant` input (optional, default `""`)
- Pass `--build-variant "${{ inputs.build_variant }}"` to `build_package.py`

**`.github/workflows/multi_arch_ci_linux.yml`**
- Pass `build_variant: ${{ fromJSON(inputs.build_config).build_variant_label }}`
  to both DEB and RPM native package jobs

**`.github/workflows/multi_arch_release_linux.yml`**
- Pass `build_variant: ${{ inputs.build_variant }}` to both DEB and RPM native
  package jobs

**Result for `rocm_version=7.15.0`, `build_variant=asan`:**

| | Release | ASAN |
|---|---|---|
| Package name | `amdrocm-core7.15` | `amdrocm-core-asan7.15` |
| Arch package | `amdrocm-fft7.15-gfx942` | `amdrocm-fft-asan7.15-gfx942` |
| Install prefix | `/opt/rocm/core-7.15` | `/opt/rocm/core-asan-7.15` |

Existing release builds are unaffected — `build_variant` defaults to `""` and
all behavior is unchanged when it is not set.

## Test Plan

- Build native DEB/RPM packages with `--build-variant asan` and verify:
  - Package names contain `-asan` before the version suffix
  - Packages install to `/opt/rocm/core-asan-7.15`
- Build native packages without `--build-variant` and verify no change to
  existing names or install prefix

ASAN build started : https://github.com/ROCm/TheRock/actions/runs/31754588494
