### PR TITLE
fix(hiptensor): don't build/publish hipTensor on CK-less families to avoid clobbering the real _generic artifact

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -828,8 +828,10 @@ test_matrix = {
             "windows": 1,
         },
         "exclude_family": {
-            # hipTensor does not support gfx103X (see TheRock#2074)
-            "linux": ["gfx1030"],
+            # hipTensor requires composable_kernel, which is filtered out on some platforms,
+            # so no hipTensor test artifact is produced for that family (see TheRock#2074).
+            "linux": ["gfx900", "gfx90c", "gfx906", "gfx101X-all", "gfx103X-all"],
+            "windows": ["gfx900", "gfx90c", "gfx906", "gfx101X-all", "gfx103X-all"],
         },
     },
 }

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -23,6 +23,16 @@ else()
   )
 endif()
 
+# hipTensor is built conditionally to composable_kernel availability (CK is a hard
+# build dependency). _ck_enabled, set by math-libs/CMakeLists.txt, is OFF when
+# CK and hipTensor were filtered out for the selected gfx targets.
+# _hiptensor_available reflect the actual built status so the example does not
+# find_package() a missing hiptensor.
+set(_hiptensor_available OFF)
+if(_ck_enabled AND THEROCK_ENABLE_HIPTENSOR)
+  set(_hiptensor_available ON)
+endif()
+
 # Examples are configured against the installed ROCm prefix. The
 # cpp-sdk-user project requires HIP (LANGUAGES CXX HIP), so skip when
 # HIP is not enabled (e.g. in early multi-arch CI stages) or when
@@ -42,7 +52,7 @@ if(THEROCK_ENABLE_HIP_RUNTIME AND "${THEROCK_SANITIZER}" STREQUAL "")
           "-DTHEROCK_ENABLE_HIPDNN=${THEROCK_ENABLE_HIPDNN}"
           "-DTHEROCK_ENABLE_LIBHIPCXX=${THEROCK_ENABLE_LIBHIPCXX}"
           "-DTHEROCK_ENABLE_MIOPEN=${THEROCK_ENABLE_MIOPEN}"
-          "-DTHEROCK_ENABLE_HIPTENSOR=${THEROCK_ENABLE_HIPTENSOR}"
+          "-DTHEROCK_ENABLE_HIPTENSOR=${_hiptensor_available}"
           "-DTHEROCK_ENABLE_PRIM=${THEROCK_ENABLE_PRIM}"
           "-DTHEROCK_ENABLE_RAND=${THEROCK_ENABLE_RAND}"
           "-DTHEROCK_ENABLE_RCCL=${THEROCK_ENABLE_RCCL}"

--- a/math-libs/CMakeLists.txt
+++ b/math-libs/CMakeLists.txt
@@ -619,16 +619,12 @@ if(_ck_enabled)
   )
 endif()
 
-if(THEROCK_ENABLE_HIPTENSOR)
+# Gate on _ck_enabled so CK-less families don't publish a stub-only hipTensor
+# _generic that would clobber the real library _generic on the shared artifact key.
+if(THEROCK_ENABLE_HIPTENSOR AND _ck_enabled)
   ##############################################################################
   # hipTensor
   ##############################################################################
-
-  # Set composable_kernel as a build dependency only when it's available.
-  set(_hiptensor_build_deps)
-  if(_ck_enabled)
-    list(APPEND _hiptensor_build_deps composable_kernel)
-  endif()
 
   therock_cmake_subproject_declare(hipTensor
     EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/hiptensor"
@@ -648,7 +644,7 @@ if(THEROCK_ENABLE_HIPTENSOR)
     BUILD_DEPS
       rocm-cmake
       therock-googletest
-      ${_hiptensor_build_deps}
+      composable_kernel
     RUNTIME_DEPS
       hip-clr
   )


### PR DESCRIPTION
## Motivation

  hipTensor's Windows test job fails intermittently with `Test directory does not
  exist: build\bin\hiptensor`, and the dist can silently ship a stub `hiptensor.dll`
  that returns `HIPTENSOR_STATUS_NOT_SUPPORTED` for every call.

  Root cause is an artifact packaging race, not a hipTensor bug:

  - `hiptensor` is a `target-specific` artifact bundling `lib+dev+dbg+test`
    (`BUILD_TOPOLOGY.toml`). With split enabled (default), every per-GPU-family Stage
    job splits it into `_generic` + `_gfxNNNN`.
  - The splitter only peels device code into per-arch kpacks; all host files (the
    `bin/hiptensor/` CTest tree, configs, and the host `hiptensor.dll`/`.so`) land in
    `_generic`.
  - Every family uploads `_generic` to a **family-agnostic S3 key**
    (`{run_id}-{platform}/hiptensor_<component>_generic.tar.zst`) with plain
    last-writer-wins semantics.
  - On families where Composable Kernel is filtered out (`_ck_enabled=OFF`:
    gfx900/906/90c, gfx101X, gfx103X), hipTensor is still declared and built — but in
    **stub mode** (`HIPTENSOR_DISABLE_DEVICE` forced ON): no tests, and only a tiny
    host-only stub library.

  So a stub family's near-empty `_generic` can overwrite a real CK-enabled family's.
  Confirmed on run `31757542394` (last writer was gfx103X-all):

  | `_generic` | CK-enabled upload | stub upload | stored on key |
  |---|---|---|---|
  | `hiptensor_test` | 494 files, ~5.6 MB | 1 file, 156 B | **empty stub** |
  | `hiptensor_lib`  | ~65 MB host DLL    | ~12 KB stub DLL | **stub DLL** |

GitHub issue: https://github.com/ROCm/TheRock/issues/7385

## Technical Details

  hipTensor hard-requires Composable Kernel for any real (device + test) build, so a
  CK-less family can only ever produce a stub/empty artifact that no one consumes
  (the consumer graph lists zero consumers of `hiptensor`). Gate the whole subproject
  on `_ck_enabled`, mirroring how `composable_kernel` itself is gated:

  - **`math-libs/CMakeLists.txt`** — change the gate to
    `if(THEROCK_ENABLE_HIPTENSOR AND _ck_enabled)` and drop the now-dead
    `_hiptensor_build_deps` sub-guard (depend on `composable_kernel` directly, since
    it's always available inside the block). CK-less families now neither build nor
    publish hipTensor, so only equivalent CK-enabled families write the shared
    `_generic` key (a harmless identical-content race).
  - **`build_tools/github_actions/fetch_test_configurations.py`** — extend the
    `hiptensor` test job's `exclude_family` to all CK-less families on both platforms,
    so they don't schedule a hipTensor test job that would find no artifact.

  This fixes both the `test` (reported failure) and `lib` (latent stub-DLL) clobber
  in one place. No change needed in rocm-libraries; hipTensor stays `target-specific`.

## Test Plan and Results

  On a CI run with both a CK-enabled Windows family (gfx110X-all / gfx1151) and a
  CK-less one (gfx103X-all):
  - [ ] CK-less "Stage - Math Libs" jobs no longer configure/build hipTensor (no Including subproject hipTensor, no hiptensor_*_generic upload).
  - [ ] The Test hiptensor job (gfx110X-all / gfx1151) gets past Test Directory: build\bin\hiptensor and runs ctest; CK-less families schedule no hiptensor test job.
  - [ ] therock-artifacts / therock-dist still configure on stub families (hiptensor simply absent, matching CK and other EXCLUDE_TARGET_PROJECTS-excluded projects).

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
