### PR TITLE
[packaging] Package profiler-hub and harden deb build failure handling

### DIFF
--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -563,16 +563,16 @@ def libraries_artifact_filter(target_family: str, an: ArtifactName) -> bool:
 
 def profiler_artifact_filter(an: ArtifactName) -> bool:
     return an.name in [
+        "profiler-hub",
         "rocprofiler-compute",
         "rocprofiler-systems",
     ] and an.component in ["lib", "run"]
 
 
 # File-path allowlist for the rocm-profiler wheel, applied on top of
-# profiler_artifact_filter(). rocprofiler-systems' own ProfilerHub.cmake
-# vendors profiler-hub as a runtime .so dependency (NEEDED libprofiler-hub.so.0);
-# it stages into the same lib/ dir as librocprof-sys* but needs its own glob
-# entry here, or it gets silently dropped from the wheel.
+# profiler_artifact_filter(). librocprof-sys* keeps its NEEDED entry on
+# libprofiler-hub.so.0, but the library now ships in profiler-hub's own
+# artifact, so that name must appear in the filter above as well as here.
 PROFILER_WHEEL_INCLUDES = [
     # rocprofiler-systems
     "bin/rocprof-sys-*",

--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -1583,7 +1583,7 @@
     ],
     "Maintainer": "ROCm Dev Support <rocm-dev.support@amd.com>",
     "Description_Short": "ROCm profiler tools ",
-    "Description_Long": "Contains rocprofiler-sdk, aqlprofile, roctracer and rocprof-trace-decoder",
+    "Description_Long": "Contains rocprofiler-sdk, aqlprofile, roctracer, rocprof-trace-decoder and profiler-hub",
     "Section": "devel",
     "Priority": "optional",
     "Group": "unknown",
@@ -1645,6 +1645,20 @@
             ]
           }
         ]
+      },
+      {
+        "Artifact": "profiler-hub",
+        "Artifact_Subdir": [
+          {
+            "Name": "profiler-hub",
+            "Components": [
+              "lib",
+              "dev",
+              "run",
+              "doc"
+            ]
+          }
+        ]
       }
     ],
     "Gfxarch": "False"
@@ -1669,7 +1683,7 @@
     ],
     "Maintainer": "ROCm Dev Support <rocm-dev.support@amd.com>",
     "Description_Short": "ROCm profiler tools test",
-    "Description_Long": "Contains tests for rocprofiler-compute and rocprofiler-systems",
+    "Description_Long": "Contains tests for rocprofiler-compute, rocprofiler-systems and profiler-hub",
     "Section": "devel",
     "Priority": "optional",
     "Group": "unknown",
