### PR TITLE
grpc: add ppc64le build support

### DIFF
--- a/test_tools/therock_consumer_graph.json
+++ b/test_tools/therock_consumer_graph.json
@@ -36,6 +36,7 @@
       "rocr-runtime",
       "rocrtst",
       "therock-elfio",
+      "therock-grpc",
       "therock-spdlog"
     ]
   },

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -52,6 +52,7 @@ if(THEROCK_ENABLE_MPI)
   add_subdirectory(openmpi)
 endif()
 
-# gRPC: Static library for RDC (built on-demand when depended upon)
-# See: docs/rfcs/RFC0007-rdc-therock-integration.md
-add_subdirectory(grpc)
+# gRPC depends on amd-llvm toolchain, only needed by RDC.
+if(THEROCK_ENABLE_RDC)
+  add_subdirectory(grpc)
+endif()

--- a/third-party/grpc/CMakeLists.txt
+++ b/third-party/grpc/CMakeLists.txt
@@ -13,8 +13,16 @@ therock_subproject_fetch(therock-grpc-sources
 
 set(_binary_dir "${CMAKE_CURRENT_BINARY_DIR}/build")
 
+# BoringSSL does not support ppc64le, so use system OpenSSL there.
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "ppc64")
+  set(_grpc_ssl_provider package)
+else()
+  set(_grpc_ssl_provider module)
+endif()
+
 therock_cmake_subproject_declare(therock-grpc
   USE_DIST_AMDGPU_TARGETS
+  COMPILER_TOOLCHAIN amd-llvm
   EXTERNAL_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/source"
   BINARY_DIR "${_binary_dir}"
   NO_MERGE_COMPILE_COMMANDS
@@ -33,7 +41,7 @@ therock_cmake_subproject_declare(therock-grpc
     -DgRPC_ABSL_PROVIDER=module
     -DgRPC_CARES_PROVIDER=module
     -DgRPC_RE2_PROVIDER=module
-    -DgRPC_SSL_PROVIDER=module
+    -DgRPC_SSL_PROVIDER=${_grpc_ssl_provider}
     -DgRPC_PROTOBUF_PROVIDER=module
 
     # Disable tests and unnecessary language plugins


### PR DESCRIPTION
## Motivation

Part of https://github.com/ROCm/TheRock/issues/5518 non-x86 portability support

We run into 2 issues when building grpc (Google RCP) on ppc64le:

1. There is an ABI mismatch when linking the GCC-built grpc to the clang-built RDC.
2.  BoringSSL (grpc dependency) does not recognize POWER architecture.

The solution for building on POWER is to:

1. Build grpc using clang instead of GCC
2. Use the system's TLS provider instead of Boring SSL.

## Technical Details

- Use `COMPILER_TOOLCHAIN amd-llvm` for gRPC on ppc64le to match the compiler used for RDC, avoiding TLS ABI mismatch.
- Set `gRPC_SSL_PROVIDER=package` on ppc64le to use system OpenSSL instead of the vendored BoringSSL, which does not support the POWER architecture.
- On all other architectures, behavior is unchanged (`gRPC_SSL_PROVIDER=module` with the vendored BoringSSL, system default compiler).
- RDC is the only consumer of gRPC in TheRock.

## Test Plan

- Full TheRock build on ppc64le (openpower15, MI210, gfx90a).
- RDC unit tests via ctest.
- RDC server/client integration test with unauthenticated gRPC.
- RDC server/client integration test with mutual TLS authentication using pinned certificates, exercising the system OpenSSL code path.

## Test Result

- All 3 RDC unit tests pass (rdc_codec_tests, rdc_diag_kernel_tests, rdc_unit_tests).
- RDC server/client communication over unauthenticated gRPC: both MI210 GPUs discovered successfully.
- RDC server/client communication over mutual TLS (pinned certs, system OpenSSL 3.5.5): both MI210 GPUs discovered successfully, clean exit.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.