### PR TITLE
 fix(feat): Add parallel package building with ProcessPoolExecutor

### DIFF
--- a/build_tools/packaging/linux/build_package.py
+++ b/build_tools/packaging/linux/build_package.py
@@ -812,8 +812,8 @@ def main(argv: list[str]):
         "-j",
         "--parallel",
         type=int,
-        default=os.cpu_count() or 1,
-        help="Number of parallel package builds (default: all available cores)",
+        default=min(8, os.cpu_count() or 1),
+        help="Number of parallel package builds (default: min(8, cpu_count))",
     )
 
     args = p.parse_args(argv)

--- a/build_tools/packaging/linux/build_package.py
+++ b/build_tools/packaging/linux/build_package.py
@@ -44,6 +44,7 @@ import tempfile
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import replace
 from pathlib import Path
+from typing import NamedTuple
 
 # Setup paths
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -68,6 +69,14 @@ logger = TheRockLogger(__name__)
 
 # Default install prefix
 DEFAULT_INSTALL_PREFIX = "/opt/rocm/core"
+
+
+class BuildTask(NamedTuple):
+    """Task for parallel package building via ProcessPoolExecutor."""
+
+    pkg_name: str
+    config: PackageConfig
+    logs_dir: Path
 
 
 def load_kpack_from_manifest(artifacts_dir: Path) -> bool:
@@ -614,33 +623,33 @@ def create_package_config(args: argparse.Namespace) -> PackageConfig:
     )
 
 
-def build_pkg(args):
+def build_pkg(task: BuildTask) -> tuple[str, list[str], str | None]:
     """Build a single package in isolated process. Used by ProcessPoolExecutor."""
-    pkg_name, config, logs_dir = args
-    pkg_log_file = logs_dir / f"{config.pkg_type}-{pkg_name}.log"
-    temp_dir = tempfile.mkdtemp(prefix=f"pkg_{pkg_name}_")
-    try:
-        pkg_config = replace(config, dest_dir=Path(temp_dir))
-        with capture_console(pkg_log_file):
-            output_list = build_package_variants(pkg_name, pkg_config)
-        # Move packages to final dest
-        result = []
-        config.dest_dir.mkdir(parents=True, exist_ok=True)
-        for f in output_list:
-            src = Path(temp_dir) / f
-            if src.exists():
-                dst = config.dest_dir / f
-                shutil.move(str(src), str(dst))
-                result.append(f)
-        return (pkg_name, result, None)
-    except SystemExit as e:
-        logger.error(f"SystemExit: exited with code {e.code}")
-        return (pkg_name, [], f"SystemExit: exited with code {e.code}")
-    except Exception as e:
-        logger.error(f"{type(e).__name__}: {e}")
-        return (pkg_name, [], f"{type(e).__name__}: {e}")
-    finally:
-        shutil.rmtree(temp_dir, ignore_errors=True)
+    pkg_log_file = task.logs_dir / f"{task.config.pkg_type}-{task.pkg_name}.log"
+    with tempfile.TemporaryDirectory(
+        prefix=f"pkg_{task.pkg_name}_", ignore_cleanup_errors=True
+    ) as temp_dir_str:
+        temp_dir = Path(temp_dir_str)
+        try:
+            pkg_config = replace(task.config, dest_dir=temp_dir)
+            with capture_console(pkg_log_file):
+                output_list = build_package_variants(task.pkg_name, pkg_config)
+            # Move packages from temp_dir to final dest_dir.
+            # output_list contains plain filenames (e.g., "amdrocm-core-7.1.1.deb"), not paths.
+            # This is guaranteed by move_packages_to_destination() which appends file_path.name.
+            result: list[str] = []
+            task.config.dest_dir.mkdir(parents=True, exist_ok=True)
+            for f in output_list:
+                src = temp_dir / f
+                if src.exists():
+                    dst = task.config.dest_dir / f
+                    shutil.move(str(src), str(dst))
+                    result.append(f)
+            return (task.pkg_name, result, None)
+        except SystemExit as e:
+            return (task.pkg_name, [], f"SystemExit: exited with code {e.code}")
+        except Exception as e:
+            return (task.pkg_name, [], f"{type(e).__name__}: {e}")
 
 
 def run(args: argparse.Namespace):
