### PR TITLE
[release] Support BKC release types in release workflows

### DIFF
--- a/.github/actions/configure_aws_artifacts_credentials/action.yml
+++ b/.github/actions/configure_aws_artifacts_credentials/action.yml
@@ -6,13 +6,13 @@ name: "Configure AWS credentials for artifact uploads"
 description: >-
   Determine the IAM role for the artifacts S3 bucket and assume it via OIDC.
   * Forks and external repos skip OIDC and use runner base credentials.
-  * Release builds (dev/nightly/prerelease) use 'therock-{release_type}' roles.
+  * Release builds use the IAM role for their destination release bucket.
   * Other CI runs use the 'therock-ci' role.
   See the "Authentication" section in docs/development/s3_buckets.md.
 
 inputs:
   release_type:
-    description: 'Release type: "ci", "dev", "nightly", or "prerelease"'
+    description: 'Release type: "ci", "dev", "dev-bkc", "nightly", "nightly-bkc", or "prerelease"'
     default: ci
 
 runs:

--- a/.github/actions/setup_test_environment/action.yml
+++ b/.github/actions/setup_test_environment/action.yml
@@ -24,7 +24,7 @@ inputs:
   FETCH_ARTIFACT_ARGS:
     description: (string) Extra arguments to install_rocm_from_artifacts.py (e.g. `--blas --tests`)
   RELEASE_TYPE:
-    description: 'Release type: "ci", "dev", "nightly", or "prerelease"'
+    description: "Release type for the artifacts being tested"
     default: ci
 
 runs:

--- a/.github/workflows/build_portable_linux_python_packages.yml
+++ b/.github/workflows/build_portable_linux_python_packages.yml
@@ -37,7 +37,7 @@ on:
         description: "package_version to set on packages, e.g. '7.13.0.dev0+dbd7369489260265fc6ddfc9d0de1262a95fe974'"
         type: string
       release_type:
-        description: 'Release type: "ci" for CI, or "dev", "nightly", "prerelease".'
+        description: "Release type used for package publishing."
         type: string
         default: ""
       repository:

--- a/.github/workflows/build_windows_python_packages.yml
+++ b/.github/workflows/build_windows_python_packages.yml
@@ -37,7 +37,7 @@ on:
         description: "package_version to set on packages, e.g. '7.13.0.dev0+dbd7369489260265fc6ddfc9d0de1262a95fe974'"
         type: string
       release_type:
-        description: 'Release type: "ci" for CI, or "dev", "nightly", "prerelease".'
+        description: "Release type used for package publishing."
         type: string
         default: ""
       repository:

--- a/.github/workflows/multi_arch_build_native_linux_packages.yml
+++ b/.github/workflows/multi_arch_build_native_linux_packages.yml
@@ -31,7 +31,7 @@ on:
         type: string
         default: ""
       release_type:
-        description: "Release type: 'ci', 'dev', 'nightly', or 'prerelease'"
+        description: "Release type used for artifact storage and package publishing."
         required: false
         type: string
         default: ci

--- a/.github/workflows/multi_arch_build_portable_linux.yml
+++ b/.github/workflows/multi_arch_build_portable_linux.yml
@@ -46,7 +46,7 @@ on:
         default: "aws-linux-scale-rocm-prod"
         description: "Build runner label (selected by configure script with weighted distribution)"
       release_type:
-        description: 'Release type: "ci", "dev", "nightly", or "prerelease"'
+        description: "Release type used for artifact storage and package versioning."
         type: string
         default: ci
       repository:

--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -192,7 +192,12 @@ jobs:
       PACKAGE_DIST_DIR: ${{ github.workspace }}/output/packages/dist
       optional_build_prod_arguments: ""
       # TODO: Move the sccache bucket and IAM role mapping into a shared script.
-      SCCACHE_BUCKET: "${{ inputs.release_type == 'dev-bkc' && 'therock-pytorch-sccache-dev' || inputs.release_type == 'nightly-bkc' && 'therock-pytorch-sccache-nightly' || format('therock-pytorch-sccache-{0}', inputs.release_type) }}"
+      SCCACHE_BUCKET: >-
+        ${{
+          inputs.release_type == 'dev-bkc' && 'therock-pytorch-sccache-dev'
+          || inputs.release_type == 'nightly-bkc' && 'therock-pytorch-sccache-nightly'
+          || format('therock-pytorch-sccache-{0}', inputs.release_type)
+        }}
       SCCACHE_REGION: us-east-1
       SCCACHE_S3_KEY_PREFIX: "linux/multiarch/v1/"
       SCCACHE_S3_USE_SSL: "true"
