### PR TITLE
feat(ci): populate baseline-run-id from merged PR's CI run

### DIFF
--- a/build_tools/github_actions/bump_automation.py
+++ b/build_tools/github_actions/bump_automation.py
@@ -107,6 +107,40 @@ def gh_api(
     return response.json()
 
 
+def get_baseline_run_id_from_merged_pr(
+    repo: str, token: str, merge_commit_sha: str, workflow_name: str = "Multi-Arch CI"
+) -> str | None:
+    """Get the baseline run ID from the PR that was just merged."""
+    # Find the PR that produced this merge commit
+    prs = gh_api(token, f"repos/{repo}/commits/{merge_commit_sha}/pulls")
+    pr = next(
+        (
+            p
+            for p in prs
+            if p.get("merged_at") and p.get("merge_commit_sha") == merge_commit_sha
+        ),
+        None,
+    )
+    if not pr:
+        print(f"[WARN] No merged PR found for commit {merge_commit_sha[:7]}")
+        return None
+
+    # Get the completed workflow run for this PR's head commit
+    pr_head_sha = pr["head"]["sha"]
+    runs = gh_api(
+        token, f"repos/{repo}/actions/runs?head_sha={pr_head_sha}&status=completed"
+    )
+    for run in runs.get("workflow_runs", []):
+        if run["name"] == workflow_name:
+            print(
+                f"[INFO] Found {workflow_name} run {run['id']} for PR #{pr['number']}"
+            )
+            return str(run["id"])
+
+    print(f"[WARN] No {workflow_name} run found for PR #{pr['number']}")
+    return None
+
+
 def latest_commit(repo: str, token: str, branch: str | None = None) -> str:
     """Return the SHA of the latest commit on the given branch, or the default branch."""
     url = f"repos/{repo}/commits"
@@ -183,21 +217,21 @@ def update_ref_in_file(file_path: str, new_sha: str) -> None:
     print(f"[INFO] Updated {file_path}")
 
 
-def update_ci_env_file(file_path: str, new_sha: str) -> None:
-    """Update the therock-ref value in a ci-env composite action file.
-
-    Matches:
-      therock-ref:
-        description: ...
-        value: "<old_sha>" # <date> commit
-    """
+def update_ci_env_file(
+    file_path: str, new_sha: str, baseline_run_id: str | None = None
+) -> None:
+    """Update therock-ref and baseline-run-id in a ci-env composite action file."""
     with open(file_path, "r") as f:
         lines = f.readlines()
 
     updated_lines = []
     in_therock_ref = False
+    in_baseline_run_id = False
+
     for line in lines:
         stripped = line.strip()
+
+        # Handle therock-ref updates
         if stripped == "therock-ref:":
             in_therock_ref = True
             updated_lines.append(line)
@@ -206,12 +240,35 @@ def update_ci_env_file(file_path: str, new_sha: str) -> None:
         if in_therock_ref and stripped.startswith("value:"):
             indent = line[: line.find("value:")]
             date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-            updated_lines.append(f'{indent}value: "{new_sha}" # {date} commit\n')
+            updated_lines.append(f'{indent}value: "{new_sha}" # {date}\n')
             in_therock_ref = False
             continue
 
         if in_therock_ref and stripped and not stripped.startswith("description:"):
             in_therock_ref = False
+
+        # Handle baseline-run-id updates
+        if stripped == "baseline-run-id:":
+            in_baseline_run_id = True
+            updated_lines.append(line)
+            continue
+
+        if in_baseline_run_id and stripped.startswith("value:"):
+            indent = line[: line.find("value:")]
+            if baseline_run_id:
+                updated_lines.append(
+                    f'{indent}value: "{baseline_run_id}" # Updated by assistant-librarian[bot] on submodule bumps\n'
+                )
+            else:
+                # Keep empty if no successful run found
+                updated_lines.append(
+                    f'{indent}value: "" # Updated by assistant-librarian[bot] on submodule bumps\n'
+                )
+            in_baseline_run_id = False
+            continue
+
+        if in_baseline_run_id and stripped and not stripped.startswith("description:"):
+            in_baseline_run_id = False
 
         updated_lines.append(line)
 
@@ -219,6 +276,8 @@ def update_ci_env_file(file_path: str, new_sha: str) -> None:
         f.writelines(updated_lines)
 
     print(f"[INFO] Updated {file_path}")
+    if baseline_run_id:
+        print(f"[INFO] Set baseline-run-id to {baseline_run_id}")
 
 
 def close_stale_prs(submodule: str, old_sha: str, token: str) -> None:
@@ -397,6 +456,19 @@ def handle_push(before: str, after: str, tokens: dict[str, str]) -> None:
         print(f"[INFO] {changed} uses submodule-only bumping, skipping ref update")
         return
 
+    # For ci-env updater, get baseline run ID from the merged PR
+    baseline_run_id = None
+    if config.get("updater") == "ci-env":
+        baseline_run_id = get_baseline_run_id_from_merged_pr(
+            THEROCK_REPO, token, after, workflow_name="Multi-Arch CI"
+        )
+        if baseline_run_id:
+            print(f"[INFO] Using baseline run ID {baseline_run_id} from merged PR")
+        else:
+            print(
+                f"[WARN] Could not get baseline run ID from merged PR, proceeding without it"
+            )
+
     # Update workflow YAML
     repo_name = config["repo"]
     branch = f"update-therock-{changed}-{after[:7]}"
@@ -415,17 +487,26 @@ def handle_push(before: str, after: str, tokens: dict[str, str]) -> None:
 
         run(["git", "checkout", "-b", branch])
 
-        updater = (
-            update_ci_env_file
-            if config.get("updater") == "ci-env"
-            else update_ref_in_file
-        )
+        updater = config.get("updater")
         for f in config["files"]:
-            updater(f, after)
+            if updater == "ci-env":
+                update_ci_env_file(f, after, baseline_run_id)
+            else:
+                update_ref_in_file(f, after)
 
         run(["git", "add"] + config["files"])
-        _git_commit(f"Update TheRock ref to {after[:7]}")
+
+        commit_msg = f"Update TheRock ref to {after[:7]}"
+        if baseline_run_id:
+            commit_msg += f" (baseline: {baseline_run_id})"
+        _git_commit(commit_msg)
+
         run(["git", "push", "origin", branch])
+
+        pr_body = f"Updated TheRock ref to `{after[:7]}` due to submodule bump"
+        if baseline_run_id:
+            pr_body += f"\n\nBaseline run ID: [{baseline_run_id}](https://github.com/{THEROCK_REPO}/actions/runs/{baseline_run_id})"
+
         gh_api(
             token,
             f"repos/{repo_name}/pulls",
@@ -434,7 +515,7 @@ def handle_push(before: str, after: str, tokens: dict[str, str]) -> None:
                 "title": f"Update TheRock reference to ({after[:7]})",
                 "head": branch,
                 "base": "develop",
-                "body": f"Updated TheRock ref to `{after[:7]}` due to submodule bump",
+                "body": pr_body,
             },
         )
 


### PR DESCRIPTION
When bumping rocm-libraries therock-ref, also update the baseline-run-id in ci-env/action.yml with the completed Multi-Arch CI run ID from the merged PR. This allows rocm-libraries multi-arch CI to reuse prebuilt artifacts from TheRock.

Paired with https://github.com/ROCm/rocm-libraries/pull/10894

Changes:
- Add get_merged_pr_for_commit() to find the PR that produced a merge commit
- Add get_workflow_run_id_for_pr() to get successful CI run ID from PR head
- Add get_baseline_run_id_from_merged_pr() to orchestrate the above
- Modify update_ci_env_file() to also update baseline-run-id
- Modify handle_push() to fetch and pass baseline_run_id for ci-env updates