@@ -671,7 +680,8 @@ def run(args: argparse.Namespace):
 
     with ProcessPoolExecutor(max_workers=args.parallel) as executor:
         futures = {
-            executor.submit(build_pkg, (pkg, config, logs_dir)): pkg for pkg in pkg_list
+            executor.submit(build_pkg, BuildTask(pkg, config, logs_dir)): pkg
+            for pkg in pkg_list
         }
         for future in as_completed(futures):
             pkg_name = futures[future]

--- a/build_tools/packaging/linux/build_package.py
+++ b/build_tools/packaging/linux/build_package.py
@@ -37,9 +37,11 @@ create RPM and DEB packages and upload to artifactory server
 import argparse
 import json
 import os
+import shutil
 import sys
-import traceback
+import tempfile
 
+from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import replace
 from pathlib import Path
 
@@ -219,7 +221,6 @@ def build_gfxarch_package_variants(pkg_name, config: PackageConfig) -> list:
     if pkg:
         built_packages.extend(pkg)
 
-    cleanup_build_directory(config)
     return built_packages
 
 
@@ -253,7 +254,6 @@ def build_simple_package_variants(pkg_name, config: PackageConfig) -> list:
     if pkg:
         built_packages.extend(pkg)
 
-    cleanup_build_directory(config)
     return built_packages
 
 
@@ -304,7 +304,6 @@ def build_singlearch_package_variants(pkg_name, config: PackageConfig) -> list:
     except Exception as e:
         logger.error(f"Failed to build non-versioned package for {pkg_name}: {e}")
 
-    cleanup_build_directory(config)
     return built_packages
 
 
