### PR TITLE
ci(jax): read the suite environment from where it lives now

### DIFF
--- a/build_tools/github_actions/tests/run_jax_tests_test.py
+++ b/build_tools/github_actions/tests/run_jax_tests_test.py
@@ -108,7 +108,7 @@ def write_split_suite_script(
     (jax_dir / runner.RELATIVE_SUITE_ENV_SCRIPT).parent.mkdir(
         parents=True, exist_ok=True
     )
-    (jax_dir / runner.RELATIVE_SUITE_ENV_SCRIPT).write_text(section)
+    (jax_dir / runner.RELATIVE_SUITE_ENV_SCRIPT).write_text(section + "\n")
     (jax_dir / runner.RELATIVE_SUITE_SCRIPT).write_text(
         "#!/bin/bash\nsource ci/envs/default.env\n"
         f"source {runner.RELATIVE_SUITE_ENV_SCRIPT.as_posix()}\nexit 1\n"
@@ -241,6 +241,21 @@ class SuiteEnvironmentTest(unittest.TestCase):
             runner.suite_environment(self.jax_dir, dict(os.environ))
 
         self.assertIn("exited 1", str(caught.exception))
+
+    def test_a_failure_names_the_file_it_came_from(self):
+        # Either file can be the one at fault, so pointing at the other would
+        # send whoever reads this to the wrong checkout.
+        write_split_suite_script(self.jax_dir)
+        env_script = self.jax_dir / runner.RELATIVE_SUITE_ENV_SCRIPT
+        env_script.write_text(env_script.read_text() + "false\n")
+
+        with self.assertRaises(runner.SuiteEnvironmentError) as caught:
+            runner.suite_environment(self.jax_dir, dict(os.environ))
+
+        self.assertIn(
+            os.fspath(runner.RELATIVE_SUITE_ENV_SCRIPT), str(caught.exception)
+        )
+        self.assertNotIn(os.fspath(runner.RELATIVE_SUITE_SCRIPT), str(caught.exception))
 
     def test_a_missing_default_env_is_fatal(self):
         write_suite_script(self.jax_dir)

--- a/build_tools/github_actions/tests/run_jax_tests_test.py
+++ b/build_tools/github_actions/tests/run_jax_tests_test.py
@@ -89,12 +89,29 @@ exit 1
 
 
 def write_suite_script(jax_dir: Path, allocator="address", conditional="yes") -> None:
+    """A checkout from before the environment moved out of the suite script."""
     (jax_dir / "ci" / "envs").mkdir(parents=True, exist_ok=True)
     (jax_dir / "ci" / "envs" / "default.env").write_text(
         "export JAXCI_ENABLE_X64=${JAXCI_ENABLE_X64:-0}\n"
     )
     (jax_dir / runner.RELATIVE_SUITE_SCRIPT).write_text(
         SUITE_SCRIPT_TEMPLATE.format(allocator=allocator, conditional=conditional)
+    )
+
+
+def write_split_suite_script(
+    jax_dir: Path, allocator="address", conditional="yes"
+) -> None:
+    """A checkout as it is now, with the environment in its own file."""
+    write_suite_script(jax_dir, allocator=allocator, conditional=conditional)
+    section = runner.env_section((jax_dir / runner.RELATIVE_SUITE_SCRIPT).read_text())
+    (jax_dir / runner.RELATIVE_SUITE_ENV_SCRIPT).parent.mkdir(
+        parents=True, exist_ok=True
+    )
+    (jax_dir / runner.RELATIVE_SUITE_ENV_SCRIPT).write_text(section)
+    (jax_dir / runner.RELATIVE_SUITE_SCRIPT).write_text(
+        "#!/bin/bash\nsource ci/envs/default.env\n"
+        f"source {runner.RELATIVE_SUITE_ENV_SCRIPT.as_posix()}\nexit 1\n"
     )
 
 
@@ -182,6 +199,16 @@ class SuiteEnvironmentTest(unittest.TestCase):
     def test_the_retry_pass_inherits_skipping_slow_tests(self):
         self.assertEqual(self.suite_env()["JAX_SKIP_SLOW_TESTS"], "true")
 
+    def test_the_environment_file_is_read_when_the_checkout_has_one(self):
+        # Newer ROCm/jax keeps the environment in its own file rather than in a
+        # marked section of the suite script.
+        write_split_suite_script(self.jax_dir, allocator="platform")
+
+        env = runner.suite_environment(self.jax_dir, dict(os.environ))
+
+        self.assertEqual(env["XLA_PYTHON_CLIENT_ALLOCATOR"], "platform")
+        self.assertNotIn("SHOULD_NOT_LEAK", env)
+
     def test_a_renamed_section_is_fatal(self):
         # Carrying on would run the retry pass, which decides the result, under an
         # environment that does not match the run it is checking.
@@ -193,9 +220,12 @@ class SuiteEnvironmentTest(unittest.TestCase):
         with self.assertRaises(runner.SuiteEnvironmentError) as caught:
             runner.suite_environment(self.jax_dir, dict(os.environ))
 
-        # The message has to say what to fix, since the markers live upstream.
+        # The message has to say what to fix, since the scripts live upstream.
         self.assertIn(runner.ENV_SECTION_START, str(caught.exception))
         self.assertIn("ENV_SECTION_START", str(caught.exception))
+        self.assertIn(
+            os.fspath(runner.RELATIVE_SUITE_ENV_SCRIPT), str(caught.exception)
+        )
 
     def test_a_section_that_fails_is_fatal(self):
         # Its device queries feed the values it exports, so a section that

--- a/external-builds/jax/run_jax_tests.py
+++ b/external-builds/jax/run_jax_tests.py
@@ -104,11 +104,15 @@ REPORT_GLOB = "logs/pytest_results*.json"
 PYTEST_EXIT_ALL_PASSED = 0
 PYTEST_EXIT_TESTS_FAILED = 1
 
-# The section of the suite script that only computes the environment: exports,
-# echoes and device queries, with the installs above it and the test run below it.
-# Evaluating it is how the per-version environment reaches the retry pass, which
-# has to match the run it is checking. Sourcing the script itself would run the
-# tests, and copying its values here would be a second source of truth.
+# What the suite script sources for its environment: exports, echoes and device
+# queries, and nothing that installs or tests. Evaluating it is how the
+# per-version environment reaches the retry pass, which has to match the run it
+# is checking. Sourcing the suite script itself would run the tests, and copying
+# its values here would be a second source of truth.
+RELATIVE_SUITE_ENV_SCRIPT = Path("ci") / "utilities" / "rocm_test_env.sh"
+
+# Where that environment lived before it moved into the file above, as a section
+# of the suite script, with the installs above it and the test run below it.
 ENV_SECTION_START = "# Set up the generic test environment variables"
 ENV_SECTION_END = "# Run tests"
 
@@ -209,25 +213,45 @@ def _read_env_dump(path: Path) -> dict[str, str]:
     return {name: value for name, separator, value in pairs if separator}
 
 
-def suite_environment(jax_dir: Path, env: dict[str, str]) -> dict[str, str]:
-    """What the suite script's environment section exports.
+def suite_env_program(jax_dir: Path) -> str:
+    """The shell that computes the suite's environment, and only that.
 
-    Evaluated in a shell that dumps its environment on either side of the section,
-    so the result is what the section itself changed rather than a guess at which
-    names look interesting.
+    A checkout from before the environment moved out of the suite script keeps it
+    in a marked section there, which is what gets evaluated instead.
 
     Raises:
-        SuiteEnvironmentError: if the section cannot be found or evaluated. This
-            fails the run by design, because the retry pass decides the result and
-            a wrong environment there would decide it wrongly.
+        SuiteEnvironmentError: if the checkout holds neither.
     """
-    section = env_section((jax_dir / RELATIVE_SUITE_SCRIPT).read_text())
+    if (jax_dir / RELATIVE_SUITE_ENV_SCRIPT).exists():
+        return f"source {shlex.quote(os.fspath(RELATIVE_SUITE_ENV_SCRIPT))}"
+
+    older = jax_dir / RELATIVE_SUITE_SCRIPT
+    section = env_section(older.read_text()) if older.exists() else ""
     if not section:
         raise SuiteEnvironmentError(
-            f"{RELATIVE_SUITE_SCRIPT} has no section between '{ENV_SECTION_START}' and"
-            f" '{ENV_SECTION_END}'. The script most likely renamed them, so update"
-            " ENV_SECTION_START and ENV_SECTION_END to match it."
+            f"{jax_dir / RELATIVE_SUITE_ENV_SCRIPT} does not exist and"
+            f" {RELATIVE_SUITE_SCRIPT} has no section between"
+            f" '{ENV_SECTION_START}' and '{ENV_SECTION_END}', so there is nothing"
+            " to read the suite's environment from. Update"
+            " RELATIVE_SUITE_ENV_SCRIPT, or ENV_SECTION_START and"
+            " ENV_SECTION_END, to match what the checkout has."
         )
+    return section
+
+
+def suite_environment(jax_dir: Path, env: dict[str, str]) -> dict[str, str]:
+    """What the suite exports before it runs anything.
+
+    Evaluated in a shell that dumps its environment on either side, so the result
+    is what the suite itself changed rather than a guess at which names look
+    interesting.
+
+    Raises:
+        SuiteEnvironmentError: if it cannot be found or evaluated. This fails the
+            run by design, because the retry pass decides the result and a wrong
+            environment there would decide it wrongly.
+    """
+    section = suite_env_program(jax_dir)
     if not (jax_dir / RELATIVE_SUITE_ENV_FILE).exists():
         raise SuiteEnvironmentError(
             f"{RELATIVE_SUITE_ENV_FILE} is missing, and the section reads its defaults."

--- a/external-builds/jax/run_jax_tests.py
+++ b/external-builds/jax/run_jax_tests.py
@@ -13,12 +13,13 @@ of truth for how the tests run. This adds only what is ours:
   * holding the run to the CPUs the pod was given, described under "Resources".
 
 Nothing the suite script decides is repeated here. Its environment is read back
-out of the script, so a version that changes its allocator or its XLA flags,
-including behind a conditional, needs no change in this file. Reading it is
-required rather than best-effort: the retry pass decides the result, so running
-it under a different environment than the suite would make that verdict
-meaningless. A script whose section markers have been renamed fails the run with
-an error naming them.
+out of ci/utilities/rocm_test_env.sh, which the suite sources, or out of the
+marked section of the suite script in a checkout from before that file existed,
+so a version that changes its allocator or its XLA flags, including behind a
+conditional, needs no change in this file. Reading it is required rather than
+best-effort: the retry pass decides the result, so running it under a different
+environment than the suite would make that verdict meaningless. A checkout that
+holds neither fails the run with an error naming both.
 
 Retries
 -------
@@ -213,17 +214,20 @@ def _read_env_dump(path: Path) -> dict[str, str]:
     return {name: value for name, separator, value in pairs if separator}
 
 
-def suite_env_program(jax_dir: Path) -> str:
-    """The shell that computes the suite's environment, and only that.
+def suite_env_program(jax_dir: Path) -> tuple[str, Path]:
+    """The shell that computes the suite's environment, and the file it came from.
 
     A checkout from before the environment moved out of the suite script keeps it
-    in a marked section there, which is what gets evaluated instead.
+    in a marked section there, which is what gets evaluated instead. The caller
+    reports failures against the file this picked, since either can be the one at
+    fault.
 
     Raises:
         SuiteEnvironmentError: if the checkout holds neither.
     """
     if (jax_dir / RELATIVE_SUITE_ENV_SCRIPT).exists():
-        return f"source {shlex.quote(os.fspath(RELATIVE_SUITE_ENV_SCRIPT))}"
+        program = f"source {shlex.quote(os.fspath(RELATIVE_SUITE_ENV_SCRIPT))}"
+        return program, RELATIVE_SUITE_ENV_SCRIPT
 
     older = jax_dir / RELATIVE_SUITE_SCRIPT
     section = env_section(older.read_text()) if older.exists() else ""
@@ -236,7 +240,7 @@ def suite_env_program(jax_dir: Path) -> str:
             " RELATIVE_SUITE_ENV_SCRIPT, or ENV_SECTION_START and"
             " ENV_SECTION_END, to match what the checkout has."
         )
-    return section
+    return section, RELATIVE_SUITE_SCRIPT
 
 
 def suite_environment(jax_dir: Path, env: dict[str, str]) -> dict[str, str]:
@@ -251,10 +255,10 @@ def suite_environment(jax_dir: Path, env: dict[str, str]) -> dict[str, str]:
             run by design, because the retry pass decides the result and a wrong
             environment there would decide it wrongly.
     """
-    section = suite_env_program(jax_dir)
+    program, source = suite_env_program(jax_dir)
     if not (jax_dir / RELATIVE_SUITE_ENV_FILE).exists():
         raise SuiteEnvironmentError(
-            f"{RELATIVE_SUITE_ENV_FILE} is missing, and the section reads its defaults."
+            f"{RELATIVE_SUITE_ENV_FILE} is missing, and {source} reads its defaults."
             f" Is {jax_dir} a complete ROCm/jax checkout?"
         )
 
@@ -262,16 +266,16 @@ def suite_environment(jax_dir: Path, env: dict[str, str]) -> dict[str, str]:
         before = Path(tmp) / "before"
         after = Path(tmp) / "after"
         dump = "env -0 > {}".format
-        # The section's own status, kept across the dump that follows it, which
+        # The program's own status, kept across the dump that follows it, which
         # would otherwise be the status of the shell and always zero.
         script = "\n".join(
             [
                 f"source {shlex.quote(os.fspath(RELATIVE_SUITE_ENV_FILE))}",
                 dump(shlex.quote(os.fspath(before))),
-                section,
-                "section_status=$?",
+                program,
+                "program_status=$?",
                 dump(shlex.quote(os.fspath(after))),
-                "exit ${section_status}",
+                "exit ${program_status}",
             ]
         )
         proc = subprocess.run(
@@ -284,16 +288,16 @@ def suite_environment(jax_dir: Path, env: dict[str, str]) -> dict[str, str]:
         )
         if not (before.exists() and after.exists()):
             raise SuiteEnvironmentError(
-                f"Evaluating the section of {RELATIVE_SUITE_SCRIPT} produced no environment:"
+                f"Evaluating the environment {source} sets produced none:"
                 f" {proc.stderr.strip()}"
             )
         if proc.returncode != 0:
             # It exports and queries devices, so a failure means some of what it
             # exported was computed from a command that did not work.
             raise SuiteEnvironmentError(
-                f"The section of {RELATIVE_SUITE_SCRIPT} exited"
-                f" {proc.returncode}, so the environment it exported is only"
-                f" partly what the suite will run under: {proc.stderr.strip()}"
+                f"The environment {source} sets exited {proc.returncode}, so what"
+                f" it exported is only partly what the suite will run under:"
+                f" {proc.stderr.strip()}"
             )
         baseline, exported = _read_env_dump(before), _read_env_dump(after)
 


### PR DESCRIPTION
## What breaks today

Every JAX nightly test job fails before it runs a single test:

Error: ci/run_pytest_rocm.sh has no section between '# Set up the generic test environment variables' and '# Run tests'.

`run_jax_tests.py` evaluates the suite's environment so that the serial retry pass runs under the same settings as the run it is checking. It read that environment out of a marked section of `ci/run_pytest_rocm.sh`. ROCm/jax has since moved it into `ci/utilities/rocm_test_env.sh`, and every release branch from `rocm-jaxlib-v0.10.0` through `rocm-jaxlib-v0.11.0` now ships the file with no section left behind, so the lookup fails on all of them.

## The change

Source `ci/utilities/rocm_test_env.sh` when the checkout has it, and fall back to the section when it does not, since an older `--jax-ref` is still valid. The file only exports, echoes and queries devices, so sourcing it runs nothing.

Split out of #6853 so the nightly is unblocked without waiting on that stack.

Solves https://github.com/ROCm/TheRock/issues/7320

## Test plan

- [x] `pytest build_tools/github_actions/tests/run_jax_tests_test.py` (77 passed)
- [x] New coverage for the split layout, and the error now names both places to fix
- [x] Nightly JAX test job gets past the environment step