### PR TITLE
ci(pytorch): Skip windows python 3.14 + pytorch nightly test

### DIFF
--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -165,6 +165,7 @@ jobs:
     secrets: inherit
     with:
       amdgpu_families: ${{ matrix.amdgpu_families }}
+      test_amdgpu_families: ${{ matrix.test_amdgpu_families }}
       python_version: ${{ matrix.python_version }}
       pytorch_git_ref: ${{ matrix.pytorch_git_ref }}
       rocm_version: ${{ inputs.rocm_version }}

--- a/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
@@ -152,6 +152,7 @@ jobs:
     secrets: inherit
     with:
       amdgpu_families: ${{ matrix.amdgpu_families }}
+      test_amdgpu_families: ${{ matrix.test_amdgpu_families }}
       python_version: ${{ matrix.python_version }}
       pytorch_git_ref: ${{ matrix.pytorch_git_ref }}
       rocm_version: ${{ inputs.rocm_version }}

--- a/build_tools/github_actions/configure_pytorch_release_matrix.py
+++ b/build_tools/github_actions/configure_pytorch_release_matrix.py
@@ -168,6 +168,15 @@ def generate_pytorch_matrix_for_release_type(
                 "python_version": py,
                 "pytorch_git_ref": ref,
                 "amdgpu_families": families,
+                # TODO(#7185): PyTorch nightly's requirements-ci.txt pins
+                # scikit-image==0.22.0, which has no cp314 wheel and fails to
+                # build from source. Build those wheels but skip their tests
+                # until that is fixed.
+                "test_amdgpu_families": (
+                    "none"
+                    if (platform, ref, py) == ("windows", "nightly", "3.14")
+                    else "auto"
+                ),
             }
             matrix.append(row)
     return matrix

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -1216,16 +1216,19 @@ class TestExpandBuildConfigs(unittest.TestCase):
                     "python_version": "3.12",
                     "pytorch_git_ref": "release/2.11",
                     "amdgpu_families": "gfx94X-dcgpu",
+                    "test_amdgpu_families": "auto",
                 },
                 {
                     "python_version": "3.12",
                     "pytorch_git_ref": "release/2.12",
                     "amdgpu_families": "gfx94X-dcgpu",
+                    "test_amdgpu_families": "auto",
                 },
                 {
                     "python_version": "3.12",
                     "pytorch_git_ref": "release/2.13",
                     "amdgpu_families": "gfx94X-dcgpu",
+                    "test_amdgpu_families": "auto",
                 },
             ],
         )
@@ -1236,6 +1239,7 @@ class TestExpandBuildConfigs(unittest.TestCase):
                     "python_version": "3.12",
                     "pytorch_git_ref": "release/2.11",
                     "amdgpu_families": "gfx110X-all",
+                    "test_amdgpu_families": "auto",
                 }
             ],
         )

--- a/build_tools/github_actions/tests/configure_pytorch_release_matrix_test.py
+++ b/build_tools/github_actions/tests/configure_pytorch_release_matrix_test.py
@@ -35,16 +35,19 @@ class ConfigurePytorchReleaseMatrixTest(unittest.TestCase):
                     "python_version": "3.12",
                     "pytorch_git_ref": "release/2.11",
                     "amdgpu_families": "gfx94X-dcgpu",
+                    "test_amdgpu_families": "auto",
                 },
                 {
                     "python_version": "3.12",
                     "pytorch_git_ref": "release/2.12",
                     "amdgpu_families": "gfx94X-dcgpu",
+                    "test_amdgpu_families": "auto",
                 },
                 {
                     "python_version": "3.12",
                     "pytorch_git_ref": "release/2.13",
                     "amdgpu_families": "gfx94X-dcgpu",
+                    "test_amdgpu_families": "auto",
                 },
             ],
         )
@@ -67,6 +70,7 @@ class ConfigurePytorchReleaseMatrixTest(unittest.TestCase):
                     "python_version": "3.12",
                     "pytorch_git_ref": "release/2.11",
                     "amdgpu_families": "gfx110X-all",
+                    "test_amdgpu_families": "auto",
                 },
             ],
         )
@@ -87,6 +91,7 @@ class ConfigurePytorchReleaseMatrixTest(unittest.TestCase):
                     "python_version": "3.13",
                     "pytorch_git_ref": "nightly",
                     "amdgpu_families": "gfx94X-dcgpu",
+                    "test_amdgpu_families": "auto",
                 }
             ],
         )
@@ -110,6 +115,7 @@ class ConfigurePytorchReleaseMatrixTest(unittest.TestCase):
                             "python_version": "3.12",
                             "pytorch_git_ref": pytorch_git_ref,
                             "amdgpu_families": "gfx94X-dcgpu",
+                            "test_amdgpu_families": "auto",
                         }
                     ],
                 )
@@ -130,9 +136,52 @@ class ConfigurePytorchReleaseMatrixTest(unittest.TestCase):
                     "python_version": "3.12",
                     "pytorch_git_ref": "users/alice/gfx125x-bringup",
                     "amdgpu_families": "gfx125X-dcgpu",
+                    "test_amdgpu_families": "auto",
                 }
             ],
         )
+
+    def test_windows_nightly_python_314_skips_tests(self):
+        matrix = m.generate_pytorch_matrix_for_release_type(
+            release_type="nightly",
+            python_versions=["3.14"],
+            pytorch_git_refs=["nightly"],
+            amdgpu_families="gfx110X-all",
+            platform="windows",
+        )
+
+        # The row still builds and publishes wheels; only its tests are skipped.
+        self.assertEqual(
+            matrix,
+            [
+                {
+                    "python_version": "3.14",
+                    "pytorch_git_ref": "nightly",
+                    "amdgpu_families": "gfx110X-all",
+                    "test_amdgpu_families": "none",
+                }
+            ],
+        )
+
+    def test_only_windows_nightly_python_314_skips_tests(self):
+        # Each neighbor of the skipped (platform, ref, python version) keeps the
+        # normal "auto" behavior.
+        for platform, ref, python_version in (
+            ("linux", "nightly", "3.14"),
+            ("windows", "nightly", "3.13"),
+            ("windows", "release/2.13", "3.14"),
+        ):
+            with self.subTest(platform=platform, ref=ref, py=python_version):
+                matrix = m.generate_pytorch_matrix_for_release_type(
+                    release_type="nightly",
+                    python_versions=[python_version],
+                    pytorch_git_refs=[ref],
+                    amdgpu_families="gfx110X-all",
+                    platform=platform,
+                )
+
+                self.assertEqual(len(matrix), 1)
+                self.assertEqual(matrix[0]["test_amdgpu_families"], "auto")
 
     def test_generated_rows_cover_workflow_matrix_inputs(self):
         # The generate_pytorch_matrix_for_release_type script produces matrix


### PR DESCRIPTION
Fixes #7185

Skip python 3.14 x pytorch nightly test on windows, due to unable to compile dependencies.
Test run: https://github.com/ROCm/TheRock/actions/runs/32069857131/job/95510591737