### PR TITLE
[packaging] Test Debian package version validity and ordering

### DIFF
--- a/build_tools/tests/compute_rocm_package_version_test.py
+++ b/build_tools/tests/compute_rocm_package_version_test.py
@@ -262,6 +262,7 @@ class DebPackageVersionTest(unittest.TestCase):
         versions = self._compute_versions_by_release_type()
 
         # This test is disabled since current sorting is dev > nightly!
+        # See https://github.com/ROCm/TheRock/issues/7638.
         # self.assertGreater(
         #     NativeVersion(versions["nightly"]),
         #     NativeVersion(versions["dev"]),

--- a/build_tools/tests/compute_rocm_package_version_test.py
+++ b/build_tools/tests/compute_rocm_package_version_test.py
@@ -7,6 +7,7 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
+from debian.debian_support import NativeVersion
 from packaging.version import Version
 
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
@@ -242,6 +243,63 @@ class DebPackageVersionTest(unittest.TestCase):
             override_base_version="8.0.0",
         )
         self.assertEqual(version, "8.0.0~custom1")
+
+    def test_versions_are_valid(self):
+        # NativeVersion() rejects invalid Debian versions such as "7.10.0/rc0".
+        # See https://www.debian.org/doc/debian-policy/ch-controlfields.html#version.
+        versions = self._compute_versions_by_release_type()
+
+        for release_type, version in versions.items():
+            with self.subTest(release_type=release_type):
+                self.assertEqual(str(NativeVersion(version)), version)
+
+    def test_versions_sort_by_release_type(self):
+        # apt upgrade selects the greatest available version.
+        # To match other package types, we want:
+        #     release > prerelease > nightly > dev.
+        # Debian currently sorts:
+        #     release > prerelease > dev > nightly.
+        versions = self._compute_versions_by_release_type()
+
+        # This test is disabled since current sorting is dev > nightly!
+        # self.assertGreater(
+        #     NativeVersion(versions["nightly"]),
+        #     NativeVersion(versions["dev"]),
+        # )
+        self.assertGreater(
+            NativeVersion(versions["prerelease"]),
+            NativeVersion(versions["nightly"]),
+        )
+        self.assertGreater(
+            NativeVersion(versions["release"]),
+            NativeVersion(versions["prerelease"]),
+        )
+
+    @staticmethod
+    def _compute_versions_by_release_type() -> dict[str, str]:
+        common_args = {
+            "package_type": "deb",
+            "override_base_version": "7.10.0",
+        }
+        return {
+            "dev": compute_rocm_package_version.compute_version(
+                release_type="dev",
+                **common_args,
+            ),
+            "nightly": compute_rocm_package_version.compute_version(
+                release_type="nightly",
+                **common_args,
+            ),
+            "prerelease": compute_rocm_package_version.compute_version(
+                release_type="prerelease",
+                prerelease_version="0",
+                **common_args,
+            ),
+            "release": compute_rocm_package_version.compute_version(
+                release_type="release",
+                **common_args,
+            ),
+        }
 
 
 class RpmPackageVersionTest(unittest.TestCase):

--- a/docs/packaging/versioning.md
+++ b/docs/packaging/versioning.md
@@ -288,6 +288,20 @@ The script produces these versions for debian packages for each release type:
 | nightly      | `X.Y.Z~YYYYMMDD`    | `7.10.0~20251124`<br>(The nightly release on 2025-11-24)               |
 | dev          | `X.Y.Z~devYYYYMMDD` | `7.10.0~dev20251124`<br>(For dev build on 2025-11-24)d18c4)            |
 
+> [!WARNING]
+> Debian package versions currently sort as
+> `stable > prerelease > dev > nightly`, while the intended order to match
+> other package ecosystems is `stable > prerelease > nightly > dev`:
+>
+> ```python
+> >>> from debian.debian_support import NativeVersion
+> >>> NativeVersion("7.10.0~20251124") > NativeVersion("7.10.0~dev20251124")
+> False
+> ```
+>
+> As a result, apt may prefer a dev package over a nightly package when both
+> release indexes are configured.
+
 ## Native Windows package versions
 
 TODO: fill this in together with https://github.com/ROCm/TheRock/pull/2159

--- a/docs/packaging/versioning.md
+++ b/docs/packaging/versioning.md
@@ -309,6 +309,8 @@ The script produces these versions for debian packages for each release type:
 >
 > As a result, apt may prefer a dev package over a nightly package when both
 > release indexes are configured.
+>
+> See https://github.com/ROCm/TheRock/issues/7638 for details.
 
 ### Working with Debian package versions
 

--- a/docs/packaging/versioning.md
+++ b/docs/packaging/versioning.md
@@ -289,9 +289,17 @@ The script produces these versions for debian packages for each release type:
 | dev          | `X.Y.Z~devYYYYMMDD` | `7.10.0~dev20251124`<br>(For dev build on 2025-11-24)d18c4)            |
 
 > [!WARNING]
-> Debian package versions currently sort as
-> `stable > prerelease > dev > nightly`, while the intended order to match
-> other package ecosystems is `stable > prerelease > nightly > dev`:
+> Deb package version sorting is currently different than rpm and python version
+> sorting:
+>
+> | Package type | Sort order                            |
+> | ------------ | ------------------------------------- |
+> | Python       | `stable > prerelease > nightly > dev` |
+> | rpm          | `stable > prerelease > nightly > dev` |
+> | deb          | `stable > prerelease > dev > nightly` |
+>
+> This can be checked from Python using the
+> [`python-debian` package](https://pypi.org/project/python-debian/):
 >
 > ```python
 > >>> from debian.debian_support import NativeVersion
@@ -301,6 +309,14 @@ The script produces these versions for debian packages for each release type:
 >
 > As a result, apt may prefer a dev package over a nightly package when both
 > release indexes are configured.
+
+### Working with Debian package versions
+
+The `python-debian` package can be used to work with debian package versions:
+
+- https://pypi.org/project/python-debian/
+- https://salsa.debian.org/python-debian-team/python-debian
+- https://python-debian-team.pages.debian.net/python-debian/html/api/debian.debian_support.html
 
 ## Native Windows package versions
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -10,6 +10,7 @@ prettytable==3.12.0
 requests==2.33.0
 jsonschema==4.23.0
 packaging==25.0
+python-debian==1.1.1
 setuptools>=80.9.0,<82.0.0
 python-magic==0.4.27; sys_platform != "win32"
 


### PR DESCRIPTION
## Motivation

* Follow-up to https://github.com/ROCm/TheRock/pull/7389#discussion_r3787654557
* As we're adding new version types for https://github.com/ROCm/rockrel/issues/88 I wanted to expand test coverage first

This adds unit tests for our dev/nightly/prerelease/release deb package versions similar to the tests for Python package versions recently added in https://github.com/ROCm/TheRock/pull/7389.

## Technical Details

Writing these tests revealed that 'dev' deb packages currently take sort priority over 'nightly' deb packages. That doesn't look intentional, or at least it is different from python package versioning expectations, so I've added comments calling it out.

## Test Plan

The new unit tests need https://pypi.org/project/python-debian/ and can run on both Linux _and_ Windows.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