@@ -439,9 +438,6 @@ def build_nonversioned_package(pkg_name, config: PackageConfig) -> list:
 
 def cleanup_build_directory(config: PackageConfig):
     """Clean up build directory after all package variants are built.
-
-    This should only be called after all variants for a package are complete.
-    Defers cleanup to allow parallel builds of variants in the future.
 
     Parameters:
     config: Configuration object containing dest_dir and pkg_type
@@ -618,6 +614,35 @@ def create_package_config(args: argparse.Namespace) -> PackageConfig:
     )
 
 
+def build_pkg(args):
+    """Build a single package in isolated process. Used by ProcessPoolExecutor."""
+    pkg_name, config, logs_dir = args
+    pkg_log_file = logs_dir / f"{config.pkg_type}-{pkg_name}.log"
+    temp_dir = tempfile.mkdtemp(prefix=f"pkg_{pkg_name}_")
+    try:
+        pkg_config = replace(config, dest_dir=Path(temp_dir))
+        with capture_console(pkg_log_file):
+            output_list = build_package_variants(pkg_name, pkg_config)
+        # Move packages to final dest
+        result = []
+        config.dest_dir.mkdir(parents=True, exist_ok=True)
+        for f in output_list:
+            src = Path(temp_dir) / f
+            if src.exists():
+                dst = config.dest_dir / f
+                shutil.move(str(src), str(dst))
+                result.append(f)
+        return (pkg_name, result, None)
+    except SystemExit as e:
+        logger.error(f"SystemExit: exited with code {e.code}")
+        return (pkg_name, [], f"SystemExit: exited with code {e.code}")
+    except Exception as e:
+        logger.error(f"{type(e).__name__}: {e}")
+        return (pkg_name, [], f"{type(e).__name__}: {e}")
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
 def run(args: argparse.Namespace):
     # Create configuration from arguments
     config = create_package_config(args)
@@ -638,68 +663,52 @@ def run(args: argparse.Namespace):
         logger.error("No packages found to build. Package list is empty.")
         sys.exit(1)
 
-    current_pkg_idx = 0
-    try:
-        built_pkglist = []
-        failed_pkglist = []
+    logs_dir = Path(config.dest_dir) / "logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
 
-        for current_pkg_idx, pkg_name in enumerate(pkg_list):
-            logger.info(f"Creating {config.pkg_type} package: {pkg_name}")
+    built_pkglist = []
+    failed_pkglist = []
 
-            # Build all package variants for this package
-            # Capture per-package logs
-            logs_dir = Path(config.dest_dir) / "logs"
-            logs_dir.mkdir(parents=True, exist_ok=True)
-            pkg_log_file = logs_dir / f"{config.pkg_type}-{pkg_name}.log"
-            with capture_console(pkg_log_file):
-                output_list = build_package_variants(pkg_name, config)
+    with ProcessPoolExecutor(max_workers=args.parallel) as executor:
+        futures = {
+            executor.submit(build_pkg, (pkg, config, logs_dir)): pkg for pkg in pkg_list
+        }
+        for future in as_completed(futures):
+            pkg_name = futures[future]
+            try:
+                _, output_list, error = future.result()
+            except Exception as e:
+                logger.error(f"Package {pkg_name} failed: {e}")
+                failed_pkglist.append(pkg_name)
+                continue
 
-            if output_list:
+            if error:
+                logger.error(f"Package {pkg_name} failed: {error}")
+                failed_pkglist.append(pkg_name)
+            elif output_list:
                 built_pkglist.extend(output_list)
                 logger.info(
                     f"Successfully built {len(output_list)} variant(s) for {pkg_name}"
                 )
             else:
-                # Package failed to build
                 failed_pkglist.append(pkg_name)
                 logger.error(f"Failed to build any variants for {pkg_name}")
 
-        # Clean the build directories
-        cleanup_packaging_environment(config)
+    # Clean the build directories
+    cleanup_packaging_environment(config)
 
-        if built_pkglist:
-            logger.info(f"Built packages: {built_pkglist}")
+    if built_pkglist:
+        logger.info(f"Built packages: {built_pkglist}")
 
-        pkglist_status = PackageList(
-            total=pkg_list,
-            built=built_pkglist,
-            skipped=skipped_list,
-            failed=failed_pkglist,
-        )
+    pkglist_status = PackageList(
+        total=pkg_list,
+        built=built_pkglist,
+        skipped=skipped_list,
+        failed=failed_pkglist,
+    )
 
-        # Print build summary
-        print_build_summary(config, pkglist_status)
-    except SystemExit as e:
-        # Build aborted somewhere inside create_* functions
-        tb = traceback.extract_tb(sys.exc_info()[2])
-        if tb:
-            filename, line_no, func, text = tb[-1]
-            logger.error(f"Build aborted due to an error at {filename}:{line_no}: {e}")
-        else:
-            logger.error(f"Build aborted due to an error: {e}")
-        # Record failed package and all pending packages
-        failed_pkglist.append(pkg_list[current_pkg_idx])
-        pending_pkgs = pkg_list[current_pkg_idx + 1 :]
-        failed_pkglist.extend(pending_pkgs)
-        pkglist_status = PackageList(
-            total=pkg_list,
-            built=built_pkglist,
-            skipped=skipped_list,
-            failed=failed_pkglist,
-        )
-        print_build_summary(config, pkglist_status)
-        # Stop the program
-        raise
+    # Print build summary
+    print_build_summary(config, pkglist_status)
 
 
 def main(argv: list[str]):
@@ -797,6 +806,14 @@ def main(argv: list[str]):
         "--pkg-names",
         nargs="+",
         help="Specify the packages to be created",
+    )
+
+    p.add_argument(
+        "-j",
+        "--parallel",
+        type=int,
+        default=os.cpu_count() or 1,
+        help="Number of parallel package builds (default: all available cores)",
     )
 
     args = p.parse_args(argv)

--- a/build_tools/packaging/linux/rpm_package.py
+++ b/build_tools/packaging/linux/rpm_package.py
@@ -264,7 +264,7 @@ def package_with_rpmbuild(spec_file):
     # Execute the command
     try:
         subprocess.run(cmd, check=True)
-        logger.info(f"RPM Package built successfully: {spec_file.name}\n")
+        logger.info(f"RPM Package built successfully: {spec_file.parent.name}\n")
     except subprocess.CalledProcessError as e:
-        logger.error(f"Error building RPM package: {spec_file.name}: {e}")
+        logger.error(f"Error building RPM package: {spec_file.parent.name}: {e}")
         sys.exit(e.returncode)


### PR DESCRIPTION
   - Introduce -j/--parallel flag to control concurrent builds (defaults to CPU count)
   - Use ProcessPoolExecutor to build packages in parallel processes
   - Isolate each package build in a temporary directory to avoid conflicts
   - Capture per-package logs separately for easier debugging
   - Handle SystemExit and exceptions gracefully in worker processes
   - Fix RPM log message to show package name instead of 'specfile'

   This significantly reduces build time for multi-package runs by utilizing
   all available CPU cores.
   
   JIRA ID: https://github.com/ROCm/TheRock/issues/7381