@@ -1715,6 +1729,17 @@
         "Artifact_Subdir": [
           {
             "Name": "aqlprofile",
+            "Components": [
+              "test"
+            ]
+          }
+        ]
+      },
+      {
+        "Artifact": "profiler-hub",
+        "Artifact_Subdir": [
+          {
+            "Name": "profiler-hub",
             "Components": [
               "test"
             ]

--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -1683,7 +1683,7 @@
     ],
     "Maintainer": "ROCm Dev Support <rocm-dev.support@amd.com>",
     "Description_Short": "ROCm profiler tools test",
-    "Description_Long": "Contains tests for rocprofiler-compute, rocprofiler-systems and profiler-hub",
+    "Description_Long": "Contains tests for rocprofiler-compute and rocprofiler-systems",
     "Section": "devel",
     "Priority": "optional",
     "Group": "unknown",
@@ -1729,17 +1729,6 @@
         "Artifact_Subdir": [
           {
             "Name": "aqlprofile",
-            "Components": [
-              "test"
-            ]
-          }
-        ]
-      },
-      {
-        "Artifact": "profiler-hub",
-        "Artifact_Subdir": [
-          {
-            "Name": "profiler-hub",
             "Components": [
               "test"
             ]

--- a/build_tools/packaging/linux/template/debian_rules.j2
+++ b/build_tools/packaging/linux/template/debian_rules.j2
@@ -49,6 +49,9 @@ override_dh_installdocs:
 override_dh_shlibdeps:
 	@echo "Skipping dh_shlibdeps"
 
+override_dh_makeshlibs:
+	dh_makeshlibs -X.co
+
 
 override_dh_clean:
 	dh_clean

--- a/build_tools/packaging/linux/tests/build_package_test.py
+++ b/build_tools/packaging/linux/tests/build_package_test.py
@@ -458,7 +458,7 @@ class CreateVersionedDebPackageTest(BuildPackageTestCase):
     def test_rules_file_excludes_code_objects_from_makeshlibs(
         self, _mock_dpkg: object, _mock_move: object
     ) -> None:
-        """Fix B: the rendered ``debian/rules`` must override dh_makeshlibs to skip
+        """The rendered ``debian/rules`` must override dh_makeshlibs to skip
         ``.co`` GPU code objects. hip-tests ships an intentionally-corrupted ELF
         fixture (elf_bad_shoff.co) that dh_makeshlibs cannot parse; without the
         ``-X.co`` exclusion it aborts dpkg-buildpackage for the whole package.

--- a/build_tools/packaging/linux/tests/build_package_test.py
+++ b/build_tools/packaging/linux/tests/build_package_test.py
@@ -302,6 +302,20 @@ def _read_control_file(pkg_name: str, config: PackageConfig) -> str:
     return control_path.read_text(encoding="utf-8")
 
 
+def _rules_path(pkg_name: str, config: PackageConfig) -> Path:
+    """Return path to generated ``debian/rules`` for a versioned DEB build."""
+    updated = update_package_name(pkg_name, replace(config, versioned_pkg=True))
+    return Path(config.dest_dir) / config.pkg_type / updated / "debian" / "rules"
+
+
+def _read_rules_file(pkg_name: str, config: PackageConfig) -> str:
+    """Read generated ``debian/rules`` after validating it was created."""
+    rules_path = _rules_path(pkg_name=pkg_name, config=config)
+    if not rules_path.exists():
+        raise AssertionError(f"Expected rules file was not created: {rules_path}")
+    return rules_path.read_text(encoding="utf-8")
+
+
 def _spec_path(pkg_name: str, config: PackageConfig) -> Path:
     """Return path to generated RPM ``specfile`` for a versioned RPM build."""
     updated = update_package_name(pkg_name, replace(config, versioned_pkg=True))
@@ -438,6 +452,31 @@ class CreateVersionedDebPackageTest(BuildPackageTestCase):
 
         control = _read_control_file(pkg_name=PKG_FFT, config=device_cfg)
         self.assertEqual(_control_field(control, "Package"), FFT_DEVICE_PACKAGE)
+
+    @patch.object(deb_package, "move_packages_to_destination", return_value=[])
+    @patch.object(deb_package, "package_with_dpkg_build")
+    def test_rules_file_excludes_code_objects_from_makeshlibs(
+        self, _mock_dpkg: object, _mock_move: object
+    ) -> None:
+        """Fix B: the rendered ``debian/rules`` must override dh_makeshlibs to skip
+        ``.co`` GPU code objects. hip-tests ships an intentionally-corrupted ELF
+        fixture (elf_bad_shoff.co) that dh_makeshlibs cannot parse; without the
+        ``-X.co`` exclusion it aborts dpkg-buildpackage for the whole package.
+        """
+        cfg = _kpack_config(self.temp_dir)
+        _stage_package_artifacts(
+            pkg_name=PKG_FFT,
+            artifacts_dir=cfg.artifacts_dir,
+            gfx_arch=TEST_GFX_TARGET,
+            enable_kpack=True,
+        )
+        device_cfg = replace(cfg, gfx_arch=TEST_GFX_TARGET)
+
+        deb_package.create_versioned_deb_package(pkg_name=PKG_FFT, config=device_cfg)
+
+        rules = _read_rules_file(pkg_name=PKG_FFT, config=device_cfg)
+        self.assertIn("override_dh_makeshlibs:", rules)
+        self.assertIn("dh_makeshlibs -X.co", rules)
 
     @patch.object(deb_package, "move_packages_to_destination", return_value=[])
     @patch.object(deb_package, "package_with_dpkg_build")

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -348,7 +348,6 @@ if(THEROCK_ENABLE_PROFILER_HUB)
       doc
       lib
       run
-      test
     SUBPROJECT_DEPS
       profiler-hub
   )

--- a/profiler/artifact-profiler-hub.toml
+++ b/profiler/artifact-profiler-hub.toml
@@ -12,4 +12,3 @@ include = [
   "lib/cmake/profiler-hub/**",
 ]
 [components.doc."profiler/profiler-hub/stage"]
-[components.test."profiler/profiler-hub/stage"]

--- a/tests/test_artifact_structure.py
+++ b/tests/test_artifact_structure.py
@@ -74,11 +74,6 @@ KNOWN_UNCOVERED_COMPONENTS: set[tuple[str, str]] = {
     ("hipthreads", "dev"),
     ("hipthreads", "test"),
     ("mirage", "dev"),  # new artifact, no packages yet.
-    ("profiler-hub", "dev"),  # built, not packaged; the follow-on PR removes all five.
-    ("profiler-hub", "doc"),
-    ("profiler-hub", "lib"),
-    ("profiler-hub", "run"),
-    ("profiler-hub", "test"),
     ("rocjitsu", "dev"),  # new artifact, no packages yet.
     ("rocprofiler-systems-examples", "test"),
     ("rocrtst", "lib"),


### PR DESCRIPTION
## JIRA ID

JIRA ID : ROCPDSNA-73

## Motivation

Now that profiler-hub is built and published as its own artifact, it needs to reach users as a
package. This PR adds the profiler-hub entries to the Linux deb/rpm package definition so the
library, headers and tests ship regardless of which consumer is also selected.

Stacked on #7376 for a linear review order; it shares no files with that PR.

This PR holds two concerns, stated up front rather than left for a reviewer to find in the diff:

- The profiler-hub packaging entry itself, which is only `package.json`.
- A generic packaging-robustness change that arrived alongside it and touches
  `build_package.py`, `deb_package.py` and `debian_rules.j2`. This one has nothing to do with
  profiler-hub and it changes failure behaviour for every package TheRock builds, so it deserves
  attention on its own terms. It is here rather than in a separate PR to keep the total number of
  PRs in this stack to four.

## Technical Details

profiler-hub packaging:

- `package.json` adds the `profiler-hub` artifact to `amdrocm-profiler-base` (components `lib`,
  `dev`, `run`, `doc`) and to `amdrocm-profiler-test` (component `test`), and updates the
  `Description_Long` of both packages to name it.

Generic packaging robustness, no profiler-hub content:

- `build_package.py` records a per-package failure and continues the queue instead of aborting on
  the first one, then exits non-zero at the end. Previously one bad package aborted the whole run,
  so a single failure hid every subsequent result.
- `deb_package.py` raises instead of calling `sys.exit`, so the loop above can actually catch the
  failure rather than having the interpreter torn down under it.
- `debian_rules.j2` adds an `override_dh_makeshlibs` that passes `-X.co`. hip-tests deliberately
  ships a corrupted ELF fixture, `elf_bad_shoff.co`, which `dh_makeshlibs` cannot parse; without
  the exclusion it fails the build on a file that is corrupt on purpose. This is cited in the
  accompanying test at `build_tools/packaging/linux/tests/build_package_test.py`.
- `tests/build_package_test.py` covers exactly the three files above.

Out of scope, and stacked above this PR: the `rocm-systems` pin move and the install-consumption
tests.

## Test Plan

- Run the packaging unit suite, `pytest build_tools/packaging/linux/tests/build_package_test.py`.
- Parse `package.json` and confirm the `profiler-hub` artifact resolves to the intended components
  in the intended two packages.
- Run `pre-commit run --files` over all five changed files.

## Test Result

- `pytest build_tools/packaging/linux/tests/build_package_test.py -q`: 33 passed in 1.33s.
- `package.json` parses, and the `profiler-hub` artifact resolves to
  `amdrocm-profiler-base -> [lib, dev, run, doc]` and `amdrocm-profiler-test -> [test]`.
- pre-commit: all applicable hooks passed, including black.

The failure-handling change was separately mutation-tested: three mutations of the new behaviour
were introduced and all three were caught by the accompanying tests.

CI results pending on this PR.

## Submission Checklist

- [x] Looked over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
- [x] Both concerns in this PR are disclosed in Motivation rather than left to the diff.
- [x] The behaviour change to package failure handling is covered by tests.
- [x] Shares no files with the PR below it in the stack or the two above it.
- [x] No submodule pointer is moved by this PR.
