### PR TITLE
fix(profiler): correct RPATH origin for nested rocprofiler-compute targets

### DIFF
--- a/profiler/post_hook_rocprofiler-compute.cmake
+++ b/profiler/post_hook_rocprofiler-compute.cmake
@@ -4,10 +4,22 @@
 # These tests install to libexec/rocprofiler-compute/tests/ instead of the
 # default bin/. Tell TheRock the actual origin so it can compute correct
 # relative RPATH entries (including sysdeps under lib/rocm_sysdeps/lib).
-foreach(_test_target test-rocprofiler-compute-tool test-pc-sampling-collector test-compression)
+foreach(_test_target
+        test-rocprofiler-compute-tool
+        test-pc-sampling-collector
+        test-compression
+        test-roctx-recordfn)
   if(TARGET ${_test_target})
     set_target_properties(${_test_target} PROPERTIES
       THEROCK_INSTALL_RPATH_ORIGIN libexec/rocprofiler-compute/tests
     )
   endif()
 endforeach()
+
+# librocprofiler-compute-tool.so installs to lib/rocprofiler-compute/, not the
+# default lib/, so its sysdeps entry otherwise lands a directory short.
+if(TARGET rocprofiler-compute-tool)
+  set_target_properties(rocprofiler-compute-tool PROPERTIES
+    THEROCK_INSTALL_RPATH_ORIGIN lib/rocprofiler-compute
+  )
+endif()


### PR DESCRIPTION
## Motivation

`librocprofiler-compute-tool.so` installs to `lib/rocprofiler-compute/`, not the `lib/` origin assumed for shared libraries, so its `rocm_sysdeps/lib` entry is computed one directory short. 

ISSUE ID: N/A

## Technical Details

- Set `THEROCK_INSTALL_RPATH_ORIGIN lib/rocprofiler-compute` on `rocprofiler-compute-tool`, as `post_hook_rocprofiler-sdk.cmake` already does for its nested libraries. Inert until a companion rocm-systems PR drops the opt-out.
- Add `test-roctx-recordfn` to the libexec test origin list; its origin is currently computed against `bin/`.
- Declare `${THEROCK_BUNDLED_ZLIB}`, linked directly via the `compression` helper. Already satisfied transitively, so no behavior change.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)