### PR TITLE
[pytorch] Override scikit-image pin for py3.13/py3.14 test envs

### DIFF
--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -228,6 +228,10 @@ jobs:
             export CC=clang
             export CXX=clang++
           fi
+          # PyTorch's requirements-ci.txt pins some packages that predate the
+          # interpreters we test; override them before installing.
+          python external-builds/pytorch/patch_test_requirements.py \
+            external-builds/pytorch/pytorch/.ci/docker/requirements-ci.txt
           python -m pip install -r external-builds/pytorch/requirements-test.txt
           python -m pip install -r external-builds/pytorch/pytorch/.ci/docker/requirements-ci.txt
           pip freeze

--- a/.github/workflows/test_pytorch_wheels_full.yml
+++ b/.github/workflows/test_pytorch_wheels_full.yml
@@ -320,6 +320,10 @@ jobs:
 
       - name: Install test requirements
         run: |
+          # PyTorch's requirements-ci.txt pins some packages that predate the
+          # interpreters we test; override them before installing.
+          python external-builds/pytorch/patch_test_requirements.py \
+            external-builds/pytorch/pytorch/.ci/docker/requirements-ci.txt
           python -m pip install -r external-builds/pytorch/requirements-test.txt
           python -m pip install -r external-builds/pytorch/pytorch/.ci/docker/requirements-ci.txt
           pip freeze