@@ -303,7 +308,12 @@ jobs:
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-region: us-east-1
-          role-to-assume: "${{ inputs.release_type == 'dev-bkc' && 'arn:aws:iam::324352301041:role/therock-dev' || inputs.release_type == 'nightly-bkc' && 'arn:aws:iam::324352301041:role/therock-nightly' || format('arn:aws:iam::324352301041:role/therock-{0}', inputs.release_type) }}"
+          role-to-assume: >-
+            ${{
+              inputs.release_type == 'dev-bkc' && 'arn:aws:iam::324352301041:role/therock-dev'
+              || inputs.release_type == 'nightly-bkc' && 'arn:aws:iam::324352301041:role/therock-nightly'
+              || format('arn:aws:iam::324352301041:role/therock-{0}', inputs.release_type)
+            }}
           # Multi-package PyTorch builds can exceed the default 1h credential
           # window; the role's MaxSessionDuration must be >= this value.
           role-duration-seconds: 21600

--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -191,7 +191,8 @@ jobs:
     env:
       PACKAGE_DIST_DIR: ${{ github.workspace }}/output/packages/dist
       optional_build_prod_arguments: ""
-      SCCACHE_BUCKET: "therock-pytorch-sccache-${{ inputs.release_type }}"
+      # TODO: Move the sccache bucket and IAM role mapping into a shared script.
+      SCCACHE_BUCKET: "${{ inputs.release_type == 'dev-bkc' && 'therock-pytorch-sccache-dev' || inputs.release_type == 'nightly-bkc' && 'therock-pytorch-sccache-nightly' || format('therock-pytorch-sccache-{0}', inputs.release_type) }}"
       SCCACHE_REGION: us-east-1
       SCCACHE_S3_KEY_PREFIX: "linux/multiarch/v1/"
       SCCACHE_S3_USE_SSL: "true"
@@ -302,7 +303,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-region: us-east-1
-          role-to-assume: arn:aws:iam::324352301041:role/therock-${{ inputs.release_type }}
+          role-to-assume: "${{ inputs.release_type == 'dev-bkc' && 'arn:aws:iam::324352301041:role/therock-dev' || inputs.release_type == 'nightly-bkc' && 'arn:aws:iam::324352301041:role/therock-nightly' || format('arn:aws:iam::324352301041:role/therock-{0}', inputs.release_type) }}"
           # Multi-package PyTorch builds can exceed the default 1h credential
           # window; the role's MaxSessionDuration must be >= this value.
           role-duration-seconds: 21600

--- a/.github/workflows/multi_arch_build_windows.yml
+++ b/.github/workflows/multi_arch_build_windows.yml
@@ -44,7 +44,7 @@ on:
       rocm_package_version:
         type: string
       release_type:
-        description: 'Release type: "ci", "dev", "nightly", or "prerelease"'
+        description: "Release type used for artifact storage and package versioning."
         type: string
         default: ci
       repository:

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
@@ -181,7 +181,12 @@ jobs:
       PACKAGE_DIST_DIR: ${{ github.workspace }}\output\packages\dist
       optional_build_prod_arguments: ""
       # TODO: Move the sccache bucket and IAM role mapping into a shared script.
-      SCCACHE_BUCKET: "${{ inputs.release_type == 'dev-bkc' && 'therock-pytorch-sccache-dev' || inputs.release_type == 'nightly-bkc' && 'therock-pytorch-sccache-nightly' || format('therock-pytorch-sccache-{0}', inputs.release_type) }}"
+      SCCACHE_BUCKET: >-
+        ${{
+          inputs.release_type == 'dev-bkc' && 'therock-pytorch-sccache-dev'
+          || inputs.release_type == 'nightly-bkc' && 'therock-pytorch-sccache-nightly'
+          || format('therock-pytorch-sccache-{0}', inputs.release_type)
+        }}
       SCCACHE_REGION: us-east-1
       SCCACHE_S3_KEY_PREFIX: "windows/multiarch/v1/"
       SCCACHE_S3_USE_SSL: "true"
