### PR TITLE
ci: restrict rocgdb-corefile tests to gfx942

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -402,6 +402,8 @@ test_matrix = {
     },
     # Corefile tests require specific hardware support (GPU core dump capable runners).
     # test_runner is pre-pinned so the family-based runner selection loop skips it.
+    # Only gfx942 has core-dump support, so include_family opts the job in to that
+    # family alone rather than enumerating every other architecture to exclude.
     "rocgdb-corefile": {
         **_rocgdb_common,
         "job_name": "rocgdb-corefile",
@@ -414,6 +416,9 @@ test_matrix = {
             " gdb.rocm/runtime-core.exp"
         ),
         "test_runner": "linux-gfx942-gpu-rocm-mathlib",
+        "include_family": {
+            "linux": ["gfx942"],
+        },
     },
     "rocr-debug-agent": {
         "job_name": "rocr-debug-agent",

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -127,6 +127,20 @@ def _build_container_options(job_config: dict, platform: str) -> dict:
     return job_config
 
 
+def _family_matches(
+    family_list: list[str], amdgpu_families: str, family_gfx_targets: list[str]
+) -> bool:
+    """Returns True if the current AMDGPU family matches any entry in family_list.
+
+    CI may pass either the family group string (e.g. "gfx120X-all") via
+    AMDGPU_FAMILIES or refer to the individual gfx targets within that family
+    (e.g. "gfx1200", "gfx1201"). Both forms are checked using exact membership.
+    """
+    return amdgpu_families in family_list or any(
+        t in family_list for t in family_gfx_targets
+    )
+
+
 # Common settings applied to all jobs
 _common_settings = {}
 
@@ -157,6 +171,27 @@ _rocgdb_common = {
 # Similarly, "linux_cpu_runner: True" routes a component to a CPU-only machine
 # (currently aws-linux-scale-rocm-prod) via the test_artifacts.yml routing
 # expression. "multi_gpu_runner" routes to multi-GPU machines.
+#
+# A component may also restrict which GPU families it runs on via "include_family"
+# (opt-in) and "exclude_family" (opt-out). Each is a map keyed by platform
+# ("linux" and/or "windows") whose value is a list of family entries. A job runs
+# only when it matches an include (if any are listed for that platform) and
+# matches no exclude.
+#
+# The two filters are evaluated per platform and independently: a list under
+# "linux" only affects Linux runs and a list under "windows" only affects Windows
+# runs, so a platform with no list (or the empty list) is left unfiltered. This
+# means an include scoped to one platform does not gate the other. To gate both,
+# list the families under both keys, for example:
+#   "include_family": {"linux": ["gfx942"], "windows": ["gfx942"]}
+#
+# Each entry matches either the family group string passed via AMDGPU_FAMILIES
+# (e.g. "gfx120X-all", "gfx950-dcgpu") or one of the individual gfx targets within
+# that family (e.g. "gfx1200", "gfx1201"). Some families expose no individual
+# targets, so those must be matched by the group string (e.g. "gfx1150",
+# "gfx125X-dcgpu"). Examples:
+#   "exclude_family": {"linux": ["gfx1030"]}                # skip a single target
+#   "include_family": {"linux": ["gfx908", "gfx90a", "gfx942"]}  # opt in to a set
 
 test_matrix = {
     # Sanity tests - always run first as a prerequisite for other component tests
@@ -951,11 +986,10 @@ def run():
     for key in selected_matrix:
         job_name = selected_matrix[key]["job_name"]
 
-        # If the test is disabled for a particular platform, skip the test.
-        # Check both the family group string (e.g. "gfx120X-all") and the individual
-        # gfx targets within that family (e.g. "gfx1200", "gfx1201") against the
-        # exclude list, since CI may pass either form via AMDGPU_FAMILIES.
-        _exclude_list = selected_matrix[key].get("exclude_family", {}).get(platform, [])
+        # Resolve the individual gfx targets for the current family once, so both
+        # include_family and exclude_family can match either the family group
+        # string (e.g. "gfx120X-all") passed via AMDGPU_FAMILIES or the individual
+        # gfx targets within that family (e.g. "gfx1200", "gfx1201").
         _family_gfx_targets = []
         if amdgpu_families and shortened_family and shortened_family in all_families:
             _family_gfx_targets = (
@@ -963,13 +997,24 @@ def run():
                 .get(platform, {})
                 .get("fetch-gfx-targets", [])
             )
-        _is_excluded = amdgpu_families in _exclude_list or any(
-            t in _exclude_list for t in _family_gfx_targets
-        )
-        if (
-            "exclude_family" in selected_matrix[key]
-            and platform in selected_matrix[key]["exclude_family"]
-            and _is_excluded
+
+        # include_family (opt-in) and exclude_family (opt-out) together decide
+        # whether a job runs: it runs only when it matches an include (if any are
+        # listed for this platform) and matches no exclude. Matching is exact
+        # membership.
+        _include_list = selected_matrix[key].get("include_family", {}).get(platform, [])
+        if _include_list and not _family_matches(
+            _include_list, amdgpu_families, _family_gfx_targets
+        ):
+            logging.info(
+                f"Excluding job {job_name} for platform {platform} and family "
+                f"{amdgpu_families}: not listed in include_family"
+            )
+            continue
+
+        _exclude_list = selected_matrix[key].get("exclude_family", {}).get(platform, [])
+        if _exclude_list and _family_matches(
+            _exclude_list, amdgpu_families, _family_gfx_targets
         ):
             logging.info(
                 f"Excluding job {job_name} for platform {platform} and family {amdgpu_families}"

--- a/build_tools/github_actions/tests/fetch_test_configurations_test.py
+++ b/build_tools/github_actions/tests/fetch_test_configurations_test.py
@@ -266,6 +266,16 @@ class FetchTestConfigurationsTest(unittest.TestCase):
         )
         self.assertIn("inc-noexc", self._selected_names())
 
+    def test_corefile_included_on_gfx942(self):
+        # Default AMDGPU_FAMILIES is gfx94X-dcgpu, whose gfx target is gfx942.
+        os.environ["PROJECTS_TO_TEST"] = "rocgdb-corefile"
+        self.assertIn("rocgdb-corefile", self._selected_names())
+
+    def test_corefile_excluded_on_other_family(self):
+        os.environ["PROJECTS_TO_TEST"] = "rocgdb-corefile"
+        os.environ["AMDGPU_FAMILIES"] = "gfx1150"
+        self.assertNotIn("rocgdb-corefile", self._selected_names())
+
     # -----------------------
     # Functional test merging via run_extended_tests
     # -----------------------

--- a/build_tools/github_actions/tests/fetch_test_configurations_test.py
+++ b/build_tools/github_actions/tests/fetch_test_configurations_test.py
@@ -27,6 +27,9 @@ class FetchTestConfigurationsTest(unittest.TestCase):
         self._orig_get_all_families = (
             fetch_test_configurations.get_all_families_for_trigger_types
         )
+        # Snapshot the matrix keys so tests can inject temporary jobs and have
+        # them removed in tearDown.
+        self._orig_test_matrix_keys = set(fetch_test_configurations.test_matrix.keys())
 
         os.environ["AMDGPU_FAMILIES"] = "gfx94X-dcgpu"
         os.environ["TEST_TYPE"] = "full"
@@ -54,6 +57,10 @@ class FetchTestConfigurationsTest(unittest.TestCase):
         fetch_test_configurations.get_all_families_for_trigger_types = (
             self._orig_get_all_families
         )
+        # Remove any temporary jobs injected by a test.
+        for key in list(fetch_test_configurations.test_matrix.keys()):
+            if key not in self._orig_test_matrix_keys:
+                del fetch_test_configurations.test_matrix[key]
 
     def _get_components(self):
         self.assertIn("components", self.gha_output)
@@ -177,6 +184,87 @@ class FetchTestConfigurationsTest(unittest.TestCase):
 
         names = {job["job_name"] for job in components}
         self.assertNotIn("rocroller", names)
+
+    # -----------------------
+    # include_family / exclude_family matching
+    # -----------------------
+
+    def _inject_job(self, name, **extra):
+        """Register a temporary linux job and target only it via PROJECTS_TO_TEST."""
+        os.environ["PROJECTS_TO_TEST"] = name
+        fetch_test_configurations.test_matrix[name] = {
+            "job_name": name,
+            "platform": ["linux"],
+            "total_shards_dict": {"linux": 1},
+            **extra,
+        }
+
+    def _selected_names(self):
+        fetch_test_configurations.run()
+        return {job["job_name"] for job in self._get_components()}
+
+    def test_family_matches_by_group_string(self):
+        self.assertTrue(
+            fetch_test_configurations._family_matches(
+                ["gfx94X-dcgpu"], "gfx94X-dcgpu", ["gfx942"]
+            )
+        )
+
+    def test_family_matches_by_gfx_target(self):
+        self.assertTrue(
+            fetch_test_configurations._family_matches(
+                ["gfx942"], "gfx94X-dcgpu", ["gfx942"]
+            )
+        )
+
+    def test_family_matches_returns_false_when_absent(self):
+        self.assertFalse(
+            fetch_test_configurations._family_matches(
+                ["gfx1100"], "gfx94X-dcgpu", ["gfx942"]
+            )
+        )
+
+    def test_family_matches_empty_list_is_false(self):
+        self.assertFalse(
+            fetch_test_configurations._family_matches([], "gfx94X-dcgpu", ["gfx942"])
+        )
+
+    def test_include_family_matches_by_gfx_target(self):
+        self._inject_job("inc-match", include_family={"linux": ["gfx942"]})
+        self.assertIn("inc-match", self._selected_names())
+
+    def test_include_family_matches_by_group_string(self):
+        self._inject_job("inc-group", include_family={"linux": ["gfx94X-dcgpu"]})
+        self.assertIn("inc-group", self._selected_names())
+
+    def test_include_family_skips_when_not_listed(self):
+        self._inject_job("inc-miss", include_family={"linux": ["gfx1100"]})
+        self.assertNotIn("inc-miss", self._selected_names())
+
+    def test_include_family_for_other_platform_does_not_gate(self):
+        # An include list scoped to a different platform must not gate this one.
+        self._inject_job("inc-otherplat", include_family={"windows": ["gfx1100"]})
+        self.assertIn("inc-otherplat", self._selected_names())
+
+    def test_no_include_or_exclude_runs(self):
+        self._inject_job("plain")
+        self.assertIn("plain", self._selected_names())
+
+    def test_include_and_exclude_both_match_excludes_wins(self):
+        self._inject_job(
+            "inc-exc",
+            include_family={"linux": ["gfx942"]},
+            exclude_family={"linux": ["gfx942"]},
+        )
+        self.assertNotIn("inc-exc", self._selected_names())
+
+    def test_include_matches_and_exclude_does_not(self):
+        self._inject_job(
+            "inc-noexc",
+            include_family={"linux": ["gfx942"]},
+            exclude_family={"linux": ["gfx1100"]},
+        )
+        self.assertIn("inc-noexc", self._selected_names())
 
     # -----------------------
     # Functional test merging via run_extended_tests


### PR DESCRIPTION
## Summary

- Add an `include_family` opt-in filter alongside the existing `exclude_family` in the test matrix, so a job can list the gfx architectures it runs on instead of enumerating every architecture to skip. A job runs only when it matches an include (if any are listed for the platform) and matches no exclude.
- Restrict the rocgdb-corefile tests to gfx942 via `include_family`, since only gfx942 runners have GPU core-dump support. This also avoids extending an exclude list as new architectures come online.
- Add unit tests covering the include-only, exclude-only, both, and neither selection paths, plus the corefile behavior.

JIRA ID : N/A

## Test plan

- [x] Verify rocgdb-corefile job appears in the test matrix for gfx942 builds
- [x] Verify rocgdb-corefile job is absent from the test matrix for gfx110X, gfx120X, gfx1151, gfx90a, gfx950, and gfx103X builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)