### PR TITLE
[packaging] Add versioning for BKC release type

### DIFF
--- a/build_tools/compute_rocm_package_version.py
+++ b/build_tools/compute_rocm_package_version.py
@@ -31,7 +31,7 @@ Sample usage:
 
   python compute_rocm_package_version.py --release-type=nightly-bkc
   # rocm_package_version=10.1.0a20260811+bkc.20260814
-  # rocm_deb_package_version=10.1.0~20260811+bkc.20260814
+  # rocm_deb_package_version=10.1.0~20260811.bkc.20260814
   # rocm_rpm_package_version=10.1.0~20260811.bkc.20260814
 
   python compute_rocm_package_version.py --custom-version-suffix=.dev0
@@ -240,10 +240,7 @@ def compute_version(
             # Format: <rocm-version>~<YYYYMMDD>
             version_suffix_str = f"~{current_date}"
         elif release_type == "nightly-bkc":
-            bkc_separator = "+" if package_type == "deb" else "."
-            version_suffix_str = (
-                f"~{release_metadata['base-date']}{bkc_separator}bkc.{current_date}"
-            )
+            version_suffix_str = f"~{release_metadata['base-date']}.bkc.{current_date}"
         elif release_type == "prerelease":
             # Construct a prerelease version
             # deb format: <rocm-version>~pre<N>

--- a/build_tools/compute_rocm_package_version.py
+++ b/build_tools/compute_rocm_package_version.py
@@ -29,6 +29,11 @@ Sample usage:
   # rocm_deb_package_version=7.10.0~20251021
   # rocm_rpm_package_version=7.10.0~20251021
 
+  python compute_rocm_package_version.py --release-type=nightly-bkc
+  # rocm_package_version=10.1.0a20260811+bkc.20260814
+  # rocm_deb_package_version=10.1.0~20260811+bkc.20260814
+  # rocm_rpm_package_version=10.1.0~20260811+bkc.20260814
+
   python compute_rocm_package_version.py --custom-version-suffix=.dev0
   # 7.10.0.dev0
 
@@ -37,6 +42,7 @@ Sample usage:
 """
 
 import argparse
+from collections.abc import Mapping
 from datetime import datetime
 from pathlib import Path
 import json
@@ -62,6 +68,18 @@ def load_rocm_version() -> str:
     with open(version_file, "rt") as f:
         loaded_file = json.load(f)
         return loaded_file["rocm-version"]
+
+
+def load_release_metadata() -> dict[str, object]:
+    """Loads generic release metadata from the repository's version.json file."""
+    version_file = THEROCK_DIR / "version.json"
+    _log(f"Loading release metadata from file '{version_file.resolve()}'")
+    with open(version_file, "rt") as f:
+        loaded_file = json.load(f)
+        release_metadata = loaded_file.get("release-metadata", {})
+        if not isinstance(release_metadata, dict):
+            raise ValueError("release-metadata in version.json must be an object")
+        return release_metadata
 
 
 def get_git_sha(short: bool = False, override_git_sha: str | None = None):
@@ -112,17 +130,21 @@ def compute_version(
     prerelease_version: str | None = None,
     override_base_version: str | None = None,
     override_git_sha: str | None = None,
+    release_metadata: Mapping[str, object] | None = None,
 ) -> str:
     """Compute package version based on package type and release type.
 
     Args:
         package_type: Type of package ("wheel", "deb", or "rpm")
-        release_type: Release type ("ci", "dev", "nightly", "prerelease", or "release")
+        release_type: Release type ("ci", "dev", "dev-bkc", "nightly",
+            "nightly-bkc", "prerelease", or "release")
         custom_version_suffix: Custom suffix to override automatic suffix
         prerelease_version: Prerelease version number
         override_base_version: Override the base version from version.json
         override_git_sha: Explicit git SHA override, forwarded to get_git_sha().
             See get_git_sha() for details on when this is needed.
+        release_metadata: Generic metadata from version.json. Loaded automatically
+            for BKC release types when not provided.
 
     Returns:
         Computed version string appropriate for the package type
@@ -134,6 +156,27 @@ def compute_version(
     _log(f"Base version  : '{base_version}'")
     _log(f"Package type  : '{package_type}'")
 
+    bkc_base_date = None
+    if release_type in ("dev-bkc", "nightly-bkc"):
+        if release_metadata is None:
+            release_metadata = load_release_metadata()
+        bkc_base_date = release_metadata.get("base-date")
+        if not isinstance(bkc_base_date, str) or not bkc_base_date:
+            raise ValueError(
+                "release-metadata.base-date must be set in version.json "
+                f"for release type '{release_type}'"
+            )
+        try:
+            parsed_bkc_base_date = datetime.strptime(bkc_base_date, "%Y%m%d")
+        except ValueError as e:
+            raise ValueError(
+                "release-metadata.base-date must be a valid date in YYYYMMDD format"
+            ) from e
+        if parsed_bkc_base_date.strftime("%Y%m%d") != bkc_base_date:
+            raise ValueError(
+                "release-metadata.base-date must be a valid date in YYYYMMDD format"
+            )
+
     # Handle wheel packages (Python packaging standards)
     if package_type == "wheel":
         if custom_version_suffix:
@@ -142,7 +185,7 @@ def compute_version(
             version_suffix = custom_version_suffix
         elif release_type == "release":
             version_suffix = ""
-        elif release_type in ("ci", "dev"):
+        elif release_type in ("ci", "dev", "dev-bkc"):
             # Construct a dev release version:
             # https://packaging.python.org/en/latest/specifications/version-specifiers/#developmental-releases
             git_sha = get_git_sha(override_git_sha=override_git_sha)
@@ -152,6 +195,9 @@ def compute_version(
             # https://packaging.python.org/en/latest/specifications/version-specifiers/#pre-releases
             current_date = get_current_date()
             version_suffix = f"a{current_date}"
+        elif release_type == "nightly-bkc":
+            current_date = get_current_date()
+            version_suffix = f"a{bkc_base_date}+bkc.{current_date}"
         elif release_type == "prerelease":
             # Construct a prerelease (rc / "release candidate") version
             # https://packaging.python.org/en/latest/specifications/version-specifiers/#pre-releases
@@ -176,7 +222,7 @@ def compute_version(
             # Final release version - no suffix
             # Format: <rocm-version>
             version_suffix_str = ""
-        elif release_type in ("ci", "dev"):
+        elif release_type in ("ci", "dev", "dev-bkc"):
             # Construct a dev release version with date and optionally git SHA
             # deb format: <rocm-version>~dev<YYYYMMDD>
             # rpm format: <rocm-version>~<YYYYMMDD>g<short-git-sha>
@@ -191,6 +237,9 @@ def compute_version(
             # Format: <rocm-version>~<YYYYMMDD>
             current_date = get_current_date()
             version_suffix_str = f"~{current_date}"
+        elif release_type == "nightly-bkc":
+            current_date = get_current_date()
+            version_suffix_str = f"~{bkc_base_date}+bkc.{current_date}"
         elif release_type == "prerelease":
             # Construct a prerelease version
             # deb format: <rocm-version>~pre<N>
@@ -218,7 +267,15 @@ def main(argv):
     release_type_group.add_argument(
         "--release-type",
         type=str,
-        choices=["ci", "dev", "nightly", "prerelease", "release"],
+        choices=[
+            "ci",
+            "dev",
+            "dev-bkc",
+            "nightly",
+            "nightly-bkc",
+            "prerelease",
+            "release",
+        ],
         help="The type of package version to produce. 'ci' uses dev-style versions.",
     )
     release_type_group.add_argument(
@@ -247,6 +304,10 @@ def main(argv):
 
     args = parser.parse_args(argv)
 
+    release_metadata = None
+    if args.release_type in ("dev-bkc", "nightly-bkc"):
+        release_metadata = load_release_metadata()
+
     # Validation
     if args.release_type != "prerelease" and args.prerelease_version:
         parser.error("release type must be 'prerelease' if --prerelease-version is set")
@@ -265,6 +326,7 @@ def main(argv):
             prerelease_version=args.prerelease_version,
             override_base_version=args.override_base_version,
             override_git_sha=args.override_git_sha,
+            release_metadata=release_metadata,
         )
 
         # Set appropriate output variable based on package type

--- a/build_tools/compute_rocm_package_version.py
+++ b/build_tools/compute_rocm_package_version.py
@@ -49,6 +49,7 @@ import json
 import os
 import subprocess
 import sys
+from typing import Any
 
 from github_actions.github_actions_api import *
 
@@ -61,25 +62,38 @@ def _log(*args, **kwargs):
     sys.stdout.flush()
 
 
-def load_rocm_version() -> str:
-    """Loads the rocm-version from the repository's version.json file."""
-    version_file = THEROCK_DIR / "version.json"
-    _log(f"Loading version from file '{version_file.resolve()}'")
+def load_version_file(
+    version_file: Path = THEROCK_DIR / "version.json",
+) -> dict[str, Any]:
+    """Loads the repository's version.json file."""
+    _log(f"Loading version data from file '{version_file.resolve()}'")
     with open(version_file, "rt") as f:
-        loaded_file = json.load(f)
-        return loaded_file["rocm-version"]
+        version_data = json.load(f)
+    if not isinstance(version_data, dict):
+        raise ValueError("version.json must contain an object")
 
+    release_metadata = version_data.get("release-metadata", {})
+    if not isinstance(release_metadata, Mapping):
+        raise ValueError("release-metadata in version.json must be an object")
 
-def load_release_metadata() -> dict[str, object]:
-    """Loads generic release metadata from the repository's version.json file."""
-    version_file = THEROCK_DIR / "version.json"
-    _log(f"Loading release metadata from file '{version_file.resolve()}'")
-    with open(version_file, "rt") as f:
-        loaded_file = json.load(f)
-        release_metadata = loaded_file.get("release-metadata", {})
-        if not isinstance(release_metadata, dict):
-            raise ValueError("release-metadata in version.json must be an object")
-        return release_metadata
+    base_date = release_metadata.get("base-date", "")
+    if not isinstance(base_date, str):
+        raise ValueError(
+            "release-metadata.base-date must be a valid date in YYYYMMDD format"
+        )
+    if base_date:
+        if len(base_date) != 8 or not base_date.isdigit():
+            raise ValueError(
+                "release-metadata.base-date must be a valid date in YYYYMMDD format"
+            )
+        try:
+            datetime.strptime(base_date, "%Y%m%d")
+        except ValueError as e:
+            raise ValueError(
+                "release-metadata.base-date must be a valid date in YYYYMMDD format"
+            ) from e
+
+    return version_data
 
 
 def get_git_sha(short: bool = False, override_git_sha: str | None = None):
@@ -130,7 +144,7 @@ def compute_version(
     prerelease_version: str | None = None,
     override_base_version: str | None = None,
     override_git_sha: str | None = None,
-    release_metadata: Mapping[str, object] | None = None,
+    version_data: Mapping[str, Any] | None = None,
 ) -> str:
     """Compute package version based on package type and release type.
 
@@ -143,38 +157,30 @@ def compute_version(
         override_base_version: Override the base version from version.json
         override_git_sha: Explicit git SHA override, forwarded to get_git_sha().
             See get_git_sha() for details on when this is needed.
-        release_metadata: Generic metadata from version.json. Loaded automatically
-            for BKC release types when not provided.
+        version_data: Contents of version.json. Loaded automatically when required.
 
     Returns:
         Computed version string appropriate for the package type
     """
+    if version_data is None:
+        version_data = load_version_file()
+
     if override_base_version:
         base_version = override_base_version
     else:
-        base_version = load_rocm_version()
+        base_version = version_data.get("rocm-version")
+        if not isinstance(base_version, str) or not base_version:
+            raise ValueError("rocm-version must be set in version.json")
     _log(f"Base version  : '{base_version}'")
     _log(f"Package type  : '{package_type}'")
+    current_date = get_current_date()
 
-    bkc_base_date = None
     if release_type in ("dev-bkc", "nightly-bkc"):
-        if release_metadata is None:
-            release_metadata = load_release_metadata()
-        bkc_base_date = release_metadata.get("base-date")
-        if not isinstance(bkc_base_date, str) or not bkc_base_date:
+        release_metadata = version_data.get("release-metadata", {})
+        if not release_metadata.get("base-date"):
             raise ValueError(
                 "release-metadata.base-date must be set in version.json "
                 f"for release type '{release_type}'"
-            )
-        try:
-            parsed_bkc_base_date = datetime.strptime(bkc_base_date, "%Y%m%d")
-        except ValueError as e:
-            raise ValueError(
-                "release-metadata.base-date must be a valid date in YYYYMMDD format"
-            ) from e
-        if parsed_bkc_base_date.strftime("%Y%m%d") != bkc_base_date:
-            raise ValueError(
-                "release-metadata.base-date must be a valid date in YYYYMMDD format"
             )
 
     # Handle wheel packages (Python packaging standards)
@@ -193,11 +199,9 @@ def compute_version(
         elif release_type == "nightly":
             # Construct a nightly (a / "alpha") version:
             # https://packaging.python.org/en/latest/specifications/version-specifiers/#pre-releases
-            current_date = get_current_date()
             version_suffix = f"a{current_date}"
         elif release_type == "nightly-bkc":
-            current_date = get_current_date()
-            version_suffix = f"a{bkc_base_date}+bkc.{current_date}"
+            version_suffix = f"a{release_metadata['base-date']}+bkc.{current_date}"
         elif release_type == "prerelease":
             # Construct a prerelease (rc / "release candidate") version
             # https://packaging.python.org/en/latest/specifications/version-specifiers/#pre-releases
@@ -226,7 +230,6 @@ def compute_version(
             # Construct a dev release version with date and optionally git SHA
             # deb format: <rocm-version>~dev<YYYYMMDD>
             # rpm format: <rocm-version>~<YYYYMMDD>g<short-git-sha>
-            current_date = get_current_date()
             if package_type == "deb":
                 version_suffix_str = f"~dev{current_date}"
             else:  # rpm
@@ -235,11 +238,9 @@ def compute_version(
         elif release_type == "nightly":
             # Construct a nightly version with date
             # Format: <rocm-version>~<YYYYMMDD>
-            current_date = get_current_date()
             version_suffix_str = f"~{current_date}"
         elif release_type == "nightly-bkc":
-            current_date = get_current_date()
-            version_suffix_str = f"~{bkc_base_date}+bkc.{current_date}"
+            version_suffix_str = f"~{release_metadata['base-date']}+bkc.{current_date}"
         elif release_type == "prerelease":
             # Construct a prerelease version
             # deb format: <rocm-version>~pre<N>
@@ -304,10 +305,6 @@ def main(argv):
 
     args = parser.parse_args(argv)
 
-    release_metadata = None
-    if args.release_type in ("dev-bkc", "nightly-bkc"):
-        release_metadata = load_release_metadata()
-
     # Validation
     if args.release_type != "prerelease" and args.prerelease_version:
         parser.error("release type must be 'prerelease' if --prerelease-version is set")
@@ -315,6 +312,8 @@ def main(argv):
         parser.error(
             "--prerelease-version is required when release type is 'prerelease'"
         )
+
+    version_data = load_version_file()
 
     # Compute versions for all three package types: wheel, deb, and rpm
     outputs = {}
@@ -326,7 +325,7 @@ def main(argv):
             prerelease_version=args.prerelease_version,
             override_base_version=args.override_base_version,
             override_git_sha=args.override_git_sha,
-            release_metadata=release_metadata,
+            version_data=version_data,
         )
 
         # Set appropriate output variable based on package type

--- a/build_tools/compute_rocm_package_version.py
+++ b/build_tools/compute_rocm_package_version.py
@@ -32,7 +32,7 @@ Sample usage:
   python compute_rocm_package_version.py --release-type=nightly-bkc
   # rocm_package_version=10.1.0a20260811+bkc.20260814
   # rocm_deb_package_version=10.1.0~20260811+bkc.20260814
-  # rocm_rpm_package_version=10.1.0~20260811+bkc.20260814
+  # rocm_rpm_package_version=10.1.0~20260811.bkc.20260814
 
   python compute_rocm_package_version.py --custom-version-suffix=.dev0
   # 7.10.0.dev0
@@ -240,7 +240,10 @@ def compute_version(
             # Format: <rocm-version>~<YYYYMMDD>
             version_suffix_str = f"~{current_date}"
         elif release_type == "nightly-bkc":
-            version_suffix_str = f"~{release_metadata['base-date']}+bkc.{current_date}"
+            bkc_separator = "+" if package_type == "deb" else "."
+            version_suffix_str = (
+                f"~{release_metadata['base-date']}{bkc_separator}bkc.{current_date}"
+            )
         elif release_type == "prerelease":
             # Construct a prerelease version
             # deb format: <rocm-version>~pre<N>

--- a/build_tools/github_actions/tests/determine_version_test.py
+++ b/build_tools/github_actions/tests/determine_version_test.py
@@ -27,6 +27,11 @@ class DetermineVersionTest(unittest.TestCase):
         suffix = determine_version.derive_version_suffix(rocm_version)
         self.assertEqual(suffix, "+rocm7.0.0rc20250707")
 
+    def test_bkc_version_suffix(self):
+        rocm_version = "10.1.0a20260811+bkc.20260813"
+        suffix = determine_version.derive_version_suffix(rocm_version)
+        self.assertEqual(suffix, "+rocm10.1.0a20260811-bkc.20260813")
+
     def test_version_suffix_sorting(self):
         # This tests that version suffixes follow this ordering:
         # final > prerelease > alpha > dev

--- a/build_tools/tests/build_prod_wheels_version_test.py
+++ b/build_tools/tests/build_prod_wheels_version_test.py
@@ -67,6 +67,18 @@ class ComputeBuildVersionTest(unittest.TestCase):
 
         self.assertGreater(rocm_7_14, rocm_10_0)
 
+    def test_nightly_bkc_release_uses_bkc_rocm_version(self):
+        (self.source_dir / "version.txt").write_text("2.13.0\n")
+        version = compute_build_version(
+            self.source_dir,
+            "+rocm10.1.0a20260811-bkc.20260813",
+            "nightly-bkc",
+        )
+        self.assertEqual(
+            str(Version(version)),
+            "2.13.0+rocm10.1.0a20260811.bkc.20260813",
+        )
+
     def test_dev_release_tags_git_commit_in_local_segment(self):
         with mock.patch(
             "build_prod_wheels.get_source_commit_short", return_value="1a2b3c4d"

--- a/build_tools/tests/build_prod_wheels_version_test.py
+++ b/build_tools/tests/build_prod_wheels_version_test.py
@@ -79,6 +79,27 @@ class ComputeBuildVersionTest(unittest.TestCase):
             "2.13.0+rocm10.1.0a20260811.bkc.20260813",
         )
 
+    def test_nightly_bkc_sorts_between_base_and_next_nightly(self):
+        # A BKC build upgrades its base nightly, while the next regular nightly
+        # upgrades the BKC build when both are available to pip.
+        (self.source_dir / "version.txt").write_text("2.13.0\n")
+        base_nightly = Version(
+            compute_build_version(self.source_dir, "+rocm10.1.0a20260811", "nightly")
+        )
+        nightly_bkc = Version(
+            compute_build_version(
+                self.source_dir,
+                "+rocm10.1.0a20260811-bkc.20260813",
+                "nightly-bkc",
+            )
+        )
+        next_nightly = Version(
+            compute_build_version(self.source_dir, "+rocm10.1.0a20260812", "nightly")
+        )
+
+        self.assertGreater(nightly_bkc, base_nightly)
+        self.assertGreater(next_nightly, nightly_bkc)
+
     def test_dev_release_tags_git_commit_in_local_segment(self):
         with mock.patch(
             "build_prod_wheels.get_source_commit_short", return_value="1a2b3c4d"

--- a/build_tools/tests/compute_rocm_package_version_test.py
+++ b/build_tools/tests/compute_rocm_package_version_test.py
@@ -1,8 +1,10 @@
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
+import json
 import os
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -12,12 +14,98 @@ from packaging.version import Version
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 import compute_rocm_package_version
 
-TEST_BKC_RELEASE_METADATA = {"base-date": "20260811"}
+TEST_BKC_VERSION_DATA = {"release-metadata": {"base-date": "20260811"}}
 
 
 # Note: the regex matches in here aren't exact, but they should be "good enough"
 # to cover the general structure of each version string while allowing for
 # future changes like using X.Y versions instead of X.Y.Z versions.
+
+
+class VersionFileTest(unittest.TestCase):
+    def test_loads_repository_version_file(self):
+        version_data = compute_rocm_package_version.load_version_file()
+
+        self.assertIsInstance(version_data["rocm-version"], str)
+        self.assertIsInstance(version_data["release-metadata"], dict)
+
+    def test_loads_version_file_with_empty_metadata(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            version_file = Path(temp_dir) / "version.json"
+            version_file.write_text(
+                """{
+  "rocm-version": "7.9.0",
+  "release-metadata": {
+    "base-date": ""
+  }
+}
+""",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                compute_rocm_package_version.load_version_file(version_file),
+                {
+                    "rocm-version": "7.9.0",
+                    "release-metadata": {"base-date": ""},
+                },
+            )
+
+    def test_loads_version_file_with_populated_metadata(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            version_file = Path(temp_dir) / "version.json"
+            version_file.write_text(
+                """{
+  "rocm-version": "7.9.0",
+  "release-metadata": {
+    "base-date": "20260811"
+  }
+}
+""",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                compute_rocm_package_version.load_version_file(version_file),
+                {
+                    "rocm-version": "7.9.0",
+                    "release-metadata": {"base-date": "20260811"},
+                },
+            )
+
+    def test_rejects_invalid_json(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            version_file = Path(temp_dir) / "version.json"
+            # Missing closing }
+            version_file.write_text(
+                '{ "rocm-version": "7.9.0"',
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(json.JSONDecodeError):
+                compute_rocm_package_version.load_version_file(version_file)
+
+    def test_rejects_invalid_base_date_metadata(self):
+        for base_date in ("2026081", "20261301"):
+            with self.subTest(
+                base_date=base_date
+            ), tempfile.TemporaryDirectory() as temp_dir:
+                version_file = Path(temp_dir) / "version.json"
+                version_file.write_text(
+                    f"""{{
+  "rocm-version": "7.9.0",
+  "release-metadata": {{
+    "base-date": "{base_date}"
+  }}
+}}
+""",
+                    encoding="utf-8",
+                )
+
+                with self.assertRaisesRegex(
+                    ValueError, "valid date in YYYYMMDD format"
+                ):
+                    compute_rocm_package_version.load_version_file(version_file)
 
 
 class PythonPackageVersionTest(unittest.TestCase):
@@ -57,7 +145,7 @@ class PythonPackageVersionTest(unittest.TestCase):
             release_type="dev-bkc",
             override_base_version="7.9.0",
             override_git_sha="abcdef1234567890abcdef1234567890abcdef12",
-            release_metadata=TEST_BKC_RELEASE_METADATA,
+            version_data=TEST_BKC_VERSION_DATA,
         )
         self.assertEqual(version, "7.9.0.dev0+abcdef1234567890abcdef1234567890abcdef12")
 
@@ -79,7 +167,7 @@ class PythonPackageVersionTest(unittest.TestCase):
         version = compute_rocm_package_version.compute_version(
             release_type="nightly-bkc",
             override_base_version="7.9.0",
-            release_metadata=TEST_BKC_RELEASE_METADATA,
+            version_data=TEST_BKC_VERSION_DATA,
         )
         self.assertRegex(
             version,
@@ -94,18 +182,7 @@ class PythonPackageVersionTest(unittest.TestCase):
                 compute_rocm_package_version.compute_version(
                     release_type=release_type,
                     override_base_version="7.9.0",
-                    release_metadata={},
-                )
-
-    def test_bkc_version_validates_base_date_metadata(self):
-        for base_date in ("2026081", "20261301"):
-            with self.subTest(base_date=base_date), self.assertRaisesRegex(
-                ValueError, "valid date in YYYYMMDD format"
-            ):
-                compute_rocm_package_version.compute_version(
-                    release_type="nightly-bkc",
-                    override_base_version="7.9.0",
-                    release_metadata={"base-date": base_date},
+                    version_data={},
                 )
 
     def test_prerelease_version(self):
@@ -203,12 +280,12 @@ class PythonPackageVersionTest(unittest.TestCase):
             "dev-bkc": compute_rocm_package_version.compute_version(
                 release_type="dev-bkc",
                 override_git_sha="abcdef1234567890abcdef1234567890abcdef12",
-                release_metadata=TEST_BKC_RELEASE_METADATA,
+                version_data=TEST_BKC_VERSION_DATA,
                 **common_args,
             ),
             "nightly-bkc": compute_rocm_package_version.compute_version(
                 release_type="nightly-bkc",
-                release_metadata=TEST_BKC_RELEASE_METADATA,
+                version_data=TEST_BKC_VERSION_DATA,
                 **common_args,
             ),
             "nightly": compute_rocm_package_version.compute_version(
@@ -260,7 +337,7 @@ class DebPackageVersionTest(unittest.TestCase):
             package_type="deb",
             release_type="dev-bkc",
             override_base_version="8.1.0",
-            release_metadata=TEST_BKC_RELEASE_METADATA,
+            version_data=TEST_BKC_VERSION_DATA,
         )
         self.assertRegex(version, r"^8\.1\.0~dev[0-9]{8}$")
 
@@ -284,7 +361,7 @@ class DebPackageVersionTest(unittest.TestCase):
             package_type="deb",
             release_type="nightly-bkc",
             override_base_version="8.1.0",
-            release_metadata=TEST_BKC_RELEASE_METADATA,
+            version_data=TEST_BKC_VERSION_DATA,
         )
         self.assertRegex(
             version,
@@ -373,7 +450,7 @@ class RpmPackageVersionTest(unittest.TestCase):
             release_type="dev-bkc",
             override_base_version="8.1.0",
             override_git_sha="abcdef1234567890",
-            release_metadata=TEST_BKC_RELEASE_METADATA,
+            version_data=TEST_BKC_VERSION_DATA,
         )
         self.assertRegex(version, r"^8\.1\.0~[0-9]{8}gabcdef12$")
 
@@ -397,7 +474,7 @@ class RpmPackageVersionTest(unittest.TestCase):
             package_type="rpm",
             release_type="nightly-bkc",
             override_base_version="8.1.0",
-            release_metadata=TEST_BKC_RELEASE_METADATA,
+            version_data=TEST_BKC_VERSION_DATA,
         )
         self.assertRegex(
             version,

--- a/build_tools/tests/compute_rocm_package_version_test.py
+++ b/build_tools/tests/compute_rocm_package_version_test.py
@@ -367,7 +367,7 @@ class DebPackageVersionTest(unittest.TestCase):
         )
         self.assertRegex(
             version,
-            r"^8\.1\.0~20260811\+bkc\.[0-9]{8}$",
+            r"^8\.1\.0~20260811\.bkc\.[0-9]{8}$",
         )
 
     def test_prerelease_version(self):

--- a/build_tools/tests/compute_rocm_package_version_test.py
+++ b/build_tools/tests/compute_rocm_package_version_test.py
@@ -12,6 +12,8 @@ from packaging.version import Version
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 import compute_rocm_package_version
 
+TEST_BKC_RELEASE_METADATA = {"base-date": "20260811"}
+
 
 # Note: the regex matches in here aren't exact, but they should be "good enough"
 # to cover the general structure of each version string while allowing for
@@ -50,6 +52,15 @@ class PythonPackageVersionTest(unittest.TestCase):
         )
         self.assertEqual(version, "7.9.0.dev0+abcdef1234567890abcdef1234567890abcdef12")
 
+    def test_dev_bkc_version_uses_dev_version_shape(self):
+        version = compute_rocm_package_version.compute_version(
+            release_type="dev-bkc",
+            override_base_version="7.9.0",
+            override_git_sha="abcdef1234567890abcdef1234567890abcdef12",
+            release_metadata=TEST_BKC_RELEASE_METADATA,
+        )
+        self.assertEqual(version, "7.9.0.dev0+abcdef1234567890abcdef1234567890abcdef12")
+
     def test_nightly_version(self):
         version = compute_rocm_package_version.compute_version(
             release_type="nightly",
@@ -63,6 +74,39 @@ class PythonPackageVersionTest(unittest.TestCase):
         #   a
         #   [0-9]{8}    Date as YYYYMMDD
         self.assertRegex(version, r"^[0-9]+[0-9\.]*a[0-9]{8}$")
+
+    def test_nightly_bkc_version(self):
+        version = compute_rocm_package_version.compute_version(
+            release_type="nightly-bkc",
+            override_base_version="7.9.0",
+            release_metadata=TEST_BKC_RELEASE_METADATA,
+        )
+        self.assertRegex(
+            version,
+            r"^7\.9\.0a20260811\+bkc\.[0-9]{8}$",
+        )
+
+    def test_bkc_version_requires_base_date_metadata(self):
+        for release_type in ("dev-bkc", "nightly-bkc"):
+            with self.subTest(release_type=release_type), self.assertRaisesRegex(
+                ValueError, "release-metadata.base-date"
+            ):
+                compute_rocm_package_version.compute_version(
+                    release_type=release_type,
+                    override_base_version="7.9.0",
+                    release_metadata={},
+                )
+
+    def test_bkc_version_validates_base_date_metadata(self):
+        for base_date in ("2026081", "20261301"):
+            with self.subTest(base_date=base_date), self.assertRaisesRegex(
+                ValueError, "valid date in YYYYMMDD format"
+            ):
+                compute_rocm_package_version.compute_version(
+                    release_type="nightly-bkc",
+                    override_base_version="7.9.0",
+                    release_metadata={"base-date": base_date},
+                )
 
     def test_prerelease_version(self):
         version = compute_rocm_package_version.compute_version(
@@ -120,12 +164,20 @@ class PythonPackageVersionTest(unittest.TestCase):
 
     def test_versions_sort_by_release_type(self):
         # pip install --upgrade selects the greatest available version, so enforce:
-        # release > prerelease > nightly > dev.
+        # release > prerelease > nightly > nightly-bkc > dev-bkc == dev.
         versions = self._compute_versions_by_release_type()
 
+        self.assertEqual(
+            Version(versions["dev-bkc"]),
+            Version(versions["dev"]),
+        )
+        self.assertGreater(
+            Version(versions["nightly-bkc"]),
+            Version(versions["dev-bkc"]),
+        )
         self.assertGreater(
             Version(versions["nightly"]),
-            Version(versions["dev"]),
+            Version(versions["nightly-bkc"]),
         )
         self.assertGreater(
             Version(versions["prerelease"]),
@@ -146,6 +198,17 @@ class PythonPackageVersionTest(unittest.TestCase):
             "dev": compute_rocm_package_version.compute_version(
                 release_type="dev",
                 override_git_sha="abcdef1234567890abcdef1234567890abcdef12",
+                **common_args,
+            ),
+            "dev-bkc": compute_rocm_package_version.compute_version(
+                release_type="dev-bkc",
+                override_git_sha="abcdef1234567890abcdef1234567890abcdef12",
+                release_metadata=TEST_BKC_RELEASE_METADATA,
+                **common_args,
+            ),
+            "nightly-bkc": compute_rocm_package_version.compute_version(
+                release_type="nightly-bkc",
+                release_metadata=TEST_BKC_RELEASE_METADATA,
                 **common_args,
             ),
             "nightly": compute_rocm_package_version.compute_version(
@@ -192,6 +255,15 @@ class DebPackageVersionTest(unittest.TestCase):
         #   [0-9]{8}    Date as YYYYMMDD
         self.assertRegex(version, r"^[0-9]+[0-9\.]*~dev[0-9]{8}$")
 
+    def test_dev_bkc_version_uses_dev_version_shape(self):
+        version = compute_rocm_package_version.compute_version(
+            package_type="deb",
+            release_type="dev-bkc",
+            override_base_version="8.1.0",
+            release_metadata=TEST_BKC_RELEASE_METADATA,
+        )
+        self.assertRegex(version, r"^8\.1\.0~dev[0-9]{8}$")
+
     def test_nightly_version(self):
         version = compute_rocm_package_version.compute_version(
             package_type="deb",
@@ -206,6 +278,18 @@ class DebPackageVersionTest(unittest.TestCase):
         #   ~
         #   [0-9]{8}    Date as YYYYMMDD
         self.assertRegex(version, r"^[0-9]+[0-9\.]*~[0-9]{8}$")
+
+    def test_nightly_bkc_version(self):
+        version = compute_rocm_package_version.compute_version(
+            package_type="deb",
+            release_type="nightly-bkc",
+            override_base_version="8.1.0",
+            release_metadata=TEST_BKC_RELEASE_METADATA,
+        )
+        self.assertRegex(
+            version,
+            r"^8\.1\.0~20260811\+bkc\.[0-9]{8}$",
+        )
 
     def test_prerelease_version(self):
         version = compute_rocm_package_version.compute_version(
@@ -283,6 +367,16 @@ class RpmPackageVersionTest(unittest.TestCase):
         )
         self.assertRegex(version, r"^8\.1\.0~[0-9]{8}gabcdef12$")
 
+    def test_dev_bkc_version_uses_dev_version_shape(self):
+        version = compute_rocm_package_version.compute_version(
+            package_type="rpm",
+            release_type="dev-bkc",
+            override_base_version="8.1.0",
+            override_git_sha="abcdef1234567890",
+            release_metadata=TEST_BKC_RELEASE_METADATA,
+        )
+        self.assertRegex(version, r"^8\.1\.0~[0-9]{8}gabcdef12$")
+
     def test_nightly_version(self):
         version = compute_rocm_package_version.compute_version(
             package_type="rpm",
@@ -297,6 +391,18 @@ class RpmPackageVersionTest(unittest.TestCase):
         #   ~
         #   [0-9]{8}    Date as YYYYMMDD
         self.assertRegex(version, r"^[0-9]+[0-9\.]*~[0-9]{8}$")
+
+    def test_nightly_bkc_version(self):
+        version = compute_rocm_package_version.compute_version(
+            package_type="rpm",
+            release_type="nightly-bkc",
+            override_base_version="8.1.0",
+            release_metadata=TEST_BKC_RELEASE_METADATA,
+        )
+        self.assertRegex(
+            version,
+            r"^8\.1\.0~20260811\+bkc\.[0-9]{8}$",
+        )
 
     def test_prerelease_version(self):
         version = compute_rocm_package_version.compute_version(

--- a/build_tools/tests/compute_rocm_package_version_test.py
+++ b/build_tools/tests/compute_rocm_package_version_test.py
@@ -24,12 +24,33 @@ TEST_BKC_VERSION_DATA = {"release-metadata": {"base-date": "20260811"}}
 
 class VersionFileTest(unittest.TestCase):
     def test_loads_repository_version_file(self):
+        # The version file in this repository should always parse correctly.
         version_data = compute_rocm_package_version.load_version_file()
 
         self.assertIsInstance(version_data["rocm-version"], str)
         self.assertIsInstance(version_data["release-metadata"], dict)
 
+    def test_loads_version_file_without_metadata(self):
+        # Version files prior to introducing the metadata field should still
+        # parse and load without errors.
+        with tempfile.TemporaryDirectory() as temp_dir:
+            version_file = Path(temp_dir) / "version.json"
+            version_file.write_text(
+                """{
+  "rocm-version": "7.9.0"
+}
+""",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                compute_rocm_package_version.load_version_file(version_file),
+                {"rocm-version": "7.9.0"},
+            )
+
     def test_loads_version_file_with_empty_metadata(self):
+        # Metadata is expected to be empty on the default branch.
+        # It may be populated on release branches.
         with tempfile.TemporaryDirectory() as temp_dir:
             version_file = Path(temp_dir) / "version.json"
             version_file.write_text(

--- a/build_tools/tests/compute_rocm_package_version_test.py
+++ b/build_tools/tests/compute_rocm_package_version_test.py
@@ -87,9 +87,10 @@ class VersionFileTest(unittest.TestCase):
 
     def test_rejects_invalid_base_date_metadata(self):
         for base_date in ("2026081", "20261301"):
-            with self.subTest(
-                base_date=base_date
-            ), tempfile.TemporaryDirectory() as temp_dir:
+            with (
+                self.subTest(base_date=base_date),
+                tempfile.TemporaryDirectory() as temp_dir,
+            ):
                 version_file = Path(temp_dir) / "version.json"
                 version_file.write_text(
                     f"""{{
@@ -176,8 +177,9 @@ class PythonPackageVersionTest(unittest.TestCase):
 
     def test_bkc_version_requires_base_date_metadata(self):
         for release_type in ("dev-bkc", "nightly-bkc"):
-            with self.subTest(release_type=release_type), self.assertRaisesRegex(
-                ValueError, "release-metadata.base-date"
+            with (
+                self.subTest(release_type=release_type),
+                self.assertRaisesRegex(ValueError, "release-metadata.base-date"),
             ):
                 compute_rocm_package_version.compute_version(
                     release_type=release_type,
@@ -478,7 +480,7 @@ class RpmPackageVersionTest(unittest.TestCase):
         )
         self.assertRegex(
             version,
-            r"^8\.1\.0~20260811\+bkc\.[0-9]{8}$",
+            r"^8\.1\.0~20260811\.bkc\.[0-9]{8}$",
         )
 
     def test_prerelease_version(self):

--- a/docs/packaging/versioning.md
+++ b/docs/packaging/versioning.md
@@ -327,7 +327,7 @@ The script produces these versions for rpm packages for each release type:
 | stable       | `X.Y.Z`                                      | `7.10.0`                                                                                                                               |
 | prerelease   | `X.Y.Z~rcN`                                  | `7.10.0~rc0`<br>(The first release candidate for that stable release)                                                                  |
 | nightly      | `X.Y.Z~YYYYMMDD`                             | `7.10.0~20251124`<br>(The nightly release on 2025-11-24)                                                                               |
-| nightly-bkc  | `X.Y.Z~BASEDATE+bkc.YYYYMMDD`                | `10.1.0~20260811+bkc.20260814`                                                                                                         |
+| nightly-bkc  | `X.Y.Z~BASEDATE.bkc.YYYYMMDD`                | `10.1.0~20260811.bkc.20260814`                                                                                                         |
 | dev          | `X.Y.Z~YYYYMMDDg<git-hash>`                  | `7.10.0~20251124gefed3c3`<br>(For commit [`efed3c3`](https://github.com/ROCm/TheRock/commit/efed3c3b10a5cce8578f58f8eb288582c26d18c4)) |
 | dev-bkc      | `X.Y.Z~YYYYMMDDg<git-hash>`<br>(same as dev) | `10.1.0~20260814gefed3c3`                                                                                                              |
 

--- a/docs/packaging/versioning.md
+++ b/docs/packaging/versioning.md
@@ -153,11 +153,12 @@ For example, for torch version `2.9.0` built with ROCm version `7.10.0` we
 generate a composite torch version `2.9.0+rocm7.10.0`. See this table for more
 possible version combinations:
 
-| ROCm release type | ROCm version example | Composite torch version example                                                    |
-| ----------------- | -------------------- | ---------------------------------------------------------------------------------- |
-| stable            | `7.10.0`             | `2.9.0+rocm7.10.0`                                                                 |
-| nightly           | `7.10.0a20251124`    | `2.9.0+rocm7.10.0a20251124`                                                        |
-| dev               | `7.10.0.dev0+efed3c` | `2.9.0+devrocm7.10.0.dev0-efed3c`<br>_(Note the `devrocm` and `-` instead of `+`)_ |
+| ROCm release type | ROCm version example           | Composite torch version example                                                    |
+| ----------------- | ------------------------------ | ---------------------------------------------------------------------------------- |
+| stable            | `7.10.0`                       | `2.9.0+rocm7.10.0`                                                                 |
+| nightly           | `7.10.0a20251124`              | `2.9.0+rocm7.10.0a20251124`                                                        |
+| nightly-bkc       | `10.1.0a20260811+bkc.20260813` | `2.13.0+rocm10.1.0a20260811.bkc.20260813`                                          |
+| dev               | `7.10.0.dev0+efed3c`           | `2.9.0+devrocm7.10.0.dev0-efed3c`<br>_(Note the `devrocm` and `-` instead of `+`)_ |
 
 These local version identifiers are specially constructed such that the expected
 version sorting of `stable > nightly > dev` is preserved. Note that per the

--- a/docs/packaging/versioning.md
+++ b/docs/packaging/versioning.md
@@ -338,7 +338,7 @@ The script produces these versions for debian packages for each release type:
 | stable       | `X.Y.Z`                                      | `7.10.0`                                                               |
 | prerelease   | `X.Y.Z~preN`                                 | `7.10.0~pre0`<br>(The first release candidate for that stable release) |
 | nightly      | `X.Y.Z~YYYYMMDD`                             | `7.10.0~20251124`<br>(The nightly release on 2025-11-24)               |
-| nightly-bkc  | `X.Y.Z~BASEDATE+bkc.YYYYMMDD`                | `10.1.0~20260811+bkc.20260814`                                         |
+| nightly-bkc  | `X.Y.Z~BASEDATE.bkc.YYYYMMDD`                | `10.1.0~20260811.bkc.20260814`                                         |
 | dev          | `X.Y.Z~devYYYYMMDD`                          | `7.10.0~dev20251124`<br>(For dev build on 2025-11-24)                  |
 | dev-bkc      | `X.Y.Z~devYYYYMMDD`<br>(same as regular dev) | `10.1.0~dev20260814`                                                   |
 

--- a/docs/packaging/versioning.md
+++ b/docs/packaging/versioning.md
@@ -10,6 +10,7 @@ Table of contents:
 - [Overview](#overview)
   - [Constraints and design guidelines](#constraints-and-design-guidelines)
   - [Distribution channels (dev, nightly, release)](#distribution-channels-dev-nightly-release)
+- [Release branch metadata](#release-branch-metadata)
 - [Python package versions](#python-package-versions)
 - [Native Linux package versions](#native-linux-package-versions)
 - [Native Windows package versions](#native-windows-package-versions)
@@ -24,14 +25,22 @@ where
 - `Z` is the "patch version"
 
 The [`version.json`](/version.json) file at the root of TheRock defines the
-base version used for packages. Its generic `release-metadata` object contains
-fields that release types can interpret as needed. These fields are empty on
-the base branch and populated by commits on release branches. For BKC releases,
-`release-metadata.base-date` identifies the regular nightly release that the
-branch was created from. Subprojects may have their own independent library
-versions (for example
-`HIPBLASLT_PROJECT_VERSION` in
-[`rocm-libraries/projects/hipblaslt/CMakeLists.txt`](https://github.com/ROCm/rocm-libraries/blob/develop/projects/hipblaslt/CMakeLists.txt)).
+base version used for packages:
+
+```json
+{
+  "rocm-version": "10.1.0"
+}
+```
+
+> [!NOTE]
+> Subprojects may have their own independent
+> library versions (for example `HIPBLASLT_PROJECT_VERSION` in
+> [`rocm-libraries/projects/hipblaslt/CMakeLists.txt`](https://github.com/ROCm/rocm-libraries/blob/develop/projects/hipblaslt/CMakeLists.txt)):
+>
+> ```cmake
+> set(HIPBLASLT_PROJECT_VERSION "1.4.1" CACHE STRING "Semantic version string.")
+> ```
 
 <!-- TODO: touch on ABI versions in libraries (.so/.dll) -->
 
@@ -65,12 +74,43 @@ users who want early previews of upcoming releases, and QA/test team members.
 | stable releases      | https://repo.amd.com/rocm/        | Manually promoted prereleases                                                                                                                                                                                |
 | prereleases          | https://rocm.prereleases.amd.com/ | Manually triggered workflows in [rockrel](https://github.com/ROCm/rockrel)                                                                                                                                   |
 | nightly releases     | https://rocm.nightlies.amd.com/   | Scheduled workflows in [rockrel](https://github.com/ROCm/rockrel)                                                                                                                                            |
+| BKC releases         | TBD                               | Workflows in [rockrel](https://github.com/ROCm/rockrel)                                                                                                                                                      |
 | dev releases         | https://rocm.devreleases.amd.com/ | Manually triggered test workflows in [TheRock](https://github.com/ROCm/TheRock) and [rockrel](https://github.com/ROCm/rockrel)                                                                               |
 | dev builds           | No central index                  | Local builds and per-commit workflows in [TheRock](https://github.com/ROCm/TheRock),<br>[rocm-libraries](https://github.com/ROCm/rocm-libraries), [rocm-systems](https://github.com/ROCm/rocm-systems), etc. |
+
+Each distribution channel is currently hosted on a separate release index that
+can be passed to package managers like `pip` (see
+[RELEASES.md - Installing releases using pip](../../RELEASES.md#installing-releases-using-pip)
+for details). For example:
+
+```bash
+pip install --index-url=https://rocm.nightlies.amd.com/whl-multi-arch/ rocm
+pip install --index-url=https://rocm.devreleases.amd.com/whl-multi-arch/ rocm
+```
 
 With the exception of "dev releases", each distribution channel only contains
 release artifacts of the matching release type. The "dev releases" channel
 _can_ contain any type of release.
+
+## Release branch metadata
+
+The `version.json` file also contains a generic `release-metadata` object
+hosting fields that release types can interpret as needed. These fields should
+be empty on the base branch and may be populated by commits on release branches:
+
+```jsonc
+{
+  "rocm-version": "10.1.0",
+  "release-metadata": {
+    // Empty on the base branch.
+    "base-date": ""
+    // A BKC release branch could set base-date to 20260811 for a package
+    // version like 10.1.0a20260811+bkc.20260813 where
+    //   * 20260811 is fixed to when the release branch forked from mainline
+    //   * 20260813 is the current date
+  }
+}
+```
 
 ## Python package versions
 
@@ -90,6 +130,8 @@ The script produces these versions for each release type:
 | dev          | `X.Y.Z.dev0+NNNN`                          | `7.10.0.dev0+efed3c3b10a5cce8578f58f8eb288582c26d18c4`<br>(For commit [`efed3c3`](https://github.com/ROCm/TheRock/commit/efed3c3b10a5cce8578f58f8eb288582c26d18c4)) |
 | dev-bkc      | `X.Y.Z.dev0+NNNN`<br>(same as regular dev) | `10.1.0.dev0+efed3c3b10a5cce8578f58f8eb288582c26d18c4`                                                                                                              |
 
+### BKC versions
+
 For `nightly-bkc`, `BASEDATE` comes from `release-metadata.base-date` in
 `version.json` and identifies the regular nightly used to create the BKC
 branch. The date in the `bkc.YYYYMMDD` local version identifier is the BKC
@@ -99,22 +141,6 @@ than the next regular nightly:
 ```text
 10.1.0a20260811 < 10.1.0a20260811+bkc.20260814 < 10.1.0a20260812
 ```
-
-Both BKC release types require the base date metadata to be populated on their
-release branch. The `dev-bkc` release type uses the regular dev package version
-format; its distinct release type is used to route BKC builds through release
-automation. Each BKC build date currently identifies one logical build; there
-is no additional build counter.
-
-Each distribution channel is currently hosted on a separate release index that
-can be passed to `pip` or `uv` via `--index-url`. For example:
-
-```bash
-pip install --index-url=https://rocm.nightlies.amd.com/whl-multi-arch/ rocm
-```
-
-See [RELEASES.md - Installing releases using pip](../../RELEASES.md#installing-releases-using-pip)
-for details.
 
 ### External Python package versions
 
@@ -314,9 +340,6 @@ The script produces these versions for debian packages for each release type:
 | nightly-bkc  | `X.Y.Z~BASEDATE+bkc.YYYYMMDD`                | `10.1.0~20260811+bkc.20260814`                                         |
 | dev          | `X.Y.Z~devYYYYMMDD`                          | `7.10.0~dev20251124`<br>(For dev build on 2025-11-24)                  |
 | dev-bkc      | `X.Y.Z~devYYYYMMDD`<br>(same as regular dev) | `10.1.0~dev20260814`                                                   |
-
-The native `nightly-bkc` versions use the same base nightly date and BKC build
-date as the Python package version.
 
 ## Native Windows package versions
 

--- a/docs/packaging/versioning.md
+++ b/docs/packaging/versioning.md
@@ -24,8 +24,13 @@ where
 - `Z` is the "patch version"
 
 The [`version.json`](/version.json) file at the root of TheRock defines the
-base version used for packages, while subprojects may have their own independent
-library versions (for example `HIPBLASLT_PROJECT_VERSION` in
+base version used for packages. Its generic `release-metadata` object contains
+fields that release types can interpret as needed. These fields are empty on
+the base branch and populated by commits on release branches. For BKC releases,
+`release-metadata.base-date` identifies the regular nightly release that the
+branch was created from. Subprojects may have their own independent library
+versions (for example
+`HIPBLASLT_PROJECT_VERSION` in
 [`rocm-libraries/projects/hipblaslt/CMakeLists.txt`](https://github.com/ROCm/rocm-libraries/blob/develop/projects/hipblaslt/CMakeLists.txt)).
 
 <!-- TODO: touch on ABI versions in libraries (.so/.dll) -->
@@ -76,12 +81,30 @@ Python package versions are handled by scripts:
 
 The script produces these versions for each release type:
 
-| Release type | Version format    | Version example                                                                                                                                                     |
-| ------------ | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| stable       | `X.Y.Z`           | `7.10.0`                                                                                                                                                            |
-| prerelease   | `X.Y.ZrcN`        | `7.10.0rc0`<br>(The first release candidate for that stable release)                                                                                                |
-| nightly      | `X.Y.ZaYYYYMMDD`  | `7.10.0a20251124`<br>(The nightly release on 2025-11-24)                                                                                                            |
-| dev          | `X.Y.Z.dev0+NNNN` | `7.10.0.dev0+efed3c3b10a5cce8578f58f8eb288582c26d18c4`<br>(For commit [`efed3c3`](https://github.com/ROCm/TheRock/commit/efed3c3b10a5cce8578f58f8eb288582c26d18c4)) |
+| Release type | Version format                             | Version example                                                                                                                                                     |
+| ------------ | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| stable       | `X.Y.Z`                                    | `7.10.0`                                                                                                                                                            |
+| prerelease   | `X.Y.ZrcN`                                 | `7.10.0rc0`<br>(The first release candidate for that stable release)                                                                                                |
+| nightly      | `X.Y.ZaYYYYMMDD`                           | `7.10.0a20251124`<br>(The nightly release on 2025-11-24)                                                                                                            |
+| nightly-bkc  | `X.Y.ZaBASEDATE+bkc.YYYYMMDD`              | `10.1.0a20260811+bkc.20260814`                                                                                                                                      |
+| dev          | `X.Y.Z.dev0+NNNN`                          | `7.10.0.dev0+efed3c3b10a5cce8578f58f8eb288582c26d18c4`<br>(For commit [`efed3c3`](https://github.com/ROCm/TheRock/commit/efed3c3b10a5cce8578f58f8eb288582c26d18c4)) |
+| dev-bkc      | `X.Y.Z.dev0+NNNN`<br>(same as regular dev) | `10.1.0.dev0+efed3c3b10a5cce8578f58f8eb288582c26d18c4`                                                                                                              |
+
+For `nightly-bkc`, `BASEDATE` comes from `release-metadata.base-date` in
+`version.json` and identifies the regular nightly used to create the BKC
+branch. The date in the `bkc.YYYYMMDD` local version identifier is the BKC
+build date. This makes a BKC build sort newer than its base nightly but older
+than the next regular nightly:
+
+```text
+10.1.0a20260811 < 10.1.0a20260811+bkc.20260814 < 10.1.0a20260812
+```
+
+Both BKC release types require the base date metadata to be populated on their
+release branch. The `dev-bkc` release type uses the regular dev package version
+format; its distinct release type is used to route BKC builds through release
+automation. Each BKC build date currently identifies one logical build; there
+is no additional build counter.
 
 Each distribution channel is currently hosted on a separate release index that
 can be passed to `pip` or `uv` via `--index-url`. For example:
@@ -272,21 +295,28 @@ Native package versions are handled by scripts:
 
 The script produces these versions for rpm packages for each release type:
 
-| Release type | Version format              | Version example                                                                                                                        |
-| ------------ | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| stable       | `X.Y.Z`                     | `7.10.0`                                                                                                                               |
-| prerelease   | `X.Y.Z~rcN`                 | `7.10.0~rc0`<br>(The first release candidate for that stable release)                                                                  |
-| nightly      | `X.Y.Z~YYYYMMDD`            | `7.10.0~20251124`<br>(The nightly release on 2025-11-24)                                                                               |
-| dev          | `X.Y.Z~YYYYMMDDg<git-hash>` | `7.10.0~20251124gefed3c3`<br>(For commit [`efed3c3`](https://github.com/ROCm/TheRock/commit/efed3c3b10a5cce8578f58f8eb288582c26d18c4)) |
+| Release type | Version format                               | Version example                                                                                                                        |
+| ------------ | -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| stable       | `X.Y.Z`                                      | `7.10.0`                                                                                                                               |
+| prerelease   | `X.Y.Z~rcN`                                  | `7.10.0~rc0`<br>(The first release candidate for that stable release)                                                                  |
+| nightly      | `X.Y.Z~YYYYMMDD`                             | `7.10.0~20251124`<br>(The nightly release on 2025-11-24)                                                                               |
+| nightly-bkc  | `X.Y.Z~BASEDATE+bkc.YYYYMMDD`                | `10.1.0~20260811+bkc.20260814`                                                                                                         |
+| dev          | `X.Y.Z~YYYYMMDDg<git-hash>`                  | `7.10.0~20251124gefed3c3`<br>(For commit [`efed3c3`](https://github.com/ROCm/TheRock/commit/efed3c3b10a5cce8578f58f8eb288582c26d18c4)) |
+| dev-bkc      | `X.Y.Z~YYYYMMDDg<git-hash>`<br>(same as dev) | `10.1.0~20260814gefed3c3`                                                                                                              |
 
 The script produces these versions for debian packages for each release type:
 
-| Release type | Version format      | Version example                                                        |
-| ------------ | ------------------- | ---------------------------------------------------------------------- |
-| stable       | `X.Y.Z`             | `7.10.0`                                                               |
-| prerelease   | `X.Y.Z~preN`        | `7.10.0~pre0`<br>(The first release candidate for that stable release) |
-| nightly      | `X.Y.Z~YYYYMMDD`    | `7.10.0~20251124`<br>(The nightly release on 2025-11-24)               |
-| dev          | `X.Y.Z~devYYYYMMDD` | `7.10.0~dev20251124`<br>(For dev build on 2025-11-24)d18c4)            |
+| Release type | Version format                               | Version example                                                        |
+| ------------ | -------------------------------------------- | ---------------------------------------------------------------------- |
+| stable       | `X.Y.Z`                                      | `7.10.0`                                                               |
+| prerelease   | `X.Y.Z~preN`                                 | `7.10.0~pre0`<br>(The first release candidate for that stable release) |
+| nightly      | `X.Y.Z~YYYYMMDD`                             | `7.10.0~20251124`<br>(The nightly release on 2025-11-24)               |
+| nightly-bkc  | `X.Y.Z~BASEDATE+bkc.YYYYMMDD`                | `10.1.0~20260811+bkc.20260814`                                         |
+| dev          | `X.Y.Z~devYYYYMMDD`                          | `7.10.0~dev20251124`<br>(For dev build on 2025-11-24)                  |
+| dev-bkc      | `X.Y.Z~devYYYYMMDD`<br>(same as regular dev) | `10.1.0~dev20260814`                                                   |
+
+The native `nightly-bkc` versions use the same base nightly date and BKC build
+date as the Python package version.
 
 ## Native Windows package versions
 

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -321,22 +321,22 @@ def get_source_commit_short(source_dir: Path, length: int = 8) -> str:
 def compute_build_version(
     source_dir: Path, version_suffix: str, release_type: str
 ) -> str:
-    """Compute a wheel version, tagging dev builds with the source commit.
+    """Compute a wheel version, tagging dev release types with the source commit.
 
     Reads `<source_dir>/version.txt` as the base version and appends
     `version_suffix` (a PEP 440 local identifier like `+rocm7.10.0`). For `dev`
-    builds the 8-char source commit is merged into that single local segment,
-    e.g. `2.12.0a0+git1a2b3c4d.rocm7.10.0`, so each wheel (torch, torchaudio,
-    torchvision) records exactly which source commit produced it. PyTorch's
-    setup.py validates the version as PEP 440, which only allows a commit hash
-    in the local segment (after `+`).
+    and `dev-bkc` builds, the 8-char source commit is merged into that single
+    local segment, e.g. `2.12.0a0+git1a2b3c4d.rocm7.10.0`, so each wheel
+    (torch, torchaudio, torchvision) records exactly which source commit
+    produced it. PyTorch's setup.py validates the version as PEP 440, which only
+    allows a commit hash in the local segment (after `+`).
     TODO(#5110): reconcile with generate_pytorch_source_manifest.py once
     upfront, manifest-based version computation lands so the built version
     always matches what the manifest records.
     """
     base_version = (source_dir / "version.txt").read_text().strip()
     build_version = base_version + version_suffix
-    if release_type == "dev":
+    if release_type in ("dev", "dev-bkc"):
         commit = get_source_commit_short(source_dir)
         if commit:
             # version_suffix is a local identifier like `+rocm7.10.0`; merge the
@@ -1591,13 +1591,16 @@ def main(argv: list[str]):
     )
     build_p.add_argument(
         "--release-type",
-        choices=["ci", "dev", "nightly", "prerelease"],
+        choices=["ci", "dev", "dev-bkc", "nightly", "nightly-bkc", "prerelease"],
         default="nightly",
-        help="Release type of the build. For `dev` builds the torch wheel "
-        "version is tagged with the 8-char torch source commit in the local "
-        "segment, e.g. `2.12.0a0+git1a2b3c4d.rocm7.10.0` (torch wheel only). "
-        "The default is non-appending so other callers (CI, nightly, "
-        "prerelease) keep their plain `<base>+<suffix>` versions.",
+        help=(
+            "Release type of the build. For `dev` and `dev-bkc` builds the "
+            "torch wheel version is tagged with the 8-char torch source commit "
+            "in the local segment, e.g. "
+            "`2.12.0a0+git1a2b3c4d.rocm7.10.0` (torch wheel only). The default "
+            "is non-appending so other callers (CI, nightly, prerelease) keep "
+            "their plain `<base>+<suffix>` versions."
+        ),
     )
     build_p.add_argument(
         "--clean",

--- a/version.json
+++ b/version.json
@@ -1,3 +1,6 @@
 {
-  "rocm-version": "10.1.0"
+  "rocm-version": "10.1.0",
+  "release-metadata": {
+    "base-date": ""
+  }
 }


### PR DESCRIPTION
## Motivation

* Progress on https://github.com/ROCm/rockrel/issues/88

We're creating a new release stream that will branch off from nightly releases while carrying cherry-picks. This PR implements versioning for these releases with a local version segment (https://packaging.python.org/en/latest/specifications/version-specifiers/#local-version-segments) that extends the base nightly version:

Version type | Example
-- | --
nightly | `10.1.0a20260811`
nightly-bkc| `10.1.0a20260811+bkc.20260813`

To support testing this also adds a `dev-bkc` release type that may redirect the output buckets while keeping the same dev version scheme used for regular dev releases.

## Technical Details

To produce versions like:
```
10.1.0a20260811+bkc.20260813
10.1.0a20260811+bkc.20260814
10.1.0a20260811+bkc.20260815
```

we'll store `base-date` (e.g.  `20260811`) as metadata in version.json on the release branch and then have the script that computes the version load the current data into the local version segment.

## Test Plan

* Unit tests and local commands like `python build_tools/compute_rocm_package_version.py --release-type=nightly-bkc --override-base-version=7.99.0`
* Once the full stack of changes lands we'll be ready to trigger dev and nightly bkc releases in https://github.com/ROCm/rockrel, where this will be tested for real

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
