### PR TITLE
test: validate GITHUB_TOKEN for fetch_sources clone auth

### DIFF
--- a/.github/workflows/test_github_token_clone.yml
+++ b/.github/workflows/test_github_token_clone.yml
@@ -1,0 +1,42 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# Test workflow: validates that GITHUB_TOKEN is sufficient to authenticate
+# git clones in fetch_sources.py without GitHub throttling.
+# Triggered manually via workflow_dispatch. See: ROCm/TheRock#7170
+
+name: Test GITHUB_TOKEN Clone Auth
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test_clone_auth:
+    name: "Test fetch_sources with GITHUB_TOKEN"
+    runs-on: aws-linux-scale-rocm-prod
+    timeout-minutes: 45
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install python deps
+        run: pip install -r requirements.txt
+
+      - name: Adjust git config
+        run: git config fetch.parallel 10
+
+      - name: Configure git to use GITHUB_TOKEN for github.com clones
+        run: |
+          git config --global \
+            url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf \
+            "https://github.com/"
+
+      - name: Fetch sources
+        run: python build_tools/fetch_sources.py --jobs 12 --depth 1

--- a/.github/workflows/test_github_token_clone.yml
+++ b/.github/workflows/test_github_token_clone.yml
@@ -45,3 +45,24 @@ jobs:
 
       - name: Fetch sources
         run: python build_tools/fetch_sources.py --jobs 12 --depth 1
+
+  test_clone_no_auth:
+    name: "Test fetch_sources without GITHUB_TOKEN"
+    runs-on: aws-linux-scale-rocm-prod
+    timeout-minutes: 45
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install python deps
+        run: pip install -r requirements.txt
+
+      - name: Adjust git config
+        run: git config fetch.parallel 10
+
+      - name: Fetch sources
+        run: python build_tools/fetch_sources.py --jobs 12 --depth 1

--- a/.github/workflows/test_github_token_clone.yml
+++ b/.github/workflows/test_github_token_clone.yml
@@ -46,6 +46,35 @@ jobs:
       - name: Fetch sources
         run: python build_tools/fetch_sources.py --jobs 12 --depth 1
 
+  test_pytorch_checkout_auth:
+    name: "Test PyTorch checkout with GITHUB_TOKEN"
+    runs-on: aws-linux-scale-rocm-prod
+    timeout-minutes: 45
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install python deps
+        run: pip install -r requirements.txt
+
+      - name: Configure git to use GITHUB_TOKEN for github.com clones
+        run: |
+          git config --global \
+            url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf \
+            "https://github.com/"
+
+      - name: Checkout PyTorch Source
+        run: |
+          python external-builds/pytorch/pytorch_torch_repo.py checkout \
+            --gitrepo-origin https://github.com/ROCm/pytorch.git \
+            --repo-hashtag release/2.12 \
+            --no-hipify \
+            --no-submodules
+
   test_clone_no_auth:
     name: "Test fetch_sources without GITHUB_TOKEN"
     runs-on: aws-linux-scale-rocm-prod

--- a/.github/workflows/test_github_token_clone.yml
+++ b/.github/workflows/test_github_token_clone.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Configure git to use GITHUB_TOKEN for github.com clones
         run: |
           git config --global \
-            url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf \
+            url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf \
             "https://github.com/"
 
       - name: Fetch sources

--- a/.github/workflows/test_github_token_clone.yml
+++ b/.github/workflows/test_github_token_clone.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Configure git to use GITHUB_TOKEN for github.com clones
         run: |
           git config --global \
-            url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf \
+            url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf \
             "https://github.com/"
 
       - name: Fetch sources

--- a/.github/workflows/test_github_token_clone.yml
+++ b/.github/workflows/test_github_token_clone.yml
@@ -9,6 +9,11 @@ name: Test GITHUB_TOKEN Clone Auth
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/test_github_token_clone.yml"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Test workflow to validate whether the built-in `GITHUB_TOKEN` is sufficient to avoid GitHub throttling on `fetch_sources.py` git clones, as an alternative to a custom GitHub App.

Configures git directly in the workflow (no changes to `fetch_sources.py`):
```yaml
git config --global \
  url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf \
  "https://github.com/"
```

Then runs `fetch_sources.py` unmodified. If the job completes consistently without timeouts, `GITHUB_TOKEN` is sufficient and no custom app is needed.

Related: #7170, #7343

🤖 Generated with [Claude Code](https://claude.com/claude-code)