@@ -317,7 +322,12 @@ jobs:
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-region: us-east-1
-          role-to-assume: "${{ inputs.release_type == 'dev-bkc' && 'arn:aws:iam::324352301041:role/therock-dev' || inputs.release_type == 'nightly-bkc' && 'arn:aws:iam::324352301041:role/therock-nightly' || format('arn:aws:iam::324352301041:role/therock-{0}', inputs.release_type) }}"
+          role-to-assume: >-
+            ${{
+              inputs.release_type == 'dev-bkc' && 'arn:aws:iam::324352301041:role/therock-dev'
+              || inputs.release_type == 'nightly-bkc' && 'arn:aws:iam::324352301041:role/therock-nightly'
+              || format('arn:aws:iam::324352301041:role/therock-{0}', inputs.release_type)
+            }}
           # Multi-package PyTorch builds can exceed the default 1h credential
           # window; the role's MaxSessionDuration must be >= this value.
           role-duration-seconds: 21600

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
@@ -180,7 +180,8 @@ jobs:
       # Note the \ here instead of /. This should be used from 'cmd' not 'bash'!
       PACKAGE_DIST_DIR: ${{ github.workspace }}\output\packages\dist
       optional_build_prod_arguments: ""
-      SCCACHE_BUCKET: "therock-pytorch-sccache-${{ inputs.release_type }}"
+      # TODO: Move the sccache bucket and IAM role mapping into a shared script.
+      SCCACHE_BUCKET: "${{ inputs.release_type == 'dev-bkc' && 'therock-pytorch-sccache-dev' || inputs.release_type == 'nightly-bkc' && 'therock-pytorch-sccache-nightly' || format('therock-pytorch-sccache-{0}', inputs.release_type) }}"
       SCCACHE_REGION: us-east-1
       SCCACHE_S3_KEY_PREFIX: "windows/multiarch/v1/"
       SCCACHE_S3_USE_SSL: "true"
@@ -316,7 +317,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-region: us-east-1
-          role-to-assume: arn:aws:iam::324352301041:role/therock-${{ inputs.release_type }}
+          role-to-assume: "${{ inputs.release_type == 'dev-bkc' && 'arn:aws:iam::324352301041:role/therock-dev' || inputs.release_type == 'nightly-bkc' && 'arn:aws:iam::324352301041:role/therock-nightly' || format('arn:aws:iam::324352301041:role/therock-{0}', inputs.release_type) }}"
           # Multi-package PyTorch builds can exceed the default 1h credential
           # window; the role's MaxSessionDuration must be >= this value.
           role-duration-seconds: 21600

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -29,7 +29,7 @@ on:
       test_type:
         type: string
       release_type:
-        description: 'Release type: "ci", "dev", "nightly", or "prerelease"'
+        description: "Release type used for artifact storage and package versioning."
         type: string
         default: ci
       external_repo_config:

--- a/.github/workflows/multi_arch_ci_windows.yml
+++ b/.github/workflows/multi_arch_ci_windows.yml
@@ -23,7 +23,7 @@ on:
       test_type:
         type: string
       release_type:
-        description: 'Release type: "ci", "dev", "nightly", or "prerelease".'
+        description: "Release type used for artifact storage and package versioning."
         type: string
         default: ci
       external_repo_config:

--- a/.github/workflows/multi_arch_release.yml
+++ b/.github/workflows/multi_arch_release.yml
@@ -19,7 +19,7 @@ on:
   workflow_call:
     inputs:
       release_type:
-        description: 'Release type: "dev", "nightly", or "prerelease".'
+        description: 'Release type: "dev", "dev-bkc", "nightly", "nightly-bkc", or "prerelease".'
         type: string
         required: true
       prerelease_version:
@@ -62,10 +62,13 @@ on:
   workflow_dispatch:
     inputs:
       release_type:
-        description: 'Release type; developer-triggered jobs should use "dev".'
+        description: 'Release type; ordinary developer-triggered jobs should use "dev".'
         type: choice
+        # Only dev-channel release types are exposed for manual dispatch in
+        # TheRock. Nightly release types are supplied by rockrel.
         options:
           - dev
+          - dev-bkc
         default: dev
       prerelease_version:
         description: Prerelease version number such as '2'. This gets appended to the computed version after 'rc', like '7.10.0rc2'

--- a/.github/workflows/multi_arch_release.yml
+++ b/.github/workflows/multi_arch_release.yml
@@ -68,7 +68,6 @@ on:
         # TheRock. Nightly release types are supplied by rockrel.
         options:
           - dev
-          - dev-bkc
         default: dev
       prerelease_version:
         description: Prerelease version number such as '2'. This gets appended to the computed version after 'rc', like '7.10.0rc2'

--- a/.github/workflows/multi_arch_release_asan.yml
+++ b/.github/workflows/multi_arch_release_asan.yml
@@ -50,7 +50,6 @@ on:
         type: choice
         options:
           - dev
