### PR TITLE
Relocate /opt/rocm compat symlinks from amdrocm-core to amdrocm-sysdeps

### DIFF
--- a/build_tools/packaging/linux/deb_package.py
+++ b/build_tools/packaging/linux/deb_package.py
@@ -407,6 +407,19 @@ def generate_debian_postscripts(pkg_info, deb_dir, config: PackageConfig):
                 f.write(template.render(context))
             os.chmod(script_file, 0o755)
 
+    # Non-executable dpkg control files (e.g. debian/triggers). debhelper installs
+    # these into the .deb control area automatically.
+    NONEXEC_CONTROL = {"triggers"}
+    for control in NONEXEC_CONTROL:
+        pattern = f"{pkg_name}-{control}.j2"
+        for file in templates_root.glob(pattern):
+            control_file = Path(deb_dir) / control
+            template = env.get_template(str(file.relative_to(SCRIPT_DIR)))
+            with control_file.open("w", encoding="utf-8") as f:
+                # dpkg requires newline-terminated directives; Jinja strips the
+                # template's trailing newline, so re-add exactly one.
+                f.write(template.render(context).rstrip("\n") + "\n")
+
 
 def copy_package_contents(source_dir, destination_dir):
     """Copy package contents from artfactory to package build directory

--- a/build_tools/packaging/linux/deb_package.py
+++ b/build_tools/packaging/linux/deb_package.py
@@ -407,8 +407,7 @@ def generate_debian_postscripts(pkg_info, deb_dir, config: PackageConfig):
                 f.write(template.render(context))
             os.chmod(script_file, 0o755)
 
-    # Non-executable dpkg control files (e.g. debian/triggers). debhelper installs
-    # these into the .deb control area automatically.
+    # Non-executable dpkg control files (e.g. debian/triggers); dh_installdeb ships them.
     NONEXEC_CONTROL = {"triggers"}
     for control in NONEXEC_CONTROL:
         pattern = f"{pkg_name}-{control}.j2"
@@ -416,8 +415,7 @@ def generate_debian_postscripts(pkg_info, deb_dir, config: PackageConfig):
             control_file = Path(deb_dir) / control
             template = env.get_template(str(file.relative_to(SCRIPT_DIR)))
             with control_file.open("w", encoding="utf-8") as f:
-                # dpkg requires newline-terminated directives; Jinja strips the
-                # template's trailing newline, so re-add exactly one.
+                # Jinja strips the trailing newline; dpkg needs directives newline-terminated.
                 f.write(template.render(context).rstrip("\n") + "\n")
 
 

--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -2188,6 +2188,7 @@
       }
     ],
     "Gfxarch": "False",
+    "Postinstall": "True",
     "Disable_DWZ": "True",
     "Disable_DEB_STRIP": "True"
   },

--- a/build_tools/packaging/linux/rpm_package.py
+++ b/build_tools/packaging/linux/rpm_package.py
@@ -205,6 +205,7 @@ def generate_rpm_postscripts(pkg_info, config: PackageConfig):
         "postinst": "%post",
         "prerm": "%preun",
         "postrm": "%postun",
+        "transfiletriggerin": "%transfiletriggerin",
     }
     pkg_name = pkg_info.get("Package")
     parts = config.rocm_version.split(".")

--- a/build_tools/packaging/linux/template/rpm_specfile.j2
+++ b/build_tools/packaging/linux/template/rpm_specfile.j2
@@ -88,3 +88,8 @@ rm -rf $RPM_BUILD_ROOT
 %postun
 {{ rpm_scripts['%postun'] }}
 {% endif %}
+
+{% if rpm_scripts['%transfiletriggerin'] %}
+%transfiletriggerin -- {{ install_prefix }}
+{{ rpm_scripts['%transfiletriggerin'] }}
+{% endif %}

--- a/build_tools/packaging/linux/template/scripts/_alternatives_lib.j2
+++ b/build_tools/packaging/linux/template/scripts/_alternatives_lib.j2
@@ -1,19 +1,8 @@
-{# Shared helpers for the /opt/rocm compat directory symlinks (issue ROCm/ROCm#6599).
-   Included by amdrocm-sysdeps postinst/prerm/transfiletriggerin. No mkdir: the
-   registration runs after payload is unpacked (dpkg trigger / rpm transfiletrigger)
-   and only registers slots whose target already exists, so it never turns a
-   payload-owned symlink (e.g. amdgcn -> lib/llvm/amdgcn) into a directory. #}
-alt_prefix() {
-    # The trigger watch path (%transfiletriggerin -- {{ install_prefix }}) and the
-    # deb path trigger both key on the build-time prefix, so relocation is not
-    # supported anyway; use the literal prefix rather than $RPM_INSTALL_PREFIX0,
-    # which is not guaranteed to be set in a file-trigger scriptlet.
-    printf '%s' "{{ install_prefix }}"
-}
-
-# Priority packs the version (base-14 major/minor/patch) plus a minutes-since-2020
-# tiebreaker so the highest version (else newest install) wins the /opt/rocm slot.
+{# Shared helpers for the /opt/rocm compat symlinks, included by the amdrocm-sysdeps
+   maintainer scripts. Registration runs after payload unpack and skips slots whose
+   target is absent, so it never turns a payload-owned symlink into a directory. #}
 alt_score() {
+    # base-14 version pack + minutes-since-2020 tiebreaker; highest wins the slot.
     local now s
     now=$(date -u +%s)
     s=$(( {{ version_major }} - 3 ))
@@ -25,10 +14,9 @@ alt_score() {
 alt_install() {
     command -v update-alternatives >/dev/null || return 0
     local p score
-    p="$(alt_prefix)"; [ -n "$p" ] || return 0
+    p="{{ install_prefix }}"
     score="$(alt_score)"
-    # _reg <link> <target> <name>: register only if the target exists (dir or
-    # symlink), so a slot missing at this point is simply skipped, never created.
+    # register a slot only if its target exists (dir or symlink); never create it.
     _reg() { if [ -e "$2" ]; then update-alternatives --install "$1" "$3" "$2" "$score" || true; fi; }
     _reg /opt/rocm/core                     "$p"          core
     _reg /opt/rocm/core-{{ version_major }} "$p"          core-{{ version_major }}
@@ -44,8 +32,7 @@ alt_install() {
 
 alt_remove() {
     command -v update-alternatives >/dev/null || return 0
-    local p
-    p="$(alt_prefix)"; [ -n "$p" ] || return 0
+    local p="{{ install_prefix }}"
     update-alternatives --remove core                     "$p"         || true
     update-alternatives --remove core-{{ version_major }} "$p"         || true
     update-alternatives --remove rocm-bin                 "$p/bin"     || true

--- a/build_tools/packaging/linux/template/scripts/_alternatives_lib.j2
+++ b/build_tools/packaging/linux/template/scripts/_alternatives_lib.j2
@@ -3,20 +3,12 @@
    registration runs after payload is unpacked (dpkg trigger / rpm transfiletrigger)
    and only registers slots whose target already exists, so it never turns a
    payload-owned symlink (e.g. amdgcn -> lib/llvm/amdgcn) into a directory. #}
-is_debian_like() {
-    local id_like="$1"
-    case " $id_like " in
-        (*" debian "*|*" ubuntu "*) return 0 ;;
-        (*) return 1 ;;
-    esac
-}
-
 alt_prefix() {
-    {% if target == "deb" %}
+    # The trigger watch path (%transfiletriggerin -- {{ install_prefix }}) and the
+    # deb path trigger both key on the build-time prefix, so relocation is not
+    # supported anyway; use the literal prefix rather than $RPM_INSTALL_PREFIX0,
+    # which is not guaranteed to be set in a file-trigger scriptlet.
     printf '%s' "{{ install_prefix }}"
-    {% else %}
-    printf '%s' "$RPM_INSTALL_PREFIX0"
-    {% endif %}
 }
 
 # Priority packs the version (base-14 major/minor/patch) plus a minutes-since-2020

--- a/build_tools/packaging/linux/template/scripts/_alternatives_lib.j2
+++ b/build_tools/packaging/linux/template/scripts/_alternatives_lib.j2
@@ -1,0 +1,67 @@
+{# Shared helpers for the /opt/rocm compat directory symlinks (issue ROCm/ROCm#6599).
+   Included by amdrocm-sysdeps postinst/prerm/transfiletriggerin. No mkdir: the
+   registration runs after payload is unpacked (dpkg trigger / rpm transfiletrigger)
+   and only registers slots whose target already exists, so it never turns a
+   payload-owned symlink (e.g. amdgcn -> lib/llvm/amdgcn) into a directory. #}
+is_debian_like() {
+    local id_like="$1"
+    case " $id_like " in
+        (*" debian "*|*" ubuntu "*) return 0 ;;
+        (*) return 1 ;;
+    esac
+}
+
+alt_prefix() {
+    {% if target == "deb" %}
+    printf '%s' "{{ install_prefix }}"
+    {% else %}
+    printf '%s' "$RPM_INSTALL_PREFIX0"
+    {% endif %}
+}
+
+# Priority packs the version (base-14 major/minor/patch) plus a minutes-since-2020
+# tiebreaker so the highest version (else newest install) wins the /opt/rocm slot.
+alt_score() {
+    local now s
+    now=$(date -u +%s)
+    s=$(( {{ version_major }} - 3 ))
+    s=$(( s * 14 + {{ version_minor }} ))
+    s=$(( s * 14 + {{ version_patch }} ))
+    printf '%s' "$(( s * 1000000 + (now - 1600000000) / 60 ))"
+}
+
+alt_install() {
+    command -v update-alternatives >/dev/null || return 0
+    local p score
+    p="$(alt_prefix)"; [ -n "$p" ] || return 0
+    score="$(alt_score)"
+    # _reg <link> <target> <name>: register only if the target exists (dir or
+    # symlink), so a slot missing at this point is simply skipped, never created.
+    _reg() { if [ -e "$2" ]; then update-alternatives --install "$1" "$3" "$2" "$score" || true; fi; }
+    _reg /opt/rocm/core                     "$p"          core
+    _reg /opt/rocm/core-{{ version_major }} "$p"          core-{{ version_major }}
+    _reg /opt/rocm/bin                      "$p/bin"      rocm-bin
+    _reg /opt/rocm/lib                      "$p/lib"      rocm-lib
+    _reg /opt/rocm/include                  "$p/include"  rocm-include
+    _reg /opt/rocm/llvm                     "$p/llvm"     rocm-llvm
+    _reg /opt/rocm/amdgcn                   "$p/amdgcn"   rocm-amdgcn
+    _reg /opt/rocm/libexec                  "$p/libexec"  rocm-libexec
+    _reg /opt/rocm/share                    "$p/share"    rocm-share
+    return 0
+}
+
+alt_remove() {
+    command -v update-alternatives >/dev/null || return 0
+    local p
+    p="$(alt_prefix)"; [ -n "$p" ] || return 0
+    update-alternatives --remove core                     "$p"         || true
+    update-alternatives --remove core-{{ version_major }} "$p"         || true
+    update-alternatives --remove rocm-bin                 "$p/bin"     || true
+    update-alternatives --remove rocm-lib                 "$p/lib"     || true
+    update-alternatives --remove rocm-include             "$p/include" || true
+    update-alternatives --remove rocm-llvm                "$p/llvm"    || true
+    update-alternatives --remove rocm-amdgcn              "$p/amdgcn"  || true
+    update-alternatives --remove rocm-libexec             "$p/libexec" || true
+    update-alternatives --remove rocm-share               "$p/share"   || true
+    return 0
+}

--- a/build_tools/packaging/linux/template/scripts/amdrocm-core-postinst.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-core-postinst.j2
@@ -52,20 +52,7 @@ do_update_alternatives(){
        PKG_INSTALL_PREFIX="$RPM_INSTALL_PREFIX0"
     {% endif %}
 
-    # Install /opt/rocm/core soft link
-    update-alternatives --install "/opt/rocm/core" "core" "$PKG_INSTALL_PREFIX" "$altscore"
-    update-alternatives --install "/opt/rocm/core-{{ version_major }}" "core-{{ version_major }}" "$PKG_INSTALL_PREFIX" "$altscore"
-
-    # Install /opt/rocm/bin, /opt/rocm/lib, and /opt/rocm/include soft links
-    update-alternatives --install "/opt/rocm/bin" "rocm-bin" "$PKG_INSTALL_PREFIX/bin" "$altscore"
-    update-alternatives --install "/opt/rocm/lib" "rocm-lib" "$PKG_INSTALL_PREFIX/lib" "$altscore"
-    update-alternatives --install "/opt/rocm/include" "rocm-include" "$PKG_INSTALL_PREFIX/include" "$altscore"
-
-    # Install /opt/rocm/llvm, /opt/rocm/amdgcn, /opt/rocm/libexec, and /opt/rocm/share soft links
-    update-alternatives --install "/opt/rocm/llvm" "rocm-llvm" "$PKG_INSTALL_PREFIX/llvm" "$altscore"
-    update-alternatives --install "/opt/rocm/amdgcn" "rocm-amdgcn" "$PKG_INSTALL_PREFIX/amdgcn" "$altscore"
-    update-alternatives --install "/opt/rocm/libexec" "rocm-libexec" "$PKG_INSTALL_PREFIX/libexec" "$altscore"
-    update-alternatives --install "/opt/rocm/share" "rocm-share" "$PKG_INSTALL_PREFIX/share" "$altscore"
+    # /opt/rocm/{core,bin,lib,...} symlinks are now owned by amdrocm-sysdeps (a universal dep).
 
     for i in "${binaries[@]}"
     do

--- a/build_tools/packaging/linux/template/scripts/amdrocm-core-prerm.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-core-prerm.j2
@@ -30,20 +30,7 @@ do_update_alternatives(){
             "$PKG_INSTALL_PREFIX/bin/$i" || true
     done
 
-    # Remove /opt/rocm/core soft link
-    update-alternatives --remove "core" "$PKG_INSTALL_PREFIX" || true
-    update-alternatives --remove "core-{{ version_major }}" "$PKG_INSTALL_PREFIX" || true
-
-    # Remove /opt/rocm/bin, /opt/rocm/lib, and /opt/rocm/include soft links
-    update-alternatives --remove "rocm-bin" "$PKG_INSTALL_PREFIX/bin" || true
-    update-alternatives --remove "rocm-lib" "$PKG_INSTALL_PREFIX/lib" || true
-    update-alternatives --remove "rocm-include" "$PKG_INSTALL_PREFIX/include" || true
-
-    # Remove /opt/rocm/llvm, /opt/rocm/amdgcn, /opt/rocm/libexec, and /opt/rocm/share  soft links
-    update-alternatives --remove "rocm-llvm" "$PKG_INSTALL_PREFIX/llvm" || true
-    update-alternatives --remove "rocm-amdgcn" "$PKG_INSTALL_PREFIX/amdgcn" || true
-    update-alternatives --remove "rocm-libexec" "$PKG_INSTALL_PREFIX/libexec" || true
-    update-alternatives --remove "rocm-share" "$PKG_INSTALL_PREFIX/share" || true
+    # /opt/rocm/{core,bin,lib,...} symlinks are now owned/removed by amdrocm-sysdeps (a universal dep).
 }
 
 if [ -e /etc/os-release ] && source /etc/os-release && is_debian_like "${ID_LIKE:-$ID}"

--- a/build_tools/packaging/linux/template/scripts/amdrocm-sysdeps-postinst.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-sysdeps-postinst.j2
@@ -1,8 +1,7 @@
 #!/bin/bash
 {% include "template/scripts/_alternatives_lib.j2" %}
 {% if target == "deb" %}
-# deb: run on initial configure and whenever the dpkg path trigger fires after
-# payload packages have unpacked files under the prefix (see amdrocm-sysdeps triggers).
+# deb: register on configure and on the dpkg trigger (fires after payload unpack).
 case "$1" in
     (configure|triggered) alt_install ;;
     (abort-upgrade|abort-remove|abort-deconfigure) : ;;

--- a/build_tools/packaging/linux/template/scripts/amdrocm-sysdeps-postinst.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-sysdeps-postinst.j2
@@ -1,71 +1,15 @@
 #!/bin/bash
-
-is_debian_like() {
-    local id_like="$1"
-    case " $id_like " in
-        (*" debian "*|*" ubuntu "*)
-            return 0
-            ;;
-        (*)
-            return 1
-            ;;
-    esac
-}
-
-do_update_alternatives(){
-    # skip update if program doesn't exist
-    command -v update-alternatives >/dev/null || return 0
-    local altscore now
-    now=$(date -u +%s)
-
-    # Highest semver wins (else newest install); score must fit in 32 bits.
-    altscore=$(({{ version_major }} - 3))
-    altscore=$((altscore * 14 + {{ version_minor }})) # Allow up to 14 minor
-    altscore=$((altscore * 14 + {{ version_patch }})) # Allow up to 14 patch
-    altscore=$((altscore*1000000+(now-1600000000)/60))
-
-    {% if target == "deb" %}
-       PKG_INSTALL_PREFIX={{ install_prefix }}
-    {% else %}
-       PKG_INSTALL_PREFIX="$RPM_INSTALL_PREFIX0"
-    {% endif %}
-
-    # Guard against an empty prefix so the mkdir below never lands at /.
-    [ -n "$PKG_INSTALL_PREFIX" ] || return 0
-
-    # Seed dirs first: update-alternatives errors on a missing target, and sysdeps configures before payload ships them.
-    mkdir -p "$PKG_INSTALL_PREFIX"/bin "$PKG_INSTALL_PREFIX"/lib "$PKG_INSTALL_PREFIX"/include "$PKG_INSTALL_PREFIX"/llvm "$PKG_INSTALL_PREFIX"/amdgcn "$PKG_INSTALL_PREFIX"/libexec "$PKG_INSTALL_PREFIX"/share
-
-    # Install /opt/rocm/core soft link
-    update-alternatives --install "/opt/rocm/core" "core" "$PKG_INSTALL_PREFIX" "$altscore"
-    update-alternatives --install "/opt/rocm/core-{{ version_major }}" "core-{{ version_major }}" "$PKG_INSTALL_PREFIX" "$altscore"
-
-    # Install /opt/rocm/bin, /opt/rocm/lib, and /opt/rocm/include soft links
-    update-alternatives --install "/opt/rocm/bin" "rocm-bin" "$PKG_INSTALL_PREFIX/bin" "$altscore"
-    update-alternatives --install "/opt/rocm/lib" "rocm-lib" "$PKG_INSTALL_PREFIX/lib" "$altscore"
-    update-alternatives --install "/opt/rocm/include" "rocm-include" "$PKG_INSTALL_PREFIX/include" "$altscore"
-
-    # Install /opt/rocm/llvm, /opt/rocm/amdgcn, /opt/rocm/libexec, and /opt/rocm/share soft links
-    update-alternatives --install "/opt/rocm/llvm" "rocm-llvm" "$PKG_INSTALL_PREFIX/llvm" "$altscore"
-    update-alternatives --install "/opt/rocm/amdgcn" "rocm-amdgcn" "$PKG_INSTALL_PREFIX/amdgcn" "$altscore"
-    update-alternatives --install "/opt/rocm/libexec" "rocm-libexec" "$PKG_INSTALL_PREFIX/libexec" "$altscore"
-    update-alternatives --install "/opt/rocm/share" "rocm-share" "$PKG_INSTALL_PREFIX/share" "$altscore"
-    true
-}
-
-if [ -e /etc/os-release ] && source /etc/os-release && is_debian_like "${ID_LIKE:-$ID}"
-then
-    case "$1" in
-       (configure)
-       do_update_alternatives
-       ;;
-       (abort-upgrade|abort-remove|abort-deconfigure)
-           echo "$1"
-       ;;
-       (*)
-          exit 0
-       ;;
-    esac
-else
-    do_update_alternatives
-fi
+{% include "template/scripts/_alternatives_lib.j2" %}
+{% if target == "deb" %}
+# deb: run on initial configure and whenever the dpkg path trigger fires after
+# payload packages have unpacked files under the prefix (see amdrocm-sysdeps triggers).
+case "$1" in
+    (configure|triggered) alt_install ;;
+    (abort-upgrade|abort-remove|abort-deconfigure) : ;;
+    (*) : ;;
+esac
+{% else %}
+# rpm: registration is done by %transfiletriggerin after payload is unpacked.
+:
+{% endif %}
+exit 0

--- a/build_tools/packaging/linux/template/scripts/amdrocm-sysdeps-postinst.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-sysdeps-postinst.j2
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+is_debian_like() {
+    local id_like="$1"
+    case " $id_like " in
+        (*" debian "*|*" ubuntu "*)
+            return 0
+            ;;
+        (*)
+            return 1
+            ;;
+    esac
+}
+
+do_update_alternatives(){
+    # skip update if program doesn't exist
+    command -v update-alternatives >/dev/null || return 0
+    local altscore now
+    now=$(date -u +%s)
+
+    # Highest semver wins (else newest install); score must fit in 32 bits.
+    altscore=$(({{ version_major }} - 3))
+    altscore=$((altscore * 14 + {{ version_minor }})) # Allow up to 14 minor
+    altscore=$((altscore * 14 + {{ version_patch }})) # Allow up to 14 patch
+    altscore=$((altscore*1000000+(now-1600000000)/60))
+
+    {% if target == "deb" %}
+       PKG_INSTALL_PREFIX={{ install_prefix }}
+    {% else %}
+       PKG_INSTALL_PREFIX="$RPM_INSTALL_PREFIX0"
+    {% endif %}
+
+    # Guard against an empty prefix so the mkdir below never lands at /.
+    [ -n "$PKG_INSTALL_PREFIX" ] || return 0
+
+    # Seed dirs first: update-alternatives errors on a missing target, and sysdeps configures before payload ships them.
+    mkdir -p "$PKG_INSTALL_PREFIX"/bin "$PKG_INSTALL_PREFIX"/lib "$PKG_INSTALL_PREFIX"/include "$PKG_INSTALL_PREFIX"/llvm "$PKG_INSTALL_PREFIX"/amdgcn "$PKG_INSTALL_PREFIX"/libexec "$PKG_INSTALL_PREFIX"/share
+
+    # Install /opt/rocm/core soft link
+    update-alternatives --install "/opt/rocm/core" "core" "$PKG_INSTALL_PREFIX" "$altscore"
+    update-alternatives --install "/opt/rocm/core-{{ version_major }}" "core-{{ version_major }}" "$PKG_INSTALL_PREFIX" "$altscore"
+
+    # Install /opt/rocm/bin, /opt/rocm/lib, and /opt/rocm/include soft links
+    update-alternatives --install "/opt/rocm/bin" "rocm-bin" "$PKG_INSTALL_PREFIX/bin" "$altscore"
+    update-alternatives --install "/opt/rocm/lib" "rocm-lib" "$PKG_INSTALL_PREFIX/lib" "$altscore"
+    update-alternatives --install "/opt/rocm/include" "rocm-include" "$PKG_INSTALL_PREFIX/include" "$altscore"
+
+    # Install /opt/rocm/llvm, /opt/rocm/amdgcn, /opt/rocm/libexec, and /opt/rocm/share soft links
+    update-alternatives --install "/opt/rocm/llvm" "rocm-llvm" "$PKG_INSTALL_PREFIX/llvm" "$altscore"
+    update-alternatives --install "/opt/rocm/amdgcn" "rocm-amdgcn" "$PKG_INSTALL_PREFIX/amdgcn" "$altscore"
+    update-alternatives --install "/opt/rocm/libexec" "rocm-libexec" "$PKG_INSTALL_PREFIX/libexec" "$altscore"
+    update-alternatives --install "/opt/rocm/share" "rocm-share" "$PKG_INSTALL_PREFIX/share" "$altscore"
+    true
+}
+
+if [ -e /etc/os-release ] && source /etc/os-release && is_debian_like "${ID_LIKE:-$ID}"
+then
+    case "$1" in
+       (configure)
+       do_update_alternatives
+       ;;
+       (abort-upgrade|abort-remove|abort-deconfigure)
+           echo "$1"
+       ;;
+       (*)
+          exit 0
+       ;;
+    esac
+else
+    do_update_alternatives
+fi

--- a/build_tools/packaging/linux/template/scripts/amdrocm-sysdeps-prerm.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-sysdeps-prerm.j2
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+is_debian_like() {
+    local id_like="$1"
+    case " $id_like " in
+        (*" debian "*|*" ubuntu "*)
+            return 0
+            ;;
+        (*)
+            return 1
+            ;;
+    esac
+}
+
+do_update_alternatives(){
+    # skip update if program doesn't exist
+    command -v update-alternatives >/dev/null || return 0
+
+    {% if target == "deb" %}
+        PKG_INSTALL_PREFIX={{ install_prefix }}
+    {% else %}
+        PKG_INSTALL_PREFIX="$RPM_INSTALL_PREFIX0"
+    {% endif %}
+
+    # Remove /opt/rocm/core soft link
+    update-alternatives --remove "core" "$PKG_INSTALL_PREFIX" || true
+    update-alternatives --remove "core-{{ version_major }}" "$PKG_INSTALL_PREFIX" || true
+
+    # Remove /opt/rocm/bin, /opt/rocm/lib, and /opt/rocm/include soft links
+    update-alternatives --remove "rocm-bin" "$PKG_INSTALL_PREFIX/bin" || true
+    update-alternatives --remove "rocm-lib" "$PKG_INSTALL_PREFIX/lib" || true
+    update-alternatives --remove "rocm-include" "$PKG_INSTALL_PREFIX/include" || true
+
+    # Remove /opt/rocm/llvm, /opt/rocm/amdgcn, /opt/rocm/libexec, and /opt/rocm/share  soft links
+    update-alternatives --remove "rocm-llvm" "$PKG_INSTALL_PREFIX/llvm" || true
+    update-alternatives --remove "rocm-amdgcn" "$PKG_INSTALL_PREFIX/amdgcn" || true
+    update-alternatives --remove "rocm-libexec" "$PKG_INSTALL_PREFIX/libexec" || true
+    update-alternatives --remove "rocm-share" "$PKG_INSTALL_PREFIX/share" || true
+}
+
+if [ -e /etc/os-release ] && source /etc/os-release && is_debian_like "${ID_LIKE:-$ID}"
+then
+   case "$1" in
+       (remove|upgrade)
+           do_update_alternatives
+       ;;
+       (purge)
+           # nothing to do
+       ;;
+       (*)
+           exit 0
+       ;;
+   esac
+else
+    # RPM: remove only on true uninstall ($1=0); upgrade's new %post already re-registered them.
+    if [ "${1:-0}" = "0" ]; then
+        do_update_alternatives
+    fi
+fi

--- a/build_tools/packaging/linux/template/scripts/amdrocm-sysdeps-prerm.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-sysdeps-prerm.j2
@@ -1,59 +1,12 @@
 #!/bin/bash
-
-is_debian_like() {
-    local id_like="$1"
-    case " $id_like " in
-        (*" debian "*|*" ubuntu "*)
-            return 0
-            ;;
-        (*)
-            return 1
-            ;;
-    esac
-}
-
-do_update_alternatives(){
-    # skip update if program doesn't exist
-    command -v update-alternatives >/dev/null || return 0
-
-    {% if target == "deb" %}
-        PKG_INSTALL_PREFIX={{ install_prefix }}
-    {% else %}
-        PKG_INSTALL_PREFIX="$RPM_INSTALL_PREFIX0"
-    {% endif %}
-
-    # Remove /opt/rocm/core soft link
-    update-alternatives --remove "core" "$PKG_INSTALL_PREFIX" || true
-    update-alternatives --remove "core-{{ version_major }}" "$PKG_INSTALL_PREFIX" || true
-
-    # Remove /opt/rocm/bin, /opt/rocm/lib, and /opt/rocm/include soft links
-    update-alternatives --remove "rocm-bin" "$PKG_INSTALL_PREFIX/bin" || true
-    update-alternatives --remove "rocm-lib" "$PKG_INSTALL_PREFIX/lib" || true
-    update-alternatives --remove "rocm-include" "$PKG_INSTALL_PREFIX/include" || true
-
-    # Remove /opt/rocm/llvm, /opt/rocm/amdgcn, /opt/rocm/libexec, and /opt/rocm/share  soft links
-    update-alternatives --remove "rocm-llvm" "$PKG_INSTALL_PREFIX/llvm" || true
-    update-alternatives --remove "rocm-amdgcn" "$PKG_INSTALL_PREFIX/amdgcn" || true
-    update-alternatives --remove "rocm-libexec" "$PKG_INSTALL_PREFIX/libexec" || true
-    update-alternatives --remove "rocm-share" "$PKG_INSTALL_PREFIX/share" || true
-}
-
-if [ -e /etc/os-release ] && source /etc/os-release && is_debian_like "${ID_LIKE:-$ID}"
-then
-   case "$1" in
-       (remove|upgrade)
-           do_update_alternatives
-       ;;
-       (purge)
-           # nothing to do
-       ;;
-       (*)
-           exit 0
-       ;;
-   esac
-else
-    # RPM: remove only on true uninstall ($1=0); upgrade's new %post already re-registered them.
-    if [ "${1:-0}" = "0" ]; then
-        do_update_alternatives
-    fi
-fi
+{% include "template/scripts/_alternatives_lib.j2" %}
+{% if target == "deb" %}
+case "$1" in
+    (remove|upgrade) alt_remove ;;
+    (*) : ;;
+esac
+{% else %}
+# rpm: $1 is the remaining-install count; remove only on true uninstall.
+if [ "${1:-0}" = "0" ]; then alt_remove; fi
+{% endif %}
+exit 0

--- a/build_tools/packaging/linux/template/scripts/amdrocm-sysdeps-transfiletriggerin.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-sysdeps-transfiletriggerin.j2
@@ -1,0 +1,5 @@
+{% include "template/scripts/_alternatives_lib.j2" %}
+# Fires once at the end of any transaction that installs files under the prefix,
+# i.e. after payload packages (llvm, runtime, ...) are unpacked, so every target exists.
+alt_install
+exit 0

--- a/build_tools/packaging/linux/template/scripts/amdrocm-sysdeps-transfiletriggerin.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-sysdeps-transfiletriggerin.j2
@@ -1,5 +1,4 @@
 {% include "template/scripts/_alternatives_lib.j2" %}
-# Fires once at the end of any transaction that installs files under the prefix,
-# i.e. after payload packages (llvm, runtime, ...) are unpacked, so every target exists.
+# Fires after payload packages are unpacked, so every target exists.
 alt_install
 exit 0

--- a/build_tools/packaging/linux/template/scripts/amdrocm-sysdeps-triggers.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-sysdeps-triggers.j2
@@ -1,0 +1,1 @@
+interest-noawait {{ install_prefix }}


### PR DESCRIPTION
Partially addresses https://github.com/ROCm/ROCm/issues/6599 (symlink point only).

## Motivation

`/opt/rocm/{bin,lib,include,core,...}` compat symlinks were created only by `amdrocm-core`, which is arch-specific and pulls the full math stack. Metapackages that don't depend on it (`amdrocm-developer-tools`, `amdrocm-opencl`, `amdrocm-runtime-dev`) install without them.

## Technical Details

Move the directory `update-alternatives` from `amdrocm-core` to `amdrocm-sysdeps`, registered from a post-unpack hook so every target exists: a dpkg path trigger on deb, an rpm `%transfiletriggerin`. Registration skips any slot whose target is absent, so no directory is pre-created (an earlier `mkdir` clobbered llvm's `amdgcn`/`llvm` symlinks and broke the rpm unpack). `amdrocm-core` keeps its `/usr/bin` slaves.

TODO (follow-up): dedup `is_debian_like`/`altscore` into the shared partial for `amdrocm-core`/`-devel`, and decouple `debian/triggers` emission from the `Postinstall` key.

## Test Plan

ubuntu:24.04 (deb) and rockylinux:9 (rpm): install a lean meta with a patched `amdrocm-sysdeps`; check the `/opt/rocm` symlinks, upgrade, and uninstall. `bash -n` all rendered scripts.

## Test Result

Both formats: all symlinks created (incl. symlink-typed `amdgcn`/`llvm`), no cpio conflict, `amdrocm-core` not pulled, prerm/erase clean. The old `mkdir` approach reproduced the CI failure; the trigger approach installs clean.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
