### PR TITLE
fix(ci): regenerate stale committed consumer graph

### DIFF
--- a/test_tools/therock_consumer_graph.json
+++ b/test_tools/therock_consumer_graph.json
@@ -834,6 +834,7 @@
       "kfdtest",
       "rdc",
       "rocgdb",
+      "rocprofiler-compute",
       "rocr-runtime",
       "therock-elfutils",
       "therock-grpc"


### PR DESCRIPTION
Co-authored-by: Claude Opus 5 <noreply@anthropic.com>
Signed-off-by: Adam Van Sickle <adam.vansickle@amd.com>

## Motivation

`rocprofiler-compute` gained a `THEROCK_BUNDLED_ZLIB` runtime dep in #7421, but the
committed consumer graph was never regenerated. The drift check compares the whole
file, so any PR touching a graph-affecting path either fails it or has to carry this
line in an unrelated diff. Same class as #7298 / #7297.

## Technical Details

Regenerated `test_tools/therock_consumer_graph.json` with
`check_consumer_graph_drift.py --write` from a full-tree `THEROCK_ENABLE_ALL=ON`
`gfx94X-dcgpu` configure. No other files change.

The diff is one line: `rocprofiler-compute` added to `therock-zlib`'s consumers.

`rocprofiler-compute` has a key in `fetch_test_configurations.py`, 
so changes to `therock-zlib` can now schedule its tests. 
That follows from the dependency #7421 added.

## Test Plan

- Regenerated locally, then confirmed the result matches what CI independently
computed on #7376.

## Test Result

- Consumer graph drift check: pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
