### PR TITLE
ci: ignore hipMemcpyBatchAsync swap tests on gfx125X-dcgpu (#7268)

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_hiptests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiptests.py
@@ -90,6 +90,9 @@ TEST_TO_IGNORE = {
     "gfx125X-dcgpu": {
         "linux": [
             "Unit_hipGraphAddMemcpyNode1D_Positive_Basic",
+            # ROCM-29275: SDMA COPY_SWAP hangs the GPU on gfx1250 (rocm-systems#9923).
+            "Unit_hipMemcpyBatchAsync_Swap",
+            "Unit_hipMemcpyBatchAsync_P2P_Swap",
         ]
     },
 }


### PR DESCRIPTION
Cherry-picks commit `b63c7cfef4f7ebd86da91859ff2aa596d45e9251` from [ROCm/TheRock#7268](https://github.com/ROCm/TheRock/pull/7268) into `release/bkc/therock-10.1-20260811` for candidate build `10.1.0a20260811`.

**Draft: awaiting Express Train operator review. Do not mark ready or merge until correctness is confirmed.**

JIRA ID : ROCM-29275

## Motivation

Keep the gfx125X-dcgpu HIP test runner from selecting the currently failing `hipMemcpyBatchAsync` swap cases so gfx1250 validation can proceed.

## Technical Details

Carries the source PR unchanged as a single `git cherry-pick -x` commit. This is the TheRock runner-side companion to ROCm/rocm-systems#9923; neither PR has an ordering dependency.

## Test Plan

- Verify the release-branch patch and changed-file set match the source PR.
- Run repository pre-commit hooks on the changed Python file.
- Compile the changed Python source.
- Rely on PR CI for release-branch HIP/TheRock integration coverage.

## Test Result

- Cherry-pick applied without conflicts.
- Stable patch ID and changed-file set match the source PR.
- `git diff --check`, pre-commit, and Python compilation pass locally.
- Hardware/integration validation remains pending PR CI.

## Dependencies and ordering

No mandatory ordering requirements. Companion change: ROCm/rocm-systems#9923.

## Submission Checklist

- [x] Looked over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
- [x] PR is intentionally left in draft for operator review.
