### PR TITLE
[packaging] Refine package version tests and documentation

### DIFF
--- a/build_tools/compute_rocm_package_version.py
+++ b/build_tools/compute_rocm_package_version.py
@@ -140,6 +140,8 @@ def compute_version(
             # Trust the custom suffix to satisfy the general rules:
             # https://packaging.python.org/en/latest/specifications/version-specifiers/
             version_suffix = custom_version_suffix
+        elif release_type == "release":
+            version_suffix = ""
         elif release_type in ("ci", "dev"):
             # Construct a dev release version:
             # https://packaging.python.org/en/latest/specifications/version-specifiers/#developmental-releases
@@ -217,10 +219,7 @@ def main(argv):
         "--release-type",
         type=str,
         choices=["ci", "dev", "nightly", "prerelease", "release"],
-        help=(
-            "The type of package version to produce. "
-            "'ci' uses dev-style versions; 'release' is only valid for deb/rpm."
-        ),
+        help="The type of package version to produce. 'ci' uses dev-style versions.",
     )
     release_type_group.add_argument(
         "--custom-version-suffix",
@@ -249,9 +248,6 @@ def main(argv):
     args = parser.parse_args(argv)
 
     # Validation
-    if args.release_type == "release":
-        parser.error("'release' type is only valid for deb/rpm packages, not wheel")
-
     if args.release_type != "prerelease" and args.prerelease_version:
         parser.error("release type must be 'prerelease' if --prerelease-version is set")
     elif args.release_type == "prerelease" and not args.prerelease_version:

--- a/build_tools/tests/build_prod_wheels_version_test.py
+++ b/build_tools/tests/build_prod_wheels_version_test.py
@@ -11,6 +11,8 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
+from packaging.version import Version
+
 sys.path.insert(
     0, os.fspath(Path(__file__).parent.parent.parent / "external-builds" / "pytorch")
 )
@@ -30,6 +32,40 @@ class ComputeBuildVersionTest(unittest.TestCase):
     def test_non_dev_release_uses_base_plus_suffix(self):
         version = compute_build_version(self.source_dir, "+rocm7.10.0", "ci")
         self.assertEqual(version, "2.12.0a0+rocm7.10.0")
+
+    def test_versions_sort_by_release_type(self):
+        # Composite PyTorch versions must preserve the intended ROCm release
+        # ordering for pip install --upgrade: stable > prerelease > nightly > dev.
+        stable = Version(compute_build_version(self.source_dir, "+rocm7.14.0", "ci"))
+        prerelease = Version(
+            compute_build_version(self.source_dir, "+rocm7.14.0rc1", "prerelease")
+        )
+        nightly = Version(
+            compute_build_version(self.source_dir, "+rocm7.14.0a20260811", "nightly")
+        )
+        dev = Version(
+            compute_build_version(
+                self.source_dir,
+                "+devrocm7.14.0.dev0-1a2b3c4d",
+                "ci",
+            )
+        )
+
+        self.assertGreater(stable, prerelease)
+        self.assertGreater(prerelease, nightly)
+        self.assertGreater(nightly, dev)
+
+    def test_rocm_major_versions_have_known_sorting_issue(self):
+        # `rocm7` currently sorts above `rocm10` as local-version strings.
+        # This is tracked by https://github.com/ROCm/TheRock/issues/7183.
+        rocm_7_14 = Version(
+            compute_build_version(self.source_dir, "+rocm7.14.0a20260728", "nightly")
+        )
+        rocm_10_0 = Version(
+            compute_build_version(self.source_dir, "+rocm10.0.0a20260806", "nightly")
+        )
+
+        self.assertGreater(rocm_7_14, rocm_10_0)
 
     def test_dev_release_tags_git_commit_in_local_segment(self):
         with mock.patch(

--- a/build_tools/tests/compute_rocm_package_version_test.py
+++ b/build_tools/tests/compute_rocm_package_version_test.py
@@ -122,7 +122,6 @@ class PythonPackageVersionTest(unittest.TestCase):
         # pip install --upgrade selects the greatest available version, so enforce:
         # release > prerelease > nightly > dev.
         versions = self._compute_versions_by_release_type()
-        print(f"versions: {versions}")
 
         self.assertGreater(
             Version(versions["nightly"]),
@@ -336,15 +335,56 @@ class RpmPackageVersionTest(unittest.TestCase):
         self.assertEqual(version, "8.0.0~custom1")
 
 
+# Test meaningful combinations of argparse options through the real computation path,
+# including main()'s side effect of writing versions to GitHub Actions outputs.
 class MainFunctionTest(unittest.TestCase):
-    def test_sets_package_version_outputs(self):
+    def test_sets_dev_outputs_with_version_overrides(self):
+        override_git_sha = "abcdef1234567890abcdef1234567890abcdef12"
+        with (
+            mock.patch.dict(os.environ, {"GITHUB_SHA": "f" * 40}),
+            mock.patch.object(
+                compute_rocm_package_version, "gha_set_output"
+            ) as gha_set_output,
+        ):
+            compute_rocm_package_version.main(
+                [
+                    "--release-type",
+                    "dev",
+                    "--override-base-version",
+                    "7.99.0",
+                    "--override-git-sha",
+                    override_git_sha,
+                ]
+            )
+
+        gha_set_output.assert_called_once()
+        outputs = gha_set_output.call_args.args[0]
+        self.assertEqual(
+            set(outputs),
+            {
+                "rocm_package_version",
+                "rocm_deb_package_version",
+                "rocm_rpm_package_version",
+            },
+        )
+        self.assertEqual(
+            outputs["rocm_package_version"],
+            f"7.99.0.dev0+{override_git_sha}",
+        )
+        self.assertTrue(outputs["rocm_deb_package_version"].startswith("7.99.0~dev"))
+        self.assertTrue(outputs["rocm_rpm_package_version"].startswith("7.99.0~"))
+        self.assertTrue(outputs["rocm_rpm_package_version"].endswith("gabcdef12"))
+
+    def test_sets_prerelease_outputs(self):
         with mock.patch.object(
             compute_rocm_package_version, "gha_set_output"
         ) as gha_set_output:
             compute_rocm_package_version.main(
                 [
                     "--release-type",
-                    "release",
+                    "prerelease",
+                    "--prerelease-version",
+                    "2",
                     "--override-base-version",
                     "7.99.0",
                 ]
@@ -352,9 +392,30 @@ class MainFunctionTest(unittest.TestCase):
 
         gha_set_output.assert_called_once_with(
             {
-                "rocm_package_version": "7.99.0",
-                "rocm_deb_package_version": "7.99.0",
-                "rocm_rpm_package_version": "7.99.0",
+                "rocm_package_version": "7.99.0rc2",
+                "rocm_deb_package_version": "7.99.0~pre2",
+                "rocm_rpm_package_version": "7.99.0~rc2",
+            }
+        )
+
+    def test_sets_custom_suffix_outputs(self):
+        with mock.patch.object(
+            compute_rocm_package_version, "gha_set_output"
+        ) as gha_set_output:
+            compute_rocm_package_version.main(
+                [
+                    "--custom-version-suffix",
+                    ".custom1",
+                    "--override-base-version",
+                    "7.99.0",
+                ]
+            )
+
+        gha_set_output.assert_called_once_with(
+            {
+                "rocm_package_version": "7.99.0.custom1",
+                "rocm_deb_package_version": "7.99.0.custom1",
+                "rocm_rpm_package_version": "7.99.0.custom1",
             }
         )
 

--- a/build_tools/tests/compute_rocm_package_version_test.py
+++ b/build_tools/tests/compute_rocm_package_version_test.py
@@ -1,11 +1,11 @@
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-import argparse
-from pathlib import Path
 import os
 import sys
 import unittest
+from pathlib import Path
+from unittest import mock
 
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 import compute_rocm_package_version
@@ -39,6 +39,14 @@ class DetermineVersionTest(unittest.TestCase):
         #   .dev0+
         #   [0-9a-z]+   Git SHA (short or long)
         self.assertRegex(version, r"^[0-9]+[0-9\.]*\.dev0\+[0-9a-z]+$")
+
+    def test_dev_version_with_git_sha_override(self):
+        version = compute_rocm_package_version.compute_version(
+            release_type="dev",
+            override_base_version="7.9.0",
+            override_git_sha="abcdef1234567890abcdef1234567890abcdef12",
+        )
+        self.assertEqual(version, "7.9.0.dev0+abcdef1234567890abcdef1234567890abcdef12")
 
     def test_nightly_version(self):
         version = compute_rocm_package_version.compute_version(
@@ -210,6 +218,15 @@ class RpmPackageVersionTest(unittest.TestCase):
         #   [0-9a-z]{8} Short git SHA (8 characters)
         self.assertRegex(version, r"^[0-9]+[0-9\.]*~[0-9]{8}g[0-9a-z]{8}$")
 
+    def test_dev_version_with_git_sha_override(self):
+        version = compute_rocm_package_version.compute_version(
+            package_type="rpm",
+            release_type="dev",
+            override_base_version="8.1.0",
+            override_git_sha="abcdef1234567890",
+        )
+        self.assertRegex(version, r"^8\.1\.0~[0-9]{8}gabcdef12$")
+
     def test_nightly_version(self):
         version = compute_rocm_package_version.compute_version(
             package_type="rpm",
@@ -262,132 +279,27 @@ class RpmPackageVersionTest(unittest.TestCase):
         self.assertEqual(version, "8.0.0~custom1")
 
 
-class GitShaOverrideTest(unittest.TestCase):
-    """Tests for explicit override_git_sha parameter."""
-
-    def test_wheel_dev_uses_provided_git_sha(self):
-        version = compute_rocm_package_version.compute_version(
-            release_type="dev",
-            override_base_version="8.1.0",
-            override_git_sha="abcdef1234567890abcdef1234567890abcdef12",
-        )
-        self.assertEqual(version, "8.1.0.dev0+abcdef1234567890abcdef1234567890abcdef12")
-
-    def test_rpm_dev_truncates_long_git_sha(self):
-        version = compute_rocm_package_version.compute_version(
-            package_type="rpm",
-            release_type="dev",
-            override_base_version="8.1.0",
-            override_git_sha="abcdef1234567890",
-        )
-        # Should truncate to 8 chars
-        self.assertRegex(version, r"^8\.1\.0~[0-9]{8}gabcdef12$")
-
-    def test_main_forwards_override_git_sha_to_all_package_types(self):
-        """main() must forward --override-git-sha into the computed versions.
-
-        Regression test for the bug where main() computed versions without
-        passing args.override_git_sha, so the flag was silently ignored and
-        cross-repo callers (e.g. rocm-libraries nightlies building TheRock)
-        got the caller's GITHUB_SHA embedded instead of the requested commit.
-        """
-        override_sha = "abcdef1234567890abcdef1234567890abcdef12"
-        captured_outputs = {}
-        original_gha_set_output = compute_rocm_package_version.gha_set_output
-
-        def mock_gha_set_output(outputs):
-            captured_outputs.update(outputs)
-
-        compute_rocm_package_version.gha_set_output = mock_gha_set_output
-        try:
+class MainFunctionTest(unittest.TestCase):
+    def test_sets_package_version_outputs(self):
+        with mock.patch.object(
+            compute_rocm_package_version, "gha_set_output"
+        ) as gha_set_output:
             compute_rocm_package_version.main(
                 [
                     "--release-type",
-                    "dev",
+                    "release",
                     "--override-base-version",
                     "7.99.0",
-                    "--override-git-sha",
-                    override_sha,
                 ]
             )
-        finally:
-            compute_rocm_package_version.gha_set_output = original_gha_set_output
 
-        # Wheel embeds the full override SHA.
-        self.assertEqual(
-            captured_outputs["rocm_package_version"], f"7.99.0.dev0+{override_sha}"
+        gha_set_output.assert_called_once_with(
+            {
+                "rocm_package_version": "7.99.0",
+                "rocm_deb_package_version": "7.99.0",
+                "rocm_rpm_package_version": "7.99.0",
+            }
         )
-        # DEB uses the dev-date format and does not embed a git SHA at all.
-        self.assertRegex(
-            captured_outputs["rocm_deb_package_version"], r"^7\.99\.0~dev[0-9]{8}$"
-        )
-        self.assertNotIn(override_sha[:8], captured_outputs["rocm_deb_package_version"])
-        # RPM embeds the 8-char truncation of the same override SHA.
-        self.assertRegex(
-            captured_outputs["rocm_rpm_package_version"],
-            rf"^7\.99\.0~[0-9]{{8}}g{override_sha[:8]}$",
-        )
-
-
-class MainFunctionMultiplePackageTypesTest(unittest.TestCase):
-    """Tests for main() function: compute all package types when --package-type is omitted."""
-
-    def test_compute_all_package_types_without_flag(self):
-        """Test that when --package-type is not provided, all types are computed."""
-        captured_outputs = {}
-        original_gha_set_output = compute_rocm_package_version.gha_set_output
-
-        def mock_gha_set_output(outputs):
-            captured_outputs.update(outputs)
-
-        compute_rocm_package_version.gha_set_output = mock_gha_set_output
-
-        try:
-            compute_rocm_package_version.main(
-                ["--release-type", "dev", "--override-base-version", "8.0.0"]
-            )
-
-            # Should have all three outputs
-            self.assertIn("rocm_package_version", captured_outputs)
-            self.assertIn("rocm_deb_package_version", captured_outputs)
-            self.assertIn("rocm_rpm_package_version", captured_outputs)
-
-            # Verify formats
-            self.assertRegex(
-                captured_outputs["rocm_package_version"], r"^8\.0\.0\.dev0\+[0-9a-z]+$"
-            )
-            self.assertRegex(
-                captured_outputs["rocm_deb_package_version"], r"^8\.0\.0~dev[0-9]{8}$"
-            )
-            self.assertRegex(
-                captured_outputs["rocm_rpm_package_version"],
-                r"^8\.0\.0~[0-9]{8}g[0-9a-z]{8}$",
-            )
-        finally:
-            compute_rocm_package_version.gha_set_output = original_gha_set_output
-
-    def test_existing_workflows_still_work(self):
-        """Test that existing workflows reading rocm_package_version still work."""
-        captured_outputs = {}
-        original_gha_set_output = compute_rocm_package_version.gha_set_output
-
-        def mock_gha_set_output(outputs):
-            captured_outputs.update(outputs)
-
-        compute_rocm_package_version.gha_set_output = mock_gha_set_output
-
-        try:
-            # This mimics setup_multi_arch.yml line 66: no --package-type specified
-            compute_rocm_package_version.main(["--release-type", "dev"])
-
-            # Existing workflow reads rocm_package_version, which should still exist
-            self.assertIn("rocm_package_version", captured_outputs)
-
-            # Additional outputs don't break existing workflows (they just ignore them)
-            self.assertIn("rocm_deb_package_version", captured_outputs)
-            self.assertIn("rocm_rpm_package_version", captured_outputs)
-        finally:
-            compute_rocm_package_version.gha_set_output = original_gha_set_output
 
 
 if __name__ == "__main__":

--- a/build_tools/tests/compute_rocm_package_version_test.py
+++ b/build_tools/tests/compute_rocm_package_version_test.py
@@ -7,6 +7,8 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
+from packaging.version import Version
+
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 import compute_rocm_package_version
 
@@ -16,7 +18,7 @@ import compute_rocm_package_version
 # future changes like using X.Y versions instead of X.Y.Z versions.
 
 
-class DetermineVersionTest(unittest.TestCase):
+class PythonPackageVersionTest(unittest.TestCase):
     def test_ci_version_uses_dev_version_shape(self):
         version = compute_rocm_package_version.compute_version(
             release_type="ci",
@@ -106,6 +108,61 @@ class DetermineVersionTest(unittest.TestCase):
             override_base_version="7.9.0",
         )
         self.assertRegex(version, r"^7\.9\.0a[0-9]{8}$")
+
+    def test_versions_are_valid_and_canonical(self):
+        # Version() rejects non-PEP 440 versions such as "7.10.0~rc0".
+        # See https://packaging.python.org/en/latest/specifications/version-specifiers/.
+        versions = self._compute_versions_by_release_type()
+
+        for release_type, version in versions.items():
+            with self.subTest(release_type=release_type):
+                self.assertEqual(str(Version(version)), version)
+
+    def test_versions_sort_by_release_type(self):
+        # pip install --upgrade selects the greatest available version, so enforce:
+        # release > prerelease > nightly > dev.
+        versions = self._compute_versions_by_release_type()
+        print(f"versions: {versions}")
+
+        self.assertGreater(
+            Version(versions["nightly"]),
+            Version(versions["dev"]),
+        )
+        self.assertGreater(
+            Version(versions["prerelease"]),
+            Version(versions["nightly"]),
+        )
+        self.assertGreater(
+            Version(versions["release"]),
+            Version(versions["prerelease"]),
+        )
+
+    @staticmethod
+    def _compute_versions_by_release_type() -> dict[str, str]:
+        common_args = {
+            "package_type": "wheel",
+            "override_base_version": "7.10.0",
+        }
+        return {
+            "dev": compute_rocm_package_version.compute_version(
+                release_type="dev",
+                override_git_sha="abcdef1234567890abcdef1234567890abcdef12",
+                **common_args,
+            ),
+            "nightly": compute_rocm_package_version.compute_version(
+                release_type="nightly",
+                **common_args,
+            ),
+            "prerelease": compute_rocm_package_version.compute_version(
+                release_type="prerelease",
+                prerelease_version="0",
+                **common_args,
+            ),
+            "release": compute_rocm_package_version.compute_version(
+                release_type="release",
+                **common_args,
+            ),
+        }
 
 
 class DebPackageVersionTest(unittest.TestCase):

--- a/docs/packaging/versioning.md
+++ b/docs/packaging/versioning.md
@@ -83,21 +83,15 @@ The script produces these versions for each release type:
 | nightly      | `X.Y.ZaYYYYMMDD`  | `7.10.0a20251124`<br>(The nightly release on 2025-11-24)                                                                                                            |
 | dev          | `X.Y.Z.dev0+NNNN` | `7.10.0.dev0+efed3c3b10a5cce8578f58f8eb288582c26d18c4`<br>(For commit [`efed3c3`](https://github.com/ROCm/TheRock/commit/efed3c3b10a5cce8578f58f8eb288582c26d18c4)) |
 
-Each distribution channel (and GPU family within that channel) is currently
-hosted on a separate release index that can be passed to `pip` or `uv` via
-`--index-url`. For example:
+Each distribution channel is currently hosted on a separate release index that
+can be passed to `pip` or `uv` via `--index-url`. For example:
 
 ```bash
-pip install --index-url=https://rocm.nightlies.amd.com/v2/gfx94X-dcgpu/ rocm
+pip install --index-url=https://rocm.nightlies.amd.com/whl-multi-arch/ rocm
 ```
 
 See [RELEASES.md - Installing releases using pip](../../RELEASES.md#installing-releases-using-pip)
 for details.
-
-> [!NOTE]
-> We plan on later providing a single multi-architecture index as part of
-> multi-arch work, see
-> [RFC0008-Multi-Arch-Packaging.md - Python Packaging](../rfcs/RFC0008-Multi-Arch-Packaging.md#python-packaging).
 
 ### External Python package versions
 
@@ -133,6 +127,21 @@ True
 >>> nightly > dev
 True
 ```
+
+> [!WARNING]
+> Known issue: https://github.com/ROCm/TheRock/issues/7183.
+>
+> Package versions using ROCm version 10.0.0+ sort as _older_ than previous
+> versions using this schema:
+>
+> ```python
+> >>> from packaging.version import Version
+> >>> Version("2.12.0+rocm10.0") > Version("2.12.0+rocm7.0")
+> False
+> ```
+>
+> We plan on publishing 10.0.0+ packages to a new index to avoid this issue for
+> future installs.
 
 #### PyTorch versions
 


### PR DESCRIPTION
## Motivation

* Cleanup tests and docs prior to changes planned as part of https://github.com/ROCm/rockrel/issues/88
* Document https://github.com/ROCm/TheRock/issues/7183
* Progress on https://github.com/ROCm/TheRock/issues/3340

## Technical Details

* Added tests for Python package version schema compliance and sorting. We can add similar tests for deb/rpm packages using Linux tooling if installed/available.
* Merged `GitShaOverrideTest` tests into other test classes (seeing lots of contributions that only append tests without considering what is already tested)
* Reworked `MainFunctionMultiplePackageTypesTest` to follow repository practices for mocking and removed confusing/useless `test_existing_workflows_still_work` test

## Test Plan

* Unit tests + ran a few commands like `python build_tools/compute_rocm_package_version.py --release-type=nightly --override-base-version=7.99.0` locally.
* CI and releases should continue using their existing versions.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
