### PR TITLE
[profiler] Advance rocm-systems pin to profiler-hub packaging and ASAN fixes

### DIFF
--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -794,6 +794,14 @@ artifact_deps = ["rocprofiler-sdk", "openmpi"]
 feature_group = "PROFILER"
 disable_platforms = ["windows"]
 
+[artifacts.profiler-hub]
+artifact_group = "profiler-core"
+type = "target-neutral"
+artifact_deps = ["core-runtime", "base", "rocprofiler-sdk", "spdlog", "nlohmann-json"]
+feature_name = "PROFILER_HUB"
+feature_group = "PROFILER"
+disable_platforms = ["windows"]
+
 [artifacts.rocprofiler-systems]
 artifact_group = "profiler-apps"
 type = "target-neutral"

--- a/build_tools/packaging/linux/build_package.py
+++ b/build_tools/packaging/linux/build_package.py
@@ -621,63 +621,56 @@ def run(args: argparse.Namespace):
         print("Error: No packages found to build. Package list is empty.")
         sys.exit(1)
 
-    current_pkg_idx = 0
-    try:
-        built_pkglist = []
-        failed_pkglist = []
+    built_pkglist = []
+    failed_pkglist = []
 
-        for current_pkg_idx, pkg_name in enumerate(pkg_list):
-            print(f"Creating {config.pkg_type} package: {pkg_name}")
+    for current_pkg_idx, pkg_name in enumerate(pkg_list):
+        print(f"Creating {config.pkg_type} package: {pkg_name}")
 
+        try:
             # Build all package variants for this package
             output_list = build_package_variants(pkg_name, config)
-
-            if output_list:
-                built_pkglist.extend(output_list)
-                print(
-                    f"\n✓ Successfully built {len(output_list)} variant(s) for {pkg_name}"
-                )
+        except Exception as e:
+            # A single package's failure (e.g. dpkg-buildpackage erroring out)
+            # must not prevent the remaining queued packages from being
+            # attempted. Record it and continue to the next package.
+            tb = traceback.extract_tb(sys.exc_info()[2])
+            if tb:
+                filename, line_no, func, text = tb[-1]
+                print(f"\n✗ {pkg_name} failed at {filename}:{line_no}: {e}")
             else:
-                # Package failed to build
-                failed_pkglist.append(pkg_name)
-                print(f"\n✗ Failed to build any variants for {pkg_name}")
+                print(f"\n✗ {pkg_name} failed: {e}")
+            failed_pkglist.append(pkg_name)
+            continue
 
-        # Clean the build directories
-        cleanup_packaging_environment(config)
-
-        if built_pkglist:
-            print(f"\nBuilt packages: {built_pkglist}")
-
-        pkglist_status = PackageList(
-            total=pkg_list,
-            built=built_pkglist,
-            skipped=skipped_list,
-            failed=failed_pkglist,
-        )
-
-        # Print build summary
-        print_build_summary(config, pkglist_status)
-    except SystemExit as e:
-        # Build aborted somewhere inside create_* functions
-        tb = traceback.extract_tb(sys.exc_info()[2])
-        if tb:
-            filename, line_no, func, text = tb[-1]
-            print(f"\n❌ Build aborted due to an error at {filename}:{line_no}: {e}\n")
+        if output_list:
+            built_pkglist.extend(output_list)
+            print(
+                f"\n✓ Successfully built {len(output_list)} variant(s) for {pkg_name}"
+            )
         else:
-            print(f"\n❌ Build aborted due to an error: {e}\n")
-        # Record failed package and all pending packages
-        failed_pkglist.append(pkg_list[current_pkg_idx])
-        pending_pkgs = pkg_list[current_pkg_idx + 1 :]
-        failed_pkglist.extend(pending_pkgs)
-        pkglist_status = PackageList(
-            total=pkg_list,
-            built=built_pkglist,
-            skipped=skipped_list,
-            failed=failed_pkglist,
-        )
-        print_build_summary(config, pkglist_status)
-        # Stop the program
-        raise
+            # Package failed to build
+            failed_pkglist.append(pkg_name)
+            print(f"\n✗ Failed to build any variants for {pkg_name}")
+
+    # Clean the build directories
+    cleanup_packaging_environment(config)
+
+    if built_pkglist:
+        print(f"\nBuilt packages: {built_pkglist}")
+
+    pkglist_status = PackageList(
+        total=pkg_list,
+        built=built_pkglist,
+        skipped=skipped_list,
+        failed=failed_pkglist,
+    )
+
+    # Print build summary
+    print_build_summary(config, pkglist_status)
+
+    if failed_pkglist:
+        sys.exit(1)
 
 
 def main(argv: list[str]):

