### PR TITLE
feat(ci): plumb build_runs_on through release pytorch wheels workflows

### DIFF
--- a/.github/workflows/multi_arch_release_linux.yml
+++ b/.github/workflows/multi_arch_release_linux.yml
@@ -272,7 +272,8 @@ jobs:
               "release_type": "${{ inputs.release_type }}",
               "run_full_pytorch_tests": "${{ inputs.run_full_pytorch_tests }}",
               "ref": "${{ inputs.ref || '' }}",
-              "python_version": "${{ inputs.python_version }}"
+              "python_version": "${{ inputs.python_version }}",
+              "build_runs_on": "${{ fromJSON(inputs.build_config).build_runs_on }}"
             }
 
   trigger_release_jax_wheels:

--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -56,6 +56,10 @@ on:
         description: Run full PyTorch tests after scheduled nightly wheel builds complete.
         type: boolean
         default: false
+      build_runs_on:
+        description: "Build runner label (selected by configure script with weighted distribution)"
+        type: string
+        default: "aws-linux-scale-rocm-prod"
   workflow_dispatch:
     inputs:
       amdgpu_families:
@@ -107,6 +111,10 @@ on:
         description: Run full PyTorch tests after scheduled nightly wheel builds complete.
         type: boolean
         default: false
+      build_runs_on:
+        description: "Build runner label"
+        type: string
+        default: "aws-linux-scale-rocm-prod"
 
 run-name: Release Linux PyTorch Wheels (${{ inputs.release_type }}, ${{ inputs.rocm_version }}, ${{ inputs.amdgpu_families }})
 
@@ -174,6 +182,7 @@ jobs:
       repository: ${{ inputs.repository || github.repository }}
       ref: ${{ inputs.ref }}
       cache_type: ${{ inputs.cache_type }}
+      build_runs_on: ${{ inputs.build_runs_on }}
       # The reusable build workflow dispatches the full PyTorch test suite for
       # each successfully built (nightly, gfx94X-dcgpu, py3.12) ref using that
       # build's own torch_version output (#5777).

--- a/.github/workflows/multi_arch_release_windows.yml
+++ b/.github/workflows/multi_arch_release_windows.yml
@@ -190,7 +190,8 @@ jobs:
               "rocm_package_find_links_url": "${{ needs.build_python_packages.outputs.package_find_links_url }}",
               "release_type": "${{ inputs.release_type }}",
               "ref": "${{ inputs.ref || '' }}",
-              "python_version": "${{ inputs.python_version }}"
+              "python_version": "${{ inputs.python_version }}",
+              "build_runs_on": "${{ fromJSON(inputs.build_config).build_runs_on }}"
             }
 
   notify_quartz_completed:

--- a/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
@@ -52,6 +52,10 @@ on:
         description: "Single Python version to build (empty for full matrix)"
         type: string
         default: ""
+      build_runs_on:
+        description: "Build runner label (selected by configure script with weighted distribution)"
+        type: string
+        default: "aws-windows-scale-rocm-prod"
   workflow_dispatch:
     inputs:
       amdgpu_families:
@@ -99,6 +103,10 @@ on:
         description: "Single Python version to build (empty for full matrix)"
         type: string
         default: ""
+      build_runs_on:
+        description: "Build runner label"
+        type: string
+        default: "aws-windows-scale-rocm-prod"
 
 run-name: Release Windows PyTorch Wheels (${{ inputs.release_type }}, ${{ inputs.rocm_version }}, ${{ inputs.amdgpu_families }})
 
@@ -161,6 +169,7 @@ jobs:
       repository: ${{ inputs.repository || github.repository }}
       ref: ${{ inputs.ref }}
       cache_type: ${{ inputs.cache_type }}
+      build_runs_on: ${{ inputs.build_runs_on }}
 
   notify_quartz_completed:
     if: ${{ always() && vars.NOTIFY_QUARTZ_ENABLED == 'true' }}


### PR DESCRIPTION
Address [PR 7236 feedback](https://github.com/ROCm/TheRock/pull/7236#discussion_r3752469110): plumb the build_runs_on input through both Linux and Windows release pytorch wheels workflows to allow dynamic build runner selection for release builds.

Changes:
- Add build_runs_on input to multi_arch_release_linux_pytorch_wheels.yml
- Add build_runs_on input to multi_arch_release_windows_pytorch_wheels.yml
- Pass build_runs_on from multi_arch_release_linux.yml when triggering pytorch wheels workflow
- Pass build_runs_on from multi_arch_release_windows.yml when triggering pytorch wheels workflow

This ensures consistency with CI workflows and enables weighted runner distribution for release builds.

corresponding rockrel PR: https://github.com/ROCm/rockrel/pull/92