--- a/external-builds/pytorch/patch_test_requirements.py
+++ b/external-builds/pytorch/patch_test_requirements.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+"""Applies TheRock-specific overrides to PyTorch's `requirements-ci.txt`.
+
+We install PyTorch's own CI requirements file to test the wheels we build, but
+we test interpreter versions that some of its pins predate. Where a pin has no
+wheel for such an interpreter, pip falls back to building from source, which
+drags in an unpinned build toolchain that can break without notice.
+
+Rather than fork the file, this rewrites the affected requirement lines in the
+checked out tree just before `pip install` runs. Overrides are keyed by
+distribution name in `OVERRIDES` below; each one replaces every requirement
+line for that distribution with the given block.
+
+Usage:
+    python patch_test_requirements.py path/to/requirements-ci.txt
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Requirement lines to substitute, keyed by (normalized) distribution name.
+# Keep a comment on each entry explaining why the override exists, so that it
+# can be dropped once the upstream pin moves.
+OVERRIDES: dict[str, list[str]] = {
+    # scikit-image 0.22.0 publishes no cp313/cp314 wheel, so pip builds it from
+    # source on the Python versions we test. That build hardcodes
+    # `cpp_std=c++14` in its meson.build and does not pass through pythran's own
+    # compile flags, so it broke when pythran 0.19.0 (2026-08-17) raised its
+    # baseline to C++17 and started using `std::is_integral_v` and friends.
+    # 0.26.0 ships cp313 and cp314 wheels, so no compiler runs at all.
+    # See https://github.com/ROCm/TheRock/issues/7448
+    "scikit-image": [
+        'scikit-image==0.22.0 ; python_version < "3.13"',
+        'scikit-image==0.26.0 ; python_version >= "3.13"',
+    ],
+}
+
+# Leading distribution name of a requirement line, per PEP 508.
+_NAME_RE = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)\s*(?:[=<>!~[;]|$)")
+
+
+def normalize(name: str) -> str:
+    """Normalizes a distribution name per PEP 503."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def requirement_name(line: str) -> str | None:
+    """Returns the distribution a requirement line pins, or None if it is not one."""
+    stripped = line.split("#", 1)[0].strip()
+    if not stripped:
+        return None
+    match = _NAME_RE.match(stripped)
+    return normalize(match.group(1)) if match else None
+
+
+def patch(lines: list[str]) -> tuple[list[str], list[str]]:
+    """Applies OVERRIDES to `lines`, returning the result and the names applied."""
+    overrides = {normalize(name): block for name, block in OVERRIDES.items()}
+    patched: list[str] = []
+    applied: list[str] = []
+    for line in lines:
+        name = requirement_name(line)
+        if name is None or name not in overrides:
+            patched.append(line)
+            continue
+        # Emit the replacement block once, at the first line we match, and drop
+        # any further lines for the same distribution (upstream sometimes splits
+        # a pin across several marker-gated lines).
+        if name not in applied:
+            patched.extend(overrides[name])
+            applied.append(name)
+    return patched, applied
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "requirements",
+        type=Path,
+        help="Path to the requirements-ci.txt to rewrite in place.",
+    )
+    args = parser.parse_args(argv)
+
+    original = args.requirements.read_text().splitlines()
+    patched, applied = patch(original)
+
+    for name in OVERRIDES:
+        if normalize(name) not in applied:
+            # Not fatal: the upstream pin may simply have been dropped, in which
+            # case there is nothing to override and the install is fine as is.
+            print(
+                f"warning: no requirement for '{name}' in {args.requirements}, "
+                "override not applied (the pin may have moved upstream)",
+                file=sys.stderr,
+            )
+
+    if patched == original:
+        print(f"{args.requirements}: no changes needed")
+        return 0
+
+    args.requirements.write_text("\n".join(patched) + "\n")
+    print(f"{args.requirements}: applied overrides for {', '.join(applied)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

Fixes #7448. `pip install -r .ci/docker/requirements-ci.txt` fails on py3.13/py3.14 while building `scikit-image==0.22.0` from source:

```
pythran/pythonic/include/types/assignable.hpp:37:44: error: 'is_integral_v' is not a member of 'std'; did you mean 'is_integral'?
   37 |   using by_val_t = typename by_val<T, std::is_integral_v<std::decay_t<T>>>::type;
```

## Root cause

Nothing on our side changed — an unpinned build-time dependency moved.

* `pythran` **0.19.0** was published to PyPI on **2026-08-17 19:41 UTC** and, per its changelog, *"Bump C++ dependency to C++17"*. `assignable.hpp:37` went from `std::is_integral<...>::value` to `std::is_integral_v<...>`.
* `scikit-image` 0.22.0 hardcodes `'cpp_std=c++14'` in `meson.build:13` and pulls only pythran's *include dir*, never its cflags — so pythran's own `-std=c++17` never reaches the compile line.
* `scikit-image` 0.22.0 lists a bare `'pythran'` in `build-system.requires`, so every cold-cache source build resolves whatever is newest on PyPI.
* 0.22.0 publishes wheels for cp39–cp312 only, so py3.13/py3.14 are the only interpreters forced to compile at all.

The onset is visible across three consecutive nightlies, classifying every `Test PyTorch` job by what pip actually did:

| Run | Started (UTC) | py3.10–3.12 | py3.13 | py3.14 |
|---|---|---|---|---|
| [32006981712](https://github.com/ROCm/rockrel/actions/runs/32006981712) | Aug 17 07:42 | wheel, 0 errors | 9 cached, **3 source-build OK** | **6 source-build OK** |
| [32068860276](https://github.com/ROCm/rockrel/actions/runs/32068860276) | Aug 17 21:00 | wheel, 0 errors | 9 cached, **3 ERROR** | **8 ERROR** |
| [32098291913](https://github.com/ROCm/rockrel/actions/runs/32098291913) | Aug 18 04:12 | wheel, 0 errors | 9 cached, **3 ERROR** | **8 ERROR** |

First error in CI: `2026-08-17T23:39:13Z`, under four hours after the upload. The same jobs succeeded that morning with the same pin.

Two things worth noting for triage:

* **The arch list in the issue is noise.** The py3.13 jobs that still pass are reusing a locally built `scikit_image-0.22.0-cp313-cp313-win_amd64.whl` from the runner's pip cache (`Using cached ...` in the log). Only cold-cache runners recompile and fail, so this will look like it is spreading as caches age out.
* **py3.10–3.12 are structurally immune** — they get a prebuilt wheel and never invoke pythran.

## Fix

Override the pin to `scikit-image==0.26.0` for `python_version >= "3.13"`. 0.26.0 ships cp313 **and** cp314 wheels (including `win_amd64`), so no compiler runs at all — this removes the multi-minute source build rather than papering over the C++ standard. It mirrors the split already carried on `ROCm/pytorch` `release/2.11` (ROCm/pytorch#3423), which is exactly why the issue notes release/2.11 py3.14 was unaffected.

The override is applied in TheRock rather than in the pytorch fork because the three torch refs come from **two different repos** (`test_pytorch_wheels.yml:183-196`):

| torch ref | repo checked out |
|---|---|
| `nightly` | `pytorch/pytorch` (upstream) |
| `release/2.13` | `ROCm/pytorch` |
| `release/2.11` | `ROCm/pytorch` — split at 3.14, so **py3.13 is still broken there** |

A PR against `ROCm/pytorch` would fix at most two of the three; the nightly jobs (8 of the 11 Windows failures in the issue) would stay red pending an upstream change we do not control. Rewriting the line in the checked out tree covers all three.

`external-builds/pytorch/patch_test_requirements.py` keys overrides by distribution name, handles the pin whether upstream carries it as one line or as several marker-gated lines, is idempotent, and warns without failing if the pin disappears upstream.

Do **not** bump to 0.25.2 instead: it has no cp314 wheel and still carries `cpp_std=c++14`, so py3.14 would fail identically.

## Test plan

Verified the rewrite against all three real requirements files:

| Source | Before | After |
|---|---|---|
| `pytorch/pytorch@nightly` | `scikit-image==0.22.0` | correctly split at 3.13 |
| `ROCm/pytorch@release/2.13` | `scikit-image==0.22.0` | correctly split at 3.13 |
| `ROCm/pytorch@release/2.11` | already split at 3.14 (2 lines) | collapsed to the 3.13 pair |

Diff against upstream nightly is exactly one line becoming two, 440 → 441 lines, nothing else touched. Re-running reports `no changes needed`; a file with no `scikit-image` pin warns and exits 0 unmodified.

## Note for reviewers — this alone will not turn the test jobs green

All 80 test jobs were already failing in the Aug 17 07:42 run, *before* pythran 0.19.0, including **py3.10**, which this change does not touch. That is a separate pytest bootstrap crash: `requirements-test.txt` installs `pytest==9.0.3`, then `requirements-ci.txt` downgrades it to `pytest-7.3.2` against a modern `pluggy`:

```
_pytest/config/__init__.py:328: PluggyTeardownRaisedWarning: A plugin raised an
exception during an old-style hookwrapper teardown. Plugin: helpconfig, Hook: pytest_cmdline_parse
AssertionError:
```

Worth its own issue — otherwise this fix will land and look like it did not help.