--- a/build_tools/packaging/linux/deb_package.py
+++ b/build_tools/packaging/linux/deb_package.py
@@ -466,4 +466,7 @@ def package_with_dpkg_build(pkg_dir):
         print(f"Deb Package built successfully: {os.path.basename(pkg_dir)}")
     except subprocess.CalledProcessError as e:
         print(f"Error building deb package: {os.path.basename(pkg_dir)}: {e}")
-        sys.exit(e.returncode)
+        # Re-raise (rather than sys.exit) so the per-package loop in
+        # build_package.py can catch this, record the failure, and continue
+        # on to the remaining queued packages instead of aborting the whole run.
+        raise

--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -1583,7 +1583,7 @@
     ],
     "Maintainer": "ROCm Dev Support <rocm-dev.support@amd.com>",
     "Description_Short": "ROCm profiler tools ",
-    "Description_Long": "Contains rocprofiler-sdk, aqlprofile, roctracer and rocprof-trace-decoder",
+    "Description_Long": "Contains rocprofiler-sdk, aqlprofile, roctracer, rocprof-trace-decoder and profiler-hub",
     "Section": "devel",
     "Priority": "optional",
     "Group": "unknown",
@@ -1645,6 +1645,20 @@
             ]
           }
         ]
+      },
+      {
+        "Artifact": "profiler-hub",
+        "Artifact_Subdir": [
+          {
+            "Name": "profiler-hub",
+            "Components": [
+              "lib",
+              "dev",
+              "run",
+              "doc"
+            ]
+          }
+        ]
       }
     ],
     "Gfxarch": "False"
@@ -1669,7 +1683,7 @@
     ],
     "Maintainer": "ROCm Dev Support <rocm-dev.support@amd.com>",
     "Description_Short": "ROCm profiler tools test",
-    "Description_Long": "Contains tests for rocprofiler-compute and rocprofiler-systems",
+    "Description_Long": "Contains tests for rocprofiler-compute, rocprofiler-systems and profiler-hub",
     "Section": "devel",
     "Priority": "optional",
     "Group": "unknown",