-          - dev-bkc
         default: dev
       # For workflow_dispatch, default to a single GPU family to limit CI load for most workflow runs.
       # Note: empty string will be converted to the default by github, so we need an explicit "none".

--- a/.github/workflows/multi_arch_release_asan.yml
+++ b/.github/workflows/multi_arch_release_asan.yml
@@ -11,7 +11,7 @@ on:
   workflow_call:
     inputs:
       release_type:
-        description: 'Release type: "dev", "nightly", or "prerelease".'
+        description: 'Release type: "dev", "dev-bkc", "nightly", "nightly-bkc", or "prerelease".'
         type: string
         required: true
       prerelease_version:
@@ -46,10 +46,11 @@ on:
   workflow_dispatch:
     inputs:
       release_type:
-        description: 'Release type; developer-triggered jobs should use "dev".'
+        description: 'Release type; ordinary developer-triggered jobs should use "dev".'
         type: choice
         options:
           - dev
+          - dev-bkc
         default: dev
       # For workflow_dispatch, default to a single GPU family to limit CI load for most workflow runs.
       # Note: empty string will be converted to the default by github, so we need an explicit "none".

--- a/.github/workflows/multi_arch_release_linux.yml
+++ b/.github/workflows/multi_arch_release_linux.yml
@@ -20,7 +20,7 @@ on:
       test_type:
         type: string
       release_type:
-        description: 'Release type: "dev", "nightly", or "prerelease".'
+        description: 'Release type: "dev", "dev-bkc", "nightly", "nightly-bkc", or "prerelease".'
         type: string
         required: true
       repository:

--- a/.github/workflows/multi_arch_release_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_jax_wheels.yml
@@ -16,7 +16,7 @@ on:
         type: string
         default: ""
       release_type:
-        description: 'Release type: "dev", "nightly", or "prerelease".'
+        description: 'Release type: "dev", "dev-bkc", "nightly", "nightly-bkc", or "prerelease".'
         type: string
         required: true
       rocm_version:
@@ -46,10 +46,11 @@ on:
         type: string
         default: "gfx94X-dcgpu"
       release_type:
-        description: 'Release type; developer-triggered jobs should use "dev".'
+        description: 'Release type; ordinary developer-triggered jobs should use "dev".'
         type: choice
         options:
           - dev
+          - dev-bkc
         default: dev
       rocm_version:
         description: "ROCm package version to build against."

--- a/.github/workflows/multi_arch_release_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_jax_wheels.yml
@@ -50,7 +50,6 @@ on:
         type: choice
         options:
           - dev
-          - dev-bkc
         default: dev
       rocm_version:
         description: "ROCm package version to build against."

--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -82,10 +82,11 @@ on:
         type: string
         default: ""
       release_type:
-        description: 'Release type; developer-triggered jobs should use "dev"'
+        description: 'Release type; ordinary developer-triggered jobs should use "dev"'
         type: choice
         options:
           - dev
+          - dev-bkc
         default: dev
       repository:
         description: "Repository to checkout. Defaults to github.repository."

--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -86,7 +86,6 @@ on:
         type: choice
         options:
           - dev
-          - dev-bkc
         default: dev
       repository:
         description: "Repository to checkout. Defaults to github.repository."

--- a/.github/workflows/multi_arch_release_windows.yml
+++ b/.github/workflows/multi_arch_release_windows.yml
@@ -14,7 +14,7 @@ on:
       test_type:
         type: string
       release_type:
-        description: 'Release type: "dev", "nightly", or "prerelease".'
+        description: 'Release type: "dev", "dev-bkc", "nightly", "nightly-bkc", or "prerelease".'
         type: string
         required: true
       repository:

--- a/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
@@ -82,7 +82,6 @@ on:
         type: choice
         options:
           - dev
-          - dev-bkc
         default: dev
       repository:
         description: "Repository to checkout. Defaults to github.repository."

--- a/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
@@ -78,10 +78,11 @@ on:
         type: string
         default: ""
       release_type:
-        description: 'Release type; developer-triggered jobs should use "dev"'
+        description: 'Release type; ordinary developer-triggered jobs should use "dev"'
         type: choice
         options:
           - dev
+          - dev-bkc
         default: dev
       repository:
         description: "Repository to checkout. Defaults to github.repository."

--- a/.github/workflows/setup_multi_arch.yml
+++ b/.github/workflows/setup_multi_arch.yml
@@ -11,8 +11,9 @@ on:
         default: "release"
       release_type:
         description: >-
