### PR TITLE
fix(rocjitsu): package hotswap translator dependency

### DIFF
--- a/emulation/CMakeLists.txt
+++ b/emulation/CMakeLists.txt
@@ -21,6 +21,8 @@ if(THEROCK_ENABLE_ROCJITSU)
       -DBUILD_TESTING=${THEROCK_BUILD_TESTING}
     RUNTIME_DEPS
       ${THEROCK_BUNDLED_LIBDRM}
+    INSTALL_RPATH_DIRS
+      lib
   )
 
   therock_cmake_subproject_glob_c_sources(rocjitsu
@@ -69,6 +71,7 @@ if(THEROCK_ENABLE_ROCJITSU_HOTSWAP)
     BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rocjitsu-hotswap"
     CMAKE_ARGS
       -DROCJITSU_HOTSWAP_LIBRARY=${CMAKE_CURRENT_BINARY_DIR}/rocjitsu/dist/lib/libhsa_hotswap_rocjitsu.so
+      -DROCJITSU_HOTSWAP_TRANSLATOR_LIBRARY=${CMAKE_CURRENT_BINARY_DIR}/rocjitsu/dist/lib/librocjitsu_gfx1250_b0_to_a0.so
     BUILD_DEPS
       rocjitsu
   )

--- a/emulation/artifact-rocjitsu-hotswap.toml
+++ b/emulation/artifact-rocjitsu-hotswap.toml
@@ -3,4 +3,5 @@
 default_patterns = false
 include = [
   "lib/libhsa_hotswap_rocjitsu.so",
+  "lib/librocjitsu_gfx1250_b0_to_a0.so*",
 ]

--- a/emulation/rocjitsu-hotswap/CMakeLists.txt
+++ b/emulation/rocjitsu-hotswap/CMakeLists.txt
@@ -13,3 +13,16 @@ if(NOT EXISTS "${ROCJITSU_HOTSWAP_LIBRARY}")
 endif()
 
 install(FILES "${ROCJITSU_HOTSWAP_LIBRARY}" DESTINATION lib)
+
+if(EXISTS "${ROCJITSU_HOTSWAP_TRANSLATOR_LIBRARY}")
+  cmake_path(GET ROCJITSU_HOTSWAP_TRANSLATOR_LIBRARY PARENT_PATH _translator_dir)
+  file(GLOB _translator_libraries
+    "${_translator_dir}/librocjitsu_gfx1250_b0_to_a0.so*"
+  )
+  install(FILES ${_translator_libraries} DESTINATION lib)
+else()
+  message(WARNING
+    "RocJitsu hotswap translator library is not available in this rocm-systems revision: "
+    "${ROCJITSU_HOTSWAP_TRANSLATOR_LIBRARY}"
+  )
+endif()


### PR DESCRIPTION
Package the versioned rocjitsu gfx1250 translator shared library in the rocjitsu-hotswap artifact so the independently installed hook is self-contained. Add the rocjitsu lib directory to the install RPATH so the hook can resolve the adjacent translator at runtime.

Fixes ROCm/rocm-systems#10164