### PR TITLE
feat: Validate stage reuse with platform-specific target families

### DIFF
--- a/build_tools/github_actions/stage_reuse_decision.py
+++ b/build_tools/github_actions/stage_reuse_decision.py
@@ -142,6 +142,20 @@ def _target_families(
     return tuple(families)
 
 
+def _platform_target_families(
+    platform: str,
+    linux_amdgpu_families: Sequence[str],
+    windows_amdgpu_families: Sequence[str],
+) -> tuple[str, ...]:
+    """Return the target families required for one build platform."""
+
+    if platform == "linux":
+        return _target_families(linux_amdgpu_families, ())
+    if platform == "windows":
+        return _target_families((), windows_amdgpu_families)
+    raise ValueError(f"unsupported build platform: {platform}")
+
+
 def _required_artifacts_for_stages(
     topology: BuildTopology,
     stage_names: Sequence[str],
@@ -277,8 +291,6 @@ def compute_auto_stage_reuse(
     if topology is None and changed_files is not None:
         topology = get_topology()
 
-    families = _target_families(linux_amdgpu_families, windows_amdgpu_families)
-
     plan = plan_stage_reuse(
         changed_files=changed_files,
         platform=platforms[0],
@@ -327,7 +339,6 @@ def compute_auto_stage_reuse(
             )
         )
 
-    required = _required_artifacts_for_stages(topology, candidates, families)
     # Verify artifact availability independently for each platform. A single
     # ``baseline_selector`` (used by tests) applies to all platforms; otherwise
     # a per-platform selector is built so each platform is checked against a
@@ -338,6 +349,18 @@ def compute_auto_stage_reuse(
     baseline_error: str | None = None
 
     for platform in platforms:
+        platform_families = _platform_target_families(
+            platform,
+            linux_amdgpu_families,
+            windows_amdgpu_families,
+        )
+
+        required = _required_artifacts_for_stages(
+            topology,
+            candidates,
+            platform_families,
+        )
+
         if baseline_selector is not None:
             selector = baseline_selector
         elif baseline_selector_factory is not None:
@@ -364,12 +387,17 @@ def compute_auto_stage_reuse(
 
         available_filenames = _matched_filenames(baseline)
         available_here: list[str] = []
+
         if baseline is not None:
             for stage_name in candidates:
                 if _stage_artifacts_available(
-                    topology, stage_name, families, available_filenames
+                    topology,
+                    stage_name,
+                    platform_families,
+                    available_filenames,
                 ):
                     available_here.append(stage_name)
+
         per_platform_available[platform] = tuple(available_here)
 
     selected_run_ids = {

--- a/build_tools/github_actions/tests/stage_reuse_decision_test.py
+++ b/build_tools/github_actions/tests/stage_reuse_decision_test.py
@@ -307,7 +307,10 @@ class DefaultBaselineSelectorTest(unittest.TestCase):
             return ["sha-current", "sha-old", "sha-older"]
 
         captured, _ = self._run_with_env(
-            {"STAGE_REUSE_CURRENT_SHA": "sha-current"},
+            {
+                "GITHUB_REPOSITORY": "ROCm/TheRock",
+                "STAGE_REUSE_CURRENT_SHA": "sha-current",
+            },
             fake_history,
             fake_select="baseline",
         )
@@ -322,7 +325,10 @@ class DefaultBaselineSelectorTest(unittest.TestCase):
             return []
 
         captured, _ = self._run_with_env(
-            {"STAGE_REUSE_CURRENT_SHA": "sha-current"},
+            {
+                "GITHUB_REPOSITORY": "ROCm/TheRock",
+                "STAGE_REUSE_CURRENT_SHA": "sha-current",
+            },
             fake_history,
             fake_select="baseline",
         )
@@ -335,7 +341,10 @@ class DefaultBaselineSelectorTest(unittest.TestCase):
             raise GitHubAPIError("api down")
 
         captured, _ = self._run_with_env(
-            {"STAGE_REUSE_CURRENT_SHA": "sha-current"},
+            {
+                "GITHUB_REPOSITORY": "ROCm/TheRock",
+                "STAGE_REUSE_CURRENT_SHA": "sha-current",
+            },
             fake_history,
             fake_select="baseline",
         )
@@ -350,7 +359,10 @@ class DefaultBaselineSelectorTest(unittest.TestCase):
             return ["x"]
 
         captured, _ = self._run_with_env(
-            {"STAGE_REUSE_CURRENT_SHA": None},
+            {
+                "GITHUB_REPOSITORY": "ROCm/TheRock",
+                "STAGE_REUSE_CURRENT_SHA": None,
+            },
             fake_history,
             fake_select="baseline",
         )
@@ -414,6 +426,75 @@ class PlatformAwareAvailabilityTest(unittest.TestCase):
         )
         self.assertEqual(result.applied_reuse_stages, ("compiler-runtime",))
         self.assertIn("compiler-runtime", result.available_stages)
+
+    def test_platforms_use_only_their_own_target_families(self):
+        captured_required = {}
+
+        per_platform = {
+            "linux": _baseline(
+                "B1",
+                [
+                    "base_lib_gfx94x.tar.zst",
+                    "base_lib_generic.tar.zst",
+                ],
+            ),
+            "windows": _baseline(
+                "B1",
+                [
+                    "base_lib_gfx110x.tar.zst",
+                    "base_lib_generic.tar.zst",
+                ],
+            ),
+        }
+
+        def selector_factory(platform):
+            def selector(required):
+                captured_required[platform] = {
+                    (artifact.name, artifact.target_family) for artifact in required
+                }
+                return per_platform[platform]
+
+            return selector
+
+        result = compute_auto_stage_reuse(
+            changed_files=["rocm-libraries/projects/rocBLAS/x.cpp"],
+            mode=StageReuseMode.REUSE_STAGE,
+            linux_amdgpu_families=["gfx94x"],
+            windows_amdgpu_families=["gfx110x"],
+            topology=FakeTopology(),
+            baseline_selector_factory=selector_factory,
+        )
+
+        self.assertEqual(
+            captured_required["linux"],
+            {
+                ("base", "gfx94x"),
+                ("base", "generic"),
+            },
+        )
+
+        self.assertEqual(
+            captured_required["windows"],
+            {
+                ("base", "gfx110x"),
+                ("base", "generic"),
+            },
+        )
+
+        self.assertEqual(
+            result.platform_available["linux"],
+            ("compiler-runtime",),
+        )
+
+        self.assertEqual(
+            result.platform_available["windows"],
+            ("compiler-runtime",),
+        )
+
+        self.assertEqual(
+            result.applied_reuse_stages,
+            ("compiler-runtime",),
+        )
 
     def test_single_platform_default_is_linux(self):
         result = compute_auto_stage_reuse(


### PR DESCRIPTION
## Summary
Issue: https://github.com/ROCm/TheRock/issues/7420
Make stage-reuse artifact validation platform-specific.

Previously, Linux and Windows AMDGPU target families were combined into one set
and used when selecting and validating baselines for both platforms. This could
cause an otherwise valid baseline to be rejected because, for example, a Linux
baseline was also required to contain Windows-family artifacts.

This change:

- validates Linux stage artifacts against Linux target families plus `generic`;
- validates Windows stage artifacts against Windows target families plus `generic`;
- uses the same platform-specific family set for both baseline requirements and
  stage artifact availability checks;
- adds regression coverage using distinct Linux and Windows target families;
- makes same-repository baseline-selector tests explicitly set
  `GITHUB_REPOSITORY=ROCm/TheRock` so their behavior does not depend on the
  surrounding test environment.

## Example

Before:

```text
Linux families:   gfx94x
Windows families: gfx110x

Linux baseline required:
  gfx94x + gfx110x + generic

Windows baseline required:
  gfx94x + gfx110x + generic
  ```
 After: 
```text

Linux baseline required:
 gfx94x + generic

Windows baseline required:
 gfx110x + generic
  ```
  
Tests:
```
build_tools/github_actions/tests/stage_reuse_decision_test.py::DefaultBaselineSelectorTest::test_history_is_fetched_and_threaded PASSED             [ 20%]
build_tools/github_actions/tests/stage_reuse_decision_test.py::DefaultBaselineSelectorTest::test_empty_history_disables_commit_rule PASSED          [ 40%]
build_tools/github_actions/tests/stage_reuse_decision_test.py::DefaultBaselineSelectorTest::test_history_fetch_error_disables_commit_rule PASSED    [ 60%]
build_tools/github_actions/tests/stage_reuse_decision_test.py::DefaultBaselineSelectorTest::test_no_sha_means_no_history_fetch PASSED               [ 80%]
build_tools/github_actions/tests/stage_reuse_decision_test.py::PlatformAwareAvailabilityTest::test_platforms_use_only_their_own_target_families PASSED [100%]
```