-          Release type: "ci", "dev", "nightly", or "prerelease"; controls
-          artifact bucket selection, IAM role, and package versioning.
+          Release type: "ci", "dev", "dev-bkc", "nightly", "nightly-bkc",
+          or "prerelease"; controls artifact bucket selection, IAM role, and
+          package versioning.
         type: string
         default: ci
       prerelease_version:

--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -39,11 +39,12 @@ on:
         type: string
         default: ""
       release_type:
-        description: 'Release type: "ci" or "dev".'
+        description: 'Release type for the artifacts being tested.'
         type: choice
         options:
           - ci
           - dev
+          - dev-bkc
         default: ci
       repository:
         description: "Repository to checkout. Defaults to github.repository."

--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -44,7 +44,6 @@ on:
         options:
           - ci
           - dev
-          - dev-bkc
         default: ci
       repository:
         description: "Repository to checkout. Defaults to github.repository."

--- a/.github/workflows/test_native_linux_packages_install.yml
+++ b/.github/workflows/test_native_linux_packages_install.yml
@@ -11,7 +11,7 @@ on:
         required: true
         type: string
       release_type:
-        description: "Release Type (ci, dev, nightly, prerelease)."
+        description: "Release type for the packages being tested."
         required: true
         type: string
       gpg_key_url:
@@ -58,12 +58,13 @@ on:
         required: true
         type: string
       release_type:
-        description: 'Release type: "ci" or "dev"'
+        description: "Release type for the packages being tested."
         required: true
         type: choice
         options:
           - ci
           - dev
+          - dev-bkc
       gpg_key_url:
         description: "GPG key URL for signed repos"
         type: string

--- a/.github/workflows/test_native_linux_packages_install.yml
+++ b/.github/workflows/test_native_linux_packages_install.yml
@@ -64,7 +64,6 @@ on:
         options:
           - ci
           - dev
-          - dev-bkc
       gpg_key_url:
         description: "GPG key URL for signed repos"
         type: string

