### PR TITLE
[bkc] Cherry-pick "fix(rocjitsu): package hotswap translator dependency (#7371)"

### DIFF
--- a/emulation/CMakeLists.txt
+++ b/emulation/CMakeLists.txt
@@ -21,6 +21,8 @@ if(THEROCK_ENABLE_ROCJITSU)
       -DBUILD_TESTING=${THEROCK_BUILD_TESTING}
     RUNTIME_DEPS
       ${THEROCK_BUNDLED_LIBDRM}
+    INSTALL_RPATH_DIRS
+      lib
   )
 
   therock_cmake_subproject_glob_c_sources(rocjitsu
@@ -69,6 +71,7 @@ if(THEROCK_ENABLE_ROCJITSU_HOTSWAP)
     BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rocjitsu-hotswap"
     CMAKE_ARGS
       -DROCJITSU_HOTSWAP_LIBRARY=${CMAKE_CURRENT_BINARY_DIR}/rocjitsu/dist/lib/libhsa_hotswap_rocjitsu.so
+      -DROCJITSU_HOTSWAP_TRANSLATOR_LIBRARY=${CMAKE_CURRENT_BINARY_DIR}/rocjitsu/dist/lib/librocjitsu_gfx1250_b0_to_a0.so
     BUILD_DEPS
       rocjitsu
   )

--- a/emulation/artifact-rocjitsu-hotswap.toml
+++ b/emulation/artifact-rocjitsu-hotswap.toml
@@ -3,4 +3,5 @@
 default_patterns = false
 include = [
   "lib/libhsa_hotswap_rocjitsu.so",
+  "lib/librocjitsu_gfx1250_b0_to_a0.so*",
 ]

--- a/emulation/rocjitsu-hotswap/CMakeLists.txt
+++ b/emulation/rocjitsu-hotswap/CMakeLists.txt
@@ -13,3 +13,16 @@ if(NOT EXISTS "${ROCJITSU_HOTSWAP_LIBRARY}")
 endif()
 
 install(FILES "${ROCJITSU_HOTSWAP_LIBRARY}" DESTINATION lib)
+
+if(EXISTS "${ROCJITSU_HOTSWAP_TRANSLATOR_LIBRARY}")
+  cmake_path(GET ROCJITSU_HOTSWAP_TRANSLATOR_LIBRARY PARENT_PATH _translator_dir)
+  file(GLOB _translator_libraries
+    "${_translator_dir}/librocjitsu_gfx1250_b0_to_a0.so*"
+  )
+  install(FILES ${_translator_libraries} DESTINATION lib)
+else()
+  message(WARNING
+    "RocJitsu hotswap translator library is not available in this rocm-systems revision: "
+    "${ROCJITSU_HOTSWAP_TRANSLATOR_LIBRARY}"
+  )
+endif()


### PR DESCRIPTION
This is a cherry-pick of https://github.com/ROCm/TheRock/pull/7371 to address https://github.com/ROCm/rocm-systems/issues/10164 which is also occurring on the BKC release branch at https://github.com/ROCm/rockrel/actions/runs/32165066093/job/95802835561:
```
88/89 Test #88: therock-validate-shared-lib-libhsa_hotswap_rocjitsu.so ...........***Failed    0.02 sec
Validating shared library: /__w/rockrel/rockrel/build/emulation/rocjitsu/dist/lib/libhsa_hotswap_rocjitsu.soTraceback (most recent call last):
  File "/__w/rockrel/rockrel/build_tools/validate_shared_library.py", line 27, in <module>
    main(sys.argv[1:])
  File "/__w/rockrel/rockrel/build_tools/validate_shared_library.py", line 23, in main
    run(args)
  File "/__w/rockrel/rockrel/build_tools/validate_shared_library.py", line 15, in run
    so = ctypes.cdll.LoadLibrary(shared_lib)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/python/cp312-cp312/lib/python3.12/ctypes/__init__.py", line 460, in LoadLibrary
    return self._dlltype(name)
           ^^^^^^^^^^^^^^^^^^^
  File "/opt/python/cp312-cp312/lib/python3.12/ctypes/__init__.py", line 379, in __init__
    self._handle = _dlopen(self._name, mode)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
OSError: librocjitsu_gfx1250_b0_to_a0.so.0: cannot open shared object file: No such file or directory
```