### PR TITLE
fix(ci): add build_runs_on input to workflow_dispatch for PyTorch builds

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -167,6 +167,10 @@ on:
           - sccache
           - ccache
         default: sccache
+      build_runs_on:
+        description: "Build runner label (selected by configure script with weighted distribution)"
+        type: string
+        default: "aws-linux-scale-rocm-prod"
       run_full_pytorch_tests:
         description: >-
           Dispatch the full PyTorch test suite after a successful build.

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
@@ -83,7 +83,7 @@ on:
       build_runs_on:
         description: "Build runner label (selected by configure script with weighted distribution)"
         type: string
-        default: "azure-windows-scale-rocm"
+        default: "aws-windows-scale-rocm-prod-mix"
   workflow_dispatch:
     inputs:
       amdgpu_families:
@@ -162,6 +162,10 @@ on:
           - sccache
           - ccache
         default: sccache
+      build_runs_on:
+        description: "Build runner label (selected by configure script with weighted distribution)"
+        type: string
+        default: "aws-windows-scale-rocm-prod-mix"
 
 run-name: Build Multi-Arch Windows PyTorch Wheels (${{ inputs.release_type }}, ${{ inputs.python_version }}, ${{ inputs.pytorch_git_ref }})
 


### PR DESCRIPTION
PR #7236 added build_runs_on to workflow_call but missed adding it to workflow_dispatch. This caused manual dispatches to use the hardcoded default runner, leading to OOM failures on resource-constrained runners.

Add the missing build_runs_on input to workflow_dispatch for both Linux and Windows PyTorch wheel build workflows, allowing users to specify appropriate runners when dispatching manually.
