### PR TITLE
ci: gate on KFD IOCTL version in driver/GPU sanity check

### DIFF
--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -129,7 +129,6 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       sanity_component: ${{ steps.configure.outputs.sanity_component }}
-      run_gpu_sanity_check: ${{ steps.configure.outputs.run_gpu_sanity_check }}
       components: ${{ steps.configure.outputs.components }}
       platform: ${{ steps.configure.outputs.platform }}
       shard_arr: ${{ steps.configure.outputs.shard_arr }}
@@ -194,7 +193,7 @@ jobs:
   test_sanity_check:
     name: 'Test Sanity Check'
     needs: configure_test_matrix
-    if: ${{ needs.configure_test_matrix.outputs.run_gpu_sanity_check == 'true' }}
+    if: ${{ fromJSON(needs.configure_test_matrix.outputs.sanity_component).test_runner != '' }}
     uses: './.github/workflows/test_component.yml'
     secrets: inherit
     with:

--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -129,6 +129,7 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       sanity_component: ${{ steps.configure.outputs.sanity_component }}
+      run_gpu_sanity_check: ${{ steps.configure.outputs.run_gpu_sanity_check }}
       components: ${{ steps.configure.outputs.components }}
       platform: ${{ steps.configure.outputs.platform }}
       shard_arr: ${{ steps.configure.outputs.shard_arr }}
@@ -193,6 +194,7 @@ jobs:
   test_sanity_check:
     name: 'Test Sanity Check'
     needs: configure_test_matrix