--- a/build_tools/_therock_utils/s3_buckets.py
+++ b/build_tools/_therock_utils/s3_buckets.py
@@ -74,9 +74,22 @@ s3_bucket_configs = [
 
 _BUCKET_CONFIGS_BY_NAME = {c.name: c for c in s3_bucket_configs}
 
-_ALLOWED_ARTIFACT_RELEASE_TYPES = {"ci", "dev", "nightly", "prerelease"}
+_ALLOWED_ARTIFACT_RELEASE_TYPES = {
+    "ci",
+    "dev",
+    "dev-bkc",
+    "nightly",
+    "nightly-bkc",
+    "prerelease",
+}
 
-_ALLOWED_RELEASE_TYPES = {"dev", "nightly", "prerelease"}
+_ALLOWED_RELEASE_TYPES = {
+    "dev",
+    "dev-bkc",
+    "nightly",
+    "nightly-bkc",
+    "prerelease",
+}
 
 _ALLOWED_RELEASE_BUCKET_TYPES = {"tarball", "python", "packages"}
 
@@ -89,7 +102,8 @@ def get_artifacts_bucket_config(
     """Look up the artifacts bucket config for a repository.
 
     Args:
-        release_type: "ci", "dev", "nightly", or "prerelease".
+        release_type: "ci", "dev", "dev-bkc", "nightly", "nightly-bkc", or
+            "prerelease".
         repository: GitHub repository (e.g. "ROCm/TheRock").
         is_pr_from_fork: Whether this is a PR from a fork.
 
@@ -108,7 +122,12 @@ def get_artifacts_bucket_config(
         else:
             bucket_name = "therock-ci-artifacts"
     else:
-        bucket_name = f"therock-{release_type}-artifacts"
+        if release_type == "dev-bkc":
+            bucket_name = "therock-dev-artifacts"
+        elif release_type == "nightly-bkc":
+            bucket_name = "therock-nightly-artifacts"
+        else:
+            bucket_name = f"therock-{release_type}-artifacts"
     return _BUCKET_CONFIGS_BY_NAME[bucket_name]
 
 
@@ -119,11 +138,13 @@ def get_release_bucket_config(
     """Look up the release bucket config for a given release type and bucket type.
 
     Args:
-        release_type: "dev", "nightly", or "prerelease".
+        release_type: "dev", "dev-bkc", "nightly", "nightly-bkc", or
+            "prerelease".
         bucket_type: "tarball", "python", or "packages".
 
     Returns:
-        S3BucketConfig for the bucket ``therock-{release_type}-{bucket_type}``.
+        S3BucketConfig for the selected release bucket. BKC release types use
+        the corresponding dev or nightly bucket.
 
     Raises:
         ValueError: If release_type or bucket_type is invalid.
@@ -138,7 +159,12 @@ def get_release_bucket_config(
             f"bucket_type={bucket_type!r} is invalid, "
             f"expected one of {_ALLOWED_RELEASE_BUCKET_TYPES}"
         )
-    bucket_name = f"therock-{release_type}-{bucket_type}"
+    if release_type == "dev-bkc":
+        bucket_name = f"therock-dev-{bucket_type}"
+    elif release_type == "nightly-bkc":
+        bucket_name = f"therock-nightly-{bucket_type}"
+    else:
+        bucket_name = f"therock-{release_type}-{bucket_type}"
     return _BUCKET_CONFIGS_BY_NAME[bucket_name]
 
 

--- a/build_tools/github_actions/configure_jax_release_matrix.py
+++ b/build_tools/github_actions/configure_jax_release_matrix.py
@@ -14,7 +14,14 @@ sys.path.insert(0, str(_BUILD_TOOLS_DIR))
 
 from github_actions.github_actions_api import gha_set_output
 
-RELEASE_TYPES = ["ci", "dev", "nightly", "prerelease"]
+RELEASE_TYPES = [
+    "ci",
+    "dev",
+    "dev-bkc",
+    "nightly",
+    "nightly-bkc",
+    "prerelease",
+]
 
 # TODO: add opt-ins for CI runs to use python versions and JAX refs normally
 #       only included in release runs.

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -141,7 +141,7 @@ class CIInputs:
     commit_ref: str  # GITHUB_REF_NAME value
     base_ref: str | None  # Git ref used for diffing, or None to skip path filters
     build_variant: str  # Build variant label, e.g. "release", "asan", "tsan"
-    release_type: str = "ci"  # "ci", or "dev", "nightly", "prerelease" for releases
+    release_type: str = "ci"  # "ci", or one of the supported release types
     build_python_packages: bool = True
     build_pytorch: bool = True
     build_jax: bool = False
@@ -871,10 +871,11 @@ def _determine_test_type(
         return "full", "test labels specified"
 
     # Priority 3: release builds run deeper test suites than regular CI.
-    # * 'nightly' gets comprehensive (deeper than standard, on a daily cadence)
+    # * 'nightly' and 'nightly-bkc' get comprehensive (deeper than standard,
+    #   on a daily cadence)
     # * 'prerelease' gets full (exhaustive pre-release validation)
     # * 'dev' falls through to later priorities so changes can be tested quickly
-    if ci_inputs.release_type == "nightly":
+    if ci_inputs.release_type in ("nightly", "nightly-bkc"):
         return "comprehensive", "release build (nightly)"
     if ci_inputs.release_type == "prerelease":
         return "full", "release build (prerelease)"

--- a/build_tools/github_actions/configure_pytorch_release_matrix.py
+++ b/build_tools/github_actions/configure_pytorch_release_matrix.py
@@ -15,7 +15,14 @@ sys.path.insert(0, str(_BUILD_TOOLS_DIR))
 
 from github_actions.github_actions_api import gha_set_output
 
-RELEASE_TYPES = ["ci", "dev", "nightly", "prerelease"]
+RELEASE_TYPES = [
+    "ci",
+    "dev",
+    "dev-bkc",
+    "nightly",
+    "nightly-bkc",
+    "prerelease",
+]
 
 # TODO: add opt-ins for CI runs to use python versions and pytorch refs normally
 #       only included in release runs

--- a/build_tools/github_actions/publish_jax_to_release_bucket.py
+++ b/build_tools/github_actions/publish_jax_to_release_bucket.py
@@ -22,7 +22,9 @@ logger = logging.getLogger(__name__)
 
 MULTI_ARCH_INDEX_URLS = {
     "dev": "https://rocm.devreleases.amd.com/whl-multi-arch/",
+    "dev-bkc": "https://rocm.devreleases.amd.com/whl-multi-arch/",
     "nightly": "https://rocm.nightlies.amd.com/whl-multi-arch/",
+    "nightly-bkc": "https://rocm.nightlies.amd.com/whl-multi-arch/",
     "prerelease": "https://rocm.prereleases.amd.com/whl-multi-arch/",
 }
 
@@ -55,8 +57,8 @@ def main(argv: list[str]) -> None:
     parser.add_argument(
         "--release-type",
         required=True,
-        choices=["dev", "nightly", "prerelease"],
-        help="Release type (selects therock-{release_type}-python bucket)",
+        choices=["dev", "dev-bkc", "nightly", "nightly-bkc", "prerelease"],
+        help="Release type used to select the destination Python bucket",
     )
     parser.add_argument(
         "--structured",

--- a/build_tools/github_actions/publish_pytorch_to_release_bucket.py
+++ b/build_tools/github_actions/publish_pytorch_to_release_bucket.py
@@ -42,7 +42,9 @@ MULTI_ARCH_INDEX_URLS = {
     # TODO: Move this release bucket to CDN/index URL mapping into
     # build_tools/_therock_utils/s3_buckets.py.
     "dev": "https://rocm.devreleases.amd.com/whl-multi-arch/",
+    "dev-bkc": "https://rocm.devreleases.amd.com/whl-multi-arch/",
     "nightly": "https://rocm.nightlies.amd.com/whl-multi-arch/",
+    "nightly-bkc": "https://rocm.nightlies.amd.com/whl-multi-arch/",
     "prerelease": "https://rocm.prereleases.amd.com/whl-multi-arch/",
 }
 
@@ -75,8 +77,8 @@ def main(argv: list[str]) -> None:
     parser.add_argument(
         "--release-type",
         required=True,
-        choices=["dev", "nightly", "prerelease"],
-        help="Release type (selects therock-{release_type}-python bucket)",
+        choices=["dev", "dev-bkc", "nightly", "nightly-bkc", "prerelease"],
+        help="Release type used to select the destination Python bucket",
     )
     parser.add_argument(
         "--structured",

--- a/build_tools/github_actions/publish_rocm_to_release_buckets.py
+++ b/build_tools/github_actions/publish_rocm_to_release_buckets.py
@@ -282,7 +282,7 @@ def main(argv: list[str]) -> None:
     parser.add_argument(
         "--release-type",
         required=True,
-        choices=["dev", "nightly", "prerelease"],
+        choices=["dev", "dev-bkc", "nightly", "nightly-bkc", "prerelease"],
         help="Release type (determines source and destination buckets)",
     )
     # String "true"/"false" because GitHub Actions outputs are strings.

--- a/build_tools/github_actions/upload_tarballs.py
+++ b/build_tools/github_actions/upload_tarballs.py
@@ -153,7 +153,7 @@ def main(argv: list[str]) -> int:
     parser.add_argument(
         "--release-type",
         default="ci",
-        help='Release type: "ci", "dev", "nightly", or "prerelease"',
+        help="Release type used to select the artifacts bucket.",
     )
     parser.add_argument(
         "--output-dir",

--- a/build_tools/github_actions/write_artifacts_bucket_info.py
+++ b/build_tools/github_actions/write_artifacts_bucket_info.py
@@ -26,7 +26,7 @@ def main(argv: list[str] | None = None):
         "--release-type",
         type=str,
         default="ci",
-        help='Release type: "ci", "dev", "nightly", or "prerelease".',
+        help="Release type used to select the artifacts bucket.",
     )
     args = parser.parse_args(argv)
 

--- a/build_tools/packaging/linux/get_url_repo_params.py
+++ b/build_tools/packaging/linux/get_url_repo_params.py
@@ -90,7 +90,9 @@ def _normalize_release_type(release_type: str) -> str:
     return aliases.get(rt, rt)
 
 
-_KNOWN_RELEASE_TYPES = frozenset({"prerelease", "release", "dev", "nightly", "ci"})
+_KNOWN_RELEASE_TYPES = frozenset(
+    {"prerelease", "release", "dev", "dev-bkc", "nightly", "nightly-bkc", "ci"}
+)
 
 
 def _normalize_and_validate_release_type(release_type: str) -> str:

--- a/build_tools/packaging/linux/native_linux_package_install_test.py
+++ b/build_tools/packaging/linux/native_linux_package_install_test.py
@@ -1424,7 +1424,15 @@ def _build_argument_parser(*, exit_on_error: bool = True) -> ArgumentParser:
     parser.add_argument(
         "--release-type",
         type=str,
-        choices=["dev", "nightly", "prerelease", "release", "ci"],
+        choices=[
+            "dev",
+            "dev-bkc",
+            "nightly",
+            "nightly-bkc",
+            "prerelease",
+            "release",
+            "ci",
+        ],
         help="Type of release: 'dev', 'nightly', 'prerelease', 'release', or 'ci'",
     )
     parser.add_argument(

--- a/build_tools/setup_ccache.py
+++ b/build_tools/setup_ccache.py
@@ -255,14 +255,14 @@ def main(argv: list[str]):
     preset_group.add_argument(
         "--release-type",
         type=str,
-        choices=["ci", "dev", "nightly", "prerelease"],
-        help='Shorthand for --config-preset: "ci" and "dev" map to github-oss-dev, '
-        "others map to github-oss-release.",
+        choices=["ci", "dev", "dev-bkc", "nightly", "nightly-bkc", "prerelease"],
+        help='Shorthand for --config-preset: "ci", "dev", and "dev-bkc" map '
+        "to github-oss-dev; others map to github-oss-release.",
     )
 
     args = p.parse_args(argv)
     if args.release_type is not None:
-        if args.release_type in ("ci", "dev"):
+        if args.release_type in ("ci", "dev", "dev-bkc"):
             args.config_preset = "github-oss-dev"
         else:
             args.config_preset = "github-oss-release"

--- a/build_tools/tests/s3_buckets_test.py
+++ b/build_tools/tests/s3_buckets_test.py
@@ -63,6 +63,19 @@ class TestGetArtifactsBucketConfig(unittest.TestCase):
         )
         self.assertEqual(config.name, "therock-nightly-artifacts")
 
+    def test_bkc_release_types_use_existing_artifacts_buckets(self):
+        for release_type, bucket_name in (
+            ("dev-bkc", "therock-dev-artifacts"),
+            ("nightly-bkc", "therock-nightly-artifacts"),
+        ):
+            with self.subTest(release_type=release_type):
+                config = get_artifacts_bucket_config(
+                    release_type=release_type,
+                    repository="ROCm/TheRock",
+                    is_pr_from_fork=False,
+                )
+                self.assertEqual(config.name, bucket_name)
+
     def test_release_type_invalid_raises(self):
         with self.assertRaises(ValueError) as cm:
             get_artifacts_bucket_config(
@@ -107,6 +120,17 @@ class TestGetReleaseBucketConfig(unittest.TestCase):
         )
         self.assertEqual(config.name, "therock-prerelease-packages")
         self.assertEqual(config.iam_role, "therock-prerelease")
+
+    def test_bkc_release_types_use_existing_release_buckets(self):
+        for release_type, bucket_name in (
+            ("dev-bkc", "therock-dev-python"),
+            ("nightly-bkc", "therock-nightly-python"),
+        ):
+            with self.subTest(release_type=release_type):
+                config = get_release_bucket_config(
+                    release_type=release_type, bucket_type="python"
+                )
+                self.assertEqual(config.name, bucket_name)
 
     def test_all_combinations_exist(self):
         for release_type in ("dev", "nightly", "prerelease"):

--- a/docs/development/s3_buckets.md
+++ b/docs/development/s3_buckets.md
@@ -90,6 +90,10 @@ upload to this bucket and do not need `aws-actions/configure-aws-credentials`.
 Each release type (`dev`, `nightly`, `prerelease`, `release`) has a matching
 set of buckets.
 
+The `dev-bkc` and `nightly-bkc` release types currently use the existing `dev`
+and `nightly` buckets, IAM roles, and CDN indexes, respectively. A dedicated
+BKC bucket and index may be added in the future.
+
 The `dev`, `nightly`, and `prerelease` types are accessed via
 the `therock-{release_type}` IAM role while stable `release` buckets are
 manually promoted from prereleases via IAM user policies (see


### PR DESCRIPTION
## Motivation

* Progress on https://github.com/ROCm/rockrel/issues/88

We're creating a new release stream that will branch off from nightly releases while carrying cherry-picks. This PR adds the new `dev-bkc` and `nightly-bkc` release type to scripts and workflows that operate on release types

## Technical Details

* Dedicated S3 buckets for the BKC release stream have not yet been created, so this reuses the existing dev and nightly buckets. The package version scheme we're using will have acceptable sorting behavior when these packages start appearing alongside already published dev/nightly packages - *not* stable packages (which we don't have plans for this release type yet)
* `workflow_dispatch` triggers in TheRock only include dev release types, the `nightly-bkc` release type will need to be added to https://github.com/ROCm/rockrel
* Adding a new release type will also affect https://github.com/ROCm/TheRock/issues/7091 and https://github.com/ROCm/TheRock/pull/7238

## Test Plan

* Once the full stack of changes lands we'll be ready to trigger dev and nightly bkc releases in https://github.com/ROCm/rockrel, where this will be tested for real

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
