### PR TITLE
fix(ci): pass build_variant to all test_native_packages jobs

### DIFF
--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -198,6 +198,7 @@ jobs:
       os_profile: ubuntu2404
       artifact_group: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
       test_type: sanity
+      build_variant: ${{ fromJSON(inputs.build_config).build_variant_label }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
     permissions:
@@ -216,6 +217,7 @@ jobs:
       os_profile: rhel8
       artifact_group: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
       test_type: sanity
+      build_variant: ${{ fromJSON(inputs.build_config).build_variant_label }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
     permissions:
@@ -234,6 +236,7 @@ jobs:
       os_profile: rhel10
       artifact_group: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
       test_type: sanity
+      build_variant: ${{ fromJSON(inputs.build_config).build_variant_label }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
     permissions:
@@ -252,6 +255,7 @@ jobs:
       os_profile: sles16
       artifact_group: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
       test_type: sanity
+      build_variant: ${{ fromJSON(inputs.build_config).build_variant_label }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
     permissions:


### PR DESCRIPTION
## Summary

Fix missing `build_variant` propagation to native package install test jobs
in `multi_arch_ci_linux.yml`.

ISSUE ID : https://github.com/ROCm/TheRock/issues/7342

## Motivation

When `#7352` added `build_variant` support to native Linux packaging, it
was correctly added to the **build** jobs (`build_native_deb_packages`,
`build_native_rpm_packages`) but accidentally omitted from all four
**test** jobs (`test_native_packages_ubuntu2404`, `test_native_packages_rhel8`,
`test_native_packages_rhel10`, `test_native_packages_sles16`).

Without `build_variant`, the install test does not know to expect
variant-suffixed package names for ASAN builds, causing tests to look for
`amdrocm10.0` instead of `amdrocm-asan10.0` and fail.

## Technical Details

Added `build_variant: ${{ fromJSON(inputs.build_config).build_variant_label }}`
to all four `test_native_packages_*` jobs — the same value already passed to
the build jobs and the build_variant_label from build_config (e.g. `"asan"` for
ASAN builds, `"release"` for normal builds which is a no-op in the test).

`multi_arch_release_linux.yml` already passes `build_variant` correctly to its
native package test trigger — no change needed there.

## Test Plan

- ASAN CI build: `build_variant_label = "asan"` now flows to all test jobs
  → install test expects `amdrocm-asan10.0-gfx942` correctly
- Release CI build: `build_variant_label = "release"` flows through but is
  a no-op in the test (package names unchanged)
