### PR TITLE
fix(rocprofiler-compute): wire test-compression for TheRock install-mode CI

### DIFF
--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -264,6 +264,7 @@ if(THEROCK_ENABLE_ROCPROFILER_COMPUTE)
       ${THEROCK_BUNDLED_ELFUTILS}
       ${THEROCK_BUNDLED_LIBDRM}
       ${THEROCK_BUNDLED_SQLITE3}
+      ${THEROCK_BUNDLED_ZLIB}
       ${_openmpi_optional_dep}
     )
     therock_cmake_subproject_glob_c_sources(rocprofiler-compute

--- a/profiler/post_hook_rocprofiler-compute.cmake
+++ b/profiler/post_hook_rocprofiler-compute.cmake
@@ -4,7 +4,7 @@
 # These tests install to libexec/rocprofiler-compute/tests/ instead of the
 # default bin/. Tell TheRock the actual origin so it can compute correct
 # relative RPATH entries (including sysdeps under lib/rocm_sysdeps/lib).
-foreach(_test_target test-rocprofiler-compute-tool test-pc-sampling-collector)
+foreach(_test_target test-rocprofiler-compute-tool test-pc-sampling-collector test-compression)
   if(TARGET ${_test_target})
     set_target_properties(${_test_target} PROPERTIES
       THEROCK_INSTALL_RPATH_ORIGIN libexec/rocprofiler-compute/tests


### PR DESCRIPTION
## Motivation

Added a `test-compression` gtest in [#9711 of rocprofiler-compute,](https://github.com/ROCm/rocm-systems/pull/9711), but TheRock CI can't run it in install mode yet:

- The post-hook sets install RPATH for the other gtests under `libexec/rocprofiler-compute/tests/` but not `test-compression`
- The subproject pulls bundled elfutils/libdrm/sqlite3 but not zlib, so `pkg_check_modules(zlib)` can link system `libz` instead of bundled sysdeps

The follow-up in rocm-systems repo is to add `test-compression` to `test_categories.yaml` after this merges.

## Technical Details

- Add `test-compression` to the RPATH post-hook foreach in `profiler/post_hook_rocprofiler-compute.cmake`.
- Add `${THEROCK_BUNDLED_ZLIB}` to `rocprofiler-compute` `RUNTIME_DEPS` in `profiler/CMakeLists.txt`.

## Test Plan

- Build with rocprofiler-compute + tests enabled.
- Confirm `test-compression` installs under `libexec/rocprofiler-compute/tests/` with correct RPATH.
- Run `ctest -R test-compression`.

## Test Result

- Pending CI.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.