### PR TITLE
Drop unused dependencies

### DIFF
--- a/build_tools/third_party/s3_management/update_dependencies.py
+++ b/build_tools/third_party/s3_management/update_dependencies.py
@@ -66,8 +66,6 @@ _ALLOWED_CPYTHON_TAGS: frozenset[str] = frozenset(
 )
 
 PACKAGES_PER_PROJECT = {
-    "dbus_python": {"versions": ["latest"], "project": "jax"},
-    "flatbuffers": {"versions": ["latest"], "project": "jax"},
     "ml_dtypes": {"versions": ["latest"], "project": "jax"},
     "opt_einsum": {"versions": ["latest"], "project": "jax"},
     "tomli": {"versions": ["latest"], "project": "jax"},


### PR DESCRIPTION
## Motivation

`dbus_python` and `flatbuffers` are uploaded but have never been indexed, as the packages have not been whitelisted in `manage.py`. Hence, the dependencies have never been consumed from our mirror and can be dropped. This most likely works because `jaxlib` is consumed from PyPI.

Closes #7432.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