@@ -1715,6 +1729,17 @@
         "Artifact_Subdir": [
           {
             "Name": "aqlprofile",
+            "Components": [
+              "test"
+            ]
+          }
+        ]
+      },
+      {
+        "Artifact": "profiler-hub",
+        "Artifact_Subdir": [
+          {
+            "Name": "profiler-hub",
             "Components": [
               "test"
             ]

--- a/build_tools/packaging/linux/template/debian_rules.j2
+++ b/build_tools/packaging/linux/template/debian_rules.j2
@@ -49,6 +49,9 @@ override_dh_installdocs:
 override_dh_shlibdeps:
 	@echo "Skipping dh_shlibdeps"
 
+override_dh_makeshlibs:
+	dh_makeshlibs -X.co
+
 
 override_dh_clean:
 	dh_clean

--- a/build_tools/packaging/linux/tests/build_package_test.py
+++ b/build_tools/packaging/linux/tests/build_package_test.py
@@ -18,8 +18,11 @@ Run::
 Requires Python 3.10+ (``packaging_utils`` type syntax).
 """
 
+import contextlib
 import importlib.util
+import io
 import json
+import subprocess
 import sys
 import tempfile
 import types
@@ -59,6 +62,18 @@ DEVELOPER_TOOLS_PACKAGE = "amdrocm-developer-tools7.1"
 
 STAGING_PAYLOAD_NAME = "libdummy.so"
 STAGING_PAYLOAD_BYTES = b"\x00"
+
+# Fixtures for the run() catch-and-continue loop (Fix B). parse_input_package_list
+# is mocked in those tests, so these names are arbitrary queue entries, not real
+# package.json packages. Each "built variant" mimics a create_*_package output path.
+LOOP_PKG_1 = "pkg-alpha"
+LOOP_PKG_2 = "pkg-beta"
+LOOP_PKG_3 = "pkg-gamma"
+LOOP_VARIANT_1 = "pkg-alpha7.1_amd64.deb"
+LOOP_VARIANT_2 = "pkg-beta7.1_amd64.deb"
+LOOP_VARIANT_3 = "pkg-gamma7.1_amd64.deb"
+DPKG_CMD = ["dpkg-buildpackage", "-uc", "-us", "-b"]
+DPKG_RETURNCODE = 2
 
 
 def _setup_import_path() -> None:
@@ -301,6 +316,20 @@ def _read_control_file(pkg_name: str, config: PackageConfig) -> str:
     return control_path.read_text(encoding="utf-8")
 
 
+def _rules_path(pkg_name: str, config: PackageConfig) -> Path:
+    """Return path to generated ``debian/rules`` for a versioned DEB build."""
+    updated = update_package_name(pkg_name, replace(config, versioned_pkg=True))
+    return Path(config.dest_dir) / config.pkg_type / updated / "debian" / "rules"
+
+
+def _read_rules_file(pkg_name: str, config: PackageConfig) -> str:
+    """Read generated ``debian/rules`` after validating it was created."""
+    rules_path = _rules_path(pkg_name=pkg_name, config=config)
+    if not rules_path.exists():
+        raise AssertionError(f"Expected rules file was not created: {rules_path}")
+    return rules_path.read_text(encoding="utf-8")
+
+
 def _spec_path(pkg_name: str, config: PackageConfig) -> Path:
     """Return path to generated RPM ``specfile`` for a versioned RPM build."""
     updated = update_package_name(pkg_name, replace(config, versioned_pkg=True))
@@ -437,6 +466,31 @@ class CreateVersionedDebPackageTest(BuildPackageTestCase):
 
         control = _read_control_file(pkg_name=PKG_FFT, config=device_cfg)
         self.assertEqual(_control_field(control, "Package"), FFT_DEVICE_PACKAGE)
+
+    @patch.object(deb_package, "move_packages_to_destination", return_value=[])
+    @patch.object(deb_package, "package_with_dpkg_build")
+    def test_rules_file_excludes_code_objects_from_makeshlibs(
+        self, _mock_dpkg: object, _mock_move: object
+    ) -> None:
+        """Fix B: the rendered ``debian/rules`` must override dh_makeshlibs to skip
+        ``.co`` GPU code objects. hip-tests ships an intentionally-corrupted ELF
+        fixture (elf_bad_shoff.co) that dh_makeshlibs cannot parse; without the
+        ``-X.co`` exclusion it aborts dpkg-buildpackage for the whole package.
+        """
+        cfg = _kpack_config(self.temp_dir)
+        _stage_package_artifacts(
+            pkg_name=PKG_FFT,
+            artifacts_dir=cfg.artifacts_dir,
+            gfx_arch=TEST_GFX_TARGET,
+            enable_kpack=True,
+        )
+        device_cfg = replace(cfg, gfx_arch=TEST_GFX_TARGET)
+
+        deb_package.create_versioned_deb_package(pkg_name=PKG_FFT, config=device_cfg)
+
+        rules = _read_rules_file(pkg_name=PKG_FFT, config=device_cfg)
+        self.assertIn("override_dh_makeshlibs:", rules)
+        self.assertIn("dh_makeshlibs -X.co", rules)
 
     @patch.object(deb_package, "move_packages_to_destination", return_value=[])
     @patch.object(deb_package, "package_with_dpkg_build")
@@ -702,6 +756,299 @@ class ParseInputPackageListTest(BuildPackageTestCase):
         )
         self.assertEqual(set(pkg_list), {PKG_CORE_SDK, PKG_CK})
         self.assertEqual(skipped, [])
+
+
+# ---------------------------------------------------------------------------
+# Fix B, Layer 1 — deb_package.package_with_dpkg_build re-raises (no sys.exit)
+# ---------------------------------------------------------------------------
+class PackageWithDpkgBuildTest(unittest.TestCase):
+    """``package_with_dpkg_build`` propagates dpkg failures as CalledProcessError.
+
+    Fix B (cc2d0ae0d) changed the ``except`` handler from ``sys.exit(e.returncode)``
+    to ``raise`` so the per-package loop in ``build_package.run`` can catch it and
+    continue instead of the whole run being torn down by an uncaught ``SystemExit``.
+    """
+
+    @patch.object(deb_package.subprocess, "run")
+    def test_dpkg_failure_raises_calledprocesserror_not_systemexit(
+        self, mock_run: object
+    ) -> None:
+        """dpkg-buildpackage failure surfaces as CalledProcessError, never SystemExit.
+
+        This is the exact regression that used to kill the whole packaging queue.
+        assertRaises(CalledProcessError) also proves it is NOT SystemExit: a
+        SystemExit would not be caught here and would fail the test.
+        """
+        mock_run.side_effect = subprocess.CalledProcessError(DPKG_RETURNCODE, DPKG_CMD)
+        with self.assertRaises(subprocess.CalledProcessError) as cm:
+            deb_package.package_with_dpkg_build("/tmp/does-not-matter")
+        self.assertEqual(cm.exception.returncode, DPKG_RETURNCODE)
+
+    @patch.object(deb_package.subprocess, "run")
+    def test_dpkg_success_returns_none_and_prints_success(
+        self, mock_run: object
+    ) -> None:
+        """Success path returns normally (no exception) and prints the success line."""
+        mock_run.return_value = subprocess.CompletedProcess(DPKG_CMD, 0)
+        stream = io.StringIO()
+        with contextlib.redirect_stdout(stream):
+            result = deb_package.package_with_dpkg_build("/tmp/some-pkg")
+        self.assertIsNone(result)
+        self.assertIn("built successfully", stream.getvalue())
+
+
+# ---------------------------------------------------------------------------
+# Fix B, Layer 2 — build_package.run per-package catch-and-continue loop
+# ---------------------------------------------------------------------------
+class RunCatchAndContinueTest(BuildPackageTestCase):
+    """``run`` records per-package failures and continues instead of aborting.
+
+    Fix B replaced the outer ``try/except SystemExit`` (which marked the current
+    AND all not-yet-attempted packages failed, then re-raised) with a per-package
+    ``try/except Exception`` that records the failure and ``continue``s. The build
+    summary always prints, and ``sys.exit(1)`` fires only if any package failed.
+
+    ``parse_input_package_list`` is mocked to control the queue; the filesystem and
+    dpkg are never touched. ``print_build_summary`` receives a ``PackageList`` whose
+    ``built`` / ``failed`` sets are the contract under test.
+    """
+
+    def _run(
+        self,
+        mock_parse: object,
+        mock_variants: object,
+        *,
+        pkg_list: list[str],
+        variants_side_effect: list[object],
+    ) -> None:
+        """Drive ``build_package.run`` with a mocked queue and variant results."""
+        mock_parse.return_value = (pkg_list, [])
+        mock_variants.side_effect = variants_side_effect
+        build_package.run(_args(self.temp_dir))
+
+    @staticmethod
+    def _summary_pkglist(mock_summary: object) -> object:
+        """Return the ``PackageList`` passed to ``print_build_summary``."""
+        assert mock_summary.call_count == 1, "print_build_summary must be called once"
+        return mock_summary.call_args.args[1]
+
+    @staticmethod
+    def _attempted_pkgs(mock_variants: object) -> list[str]:
+        """Return, in order, the package names ``build_package_variants`` was called for."""
+        return [call.args[0] for call in mock_variants.call_args_list]
+
+    @patch.object(build_package, "parse_input_package_list")
+    @patch.object(build_package, "cleanup_packaging_environment")
+    @patch.object(build_package, "print_build_summary")
+    @patch.object(build_package, "build_package_variants")
+    def test_failure_does_not_abort_loop_later_package_still_built(
+        self,
+        mock_variants: object,
+        mock_summary: object,
+        _mock_cleanup: object,
+        mock_parse: object,
+    ) -> None:
+        """pkg#1 raising must not stop pkg#2 from being attempted and built."""
+        with self.assertRaises(SystemExit):
+            self._run(
+                mock_parse,
+                mock_variants,
+                pkg_list=[LOOP_PKG_1, LOOP_PKG_2],
+                variants_side_effect=[RuntimeError("boom"), [LOOP_VARIANT_2]],
+            )
+        self.assertEqual(self._attempted_pkgs(mock_variants), [LOOP_PKG_1, LOOP_PKG_2])
+        status = self._summary_pkglist(mock_summary)
+        self.assertIn(LOOP_VARIANT_2, status.built)
+
+    @patch.object(build_package, "parse_input_package_list")
+    @patch.object(build_package, "cleanup_packaging_environment")
+    @patch.object(build_package, "print_build_summary")
+    @patch.object(build_package, "build_package_variants")
+    def test_raising_package_recorded_as_failed(
+        self,
+        mock_variants: object,
+        mock_summary: object,
+        _mock_cleanup: object,
+        mock_parse: object,
+    ) -> None:
+        """The package whose variants build raised lands in the failed set."""
+        with self.assertRaises(SystemExit):
+            self._run(
+                mock_parse,
+                mock_variants,
+                pkg_list=[LOOP_PKG_1, LOOP_PKG_2],
+                variants_side_effect=[RuntimeError("boom"), [LOOP_VARIANT_2]],
+            )
+        status = self._summary_pkglist(mock_summary)
+        self.assertEqual(status.failed, [LOOP_PKG_1])
+        self.assertEqual(status.built, [LOOP_VARIANT_2])
+
+    @patch.object(build_package, "parse_input_package_list")
+    @patch.object(build_package, "cleanup_packaging_environment")
+    @patch.object(build_package, "print_build_summary")
+    @patch.object(build_package, "build_package_variants")
+    def test_empty_output_list_recorded_as_failed(
+        self,
+        mock_variants: object,
+        mock_summary: object,
+        _mock_cleanup: object,
+        mock_parse: object,
+    ) -> None:
+        """The other failure mode: variants build returns [] (no exception) → failed."""
+        with self.assertRaises(SystemExit):
+            self._run(
+                mock_parse,
+                mock_variants,
+                pkg_list=[LOOP_PKG_1],
+                variants_side_effect=[[]],
+            )
+        status = self._summary_pkglist(mock_summary)
+        self.assertEqual(status.failed, [LOOP_PKG_1])
+        self.assertEqual(status.built, [])
+
+    @patch.object(build_package, "parse_input_package_list")
+    @patch.object(build_package, "cleanup_packaging_environment")
+    @patch.object(build_package, "print_build_summary")
+    @patch.object(build_package, "build_package_variants")
+    def test_exits_with_code_1_when_any_package_failed(
+        self,
+        mock_variants: object,
+        _mock_summary: object,
+        _mock_cleanup: object,
+        mock_parse: object,
+    ) -> None:
+        """run() calls sys.exit(1) when the failed set is non-empty."""
+        with self.assertRaises(SystemExit) as cm:
+            self._run(
+                mock_parse,
+                mock_variants,
+                pkg_list=[LOOP_PKG_1],
+                variants_side_effect=[RuntimeError("boom")],
+            )
+        self.assertEqual(cm.exception.code, 1)
+
+    @patch.object(build_package, "parse_input_package_list")
+    @patch.object(build_package, "cleanup_packaging_environment")
+    @patch.object(build_package, "print_build_summary")
+    @patch.object(build_package, "build_package_variants")
+    def test_no_nonzero_exit_when_all_packages_succeed(
+        self,
+        mock_variants: object,
+        mock_summary: object,
+        _mock_cleanup: object,
+        mock_parse: object,
+    ) -> None:
+        """All-success path returns normally (no SystemExit) with the full built set."""
+        self._run(
+            mock_parse,
+            mock_variants,
+            pkg_list=[LOOP_PKG_1, LOOP_PKG_2],
+            variants_side_effect=[[LOOP_VARIANT_1], [LOOP_VARIANT_2]],
+        )
+        status = self._summary_pkglist(mock_summary)
+        self.assertEqual(status.failed, [])
+        self.assertEqual(status.built, [LOOP_VARIANT_1, LOOP_VARIANT_2])
+
+    @patch.object(build_package, "parse_input_package_list")
+    @patch.object(build_package, "cleanup_packaging_environment")
+    @patch.object(build_package, "print_build_summary")
+    @patch.object(build_package, "build_package_variants")
+    def test_summary_printed_when_all_succeed(
+        self,
+        mock_variants: object,
+        mock_summary: object,
+        _mock_cleanup: object,
+        mock_parse: object,
+    ) -> None:
+        """print_build_summary is called on the all-success path."""
+        self._run(
+            mock_parse,
+            mock_variants,
+            pkg_list=[LOOP_PKG_1],
+            variants_side_effect=[[LOOP_VARIANT_1]],
+        )
+        mock_summary.assert_called_once()
+
+    @patch.object(build_package, "parse_input_package_list")
+    @patch.object(build_package, "cleanup_packaging_environment")
+    @patch.object(build_package, "print_build_summary")
+    @patch.object(build_package, "build_package_variants")
+    def test_summary_printed_when_some_failed(
+        self,
+        mock_variants: object,
+        mock_summary: object,
+        _mock_cleanup: object,
+        mock_parse: object,
+    ) -> None:
+        """Regression: the summary must still print even when a package failed."""
+        with self.assertRaises(SystemExit):
+            self._run(
+                mock_parse,
+                mock_variants,
+                pkg_list=[LOOP_PKG_1],
+                variants_side_effect=[RuntimeError("boom")],
+            )
+        mock_summary.assert_called_once()
+
+    @patch.object(build_package, "parse_input_package_list")
+    @patch.object(build_package, "cleanup_packaging_environment")
+    @patch.object(build_package, "print_build_summary")
+    @patch.object(build_package, "build_package_variants")
+    def test_first_and_last_fail_middle_succeeds_partial_progress(
+        self,
+        mock_variants: object,
+        mock_summary: object,
+        _mock_cleanup: object,
+        mock_parse: object,
+    ) -> None:
+        """Edge: first and last fail, middle succeeds — all three attempted, sets exact."""
+        with self.assertRaises(SystemExit):
+            self._run(
+                mock_parse,
+                mock_variants,
+                pkg_list=[LOOP_PKG_1, LOOP_PKG_2, LOOP_PKG_3],
+                variants_side_effect=[
+                    RuntimeError("boom-1"),
+                    [LOOP_VARIANT_2],
+                    RuntimeError("boom-3"),
+                ],
+            )
+        self.assertEqual(
+            self._attempted_pkgs(mock_variants),
+            [LOOP_PKG_1, LOOP_PKG_2, LOOP_PKG_3],
+        )
+        status = self._summary_pkglist(mock_summary)
+        self.assertEqual(status.built, [LOOP_VARIANT_2])
+        self.assertEqual(status.failed, [LOOP_PKG_1, LOOP_PKG_3])
+
+    @patch.object(build_package, "parse_input_package_list")
+    @patch.object(build_package, "cleanup_packaging_environment")
+    @patch.object(build_package, "print_build_summary")
+    @patch.object(build_package, "build_package_variants")
+    def test_calledprocesserror_from_dpkg_propagates_and_is_caught(
+        self,
+        mock_variants: object,
+        mock_summary: object,
+        _mock_cleanup: object,
+        mock_parse: object,
+    ) -> None:
+        """Cross-layer: a CalledProcessError (what Layer 1 now raises) propagating up
+        through build_package_variants is exactly what run()'s except catches, so the
+        queue continues rather than aborting. Proves the two Fix B changes compose."""
+        with self.assertRaises(SystemExit):
+            self._run(
+                mock_parse,
+                mock_variants,
+                pkg_list=[LOOP_PKG_1, LOOP_PKG_2],
+                variants_side_effect=[
+                    subprocess.CalledProcessError(DPKG_RETURNCODE, DPKG_CMD),
+                    [LOOP_VARIANT_2],
+                ],
+            )
+        self.assertEqual(self._attempted_pkgs(mock_variants), [LOOP_PKG_1, LOOP_PKG_2])
+        status = self._summary_pkglist(mock_summary)
+        self.assertEqual(status.failed, [LOOP_PKG_1])
+        self.assertEqual(status.built, [LOOP_VARIANT_2])
 
 
 if __name__ == "__main__":

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -290,6 +290,70 @@ if(THEROCK_ENABLE_ROCPROFILER_COMPUTE)
 endif(THEROCK_ENABLE_ROCPROFILER_COMPUTE)
 
 ##############################################################################
+# profiler-hub
+# General-purpose, schema-versioned data storage library for profiling and
+# tracing tools, designed to be built and consumed standalone by any tool
+# that needs it.
+##############################################################################
+if(THEROCK_ENABLE_PROFILER_HUB)
+  set(_profiler_hub_build_deps therock-nlohmann-json therock-spdlog therock-fmt)
+  if(THEROCK_BUILD_TESTING)
+    list(APPEND _profiler_hub_build_deps therock-googletest)
+  endif()
+
+  therock_cmake_subproject_declare(profiler-hub
+    # profiler-hub is a pure host C++ library with no GPU/HIP code, so it
+    # does not require any AMDGPU targets to be selected.
+    DISABLE_AMDGPU_TARGETS
+    # Host C++ lib: build with in-tree clang (amd-llvm) so its tests get ASan-linked.
+    COMPILER_TOOLCHAIN amd-llvm
+    EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/profilers/profiler-hub"
+    BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/profiler-hub"
+    BACKGROUND_BUILD
+    CMAKE_ARGS
+      -DPROFILER_HUB_BUILD_TESTS=${THEROCK_BUILD_TESTING}
+      -DPROFILER_HUB_BUILD_BENCHMARKS=OFF
+    CMAKE_INCLUDES
+      therock_explicit_finders.cmake
+    BUILD_DEPS
+      ${_profiler_hub_build_deps}
+    RUNTIME_DEPS
+      rocprofiler-sdk
+      ${THEROCK_BUNDLED_SQLITE3}
+    INTERFACE_INCLUDE_DIRS
+      include
+    INTERFACE_LINK_DIRS
+      lib
+  )
+  therock_cmake_subproject_provide_package(profiler-hub profiler-hub lib/cmake/profiler-hub)
+  therock_cmake_subproject_activate(profiler-hub)
+
+  # Actually run the gtest binary built above instead of only compiling it.
+  therock_cmake_subproject_build_test(profiler-hub
+    COMMAND "${CMAKE_CTEST_COMMAND}" --output-on-failure --no-tests=error
+  )
+
+  therock_test_validate_shared_lib(PATH ${CMAKE_CURRENT_BINARY_DIR}/profiler-hub/dist/lib
+    LIB_NAMES
+      libprofiler-hub.so
+  )
+
+  therock_provide_artifact(profiler-hub
+    TARGET_NEUTRAL
+    DESCRIPTOR artifact-profiler-hub.toml
+    COMPONENTS
+      dbg
+      dev
+      doc
+      lib
+      run
+      test
+    SUBPROJECT_DEPS
+      profiler-hub
+  )
+endif(THEROCK_ENABLE_PROFILER_HUB)
+
+##############################################################################
 # rocprofiler-systems
 ##############################################################################
 if(THEROCK_ENABLE_ROCPROFSYS)
@@ -313,6 +377,16 @@ if(THEROCK_ENABLE_ROCPROFSYS)
     list(JOIN _rocprofsys_detected_python_versions "\;" _ROCPROFSYS_PYTHON_VERSIONS_STR)
     message(STATUS "Detected Python versions for rocprofiler-systems: ${_ROCPROFSYS_PYTHON_VERSIONS_STR}")
     message(STATUS "Detected Python root dirs for rocprofiler-systems: ${_ROCPROFSYS_PYTHON_ROOT_DIRS_STR}")
+  endif()
+
+  # rocprofiler-systems' cmake/ProfilerHub.cmake calls find_package(profiler-hub).
+  # When profiler-hub is built as a super-project subproject, TheRock's dependency
+  # provider requires it to be declared as a dep here; when it is not, find_package
+  # falls back to profiler-hub's own sparse checkout. Only declare the dep when the
+  # profiler-hub subproject actually exists.
+  set(_rocprofsys_profiler_hub_dep "")
+  if(THEROCK_ENABLE_PROFILER_HUB)
+    set(_rocprofsys_profiler_hub_dep profiler-hub)
   endif()
 
   # When libiberty is bundled; otherwise let rocprofiler-systems build its own.
@@ -358,6 +432,7 @@ if(THEROCK_ENABLE_ROCPROFSYS)
       amdsmi
       aqlprofile
       hip-clr
+      ${_rocprofsys_profiler_hub_dep}
       rocprofiler-register
       rocprofiler-sdk
       ${THEROCK_BUNDLED_LIBIBERTY}

--- a/profiler/artifact-profiler-hub.toml
+++ b/profiler/artifact-profiler-hub.toml
@@ -1,0 +1,20 @@
+# profiler-hub
+[components.lib."profiler/profiler-hub/stage"]
+include = [
+  "lib/libprofiler-hub.so*",
+]
+# profiler-hub ships no runtime executables or runtime data files.
+# 'run' has no default include patterns, so it is omitted entirely here
+# rather than declared bare - a bare entry would act as a catch-all and
+# claim the headers/static-lib/cmake files meant for 'dev' (see
+# build_tools/_therock_utils/artifact_builder.py ComponentDefaults("run", ...)).
+# Debug split is handled by the strip step; no extra files belong here.
+[components.dbg."profiler/profiler-hub/stage"]
+[components.dev."profiler/profiler-hub/stage"]
+include = [
+  "include/profiler-hub/**",
+  "lib/libprofiler-hub.a",
+  "lib/cmake/profiler-hub/**",
+]
+[components.doc."profiler/profiler-hub/stage"]
+[components.test."profiler/profiler-hub/stage"]

--- a/test_tools/therock_consumer_graph.json
+++ b/test_tools/therock_consumer_graph.json
@@ -28,6 +28,7 @@
       "kfdtest",
       "libhipcxx",
       "ocl-clr",
+      "profiler-hub",
       "rdc",
       "rocgdb",
       "rocminfo",
@@ -257,6 +258,11 @@
       "hipsparselt"
     ]
   },
+  "profiler-hub": {
+    "consumers": [
+      "rocprofiler-systems"
+    ]
+  },
   "rccl": {
     "consumers": [
       "rccl-tests"
@@ -425,6 +431,7 @@
       "hipblaslt",
       "hipsparselt",
       "miopen",
+      "profiler-hub",
       "rccl",
       "rdc",
       "rocblas",
@@ -596,6 +603,7 @@
     "consumers": [
       "hipblaslt",
       "hipdnn",
+      "profiler-hub",
       "rccl",
       "rocprofiler-systems",
       "rocroller",
@@ -644,6 +652,7 @@
       "miopen",
       "miopenprovider",
       "mxdatagenerator",
+      "profiler-hub",
       "rccl",
       "rocalution",
       "rocblas",
@@ -771,6 +780,7 @@
       "hipkernelprovider",
       "miopen",
       "miopenprovider",
+      "profiler-hub",
       "therock-frugally-deep"
     ]
   },
@@ -796,6 +806,7 @@
     "consumers": [
       "hipblaslt",
       "hipdnn",
+      "profiler-hub",
       "rocprofiler-systems",
       "rocroller"
     ]
@@ -803,6 +814,7 @@
   "therock-sqlite3": {
     "consumers": [
       "miopen",
+      "profiler-hub",
       "rocprofiler-compute",
       "rocprofiler-sdk",
       "rocprofiler-systems",


### PR DESCRIPTION
## JIRA ID

JIRA ID : ROCPDSNA-73

## Motivation

The profiler-hub build and packaging work above this PR needs two fixes that live in
rocm-systems, not in TheRock. This PR moves the `rocm-systems` submodule pointer forward to pick
them up, and does nothing else, so that the pointer move is a deliberate reviewable act rather
than incidental drift folded into a functional change.

Stacked on #7377 for a linear review order; it shares no files with that PR.

This PR is not mergeable as it stands, and is deliberately a draft. See the pin status below.

## Technical Details

- Moves the `rocm-systems` gitlink from `af82d0abb401f1e0bccebdb69d5053371507b6b5` to
  `a181b145190f0b9a73ea8969f34924c1e6e64ab6`. That is the entire diff: one line, one file.
- The target commit carries two things the stack needs. First, the profiler-hub installed CMake
  package config uses a conditional `find_package(spdlog QUIET)` instead of a fatal
  `find_dependency`, so an external project can call
  `find_package(profiler-hub CONFIG REQUIRED)` against an installed tree without spdlog being
  independently discoverable. Second, the profiler-hub unit tests carry the ASAN build fixes for
  the amd-llvm toolchain. Both come from ROCm/rocm-systems#9367.

Pin status, and why this is a draft:

- `a181b145190` is not reachable from rocm-systems `develop`. It sits on
  `users/avansick-amd/6922-rocm-systems-integration`, which merges #9367. A submodule pin must
  point at a landed upstream SHA before it can merge; this one does not yet, because no such
  commit exists until #9367 lands.
- ROCm/rocm-systems#9367 is open and awaiting approval. Once it merges to `develop`, this pin
  must be moved forward to a develop-reachable commit that contains it, and only then can this
  PR come out of draft. Re-pinning is tracked as separate follow-up work.
- Reviewers can review the intent of the move now; please do not merge it in its current state.

## Test Plan

- Confirm the diff against the PR below it in the stack is exactly the `rocm-systems` gitlink and
  nothing else.
- Confirm the target commit is present on the rocm-systems remote, so the gitlink resolves for
  anything that checks out this branch.
- Confirm the reachability claim above rather than asserting it.

## Test Result

- `git diff <base>..HEAD --name-only` returns exactly `rocm-systems`; the numstat is 1 insertion,
  1 deletion.
- `git ls-remote https://github.com/ROCm/rocm-systems.git` shows `a181b145190` at
  `refs/heads/users/avansick-amd/6922-rocm-systems-integration`, so the gitlink resolves against
  the remote.
- The same commit is not reachable from `develop`, which is exactly the condition recorded above
  and the reason this PR is a draft.

CI results pending on this PR. Note that TheRock CI resolves submodules with
`build_tools/fetch_sources.py --depth 1`, which fetches the recorded gitlink rather than a branch
tip; whether a shallow fetch resolves a non-tip SHA on this remote is the first thing this PR's
CI will establish.

## Submission Checklist

- [x] Looked over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
- [x] The submodule pointer move is isolated in its own PR and is the only change.
- [x] The pin is disclosed as not develop-reachable, with the condition for resolving it stated.
- [x] Opened as a draft because it cannot merge in its current state.
- [x] Shares no files with any other PR in the stack.