+    if: ${{ needs.configure_test_matrix.outputs.run_gpu_sanity_check == 'true' }}
     uses: './.github/workflows/test_component.yml'
     secrets: inherit
     with:

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -1179,6 +1179,9 @@ def run():
     gha_set_output(
         {
             "sanity_component": json.dumps(sanity_component),
+            "run_gpu_sanity_check": str(
+                bool(sanity_component and sanity_component.get("test_runner"))
+            ).lower(),
             "components": json.dumps(output_matrix),
             "platform": platform,
         }

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -6,7 +6,9 @@ This script determines what test configurations to run.
 
 Outputs (written to $GITHUB_OUTPUT):
   - sanity_component: JSON object for the sanity component, always present as a
-    prerequisite that must pass before other components are run.
+    prerequisite that must pass before other components are run. The
+    ``test_runner`` field within this object is non-empty only on GPU runners,
+    so callers can gate GPU-only steps on that field.
   - components: JSON array of component configs for the regular test matrix
     (excludes sanity, which is output separately above).
   - platform: lowercase OS name derived from RUNNER_OS.
@@ -1179,9 +1181,6 @@ def run():
     gha_set_output(
         {
             "sanity_component": json.dumps(sanity_component),
-            "run_gpu_sanity_check": str(
-                bool(sanity_component and sanity_component.get("test_runner"))
-            ).lower(),
             "components": json.dumps(output_matrix),
             "platform": platform,
         }

--- a/build_tools/print_driver_gpu_info.py
+++ b/build_tools/print_driver_gpu_info.py
@@ -8,21 +8,43 @@ Sanity check script for CI runners.
 On Linux:
   - run "amd-smi static"
   - run "rocminfo"
+  - report the KFD IOCTL version and warn if outside the range required by rocdbgapi (>= 1.13 and < 2.0)
 
 On Windows:
   - run "hipInfo.exe"
 
-This script prints only raw command output.
+This script always exits 0; the KFD version check is informational only.
 """
 
+import fcntl
 import os
 from pathlib import Path
 import platform
 import shlex
 import shutil
+import struct
 import subprocess
 import sys
-from typing import List, Optional
+from typing import List, Optional, Tuple
+
+
+# AMDKFD_IOC_GET_VERSION = _IOR('K', 0x01, struct { u32 major; u32 minor; })
+# _IOR: direction=0x80, size=8, type='K'=0x4b, nr=0x01 -> 0x80084b01
+_AMDKFD_IOC_GET_VERSION = 0x80084B01
+_KFD_DEVICE = "/dev/kfd"
+_KFD_VERSION_MIN = (1, 13)
+_KFD_VERSION_MAX = (2, 0)  # exclusive
+
+
+def _get_kfd_version() -> Tuple[int, int]:
+    fd = os.open(_KFD_DEVICE, os.O_RDWR)
+    try:
+        buf = bytearray(8)
+        fcntl.ioctl(fd, _AMDKFD_IOC_GET_VERSION, buf)
+        major, minor = struct.unpack("II", buf)
+        return major, minor
+    finally:
+        os.close(fd)
 
 
 def log(*args, **kwargs):
@@ -124,6 +146,23 @@ def run_sanity(os_name: str) -> None:
             args=["-r"],
             extra_command_search_paths=[bin_dir],
         )
+
+        log("\n=== KFD IOCTL version ===")
+        if not os.path.exists(_KFD_DEVICE):
+            log(f"warning: {_KFD_DEVICE} not found — is the AMDGPU driver loaded?")
+        else:
+            try:
+                major, minor = _get_kfd_version()
+                in_range = _KFD_VERSION_MIN <= (major, minor) < _KFD_VERSION_MAX
+                status = "supported" if in_range else "WARNING: NOT supported"
+                log(f"KFD IOCTL version: {major}.{minor} ({status})")
+                log(
+                    f"Required range for rocdbgapi: "
+                    f">= {_KFD_VERSION_MIN[0]}.{_KFD_VERSION_MIN[1]}"
+                    f" and < {_KFD_VERSION_MAX[0]}.{_KFD_VERSION_MAX[1]}"
+                )
+            except OSError as e:
+                log(f"warning: failed to query KFD version: {e}")
 
     log("\n=== End of sanity check ===")
 

--- a/build_tools/print_driver_gpu_info.py
+++ b/build_tools/print_driver_gpu_info.py
@@ -13,7 +13,9 @@ On Linux:
 On Windows:
   - run "hipInfo.exe"
 
-This script always exits 0; the KFD version check is informational only.
+Driver commands (amd-smi, rocminfo, hipInfo) are run with check=True and will
+cause this script to exit non-zero if they fail. The KFD version check is
+informational only and never causes a non-zero exit.
 """
 
 import fcntl

--- a/build_tools/print_driver_gpu_info.py
+++ b/build_tools/print_driver_gpu_info.py
@@ -14,8 +14,9 @@ On Windows:
   - run "hipInfo.exe"
 
 Driver commands (amd-smi, rocminfo, hipInfo) are run with check=True and will
-cause this script to exit non-zero if they fail. The KFD version check is
-informational only and never causes a non-zero exit.
+cause this script to exit non-zero if they fail. The KFD version check also
+causes a non-zero exit when the version is outside the supported range or
+cannot be queried.
 """
 
 import fcntl
@@ -113,7 +114,7 @@ def run_command_with_search(
     log(f"{command}: command not found")
 
 
-def run_sanity(os_name: str) -> None:
+def run_sanity(os_name: str) -> int:
     THIS_SCRIPT_DIR = Path(__file__).resolve().parent
     THEROCK_DIR = THIS_SCRIPT_DIR.parent
     bin_dir = Path(os.getenv("THEROCK_BIN_DIR", THEROCK_DIR / "build" / "bin"))
@@ -151,28 +152,31 @@ def run_sanity(os_name: str) -> None:
 
         log("\n=== KFD IOCTL version ===")
         if not os.path.exists(_KFD_DEVICE):
-            log(f"warning: {_KFD_DEVICE} not found — is the AMDGPU driver loaded?")
-        else:
-            try:
-                major, minor = _get_kfd_version()
-                in_range = _KFD_VERSION_MIN <= (major, minor) < _KFD_VERSION_MAX
-                status = "supported" if in_range else "WARNING: NOT supported"
-                log(f"KFD IOCTL version: {major}.{minor} ({status})")
-                log(
-                    f"Required range for rocdbgapi: "
-                    f">= {_KFD_VERSION_MIN[0]}.{_KFD_VERSION_MIN[1]}"
-                    f" and < {_KFD_VERSION_MAX[0]}.{_KFD_VERSION_MAX[1]}"
-                )
-            except OSError as e:
-                log(f"warning: failed to query KFD version: {e}")
+            log(f"error: {_KFD_DEVICE} not found — is the AMDGPU driver loaded?")
+            return 1
+        try:
+            major, minor = _get_kfd_version()
+            in_range = _KFD_VERSION_MIN <= (major, minor) < _KFD_VERSION_MAX
+            status = "supported" if in_range else "NOT supported"
+            log(f"KFD IOCTL version: {major}.{minor} ({status})")
+            log(
+                f"Required range for rocdbgapi: "
+                f">= {_KFD_VERSION_MIN[0]}.{_KFD_VERSION_MIN[1]}"
+                f" and < {_KFD_VERSION_MAX[0]}.{_KFD_VERSION_MAX[1]}"
+            )
+            if not in_range:
+                return 1
+        except OSError as e:
+            log(f"error: failed to query KFD version: {e}")
+            return 1
 
     log("\n=== End of sanity check ===")
+    return 0
 
 
 def main(argv: Optional[List[str]] = None) -> int:
     detected = platform.system()
-    run_sanity(detected)
-    return 0
+    return run_sanity(detected)
 
 
 if __name__ == "__main__":

--- a/build_tools/print_driver_gpu_info.py
+++ b/build_tools/print_driver_gpu_info.py
@@ -15,8 +15,9 @@ On Windows:
 
 Driver commands (amd-smi, rocminfo, hipInfo) are run with check=True and will
 cause this script to exit non-zero if they fail. The KFD version check also
-causes a non-zero exit when the version is outside the supported range or
-cannot be queried.
+causes a non-zero exit when the version is below the supported minimum or
+cannot be queried. A version above the supported maximum produces a warning
+but does not fail.
 """
 
 import fcntl
@@ -156,15 +157,21 @@ def run_sanity(os_name: str) -> int:
             return 1
         try:
             major, minor = _get_kfd_version()
-            in_range = _KFD_VERSION_MIN <= (major, minor) < _KFD_VERSION_MAX
-            status = "supported" if in_range else "NOT supported"
+            too_old = (major, minor) < _KFD_VERSION_MIN
+            too_new = (major, minor) >= _KFD_VERSION_MAX
+            if too_old:
+                status = "NOT supported (too old)"
+            elif too_new:
+                status = "NOT supported (warning: newer than tested range)"
+            else:
+                status = "supported"
             log(f"KFD IOCTL version: {major}.{minor} ({status})")
             log(
                 f"Required range for rocdbgapi: "
                 f">= {_KFD_VERSION_MIN[0]}.{_KFD_VERSION_MIN[1]}"
                 f" and < {_KFD_VERSION_MAX[0]}.{_KFD_VERSION_MAX[1]}"
             )
-            if not in_range:
+            if too_old:
                 return 1
         except OSError as e:
             log(f"error: failed to query KFD version: {e}")


### PR DESCRIPTION
## Summary

Extends `build_tools/print_driver_gpu_info.py` to query the KFD IOCTL
version from `/dev/kfd` and log it alongside the existing amd-smi and
rocminfo output. The sanity job now exits non-zero when the version falls
below the minimum rocdbgapi requires (>= 1.13), when `/dev/kfd` is
missing, or when the ioctl call fails. A version above the tested ceiling
(>= 2.0) produces a warning in the log but does not block testing, since
it may still work fine in practice.

The `test_sanity_check` job in `test_artifacts.yml` is gated directly
on `fromJSON(sanity_component).test_runner`, removing the separate
`run_gpu_sanity_check` output variable that was introduced in an earlier
iteration of this PR.

## Motivation

CI runs on runners with old KFD drivers (e.g. version 1.6) were producing
a cryptic rocdbgapi failure:

```
rocm-dbgapi: warning: AMD GPU driver's version 1.6 not supported (version must be >= 1.13 and < 2.0)
rocm-debug-agent: error: amd_dbgapi_process_attach(...) failed (rc=-10)
```

Surfacing the KFD version in the existing sanity step makes mismatches
immediately visible in CI logs and blocks further testing on a runner that
would produce misleading results. CPU-only runners are unaffected because
the KFD section only runs on Linux with a GPU runner.

ISSUE ID: N/A
