### PR TITLE
fix(tests): disable for gfx125X in hip_printf sanity test due to unsupported kernel code pattern

### DIFF
--- a/tests/test_rocm_sanity.py
+++ b/tests/test_rocm_sanity.py
@@ -87,6 +87,11 @@ class TestROCmSanity:
         is_windows(),
         reason="Windows offload-arch.exe is not retrieving correct data, ignoring test",
     )
+    # TODO(#7458): Re-enable once gfx1250 binary translator supports this kernel code pattern
+    @pytest.mark.skipif(
+        AMDGPU_FAMILIES == "gfx125X-dcgpu",
+        reason="gfx1250 binary translator does not yet support this kernel code pattern, see #7458",
+    )
     def test_hip_printf(self):
         platform_executable_suffix = ".exe" if is_windows() else ""
 

--- a/tests/test_rocm_sanity.py
+++ b/tests/test_rocm_sanity.py
@@ -89,7 +89,7 @@ class TestROCmSanity:
     )
     # TODO(#7458): Re-enable once gfx1250 binary translator supports this kernel code pattern
     @pytest.mark.skipif(
-        AMDGPU_FAMILIES == "gfx125X-dcgpu",
+        AMDGPU_FAMILIES and "gfx125X-dcgpu" in AMDGPU_FAMILIES,
         reason="gfx1250 binary translator does not yet support this kernel code pattern, see #7458",
     )
     def test_hip_printf(self):


### PR DESCRIPTION
## Summary

Skip `test_hip_printf` for gfx125X-dcgpu (MI455) due to a binary translator limitation.

## Problem

The gfx1250 binary translator cannot handle indirect branch instructions (`s_set_pc_i64`) generated by this test's kernel code pattern. The test fails with:

```
[hsa-hotswap-rj] error: indirect branch or call target recovery is not implemented for relocated kernel text
```

See #7458 for full details and reproduction steps.

## Changes

- Add `@pytest.mark.skipif` for `AMDGPU_FAMILIES == "gfx125X-dcgpu"`
