### PR TITLE
fix(sysdeps): make rocm_sysdeps zlib.pc reliably relocatable

### DIFF
--- a/third-party/sysdeps/common/zlib/CMakeLists.txt
+++ b/third-party/sysdeps/common/zlib/CMakeLists.txt
@@ -98,8 +98,8 @@ add_custom_target(
       # On Windows we only use the static library; skip the shared build
       # to avoid having to track the DLL alongside the static artifact.
       "$<$<BOOL:${WIN32}>:-DZLIB_BUILD_SHARED=OFF>"
-      # Disable writing pc files: we will do so ourselves.
-      -DSKIP_INSTALL_FILES=ON
+      # zlib 1.3.2 dropped SKIP_INSTALL_FILES, so it always installs its own
+      # zlib.pc. patch_install.py removes it; we install our own below.
 
   COMMAND
     "${CMAKE_COMMAND}" --build "${CMAKE_CURRENT_BINARY_DIR}/b"

--- a/third-party/sysdeps/common/zlib/patch_install.py
+++ b/third-party/sysdeps/common/zlib/patch_install.py
@@ -26,3 +26,10 @@ if platform.system() == "Linux":
 cmake_dir = Path(PREFIX) / "lib" / "cmake" / "zlib"
 if cmake_dir.is_dir():
     shutil.rmtree(cmake_dir)
+
+# Remove zlib's auto-generated pkg-config file, which hardcodes the build-time
+# prefix. TheRock installs its own relocatable zlib.pc to the same path, so
+# leaving this one in place makes the result depend on install ordering.
+pc_file = Path(PREFIX) / "lib" / "pkgconfig" / "zlib.pc"
+if pc_file.exists():
+    pc_file.unlink()


### PR DESCRIPTION
## Motivation

`lib/rocm_sysdeps/lib/pkgconfig/zlib.pc` non-deterministically ships upstream
zlib's non-relocatable file instead of TheRock's, breaking any consumer that
resolves zlib through pkg-config.

Fixes https://github.com/ROCm/TheRock/issues/7424

ISSUE ID: 7424
JIRA ID: AIPROFCOMP-816

## Technical Details

- `-DSKIP_INSTALL_FILES=ON` is a no-op: zlib 1.3.2 removed that option, so
  upstream's `zlib.pc` is always installed and races with the relocatable one
  installed from `zlib.pc.in`. Replace the flag with a comment saying so.
- Delete upstream's `zlib.pc` in `patch_install.py`, mirroring the existing
  removal of upstream's cmake config directory, so only TheRock's file can survive.

## Test Plan

- Confirm `SKIP_INSTALL_FILES` is absent from the mirrored zlib 1.3.2 sources
- Build the zlib sysdep and check `lib/rocm_sysdeps/lib/pkgconfig/zlib.pc` starts
  with `prefix=${pcfiledir}/../..`
- Confirm `pkg-config --variable=includedir zlib` against the staged pkgconfig dir
  resolves to a path that exists

## Test Result

- Verified the option is absent from the mirrored tarball
  (`bb329a0a2cd0274d05519d61c667c062e06990d72e125ee2dfa8de64f0119d16`), and confirmed
  the broken and good files alternate across the Aug 13, 14, and 17 nightly wheels
- Not built locally: a full TheRock superbuild was out of reach in my environment,
  so the staged-artifact checks above need to come from CI

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
