### PR TITLE
fix(ci): add build_runs_on to PyTorch build workflow_dispatch inputs

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -167,6 +167,10 @@ on:
           - sccache
           - ccache
         default: sccache
+      build_runs_on:
+        description: "Build runner label (selected by configure script with weighted distribution)"
+        type: string
+        default: "aws-linux-scale-rocm-prod"
       run_full_pytorch_tests:
         description: >-
           Dispatch the full PyTorch test suite after a successful build.

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
@@ -162,6 +162,10 @@ on:
           - sccache
           - ccache
         default: sccache
+      build_runs_on:
+        description: "Build runner label (selected by configure script with weighted distribution)"
+        type: string
+        default: "azure-windows-scale-rocm"
 
 run-name: Build Multi-Arch Windows PyTorch Wheels (${{ inputs.release_type }}, ${{ inputs.python_version }}, ${{ inputs.pytorch_git_ref }})
 


### PR DESCRIPTION
## Summary

Commit 69678c8 ("fix(ci): pass build_runs_on to PyTorch CI workflow for builds", #7236) changed the build job's `runs-on` from a hardcoded self-hosted label to `inputs.build_runs_on`:

```yaml
# before
runs-on: ${{ github.repository_owner == 'ROCm' && 'aws-linux-scale-rocm-prod' || 'ubuntu-24.04' }}
# after
runs-on: ${{ github.repository_owner == 'ROCm' && inputs.build_runs_on || 'ubuntu-24.04' }}
```

but it only declared the new `build_runs_on` input under `workflow_call`, **not** under `workflow_dispatch`. On a `workflow_dispatch` run, `inputs.build_runs_on` is empty, so the expression collapses:

```
true && '' || 'ubuntu-24.04'   ->   '' (falsy)   ->   'ubuntu-24.04'
```

As a result, every **dispatched** PyTorch build silently lands on a GitHub-hosted `ubuntu-24.04` (Linux) / `windows-2022` (Windows) runner instead of the self-hosted `aws-linux-scale-rocm-prod` / `azure-windows-scale-rocm` group. On those underpowered runners the full PyTorch + Triton compile is killed mid-build (exit 137, "The runner has received a shutdown signal"). The `workflow_call` path (parent `multi_arch_ci_linux.yml` passing `build_runs_on` from `build_config`) is unaffected, which is why scheduled CI didn't surface it.

## Changes

- Add `build_runs_on` to the `workflow_dispatch` inputs of `multi_arch_build_portable_linux_pytorch_wheels.yml` (default `aws-linux-scale-rocm-prod`).
- Add `build_runs_on` to the `workflow_dispatch` inputs of `multi_arch_build_windows_pytorch_wheels.yml` (default `azure-windows-scale-rocm`).

Both defaults mirror the existing `workflow_call` defaults, so dispatched builds route to the correct self-hosted runner group again.

## Test plan

- [ ] Dispatch `multi_arch_build_portable_linux_pytorch_wheels.yml` and confirm the build job runs on `aws-linux-scale-rocm-prod` (runner group `therock-ci-aws-prod`), not `ubuntu-24.04`.
- [ ] Confirm the `workflow_call` path is unchanged.
