### PR TITLE
Add DEBUG_HIP_GRAPH_MIN_OVERLAP for hip-tests

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_hiptests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiptests.py
@@ -139,6 +139,8 @@ def setup_env(env):
     # Set ROCM Path, to find rocm_agent_enum etc
     ROCM_PATH = Path(THEROCK_BIN_DIR).resolve().parent
     env["ROCM_PATH"] = str(ROCM_PATH)
+    # required for hip-tests to avoid optimizing out multi-stream tests
+    env["DEBUG_HIP_GRAPH_MIN_OVERLAP"] = str(0)
     if platform.system() == "Linux":
         HIP_LIB_PATH = Path(THEROCK_BIN_DIR).parent / "lib"
         logging.info(f"++ Setting LD_LIBRARY_PATH={HIP_LIB_PATH}")


### PR DESCRIPTION
## Motivation
With the latest optimizations, multiple small kernels in multi-stream tests collapse into a single stream, effectively voiding the check. This PR enables the debug env variable to disable this optimization in testing.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

<!-- Most pull requests should be associated with at least one GitHub issue -->

<!-- GitHub issue: https://github.com/ROCm/TheRock/issues/1234 -->
Replaces: https://github.com/ROCm/rocm-systems/pull/8240
## Technical Details
Adds env variable DEBUG_HIP_GRAPH_MIN_OVERLAP to test_hiptests.py file.
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
PSDB on hip-tests should pass as usual
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Waiting for PSDB
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
