### PR TITLE
[bkc] Apply package version changes to BKC release branch

### DIFF
--- a/.github/actions/configure_aws_artifacts_credentials/action.yml
+++ b/.github/actions/configure_aws_artifacts_credentials/action.yml
@@ -6,13 +6,13 @@ name: "Configure AWS credentials for artifact uploads"
 description: >-
   Determine the IAM role for the artifacts S3 bucket and assume it via OIDC.
   * Forks and external repos skip OIDC and use runner base credentials.
-  * Release builds (dev/nightly/prerelease) use 'therock-{release_type}' roles.
+  * Release builds use the IAM role for their destination release bucket.
   * Other CI runs use the 'therock-ci' role.
   See the "Authentication" section in docs/development/s3_buckets.md.
 
 inputs:
   release_type:
-    description: 'Release type: "ci", "dev", "nightly", or "prerelease"'
+    description: 'Release type: "ci", "dev", "dev-bkc", "nightly", "nightly-bkc", or "prerelease"'
     default: ci
 
 runs:

--- a/.github/actions/setup_test_environment/action.yml
+++ b/.github/actions/setup_test_environment/action.yml
@@ -24,7 +24,7 @@ inputs:
   FETCH_ARTIFACT_ARGS:
     description: (string) Extra arguments to install_rocm_from_artifacts.py (e.g. `--blas --tests`)
   RELEASE_TYPE:
-    description: 'Release type: "ci", "dev", "nightly", or "prerelease"'
+    description: "Release type for the artifacts being tested"
     default: ci
 
 runs:

--- a/.github/workflows/build_portable_linux_python_packages.yml
+++ b/.github/workflows/build_portable_linux_python_packages.yml
@@ -37,7 +37,7 @@ on:
         description: "package_version to set on packages, e.g. '7.13.0.dev0+dbd7369489260265fc6ddfc9d0de1262a95fe974'"
         type: string
       release_type:
-        description: 'Release type: "ci" for CI, or "dev", "nightly", "prerelease".'
+        description: "Release type used for package publishing."
         type: string
         default: ""
       repository:

--- a/.github/workflows/build_windows_python_packages.yml
+++ b/.github/workflows/build_windows_python_packages.yml
@@ -37,7 +37,7 @@ on:
         description: "package_version to set on packages, e.g. '7.13.0.dev0+dbd7369489260265fc6ddfc9d0de1262a95fe974'"
         type: string
       release_type:
-        description: 'Release type: "ci" for CI, or "dev", "nightly", "prerelease".'
+        description: "Release type used for package publishing."
         type: string
         default: ""
       repository:

--- a/.github/workflows/multi_arch_build_native_linux_packages.yml
+++ b/.github/workflows/multi_arch_build_native_linux_packages.yml
@@ -26,7 +26,7 @@ on:
         type: string
         default: ""
       release_type:
-        description: "Release type: 'ci', 'dev', 'nightly', or 'prerelease'"
+        description: "Release type used for artifact storage and package publishing."
         required: false
         type: string
         default: ci

--- a/.github/workflows/multi_arch_build_portable_linux.yml
+++ b/.github/workflows/multi_arch_build_portable_linux.yml
@@ -46,7 +46,7 @@ on:
         default: "aws-linux-scale-rocm-prod"
         description: "Build runner label (selected by configure script with weighted distribution)"
       release_type:
-        description: 'Release type: "ci", "dev", "nightly", or "prerelease"'
+        description: "Release type used for artifact storage and package versioning."
         type: string
         default: ci
       repository:

--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -187,7 +187,13 @@ jobs:
     env:
       PACKAGE_DIST_DIR: ${{ github.workspace }}/output/packages/dist
       optional_build_prod_arguments: ""
-      SCCACHE_BUCKET: "therock-pytorch-sccache-${{ inputs.release_type }}"
+      # TODO: Move the sccache bucket and IAM role mapping into a shared script.
+      SCCACHE_BUCKET: >-
+        ${{
+          inputs.release_type == 'dev-bkc' && 'therock-pytorch-sccache-dev'
+          || inputs.release_type == 'nightly-bkc' && 'therock-pytorch-sccache-nightly'
+          || format('therock-pytorch-sccache-{0}', inputs.release_type)
+        }}
       SCCACHE_REGION: us-east-1
       SCCACHE_S3_KEY_PREFIX: "linux/multiarch/v1/"
       SCCACHE_S3_USE_SSL: "true"
@@ -284,7 +290,12 @@ jobs:
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-region: us-east-1
-          role-to-assume: arn:aws:iam::324352301041:role/therock-${{ inputs.release_type }}
+          role-to-assume: >-
+            ${{
+              inputs.release_type == 'dev-bkc' && 'arn:aws:iam::324352301041:role/therock-dev'
+              || inputs.release_type == 'nightly-bkc' && 'arn:aws:iam::324352301041:role/therock-nightly'
+              || format('arn:aws:iam::324352301041:role/therock-{0}', inputs.release_type)
+            }}
           # Multi-package PyTorch builds can exceed the default 1h credential
           # window; the role's MaxSessionDuration must be >= this value.
           role-duration-seconds: 21600

--- a/.github/workflows/multi_arch_build_windows.yml
+++ b/.github/workflows/multi_arch_build_windows.yml
@@ -44,7 +44,7 @@ on:
       rocm_package_version:
         type: string
       release_type:
-        description: 'Release type: "ci", "dev", "nightly", or "prerelease"'
+        description: "Release type used for artifact storage and package versioning."
         type: string
         default: ci
       repository:

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
@@ -176,7 +176,13 @@ jobs:
       # Note the \ here instead of /. This should be used from 'cmd' not 'bash'!
       PACKAGE_DIST_DIR: ${{ github.workspace }}\output\packages\dist
       optional_build_prod_arguments: ""
-      SCCACHE_BUCKET: "therock-pytorch-sccache-${{ inputs.release_type }}"
+      # TODO: Move the sccache bucket and IAM role mapping into a shared script.
+      SCCACHE_BUCKET: >-
+        ${{
+          inputs.release_type == 'dev-bkc' && 'therock-pytorch-sccache-dev'
+          || inputs.release_type == 'nightly-bkc' && 'therock-pytorch-sccache-nightly'
+          || format('therock-pytorch-sccache-{0}', inputs.release_type)
+        }}
       SCCACHE_REGION: us-east-1
       SCCACHE_S3_KEY_PREFIX: "windows/multiarch/v1/"
       SCCACHE_S3_USE_SSL: "true"
@@ -298,7 +304,12 @@ jobs:
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-region: us-east-1
-          role-to-assume: arn:aws:iam::324352301041:role/therock-${{ inputs.release_type }}
+          role-to-assume: >-
+            ${{
+              inputs.release_type == 'dev-bkc' && 'arn:aws:iam::324352301041:role/therock-dev'
+              || inputs.release_type == 'nightly-bkc' && 'arn:aws:iam::324352301041:role/therock-nightly'
+              || format('arn:aws:iam::324352301041:role/therock-{0}', inputs.release_type)
+            }}
           # Multi-package PyTorch builds can exceed the default 1h credential
           # window; the role's MaxSessionDuration must be >= this value.
           role-duration-seconds: 21600

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -29,7 +29,7 @@ on:
       test_type:
         type: string
       release_type:
-        description: 'Release type: "ci", "dev", "nightly", or "prerelease"'
+        description: "Release type used for artifact storage and package versioning."
         type: string
         default: ci
       external_repo_config:

--- a/.github/workflows/multi_arch_ci_windows.yml
+++ b/.github/workflows/multi_arch_ci_windows.yml
@@ -23,7 +23,7 @@ on:
       test_type:
         type: string
       release_type:
-        description: 'Release type: "ci", "dev", "nightly", or "prerelease".'
+        description: "Release type used for artifact storage and package versioning."
         type: string
         default: ci
       external_repo_config:

--- a/.github/workflows/multi_arch_release.yml
+++ b/.github/workflows/multi_arch_release.yml
@@ -19,7 +19,7 @@ on:
   workflow_call:
     inputs:
       release_type:
-        description: 'Release type: "dev", "nightly", or "prerelease".'
+        description: 'Release type: "dev", "dev-bkc", "nightly", "nightly-bkc", or "prerelease".'
         type: string
         required: true
       prerelease_version:
@@ -62,8 +62,10 @@ on:
   workflow_dispatch:
     inputs:
       release_type:
-        description: 'Release type; developer-triggered jobs should use "dev".'
+        description: 'Release type; ordinary developer-triggered jobs should use "dev".'
         type: choice
+        # Only dev-channel release types are exposed for manual dispatch in
+        # TheRock. Nightly release types are supplied by rockrel.
         options:
           - dev
         default: dev

--- a/.github/workflows/multi_arch_release_asan.yml
+++ b/.github/workflows/multi_arch_release_asan.yml
@@ -11,7 +11,7 @@ on:
   workflow_call:
     inputs:
       release_type:
-        description: 'Release type: "dev", "nightly", or "prerelease".'
+        description: 'Release type: "dev", "dev-bkc", "nightly", "nightly-bkc", or "prerelease".'
         type: string
         required: true
       prerelease_version:
@@ -46,7 +46,7 @@ on:
   workflow_dispatch:
     inputs:
       release_type:
-        description: 'Release type; developer-triggered jobs should use "dev".'
+        description: 'Release type; ordinary developer-triggered jobs should use "dev".'
         type: choice
         options:
           - dev

--- a/.github/workflows/multi_arch_release_linux.yml
+++ b/.github/workflows/multi_arch_release_linux.yml
@@ -20,7 +20,7 @@ on:
       test_type:
         type: string
       release_type:
-        description: 'Release type: "dev", "nightly", or "prerelease".'
+        description: 'Release type: "dev", "dev-bkc", "nightly", "nightly-bkc", or "prerelease".'
         type: string
         required: true
       repository:

--- a/.github/workflows/multi_arch_release_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_jax_wheels.yml
@@ -16,7 +16,7 @@ on:
         type: string
         default: ""
       release_type:
-        description: 'Release type: "dev", "nightly", or "prerelease".'
+        description: 'Release type: "dev", "dev-bkc", "nightly", "nightly-bkc", or "prerelease".'
         type: string
         required: true
       rocm_version:
@@ -46,7 +46,7 @@ on:
         type: string
         default: "gfx94X-dcgpu"
       release_type:
-        description: 'Release type; developer-triggered jobs should use "dev".'
+        description: 'Release type; ordinary developer-triggered jobs should use "dev".'
         type: choice
         options:
           - dev

--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -78,7 +78,7 @@ on:
         type: string
         default: ""
       release_type:
-        description: 'Release type; developer-triggered jobs should use "dev"'
+        description: 'Release type; ordinary developer-triggered jobs should use "dev"'
         type: choice
         options:
           - dev

--- a/.github/workflows/multi_arch_release_windows.yml
+++ b/.github/workflows/multi_arch_release_windows.yml
@@ -14,7 +14,7 @@ on:
       test_type:
         type: string
       release_type:
-        description: 'Release type: "dev", "nightly", or "prerelease".'
+        description: 'Release type: "dev", "dev-bkc", "nightly", "nightly-bkc", or "prerelease".'
         type: string
         required: true
       repository:

--- a/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
@@ -74,7 +74,7 @@ on:
         type: string
         default: ""
       release_type:
-        description: 'Release type; developer-triggered jobs should use "dev"'
+        description: 'Release type; ordinary developer-triggered jobs should use "dev"'
         type: choice
         options:
           - dev

--- a/.github/workflows/setup_multi_arch.yml
+++ b/.github/workflows/setup_multi_arch.yml
@@ -11,8 +11,9 @@ on:
         default: "release"
       release_type:
         description: >-
-          Release type: "ci", "dev", "nightly", or "prerelease"; controls
-          artifact bucket selection, IAM role, and package versioning.
+          Release type: "ci", "dev", "dev-bkc", "nightly", "nightly-bkc",
+          or "prerelease"; controls artifact bucket selection, IAM role, and
+          package versioning.
         type: string
         default: ci
       prerelease_version:

--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -39,7 +39,7 @@ on:
         type: string
         default: ""
       release_type:
-        description: 'Release type: "ci" or "dev".'
+        description: 'Release type for the artifacts being tested.'
         type: choice
         options:
           - ci

--- a/.github/workflows/test_native_linux_packages_install.yml
+++ b/.github/workflows/test_native_linux_packages_install.yml
@@ -11,7 +11,7 @@ on:
         required: true
         type: string
       release_type:
-        description: "Release Type (ci, dev, nightly, prerelease)."
+        description: "Release type for the packages being tested."
         required: true
         type: string
       gpg_key_url:
@@ -53,7 +53,7 @@ on:
         required: true
         type: string
       release_type:
-        description: 'Release type: "ci" or "dev"'
+        description: "Release type for the packages being tested."
         required: true
         type: choice
         options:

--- a/build_tools/_therock_utils/s3_buckets.py
+++ b/build_tools/_therock_utils/s3_buckets.py
@@ -74,9 +74,22 @@ s3_bucket_configs = [
 
 _BUCKET_CONFIGS_BY_NAME = {c.name: c for c in s3_bucket_configs}
 
-_ALLOWED_ARTIFACT_RELEASE_TYPES = {"ci", "dev", "nightly", "prerelease"}
+_ALLOWED_ARTIFACT_RELEASE_TYPES = {
+    "ci",
+    "dev",
+    "dev-bkc",
+    "nightly",
+    "nightly-bkc",
+    "prerelease",
+}
 
-_ALLOWED_RELEASE_TYPES = {"dev", "nightly", "prerelease"}
+_ALLOWED_RELEASE_TYPES = {
+    "dev",
+    "dev-bkc",
+    "nightly",
+    "nightly-bkc",
+    "prerelease",
+}
 
 _ALLOWED_RELEASE_BUCKET_TYPES = {"tarball", "python", "packages"}
 
@@ -89,7 +102,8 @@ def get_artifacts_bucket_config(
     """Look up the artifacts bucket config for a repository.
 
     Args:
-        release_type: "ci", "dev", "nightly", or "prerelease".
+        release_type: "ci", "dev", "dev-bkc", "nightly", "nightly-bkc", or
+            "prerelease".
         repository: GitHub repository (e.g. "ROCm/TheRock").
         is_pr_from_fork: Whether this is a PR from a fork.
 
@@ -108,7 +122,12 @@ def get_artifacts_bucket_config(
         else:
             bucket_name = "therock-ci-artifacts"
     else:
-        bucket_name = f"therock-{release_type}-artifacts"
+        if release_type == "dev-bkc":
+            bucket_name = "therock-dev-artifacts"
+        elif release_type == "nightly-bkc":
+            bucket_name = "therock-nightly-artifacts"
+        else:
+            bucket_name = f"therock-{release_type}-artifacts"
     return _BUCKET_CONFIGS_BY_NAME[bucket_name]
 
 
@@ -119,11 +138,13 @@ def get_release_bucket_config(
     """Look up the release bucket config for a given release type and bucket type.
 
     Args:
-        release_type: "dev", "nightly", or "prerelease".
+        release_type: "dev", "dev-bkc", "nightly", "nightly-bkc", or
+            "prerelease".
         bucket_type: "tarball", "python", or "packages".
 
     Returns:
-        S3BucketConfig for the bucket ``therock-{release_type}-{bucket_type}``.
+        S3BucketConfig for the selected release bucket. BKC release types use
+        the corresponding dev or nightly bucket.
 
     Raises:
         ValueError: If release_type or bucket_type is invalid.
@@ -138,7 +159,12 @@ def get_release_bucket_config(
             f"bucket_type={bucket_type!r} is invalid, "
             f"expected one of {_ALLOWED_RELEASE_BUCKET_TYPES}"
         )
-    bucket_name = f"therock-{release_type}-{bucket_type}"
+    if release_type == "dev-bkc":
+        bucket_name = f"therock-dev-{bucket_type}"
+    elif release_type == "nightly-bkc":
+        bucket_name = f"therock-nightly-{bucket_type}"
+    else:
+        bucket_name = f"therock-{release_type}-{bucket_type}"
     return _BUCKET_CONFIGS_BY_NAME[bucket_name]
 
 

--- a/build_tools/compute_rocm_package_version.py
+++ b/build_tools/compute_rocm_package_version.py
@@ -29,6 +29,11 @@ Sample usage:
   # rocm_deb_package_version=7.10.0~20251021
   # rocm_rpm_package_version=7.10.0~20251021
 
+  python compute_rocm_package_version.py --release-type=nightly-bkc
+  # rocm_package_version=10.1.0a20260811+bkc.20260814
+  # rocm_deb_package_version=10.1.0~20260811.bkc.20260814
+  # rocm_rpm_package_version=10.1.0~20260811.bkc.20260814
+
   python compute_rocm_package_version.py --custom-version-suffix=.dev0
   # 7.10.0.dev0
 
@@ -37,12 +42,14 @@ Sample usage:
 """
 
 import argparse
+from collections.abc import Mapping
 from datetime import datetime
 from pathlib import Path
 import json
 import os
 import subprocess
 import sys
+from typing import Any
 
 from github_actions.github_actions_api import *
 
@@ -55,13 +62,38 @@ def _log(*args, **kwargs):
     sys.stdout.flush()
 
 
-def load_rocm_version() -> str:
-    """Loads the rocm-version from the repository's version.json file."""
-    version_file = THEROCK_DIR / "version.json"
-    _log(f"Loading version from file '{version_file.resolve()}'")
+def load_version_file(
+    version_file: Path = THEROCK_DIR / "version.json",
+) -> dict[str, Any]:
+    """Loads the repository's version.json file."""
+    _log(f"Loading version data from file '{version_file.resolve()}'")
     with open(version_file, "rt") as f:
-        loaded_file = json.load(f)
-        return loaded_file["rocm-version"]
+        version_data = json.load(f)
+    if not isinstance(version_data, dict):
+        raise ValueError("version.json must contain an object")
+
+    release_metadata = version_data.get("release-metadata", {})
+    if not isinstance(release_metadata, Mapping):
+        raise ValueError("release-metadata in version.json must be an object")
+
+    base_date = release_metadata.get("base-date", "")
+    if not isinstance(base_date, str):
+        raise ValueError(
+            "release-metadata.base-date must be a valid date in YYYYMMDD format"
+        )
+    if base_date:
+        if len(base_date) != 8 or not base_date.isdigit():
+            raise ValueError(
+                "release-metadata.base-date must be a valid date in YYYYMMDD format"
+            )
+        try:
+            datetime.strptime(base_date, "%Y%m%d")
+        except ValueError as e:
+            raise ValueError(
+                "release-metadata.base-date must be a valid date in YYYYMMDD format"
+            ) from e
+
+    return version_data
 
 
 def get_git_sha(short: bool = False, override_git_sha: str | None = None):
@@ -112,27 +144,44 @@ def compute_version(
     prerelease_version: str | None = None,
     override_base_version: str | None = None,
     override_git_sha: str | None = None,
+    version_data: Mapping[str, Any] | None = None,
 ) -> str:
     """Compute package version based on package type and release type.
 
     Args:
         package_type: Type of package ("wheel", "deb", or "rpm")
-        release_type: Release type ("ci", "dev", "nightly", "prerelease", or "release")
+        release_type: Release type ("ci", "dev", "dev-bkc", "nightly",
+            "nightly-bkc", "prerelease", or "release")
         custom_version_suffix: Custom suffix to override automatic suffix
         prerelease_version: Prerelease version number
         override_base_version: Override the base version from version.json
         override_git_sha: Explicit git SHA override, forwarded to get_git_sha().
             See get_git_sha() for details on when this is needed.
+        version_data: Contents of version.json. Loaded automatically when required.
 
     Returns:
         Computed version string appropriate for the package type
     """
+    if version_data is None:
+        version_data = load_version_file()
+
     if override_base_version:
         base_version = override_base_version
     else:
-        base_version = load_rocm_version()
+        base_version = version_data.get("rocm-version")
+        if not isinstance(base_version, str) or not base_version:
+            raise ValueError("rocm-version must be set in version.json")
     _log(f"Base version  : '{base_version}'")
     _log(f"Package type  : '{package_type}'")
+    current_date = get_current_date()
+
+    if release_type in ("dev-bkc", "nightly-bkc"):
+        release_metadata = version_data.get("release-metadata", {})
+        if not release_metadata.get("base-date"):
+            raise ValueError(
+                "release-metadata.base-date must be set in version.json "
+                f"for release type '{release_type}'"
+            )
 
     # Handle wheel packages (Python packaging standards)
     if package_type == "wheel":
@@ -142,7 +191,7 @@ def compute_version(
             version_suffix = custom_version_suffix
         elif release_type == "release":
             version_suffix = ""
-        elif release_type in ("ci", "dev"):
+        elif release_type in ("ci", "dev", "dev-bkc"):
             # Construct a dev release version:
             # https://packaging.python.org/en/latest/specifications/version-specifiers/#developmental-releases
             git_sha = get_git_sha(override_git_sha=override_git_sha)
@@ -150,8 +199,9 @@ def compute_version(
         elif release_type == "nightly":
             # Construct a nightly (a / "alpha") version:
             # https://packaging.python.org/en/latest/specifications/version-specifiers/#pre-releases
-            current_date = get_current_date()
             version_suffix = f"a{current_date}"
+        elif release_type == "nightly-bkc":
+            version_suffix = f"a{release_metadata['base-date']}+bkc.{current_date}"
         elif release_type == "prerelease":
             # Construct a prerelease (rc / "release candidate") version
             # https://packaging.python.org/en/latest/specifications/version-specifiers/#pre-releases
@@ -176,11 +226,10 @@ def compute_version(
             # Final release version - no suffix
             # Format: <rocm-version>
             version_suffix_str = ""
-        elif release_type in ("ci", "dev"):
+        elif release_type in ("ci", "dev", "dev-bkc"):
             # Construct a dev release version with date and optionally git SHA
             # deb format: <rocm-version>~dev<YYYYMMDD>
             # rpm format: <rocm-version>~<YYYYMMDD>g<short-git-sha>
-            current_date = get_current_date()
             if package_type == "deb":
                 version_suffix_str = f"~dev{current_date}"
             else:  # rpm
@@ -189,8 +238,9 @@ def compute_version(
         elif release_type == "nightly":
             # Construct a nightly version with date
             # Format: <rocm-version>~<YYYYMMDD>
-            current_date = get_current_date()
             version_suffix_str = f"~{current_date}"
+        elif release_type == "nightly-bkc":
+            version_suffix_str = f"~{release_metadata['base-date']}.bkc.{current_date}"
         elif release_type == "prerelease":
             # Construct a prerelease version
             # deb format: <rocm-version>~pre<N>
@@ -218,7 +268,15 @@ def main(argv):
     release_type_group.add_argument(
         "--release-type",
         type=str,
-        choices=["ci", "dev", "nightly", "prerelease", "release"],
+        choices=[
+            "ci",
+            "dev",
+            "dev-bkc",
+            "nightly",
+            "nightly-bkc",
+            "prerelease",
+            "release",
+        ],
         help="The type of package version to produce. 'ci' uses dev-style versions.",
     )
     release_type_group.add_argument(
@@ -255,6 +313,8 @@ def main(argv):
             "--prerelease-version is required when release type is 'prerelease'"
         )
 
+    version_data = load_version_file()
+
     # Compute versions for all three package types: wheel, deb, and rpm
     outputs = {}
     for pkg_type in ["wheel", "deb", "rpm"]:
@@ -265,6 +325,7 @@ def main(argv):
             prerelease_version=args.prerelease_version,
             override_base_version=args.override_base_version,
             override_git_sha=args.override_git_sha,
+            version_data=version_data,
         )
 
         # Set appropriate output variable based on package type

--- a/build_tools/compute_rocm_package_version.py
+++ b/build_tools/compute_rocm_package_version.py
@@ -140,6 +140,8 @@ def compute_version(
             # Trust the custom suffix to satisfy the general rules:
             # https://packaging.python.org/en/latest/specifications/version-specifiers/
             version_suffix = custom_version_suffix
+        elif release_type == "release":
+            version_suffix = ""
         elif release_type in ("ci", "dev"):
             # Construct a dev release version:
             # https://packaging.python.org/en/latest/specifications/version-specifiers/#developmental-releases
@@ -217,10 +219,7 @@ def main(argv):
         "--release-type",
         type=str,
         choices=["ci", "dev", "nightly", "prerelease", "release"],
-        help=(
-            "The type of package version to produce. "
-            "'ci' uses dev-style versions; 'release' is only valid for deb/rpm."
-        ),
+        help="The type of package version to produce. 'ci' uses dev-style versions.",
     )
     release_type_group.add_argument(
         "--custom-version-suffix",
@@ -249,9 +248,6 @@ def main(argv):
     args = parser.parse_args(argv)
 
     # Validation
-    if args.release_type == "release":
-        parser.error("'release' type is only valid for deb/rpm packages, not wheel")
-
     if args.release_type != "prerelease" and args.prerelease_version:
         parser.error("release type must be 'prerelease' if --prerelease-version is set")
     elif args.release_type == "prerelease" and not args.prerelease_version:

--- a/build_tools/github_actions/configure_jax_release_matrix.py
+++ b/build_tools/github_actions/configure_jax_release_matrix.py
@@ -14,7 +14,14 @@ sys.path.insert(0, str(_BUILD_TOOLS_DIR))
 
 from github_actions.github_actions_api import gha_set_output
 
-RELEASE_TYPES = ["ci", "dev", "nightly", "prerelease"]
+RELEASE_TYPES = [
+    "ci",
+    "dev",
+    "dev-bkc",
+    "nightly",
+    "nightly-bkc",
+    "prerelease",
+]
 
 # TODO: add opt-ins for CI runs to use python versions and JAX refs normally
 #       only included in release runs.

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -141,7 +141,7 @@ class CIInputs:
     commit_ref: str  # GITHUB_REF_NAME value
     base_ref: str | None  # Git ref used for diffing, or None to skip path filters
     build_variant: str  # Build variant label, e.g. "release", "asan", "tsan"
-    release_type: str = "ci"  # "ci", or "dev", "nightly", "prerelease" for releases
+    release_type: str = "ci"  # "ci", or one of the supported release types
     build_python_packages: bool = True
     build_pytorch: bool = True
     build_jax: bool = False
@@ -871,10 +871,11 @@ def _determine_test_type(
         return "full", "test labels specified"
 
     # Priority 3: release builds run deeper test suites than regular CI.
-    # * 'nightly' gets comprehensive (deeper than standard, on a daily cadence)
+    # * 'nightly' and 'nightly-bkc' get comprehensive (deeper than standard,
+    #   on a daily cadence)
     # * 'prerelease' gets full (exhaustive pre-release validation)
     # * 'dev' falls through to later priorities so changes can be tested quickly
-    if ci_inputs.release_type == "nightly":
+    if ci_inputs.release_type in ("nightly", "nightly-bkc"):
         return "comprehensive", "release build (nightly)"
     if ci_inputs.release_type == "prerelease":
         return "full", "release build (prerelease)"

--- a/build_tools/github_actions/configure_pytorch_release_matrix.py
+++ b/build_tools/github_actions/configure_pytorch_release_matrix.py
@@ -15,7 +15,14 @@ sys.path.insert(0, str(_BUILD_TOOLS_DIR))
 
 from github_actions.github_actions_api import gha_set_output
 
-RELEASE_TYPES = ["ci", "dev", "nightly", "prerelease"]
+RELEASE_TYPES = [
+    "ci",
+    "dev",
+    "dev-bkc",
+    "nightly",
+    "nightly-bkc",
+    "prerelease",
+]
 
 # TODO: add opt-ins for CI runs to use python versions and pytorch refs normally
 #       only included in release runs

--- a/build_tools/github_actions/publish_jax_to_release_bucket.py
+++ b/build_tools/github_actions/publish_jax_to_release_bucket.py
@@ -22,7 +22,9 @@ logger = logging.getLogger(__name__)
 
 MULTI_ARCH_INDEX_URLS = {
     "dev": "https://rocm.devreleases.amd.com/whl-multi-arch/",
+    "dev-bkc": "https://rocm.devreleases.amd.com/whl-multi-arch/",
     "nightly": "https://rocm.nightlies.amd.com/whl-multi-arch/",
+    "nightly-bkc": "https://rocm.nightlies.amd.com/whl-multi-arch/",
     "prerelease": "https://rocm.prereleases.amd.com/whl-multi-arch/",
 }
 
@@ -55,8 +57,8 @@ def main(argv: list[str]) -> None:
     parser.add_argument(
         "--release-type",
         required=True,
-        choices=["dev", "nightly", "prerelease"],
-        help="Release type (selects therock-{release_type}-python bucket)",
+        choices=["dev", "dev-bkc", "nightly", "nightly-bkc", "prerelease"],
+        help="Release type used to select the destination Python bucket",
     )
     parser.add_argument(
         "--structured",

--- a/build_tools/github_actions/publish_pytorch_to_release_bucket.py
+++ b/build_tools/github_actions/publish_pytorch_to_release_bucket.py
@@ -42,7 +42,9 @@ MULTI_ARCH_INDEX_URLS = {
     # TODO: Move this release bucket to CDN/index URL mapping into
     # build_tools/_therock_utils/s3_buckets.py.
     "dev": "https://rocm.devreleases.amd.com/whl-multi-arch/",
+    "dev-bkc": "https://rocm.devreleases.amd.com/whl-multi-arch/",
     "nightly": "https://rocm.nightlies.amd.com/whl-multi-arch/",
+    "nightly-bkc": "https://rocm.nightlies.amd.com/whl-multi-arch/",
     "prerelease": "https://rocm.prereleases.amd.com/whl-multi-arch/",
 }
 
@@ -75,8 +77,8 @@ def main(argv: list[str]) -> None:
     parser.add_argument(
         "--release-type",
         required=True,
-        choices=["dev", "nightly", "prerelease"],
-        help="Release type (selects therock-{release_type}-python bucket)",
+        choices=["dev", "dev-bkc", "nightly", "nightly-bkc", "prerelease"],
+        help="Release type used to select the destination Python bucket",
     )
     parser.add_argument(
         "--structured",

--- a/build_tools/github_actions/publish_rocm_to_release_buckets.py
+++ b/build_tools/github_actions/publish_rocm_to_release_buckets.py
@@ -282,7 +282,7 @@ def main(argv: list[str]) -> None:
     parser.add_argument(
         "--release-type",
         required=True,
-        choices=["dev", "nightly", "prerelease"],
+        choices=["dev", "dev-bkc", "nightly", "nightly-bkc", "prerelease"],
         help="Release type (determines source and destination buckets)",
     )
     # String "true"/"false" because GitHub Actions outputs are strings.

--- a/build_tools/github_actions/tests/determine_version_test.py
+++ b/build_tools/github_actions/tests/determine_version_test.py
@@ -27,6 +27,11 @@ class DetermineVersionTest(unittest.TestCase):
         suffix = determine_version.derive_version_suffix(rocm_version)
         self.assertEqual(suffix, "+rocm7.0.0rc20250707")
 
+    def test_bkc_version_suffix(self):
+        rocm_version = "10.1.0a20260811+bkc.20260813"
+        suffix = determine_version.derive_version_suffix(rocm_version)
+        self.assertEqual(suffix, "+rocm10.1.0a20260811-bkc.20260813")
+
     def test_version_suffix_sorting(self):
         # This tests that version suffixes follow this ordering:
         # final > prerelease > alpha > dev

--- a/build_tools/github_actions/upload_tarballs.py
+++ b/build_tools/github_actions/upload_tarballs.py
@@ -153,7 +153,7 @@ def main(argv: list[str]) -> int:
     parser.add_argument(
         "--release-type",
         default="ci",
-        help='Release type: "ci", "dev", "nightly", or "prerelease"',
+        help="Release type used to select the artifacts bucket.",
     )
     parser.add_argument(
         "--output-dir",

--- a/build_tools/github_actions/write_artifacts_bucket_info.py
+++ b/build_tools/github_actions/write_artifacts_bucket_info.py
@@ -26,7 +26,7 @@ def main(argv: list[str] | None = None):
         "--release-type",
         type=str,
         default="ci",
-        help='Release type: "ci", "dev", "nightly", or "prerelease".',
+        help="Release type used to select the artifacts bucket.",
     )
     args = parser.parse_args(argv)
 

--- a/build_tools/packaging/linux/get_url_repo_params.py
+++ b/build_tools/packaging/linux/get_url_repo_params.py
@@ -90,7 +90,9 @@ def _normalize_release_type(release_type: str) -> str:
     return aliases.get(rt, rt)
 
 
-_KNOWN_RELEASE_TYPES = frozenset({"prerelease", "release", "dev", "nightly", "ci"})
+_KNOWN_RELEASE_TYPES = frozenset(
+    {"prerelease", "release", "dev", "dev-bkc", "nightly", "nightly-bkc", "ci"}
+)
 
 
 def _normalize_and_validate_release_type(release_type: str) -> str:

--- a/build_tools/packaging/linux/native_linux_package_install_test.py
+++ b/build_tools/packaging/linux/native_linux_package_install_test.py
@@ -1405,7 +1405,15 @@ def _build_argument_parser(*, exit_on_error: bool = True) -> ArgumentParser:
     parser.add_argument(
         "--release-type",
         type=str,
-        choices=["dev", "nightly", "prerelease", "release", "ci"],
+        choices=[
+            "dev",
+            "dev-bkc",
+            "nightly",
+            "nightly-bkc",
+            "prerelease",
+            "release",
+            "ci",
+        ],
         help="Type of release: 'dev', 'nightly', 'prerelease', 'release', or 'ci'",
     )
     parser.add_argument(

--- a/build_tools/setup_ccache.py
+++ b/build_tools/setup_ccache.py
@@ -255,14 +255,14 @@ def main(argv: list[str]):
     preset_group.add_argument(
         "--release-type",
         type=str,
-        choices=["ci", "dev", "nightly", "prerelease"],
-        help='Shorthand for --config-preset: "ci" and "dev" map to github-oss-dev, '
-        "others map to github-oss-release.",
+        choices=["ci", "dev", "dev-bkc", "nightly", "nightly-bkc", "prerelease"],
+        help='Shorthand for --config-preset: "ci", "dev", and "dev-bkc" map '
+        "to github-oss-dev; others map to github-oss-release.",
     )
 
     args = p.parse_args(argv)
     if args.release_type is not None:
-        if args.release_type in ("ci", "dev"):
+        if args.release_type in ("ci", "dev", "dev-bkc"):
             args.config_preset = "github-oss-dev"
         else:
             args.config_preset = "github-oss-release"

--- a/build_tools/tests/build_prod_wheels_version_test.py
+++ b/build_tools/tests/build_prod_wheels_version_test.py
@@ -11,6 +11,8 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
+from packaging.version import Version
+
 sys.path.insert(
     0, os.fspath(Path(__file__).parent.parent.parent / "external-builds" / "pytorch")
 )
@@ -30,6 +32,40 @@ class ComputeBuildVersionTest(unittest.TestCase):
     def test_non_dev_release_uses_base_plus_suffix(self):
         version = compute_build_version(self.source_dir, "+rocm7.10.0", "ci")
         self.assertEqual(version, "2.12.0a0+rocm7.10.0")
+
+    def test_versions_sort_by_release_type(self):
+        # Composite PyTorch versions must preserve the intended ROCm release
+        # ordering for pip install --upgrade: stable > prerelease > nightly > dev.
+        stable = Version(compute_build_version(self.source_dir, "+rocm7.14.0", "ci"))
+        prerelease = Version(
+            compute_build_version(self.source_dir, "+rocm7.14.0rc1", "prerelease")
+        )
+        nightly = Version(
+            compute_build_version(self.source_dir, "+rocm7.14.0a20260811", "nightly")
+        )
+        dev = Version(
+            compute_build_version(
+                self.source_dir,
+                "+devrocm7.14.0.dev0-1a2b3c4d",
+                "ci",
+            )
+        )
+
+        self.assertGreater(stable, prerelease)
+        self.assertGreater(prerelease, nightly)
+        self.assertGreater(nightly, dev)
+
+    def test_rocm_major_versions_have_known_sorting_issue(self):
+        # `rocm7` currently sorts above `rocm10` as local-version strings.
+        # This is tracked by https://github.com/ROCm/TheRock/issues/7183.
+        rocm_7_14 = Version(
+            compute_build_version(self.source_dir, "+rocm7.14.0a20260728", "nightly")
+        )
+        rocm_10_0 = Version(
+            compute_build_version(self.source_dir, "+rocm10.0.0a20260806", "nightly")
+        )
+
+        self.assertGreater(rocm_7_14, rocm_10_0)
 
     def test_dev_release_tags_git_commit_in_local_segment(self):
         with mock.patch(

--- a/build_tools/tests/build_prod_wheels_version_test.py
+++ b/build_tools/tests/build_prod_wheels_version_test.py
@@ -67,6 +67,39 @@ class ComputeBuildVersionTest(unittest.TestCase):
 
         self.assertGreater(rocm_7_14, rocm_10_0)
 
+    def test_nightly_bkc_release_uses_bkc_rocm_version(self):
+        (self.source_dir / "version.txt").write_text("2.13.0\n")
+        version = compute_build_version(
+            self.source_dir,
+            "+rocm10.1.0a20260811-bkc.20260813",
+            "nightly-bkc",
+        )
+        self.assertEqual(
+            str(Version(version)),
+            "2.13.0+rocm10.1.0a20260811.bkc.20260813",
+        )
+
+    def test_nightly_bkc_sorts_between_base_and_next_nightly(self):
+        # A BKC build upgrades its base nightly, while the next regular nightly
+        # upgrades the BKC build when both are available to pip.
+        (self.source_dir / "version.txt").write_text("2.13.0\n")
+        base_nightly = Version(
+            compute_build_version(self.source_dir, "+rocm10.1.0a20260811", "nightly")
+        )
+        nightly_bkc = Version(
+            compute_build_version(
+                self.source_dir,
+                "+rocm10.1.0a20260811-bkc.20260813",
+                "nightly-bkc",
+            )
+        )
+        next_nightly = Version(
+            compute_build_version(self.source_dir, "+rocm10.1.0a20260812", "nightly")
+        )
+
+        self.assertGreater(nightly_bkc, base_nightly)
+        self.assertGreater(next_nightly, nightly_bkc)
+
     def test_dev_release_tags_git_commit_in_local_segment(self):
         with mock.patch(
             "build_prod_wheels.get_source_commit_short", return_value="1a2b3c4d"

--- a/build_tools/tests/compute_rocm_package_version_test.py
+++ b/build_tools/tests/compute_rocm_package_version_test.py
@@ -1,11 +1,13 @@
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-import argparse
-from pathlib import Path
 import os
 import sys
 import unittest
+from pathlib import Path
+from unittest import mock
+
+from packaging.version import Version
 
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 import compute_rocm_package_version
@@ -16,7 +18,7 @@ import compute_rocm_package_version
 # future changes like using X.Y versions instead of X.Y.Z versions.
 
 
-class DetermineVersionTest(unittest.TestCase):
+class PythonPackageVersionTest(unittest.TestCase):
     def test_ci_version_uses_dev_version_shape(self):
         version = compute_rocm_package_version.compute_version(
             release_type="ci",
@@ -39,6 +41,14 @@ class DetermineVersionTest(unittest.TestCase):
         #   .dev0+
         #   [0-9a-z]+   Git SHA (short or long)
         self.assertRegex(version, r"^[0-9]+[0-9\.]*\.dev0\+[0-9a-z]+$")
+
+    def test_dev_version_with_git_sha_override(self):
+        version = compute_rocm_package_version.compute_version(
+            release_type="dev",
+            override_base_version="7.9.0",
+            override_git_sha="abcdef1234567890abcdef1234567890abcdef12",
+        )
+        self.assertEqual(version, "7.9.0.dev0+abcdef1234567890abcdef1234567890abcdef12")
 
     def test_nightly_version(self):
         version = compute_rocm_package_version.compute_version(
@@ -98,6 +108,60 @@ class DetermineVersionTest(unittest.TestCase):
             override_base_version="7.9.0",
         )
         self.assertRegex(version, r"^7\.9\.0a[0-9]{8}$")
+
+    def test_versions_are_valid_and_canonical(self):
+        # Version() rejects non-PEP 440 versions such as "7.10.0~rc0".
+        # See https://packaging.python.org/en/latest/specifications/version-specifiers/.
+        versions = self._compute_versions_by_release_type()
+
+        for release_type, version in versions.items():
+            with self.subTest(release_type=release_type):
+                self.assertEqual(str(Version(version)), version)
+
+    def test_versions_sort_by_release_type(self):
+        # pip install --upgrade selects the greatest available version, so enforce:
+        # release > prerelease > nightly > dev.
+        versions = self._compute_versions_by_release_type()
+
+        self.assertGreater(
+            Version(versions["nightly"]),
+            Version(versions["dev"]),
+        )
+        self.assertGreater(
+            Version(versions["prerelease"]),
+            Version(versions["nightly"]),
+        )
+        self.assertGreater(
+            Version(versions["release"]),
+            Version(versions["prerelease"]),
+        )
+
+    @staticmethod
+    def _compute_versions_by_release_type() -> dict[str, str]:
+        common_args = {
+            "package_type": "wheel",
+            "override_base_version": "7.10.0",
+        }
+        return {
+            "dev": compute_rocm_package_version.compute_version(
+                release_type="dev",
+                override_git_sha="abcdef1234567890abcdef1234567890abcdef12",
+                **common_args,
+            ),
+            "nightly": compute_rocm_package_version.compute_version(
+                release_type="nightly",
+                **common_args,
+            ),
+            "prerelease": compute_rocm_package_version.compute_version(
+                release_type="prerelease",
+                prerelease_version="0",
+                **common_args,
+            ),
+            "release": compute_rocm_package_version.compute_version(
+                release_type="release",
+                **common_args,
+            ),
+        }
 
 
 class DebPackageVersionTest(unittest.TestCase):
@@ -210,6 +274,15 @@ class RpmPackageVersionTest(unittest.TestCase):
         #   [0-9a-z]{8} Short git SHA (8 characters)
         self.assertRegex(version, r"^[0-9]+[0-9\.]*~[0-9]{8}g[0-9a-z]{8}$")
 
+    def test_dev_version_with_git_sha_override(self):
+        version = compute_rocm_package_version.compute_version(
+            package_type="rpm",
+            release_type="dev",
+            override_base_version="8.1.0",
+            override_git_sha="abcdef1234567890",
+        )
+        self.assertRegex(version, r"^8\.1\.0~[0-9]{8}gabcdef12$")
+
     def test_nightly_version(self):
         version = compute_rocm_package_version.compute_version(
             package_type="rpm",
@@ -262,44 +335,17 @@ class RpmPackageVersionTest(unittest.TestCase):
         self.assertEqual(version, "8.0.0~custom1")
 
 
-class GitShaOverrideTest(unittest.TestCase):
-    """Tests for explicit override_git_sha parameter."""
-
-    def test_wheel_dev_uses_provided_git_sha(self):
-        version = compute_rocm_package_version.compute_version(
-            release_type="dev",
-            override_base_version="8.1.0",
-            override_git_sha="abcdef1234567890abcdef1234567890abcdef12",
-        )
-        self.assertEqual(version, "8.1.0.dev0+abcdef1234567890abcdef1234567890abcdef12")
-
-    def test_rpm_dev_truncates_long_git_sha(self):
-        version = compute_rocm_package_version.compute_version(
-            package_type="rpm",
-            release_type="dev",
-            override_base_version="8.1.0",
-            override_git_sha="abcdef1234567890",
-        )
-        # Should truncate to 8 chars
-        self.assertRegex(version, r"^8\.1\.0~[0-9]{8}gabcdef12$")
-
-    def test_main_forwards_override_git_sha_to_all_package_types(self):
-        """main() must forward --override-git-sha into the computed versions.
-
-        Regression test for the bug where main() computed versions without
-        passing args.override_git_sha, so the flag was silently ignored and
-        cross-repo callers (e.g. rocm-libraries nightlies building TheRock)
-        got the caller's GITHUB_SHA embedded instead of the requested commit.
-        """
-        override_sha = "abcdef1234567890abcdef1234567890abcdef12"
-        captured_outputs = {}
-        original_gha_set_output = compute_rocm_package_version.gha_set_output
-
-        def mock_gha_set_output(outputs):
-            captured_outputs.update(outputs)
-
-        compute_rocm_package_version.gha_set_output = mock_gha_set_output
-        try:
+# Test meaningful combinations of argparse options through the real computation path,
+# including main()'s side effect of writing versions to GitHub Actions outputs.
+class MainFunctionTest(unittest.TestCase):
+    def test_sets_dev_outputs_with_version_overrides(self):
+        override_git_sha = "abcdef1234567890abcdef1234567890abcdef12"
+        with (
+            mock.patch.dict(os.environ, {"GITHUB_SHA": "f" * 40}),
+            mock.patch.object(
+                compute_rocm_package_version, "gha_set_output"
+            ) as gha_set_output,
+        ):
             compute_rocm_package_version.main(
                 [
                     "--release-type",
@@ -307,87 +353,71 @@ class GitShaOverrideTest(unittest.TestCase):
                     "--override-base-version",
                     "7.99.0",
                     "--override-git-sha",
-                    override_sha,
+                    override_git_sha,
                 ]
             )
-        finally:
-            compute_rocm_package_version.gha_set_output = original_gha_set_output
 
-        # Wheel embeds the full override SHA.
+        gha_set_output.assert_called_once()
+        outputs = gha_set_output.call_args.args[0]
         self.assertEqual(
-            captured_outputs["rocm_package_version"], f"7.99.0.dev0+{override_sha}"
+            set(outputs),
+            {
+                "rocm_package_version",
+                "rocm_deb_package_version",
+                "rocm_rpm_package_version",
+            },
         )
-        # DEB uses the dev-date format and does not embed a git SHA at all.
-        self.assertRegex(
-            captured_outputs["rocm_deb_package_version"], r"^7\.99\.0~dev[0-9]{8}$"
+        self.assertEqual(
+            outputs["rocm_package_version"],
+            f"7.99.0.dev0+{override_git_sha}",
         )
-        self.assertNotIn(override_sha[:8], captured_outputs["rocm_deb_package_version"])
-        # RPM embeds the 8-char truncation of the same override SHA.
-        self.assertRegex(
-            captured_outputs["rocm_rpm_package_version"],
-            rf"^7\.99\.0~[0-9]{{8}}g{override_sha[:8]}$",
-        )
+        self.assertTrue(outputs["rocm_deb_package_version"].startswith("7.99.0~dev"))
+        self.assertTrue(outputs["rocm_rpm_package_version"].startswith("7.99.0~"))
+        self.assertTrue(outputs["rocm_rpm_package_version"].endswith("gabcdef12"))
 
-
-class MainFunctionMultiplePackageTypesTest(unittest.TestCase):
-    """Tests for main() function: compute all package types when --package-type is omitted."""
-
-    def test_compute_all_package_types_without_flag(self):
-        """Test that when --package-type is not provided, all types are computed."""
-        captured_outputs = {}
-        original_gha_set_output = compute_rocm_package_version.gha_set_output
-
-        def mock_gha_set_output(outputs):
-            captured_outputs.update(outputs)
-
-        compute_rocm_package_version.gha_set_output = mock_gha_set_output
-
-        try:
+    def test_sets_prerelease_outputs(self):
+        with mock.patch.object(
+            compute_rocm_package_version, "gha_set_output"
+        ) as gha_set_output:
             compute_rocm_package_version.main(
-                ["--release-type", "dev", "--override-base-version", "8.0.0"]
+                [
+                    "--release-type",
+                    "prerelease",
+                    "--prerelease-version",
+                    "2",
+                    "--override-base-version",
+                    "7.99.0",
+                ]
             )
 
-            # Should have all three outputs
-            self.assertIn("rocm_package_version", captured_outputs)
-            self.assertIn("rocm_deb_package_version", captured_outputs)
-            self.assertIn("rocm_rpm_package_version", captured_outputs)
+        gha_set_output.assert_called_once_with(
+            {
+                "rocm_package_version": "7.99.0rc2",
+                "rocm_deb_package_version": "7.99.0~pre2",
+                "rocm_rpm_package_version": "7.99.0~rc2",
+            }
+        )
 
-            # Verify formats
-            self.assertRegex(
-                captured_outputs["rocm_package_version"], r"^8\.0\.0\.dev0\+[0-9a-z]+$"
+    def test_sets_custom_suffix_outputs(self):
+        with mock.patch.object(
+            compute_rocm_package_version, "gha_set_output"
+        ) as gha_set_output:
+            compute_rocm_package_version.main(
+                [
+                    "--custom-version-suffix",
+                    ".custom1",
+                    "--override-base-version",
+                    "7.99.0",
+                ]
             )
-            self.assertRegex(
-                captured_outputs["rocm_deb_package_version"], r"^8\.0\.0~dev[0-9]{8}$"
-            )
-            self.assertRegex(
-                captured_outputs["rocm_rpm_package_version"],
-                r"^8\.0\.0~[0-9]{8}g[0-9a-z]{8}$",
-            )
-        finally:
-            compute_rocm_package_version.gha_set_output = original_gha_set_output
 
-    def test_existing_workflows_still_work(self):
-        """Test that existing workflows reading rocm_package_version still work."""
-        captured_outputs = {}
-        original_gha_set_output = compute_rocm_package_version.gha_set_output
-
-        def mock_gha_set_output(outputs):
-            captured_outputs.update(outputs)
-
-        compute_rocm_package_version.gha_set_output = mock_gha_set_output
-
-        try:
-            # This mimics setup_multi_arch.yml line 66: no --package-type specified
-            compute_rocm_package_version.main(["--release-type", "dev"])
-
-            # Existing workflow reads rocm_package_version, which should still exist
-            self.assertIn("rocm_package_version", captured_outputs)
-
-            # Additional outputs don't break existing workflows (they just ignore them)
-            self.assertIn("rocm_deb_package_version", captured_outputs)
-            self.assertIn("rocm_rpm_package_version", captured_outputs)
-        finally:
-            compute_rocm_package_version.gha_set_output = original_gha_set_output
+        gha_set_output.assert_called_once_with(
+            {
+                "rocm_package_version": "7.99.0.custom1",
+                "rocm_deb_package_version": "7.99.0.custom1",
+                "rocm_rpm_package_version": "7.99.0.custom1",
+            }
+        )
 
 
 if __name__ == "__main__":

--- a/build_tools/tests/compute_rocm_package_version_test.py
+++ b/build_tools/tests/compute_rocm_package_version_test.py
@@ -1,8 +1,10 @@
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
+import json
 import os
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -12,10 +14,120 @@ from packaging.version import Version
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 import compute_rocm_package_version
 
+TEST_BKC_VERSION_DATA = {"release-metadata": {"base-date": "20260811"}}
+
 
 # Note: the regex matches in here aren't exact, but they should be "good enough"
 # to cover the general structure of each version string while allowing for
 # future changes like using X.Y versions instead of X.Y.Z versions.
+
+
+class VersionFileTest(unittest.TestCase):
+    def test_loads_repository_version_file(self):
+        # The version file in this repository should always parse correctly.
+        version_data = compute_rocm_package_version.load_version_file()
+
+        self.assertIsInstance(version_data["rocm-version"], str)
+        self.assertIsInstance(version_data["release-metadata"], dict)
+
+    def test_loads_version_file_without_metadata(self):
+        # Version files prior to introducing the metadata field should still
+        # parse and load without errors.
+        with tempfile.TemporaryDirectory() as temp_dir:
+            version_file = Path(temp_dir) / "version.json"
+            version_file.write_text(
+                """{
+  "rocm-version": "7.9.0"
+}
+""",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                compute_rocm_package_version.load_version_file(version_file),
+                {"rocm-version": "7.9.0"},
+            )
+
+    def test_loads_version_file_with_empty_metadata(self):
+        # Metadata is expected to be empty on the default branch.
+        # It may be populated on release branches.
+        with tempfile.TemporaryDirectory() as temp_dir:
+            version_file = Path(temp_dir) / "version.json"
+            version_file.write_text(
+                """{
+  "rocm-version": "7.9.0",
+  "release-metadata": {
+    "base-date": ""
+  }
+}
+""",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                compute_rocm_package_version.load_version_file(version_file),
+                {
+                    "rocm-version": "7.9.0",
+                    "release-metadata": {"base-date": ""},
+                },
+            )
+
+    def test_loads_version_file_with_populated_metadata(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            version_file = Path(temp_dir) / "version.json"
+            version_file.write_text(
+                """{
+  "rocm-version": "7.9.0",
+  "release-metadata": {
+    "base-date": "20260811"
+  }
+}
+""",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                compute_rocm_package_version.load_version_file(version_file),
+                {
+                    "rocm-version": "7.9.0",
+                    "release-metadata": {"base-date": "20260811"},
+                },
+            )
+
+    def test_rejects_invalid_json(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            version_file = Path(temp_dir) / "version.json"
+            # Missing closing }
+            version_file.write_text(
+                '{ "rocm-version": "7.9.0"',
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(json.JSONDecodeError):
+                compute_rocm_package_version.load_version_file(version_file)
+
+    def test_rejects_invalid_base_date_metadata(self):
+        for base_date in ("2026081", "20261301"):
+            with (
+                self.subTest(base_date=base_date),
+                tempfile.TemporaryDirectory() as temp_dir,
+            ):
+                version_file = Path(temp_dir) / "version.json"
+                version_file.write_text(
+                    f"""{{
+  "rocm-version": "7.9.0",
+  "release-metadata": {{
+    "base-date": "{base_date}"
+  }}
+}}
+""",
+                    encoding="utf-8",
+                )
+
+                with self.assertRaisesRegex(
+                    ValueError, "valid date in YYYYMMDD format"
+                ):
+                    compute_rocm_package_version.load_version_file(version_file)
 
 
 class PythonPackageVersionTest(unittest.TestCase):
@@ -50,6 +162,15 @@ class PythonPackageVersionTest(unittest.TestCase):
         )
         self.assertEqual(version, "7.9.0.dev0+abcdef1234567890abcdef1234567890abcdef12")
 
+    def test_dev_bkc_version_uses_dev_version_shape(self):
+        version = compute_rocm_package_version.compute_version(
+            release_type="dev-bkc",
+            override_base_version="7.9.0",
+            override_git_sha="abcdef1234567890abcdef1234567890abcdef12",
+            version_data=TEST_BKC_VERSION_DATA,
+        )
+        self.assertEqual(version, "7.9.0.dev0+abcdef1234567890abcdef1234567890abcdef12")
+
     def test_nightly_version(self):
         version = compute_rocm_package_version.compute_version(
             release_type="nightly",
@@ -63,6 +184,29 @@ class PythonPackageVersionTest(unittest.TestCase):
         #   a
         #   [0-9]{8}    Date as YYYYMMDD
         self.assertRegex(version, r"^[0-9]+[0-9\.]*a[0-9]{8}$")
+
+    def test_nightly_bkc_version(self):
+        version = compute_rocm_package_version.compute_version(
+            release_type="nightly-bkc",
+            override_base_version="7.9.0",
+            version_data=TEST_BKC_VERSION_DATA,
+        )
+        self.assertRegex(
+            version,
+            r"^7\.9\.0a20260811\+bkc\.[0-9]{8}$",
+        )
+
+    def test_bkc_version_requires_base_date_metadata(self):
+        for release_type in ("dev-bkc", "nightly-bkc"):
+            with (
+                self.subTest(release_type=release_type),
+                self.assertRaisesRegex(ValueError, "release-metadata.base-date"),
+            ):
+                compute_rocm_package_version.compute_version(
+                    release_type=release_type,
+                    override_base_version="7.9.0",
+                    version_data={},
+                )
 
     def test_prerelease_version(self):
         version = compute_rocm_package_version.compute_version(
@@ -120,12 +264,20 @@ class PythonPackageVersionTest(unittest.TestCase):
 
     def test_versions_sort_by_release_type(self):
         # pip install --upgrade selects the greatest available version, so enforce:
-        # release > prerelease > nightly > dev.
+        # release > prerelease > nightly > nightly-bkc > dev-bkc == dev.
         versions = self._compute_versions_by_release_type()
 
+        self.assertEqual(
+            Version(versions["dev-bkc"]),
+            Version(versions["dev"]),
+        )
+        self.assertGreater(
+            Version(versions["nightly-bkc"]),
+            Version(versions["dev-bkc"]),
+        )
         self.assertGreater(
             Version(versions["nightly"]),
-            Version(versions["dev"]),
+            Version(versions["nightly-bkc"]),
         )
         self.assertGreater(
             Version(versions["prerelease"]),
@@ -146,6 +298,17 @@ class PythonPackageVersionTest(unittest.TestCase):
             "dev": compute_rocm_package_version.compute_version(
                 release_type="dev",
                 override_git_sha="abcdef1234567890abcdef1234567890abcdef12",
+                **common_args,
+            ),
+            "dev-bkc": compute_rocm_package_version.compute_version(
+                release_type="dev-bkc",
+                override_git_sha="abcdef1234567890abcdef1234567890abcdef12",
+                version_data=TEST_BKC_VERSION_DATA,
+                **common_args,
+            ),
+            "nightly-bkc": compute_rocm_package_version.compute_version(
+                release_type="nightly-bkc",
+                version_data=TEST_BKC_VERSION_DATA,
                 **common_args,
             ),
             "nightly": compute_rocm_package_version.compute_version(
@@ -192,6 +355,15 @@ class DebPackageVersionTest(unittest.TestCase):
         #   [0-9]{8}    Date as YYYYMMDD
         self.assertRegex(version, r"^[0-9]+[0-9\.]*~dev[0-9]{8}$")
 
+    def test_dev_bkc_version_uses_dev_version_shape(self):
+        version = compute_rocm_package_version.compute_version(
+            package_type="deb",
+            release_type="dev-bkc",
+            override_base_version="8.1.0",
+            version_data=TEST_BKC_VERSION_DATA,
+        )
+        self.assertRegex(version, r"^8\.1\.0~dev[0-9]{8}$")
+
     def test_nightly_version(self):
         version = compute_rocm_package_version.compute_version(
             package_type="deb",
@@ -206,6 +378,18 @@ class DebPackageVersionTest(unittest.TestCase):
         #   ~
         #   [0-9]{8}    Date as YYYYMMDD
         self.assertRegex(version, r"^[0-9]+[0-9\.]*~[0-9]{8}$")
+
+    def test_nightly_bkc_version(self):
+        version = compute_rocm_package_version.compute_version(
+            package_type="deb",
+            release_type="nightly-bkc",
+            override_base_version="8.1.0",
+            version_data=TEST_BKC_VERSION_DATA,
+        )
+        self.assertRegex(
+            version,
+            r"^8\.1\.0~20260811\.bkc\.[0-9]{8}$",
+        )
 
     def test_prerelease_version(self):
         version = compute_rocm_package_version.compute_version(
@@ -283,6 +467,16 @@ class RpmPackageVersionTest(unittest.TestCase):
         )
         self.assertRegex(version, r"^8\.1\.0~[0-9]{8}gabcdef12$")
 
+    def test_dev_bkc_version_uses_dev_version_shape(self):
+        version = compute_rocm_package_version.compute_version(
+            package_type="rpm",
+            release_type="dev-bkc",
+            override_base_version="8.1.0",
+            override_git_sha="abcdef1234567890",
+            version_data=TEST_BKC_VERSION_DATA,
+        )
+        self.assertRegex(version, r"^8\.1\.0~[0-9]{8}gabcdef12$")
+
     def test_nightly_version(self):
         version = compute_rocm_package_version.compute_version(
             package_type="rpm",
@@ -297,6 +491,18 @@ class RpmPackageVersionTest(unittest.TestCase):
         #   ~
         #   [0-9]{8}    Date as YYYYMMDD
         self.assertRegex(version, r"^[0-9]+[0-9\.]*~[0-9]{8}$")
+
+    def test_nightly_bkc_version(self):
+        version = compute_rocm_package_version.compute_version(
+            package_type="rpm",
+            release_type="nightly-bkc",
+            override_base_version="8.1.0",
+            version_data=TEST_BKC_VERSION_DATA,
+        )
+        self.assertRegex(
+            version,
+            r"^8\.1\.0~20260811\.bkc\.[0-9]{8}$",
+        )
 
     def test_prerelease_version(self):
         version = compute_rocm_package_version.compute_version(

--- a/build_tools/tests/s3_buckets_test.py
+++ b/build_tools/tests/s3_buckets_test.py
@@ -63,6 +63,19 @@ class TestGetArtifactsBucketConfig(unittest.TestCase):
         )
         self.assertEqual(config.name, "therock-nightly-artifacts")
 
+    def test_bkc_release_types_use_existing_artifacts_buckets(self):
+        for release_type, bucket_name in (
+            ("dev-bkc", "therock-dev-artifacts"),
+            ("nightly-bkc", "therock-nightly-artifacts"),
+        ):
+            with self.subTest(release_type=release_type):
+                config = get_artifacts_bucket_config(
+                    release_type=release_type,
+                    repository="ROCm/TheRock",
+                    is_pr_from_fork=False,
+                )
+                self.assertEqual(config.name, bucket_name)
+
     def test_release_type_invalid_raises(self):
         with self.assertRaises(ValueError) as cm:
             get_artifacts_bucket_config(
@@ -107,6 +120,17 @@ class TestGetReleaseBucketConfig(unittest.TestCase):
         )
         self.assertEqual(config.name, "therock-prerelease-packages")
         self.assertEqual(config.iam_role, "therock-prerelease")
+
+    def test_bkc_release_types_use_existing_release_buckets(self):
+        for release_type, bucket_name in (
+            ("dev-bkc", "therock-dev-python"),
+            ("nightly-bkc", "therock-nightly-python"),
+        ):
+            with self.subTest(release_type=release_type):
+                config = get_release_bucket_config(
+                    release_type=release_type, bucket_type="python"
+                )
+                self.assertEqual(config.name, bucket_name)
 
     def test_all_combinations_exist(self):
         for release_type in ("dev", "nightly", "prerelease"):

--- a/docs/development/s3_buckets.md
+++ b/docs/development/s3_buckets.md
@@ -90,6 +90,10 @@ upload to this bucket and do not need `aws-actions/configure-aws-credentials`.
 Each release type (`dev`, `nightly`, `prerelease`, `release`) has a matching
 set of buckets.
 
+The `dev-bkc` and `nightly-bkc` release types currently use the existing `dev`
+and `nightly` buckets, IAM roles, and CDN indexes, respectively. A dedicated
+BKC bucket and index may be added in the future.
+
 The `dev`, `nightly`, and `prerelease` types are accessed via
 the `therock-{release_type}` IAM role while stable `release` buckets are
 manually promoted from prereleases via IAM user policies (see

--- a/docs/packaging/versioning.md
+++ b/docs/packaging/versioning.md
@@ -83,21 +83,15 @@ The script produces these versions for each release type:
 | nightly      | `X.Y.ZaYYYYMMDD`  | `7.10.0a20251124`<br>(The nightly release on 2025-11-24)                                                                                                            |
 | dev          | `X.Y.Z.dev0+NNNN` | `7.10.0.dev0+efed3c3b10a5cce8578f58f8eb288582c26d18c4`<br>(For commit [`efed3c3`](https://github.com/ROCm/TheRock/commit/efed3c3b10a5cce8578f58f8eb288582c26d18c4)) |
 
-Each distribution channel (and GPU family within that channel) is currently
-hosted on a separate release index that can be passed to `pip` or `uv` via
-`--index-url`. For example:
+Each distribution channel is currently hosted on a separate release index that
+can be passed to `pip` or `uv` via `--index-url`. For example:
 
 ```bash
-pip install --index-url=https://rocm.nightlies.amd.com/v2/gfx94X-dcgpu/ rocm
+pip install --index-url=https://rocm.nightlies.amd.com/whl-multi-arch/ rocm
 ```
 
 See [RELEASES.md - Installing releases using pip](../../RELEASES.md#installing-releases-using-pip)
 for details.
-
-> [!NOTE]
-> We plan on later providing a single multi-architecture index as part of
-> multi-arch work, see
-> [RFC0008-Multi-Arch-Packaging.md - Python Packaging](../rfcs/RFC0008-Multi-Arch-Packaging.md#python-packaging).
 
 ### External Python package versions
 
@@ -133,6 +127,21 @@ True
 >>> nightly > dev
 True
 ```
+
+> [!WARNING]
+> Known issue: https://github.com/ROCm/TheRock/issues/7183.
+>
+> Package versions using ROCm version 10.0.0+ sort as _older_ than previous
+> versions using this schema:
+>
+> ```python
+> >>> from packaging.version import Version
+> >>> Version("2.12.0+rocm10.0") > Version("2.12.0+rocm7.0")
+> False
+> ```
+>
+> We plan on publishing 10.0.0+ packages to a new index to avoid this issue for
+> future installs.
 
 #### PyTorch versions
 

--- a/docs/packaging/versioning.md
+++ b/docs/packaging/versioning.md
@@ -10,6 +10,7 @@ Table of contents:
 - [Overview](#overview)
   - [Constraints and design guidelines](#constraints-and-design-guidelines)
   - [Distribution channels (dev, nightly, release)](#distribution-channels-dev-nightly-release)
+- [Release branch metadata](#release-branch-metadata)
 - [Python package versions](#python-package-versions)
 - [Native Linux package versions](#native-linux-package-versions)
 - [Native Windows package versions](#native-windows-package-versions)
@@ -24,9 +25,22 @@ where
 - `Z` is the "patch version"
 
 The [`version.json`](/version.json) file at the root of TheRock defines the
-base version used for packages, while subprojects may have their own independent
-library versions (for example `HIPBLASLT_PROJECT_VERSION` in
-[`rocm-libraries/projects/hipblaslt/CMakeLists.txt`](https://github.com/ROCm/rocm-libraries/blob/develop/projects/hipblaslt/CMakeLists.txt)).
+base version used for packages:
+
+```json
+{
+  "rocm-version": "10.1.0"
+}
+```
+
+> [!NOTE]
+> Subprojects may have their own independent
+> library versions (for example `HIPBLASLT_PROJECT_VERSION` in
+> [`rocm-libraries/projects/hipblaslt/CMakeLists.txt`](https://github.com/ROCm/rocm-libraries/blob/develop/projects/hipblaslt/CMakeLists.txt)):
+>
+> ```cmake
+> set(HIPBLASLT_PROJECT_VERSION "1.4.1" CACHE STRING "Semantic version string.")
+> ```
 
 <!-- TODO: touch on ABI versions in libraries (.so/.dll) -->
 
@@ -60,12 +74,43 @@ users who want early previews of upcoming releases, and QA/test team members.
 | stable releases      | https://repo.amd.com/rocm/        | Manually promoted prereleases                                                                                                                                                                                |
 | prereleases          | https://rocm.prereleases.amd.com/ | Manually triggered workflows in [rockrel](https://github.com/ROCm/rockrel)                                                                                                                                   |
 | nightly releases     | https://rocm.nightlies.amd.com/   | Scheduled workflows in [rockrel](https://github.com/ROCm/rockrel)                                                                                                                                            |
+| BKC releases         | TBD                               | Workflows in [rockrel](https://github.com/ROCm/rockrel)                                                                                                                                                      |
 | dev releases         | https://rocm.devreleases.amd.com/ | Manually triggered test workflows in [TheRock](https://github.com/ROCm/TheRock) and [rockrel](https://github.com/ROCm/rockrel)                                                                               |
 | dev builds           | No central index                  | Local builds and per-commit workflows in [TheRock](https://github.com/ROCm/TheRock),<br>[rocm-libraries](https://github.com/ROCm/rocm-libraries), [rocm-systems](https://github.com/ROCm/rocm-systems), etc. |
+
+Each distribution channel is currently hosted on a separate release index that
+can be passed to package managers like `pip` (see
+[RELEASES.md - Installing releases using pip](../../RELEASES.md#installing-releases-using-pip)
+for details). For example:
+
+```bash
+pip install --index-url=https://rocm.nightlies.amd.com/whl-multi-arch/ rocm
+pip install --index-url=https://rocm.devreleases.amd.com/whl-multi-arch/ rocm
+```
 
 With the exception of "dev releases", each distribution channel only contains
 release artifacts of the matching release type. The "dev releases" channel
 _can_ contain any type of release.
+
+## Release branch metadata
+
+The `version.json` file also contains a generic `release-metadata` object
+hosting fields that release types can interpret as needed. These fields should
+be empty on the base branch and may be populated by commits on release branches:
+
+```jsonc
+{
+  "rocm-version": "10.1.0",
+  "release-metadata": {
+    // Empty on the base branch.
+    "base-date": ""
+    // A BKC release branch could set base-date to 20260811 for a package
+    // version like 10.1.0a20260811+bkc.20260813 where
+    //   * 20260811 is fixed to when the release branch forked from mainline
+    //   * 20260813 is the current date
+  }
+}
+```
 
 ## Python package versions
 
@@ -76,22 +121,26 @@ Python package versions are handled by scripts:
 
 The script produces these versions for each release type:
 
-| Release type | Version format    | Version example                                                                                                                                                     |
-| ------------ | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| stable       | `X.Y.Z`           | `7.10.0`                                                                                                                                                            |
-| prerelease   | `X.Y.ZrcN`        | `7.10.0rc0`<br>(The first release candidate for that stable release)                                                                                                |
-| nightly      | `X.Y.ZaYYYYMMDD`  | `7.10.0a20251124`<br>(The nightly release on 2025-11-24)                                                                                                            |
-| dev          | `X.Y.Z.dev0+NNNN` | `7.10.0.dev0+efed3c3b10a5cce8578f58f8eb288582c26d18c4`<br>(For commit [`efed3c3`](https://github.com/ROCm/TheRock/commit/efed3c3b10a5cce8578f58f8eb288582c26d18c4)) |
+| Release type | Version format                             | Version example                                                                                                                                                     |
+| ------------ | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| stable       | `X.Y.Z`                                    | `7.10.0`                                                                                                                                                            |
+| prerelease   | `X.Y.ZrcN`                                 | `7.10.0rc0`<br>(The first release candidate for that stable release)                                                                                                |
+| nightly      | `X.Y.ZaYYYYMMDD`                           | `7.10.0a20251124`<br>(The nightly release on 2025-11-24)                                                                                                            |
+| nightly-bkc  | `X.Y.ZaBASEDATE+bkc.YYYYMMDD`              | `10.1.0a20260811+bkc.20260814`                                                                                                                                      |
+| dev          | `X.Y.Z.dev0+NNNN`                          | `7.10.0.dev0+efed3c3b10a5cce8578f58f8eb288582c26d18c4`<br>(For commit [`efed3c3`](https://github.com/ROCm/TheRock/commit/efed3c3b10a5cce8578f58f8eb288582c26d18c4)) |
+| dev-bkc      | `X.Y.Z.dev0+NNNN`<br>(same as regular dev) | `10.1.0.dev0+efed3c3b10a5cce8578f58f8eb288582c26d18c4`                                                                                                              |
 
-Each distribution channel is currently hosted on a separate release index that
-can be passed to `pip` or `uv` via `--index-url`. For example:
+### BKC versions
 
-```bash
-pip install --index-url=https://rocm.nightlies.amd.com/whl-multi-arch/ rocm
+For `nightly-bkc`, `BASEDATE` comes from `release-metadata.base-date` in
+`version.json` and identifies the regular nightly used to create the BKC
+branch. The date in the `bkc.YYYYMMDD` local version identifier is the BKC
+build date. This makes a BKC build sort newer than its base nightly but older
+than the next regular nightly:
+
+```text
+10.1.0a20260811 < 10.1.0a20260811+bkc.20260814 < 10.1.0a20260812
 ```
-
-See [RELEASES.md - Installing releases using pip](../../RELEASES.md#installing-releases-using-pip)
-for details.
 
 ### External Python package versions
 
@@ -104,11 +153,12 @@ For example, for torch version `2.9.0` built with ROCm version `7.10.0` we
 generate a composite torch version `2.9.0+rocm7.10.0`. See this table for more
 possible version combinations:
 
-| ROCm release type | ROCm version example | Composite torch version example                                                    |
-| ----------------- | -------------------- | ---------------------------------------------------------------------------------- |
-| stable            | `7.10.0`             | `2.9.0+rocm7.10.0`                                                                 |
-| nightly           | `7.10.0a20251124`    | `2.9.0+rocm7.10.0a20251124`                                                        |
-| dev               | `7.10.0.dev0+efed3c` | `2.9.0+devrocm7.10.0.dev0-efed3c`<br>_(Note the `devrocm` and `-` instead of `+`)_ |
+| ROCm release type | ROCm version example           | Composite torch version example                                                    |
+| ----------------- | ------------------------------ | ---------------------------------------------------------------------------------- |
+| stable            | `7.10.0`                       | `2.9.0+rocm7.10.0`                                                                 |
+| nightly           | `7.10.0a20251124`              | `2.9.0+rocm7.10.0a20251124`                                                        |
+| nightly-bkc       | `10.1.0a20260811+bkc.20260813` | `2.13.0+rocm10.1.0a20260811.bkc.20260813`                                          |
+| dev               | `7.10.0.dev0+efed3c`           | `2.9.0+devrocm7.10.0.dev0-efed3c`<br>_(Note the `devrocm` and `-` instead of `+`)_ |
 
 These local version identifiers are specially constructed such that the expected
 version sorting of `stable > nightly > dev` is preserved. Note that per the
@@ -272,21 +322,25 @@ Native package versions are handled by scripts:
 
 The script produces these versions for rpm packages for each release type:
 
-| Release type | Version format              | Version example                                                                                                                        |
-| ------------ | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| stable       | `X.Y.Z`                     | `7.10.0`                                                                                                                               |
-| prerelease   | `X.Y.Z~rcN`                 | `7.10.0~rc0`<br>(The first release candidate for that stable release)                                                                  |
-| nightly      | `X.Y.Z~YYYYMMDD`            | `7.10.0~20251124`<br>(The nightly release on 2025-11-24)                                                                               |
-| dev          | `X.Y.Z~YYYYMMDDg<git-hash>` | `7.10.0~20251124gefed3c3`<br>(For commit [`efed3c3`](https://github.com/ROCm/TheRock/commit/efed3c3b10a5cce8578f58f8eb288582c26d18c4)) |
+| Release type | Version format                               | Version example                                                                                                                        |
+| ------------ | -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| stable       | `X.Y.Z`                                      | `7.10.0`                                                                                                                               |
+| prerelease   | `X.Y.Z~rcN`                                  | `7.10.0~rc0`<br>(The first release candidate for that stable release)                                                                  |
+| nightly      | `X.Y.Z~YYYYMMDD`                             | `7.10.0~20251124`<br>(The nightly release on 2025-11-24)                                                                               |
+| nightly-bkc  | `X.Y.Z~BASEDATE.bkc.YYYYMMDD`                | `10.1.0~20260811.bkc.20260814`                                                                                                         |
+| dev          | `X.Y.Z~YYYYMMDDg<git-hash>`                  | `7.10.0~20251124gefed3c3`<br>(For commit [`efed3c3`](https://github.com/ROCm/TheRock/commit/efed3c3b10a5cce8578f58f8eb288582c26d18c4)) |
+| dev-bkc      | `X.Y.Z~YYYYMMDDg<git-hash>`<br>(same as dev) | `10.1.0~20260814gefed3c3`                                                                                                              |
 
 The script produces these versions for debian packages for each release type:
 
-| Release type | Version format      | Version example                                                        |
-| ------------ | ------------------- | ---------------------------------------------------------------------- |
-| stable       | `X.Y.Z`             | `7.10.0`                                                               |
-| prerelease   | `X.Y.Z~preN`        | `7.10.0~pre0`<br>(The first release candidate for that stable release) |
-| nightly      | `X.Y.Z~YYYYMMDD`    | `7.10.0~20251124`<br>(The nightly release on 2025-11-24)               |
-| dev          | `X.Y.Z~devYYYYMMDD` | `7.10.0~dev20251124`<br>(For dev build on 2025-11-24)d18c4)            |
+| Release type | Version format                               | Version example                                                        |
+| ------------ | -------------------------------------------- | ---------------------------------------------------------------------- |
+| stable       | `X.Y.Z`                                      | `7.10.0`                                                               |
+| prerelease   | `X.Y.Z~preN`                                 | `7.10.0~pre0`<br>(The first release candidate for that stable release) |
+| nightly      | `X.Y.Z~YYYYMMDD`                             | `7.10.0~20251124`<br>(The nightly release on 2025-11-24)               |
+| nightly-bkc  | `X.Y.Z~BASEDATE.bkc.YYYYMMDD`                | `10.1.0~20260811.bkc.20260814`                                         |
+| dev          | `X.Y.Z~devYYYYMMDD`                          | `7.10.0~dev20251124`<br>(For dev build on 2025-11-24)                  |
+| dev-bkc      | `X.Y.Z~devYYYYMMDD`<br>(same as regular dev) | `10.1.0~dev20260814`                                                   |
 
 ## Native Windows package versions
 

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -313,22 +313,22 @@ def get_source_commit_short(source_dir: Path, length: int = 8) -> str:
 def compute_build_version(
     source_dir: Path, version_suffix: str, release_type: str
 ) -> str:
-    """Compute a wheel version, tagging dev builds with the source commit.
+    """Compute a wheel version, tagging dev release types with the source commit.
 
     Reads `<source_dir>/version.txt` as the base version and appends
     `version_suffix` (a PEP 440 local identifier like `+rocm7.10.0`). For `dev`
-    builds the 8-char source commit is merged into that single local segment,
-    e.g. `2.12.0a0+git1a2b3c4d.rocm7.10.0`, so each wheel (torch, torchaudio,
-    torchvision) records exactly which source commit produced it. PyTorch's
-    setup.py validates the version as PEP 440, which only allows a commit hash
-    in the local segment (after `+`).
+    and `dev-bkc` builds, the 8-char source commit is merged into that single
+    local segment, e.g. `2.12.0a0+git1a2b3c4d.rocm7.10.0`, so each wheel
+    (torch, torchaudio, torchvision) records exactly which source commit
+    produced it. PyTorch's setup.py validates the version as PEP 440, which only
+    allows a commit hash in the local segment (after `+`).
     TODO(#5110): reconcile with generate_pytorch_source_manifest.py once
     upfront, manifest-based version computation lands so the built version
     always matches what the manifest records.
     """
     base_version = (source_dir / "version.txt").read_text().strip()
     build_version = base_version + version_suffix
-    if release_type == "dev":
+    if release_type in ("dev", "dev-bkc"):
         commit = get_source_commit_short(source_dir)
         if commit:
             # version_suffix is a local identifier like `+rocm7.10.0`; merge the
@@ -1583,13 +1583,16 @@ def main(argv: list[str]):
     )
     build_p.add_argument(
         "--release-type",
-        choices=["ci", "dev", "nightly", "prerelease"],
+        choices=["ci", "dev", "dev-bkc", "nightly", "nightly-bkc", "prerelease"],
         default="nightly",
-        help="Release type of the build. For `dev` builds the torch wheel "
-        "version is tagged with the 8-char torch source commit in the local "
-        "segment, e.g. `2.12.0a0+git1a2b3c4d.rocm7.10.0` (torch wheel only). "
-        "The default is non-appending so other callers (CI, nightly, "
-        "prerelease) keep their plain `<base>+<suffix>` versions.",
+        help=(
+            "Release type of the build. For `dev` and `dev-bkc` builds the "
+            "torch wheel version is tagged with the 8-char torch source commit "
+            "in the local segment, e.g. "
+            "`2.12.0a0+git1a2b3c4d.rocm7.10.0` (torch wheel only). The default "
+            "is non-appending so other callers (CI, nightly, prerelease) keep "
+            "their plain `<base>+<suffix>` versions."
+        ),
     )
     build_p.add_argument(
         "--clean",

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "rocm-version": "10.1.0",
   "release-metadata": {
-    "base-date": ""
+    "base-date": "20260811"
   }
 }

--- a/version.json
+++ b/version.json
@@ -1,3 +1,6 @@
 {
-  "rocm-version": "10.1.0"
+  "rocm-version": "10.1.0",
+  "release-metadata": {
+    "base-date": ""
+  }
 }


### PR DESCRIPTION
## Motivation

Progress on setting up the BKC release channel for https://github.com/ROCm/rockrel/issues/88.

This cherry-picks three commits and includes one new commit unique to the release branch:
* https://github.com/ROCm/TheRock/pull/7389
* https://github.com/ROCm/TheRock/pull/7390
* https://github.com/ROCm/TheRock/pull/7392
* Set base-date in version.json to 20260811

Together with https://github.com/ROCm/rockrel/pull/94 we'll now be able to trigger releases with the `dev-bkc` and `nightly-bkc` release type and `nightly-bkc` releases will use versions with local version identifiers extending the base nightly version:
```
10.1.0a20260811
10.1.0a20260811+bkc.20260818
```

## Technical Details

This still uploads `dev-bkc` releases to https://rocm.devreleases.amd.com/ and `nightly-bkc` releases to https://rocm.nightlies.amd.com/. We are planning on creating a new release stream for these packages with separate S3 buckets and cloudfront URLs but that will follow later as part of the repo.amd.com work (see https://github.com/ROCm/TheRock/blob/main/docs/rfcs/RFC0012-Repo-Structure.md).

## Test Plan

From this branch I ran:
```
(.venv) λ python build_tools/compute_rocm_package_version.py --release-type=nightly-bkc
Loading version data from file 'D:\projects\TheRock\version.json'
Base version  : '10.1.0'
Package type  : 'wheel'
Version suffix: 'a20260811+bkc.20260818'
Full version  : '10.1.0a20260811+bkc.20260818'
Base version  : '10.1.0'
Package type  : 'deb'
Version suffix: '~20260811.bkc.20260818'
Full version  : '10.1.0~20260811.bkc.20260818'
Base version  : '10.1.0'
Package type  : 'rpm'
Version suffix: '~20260811.bkc.20260818'
Full version  : '10.1.0~20260811.bkc.20260818'
Setting github output:
{
  "rocm_package_version": "10.1.0a20260811+bkc.20260818",
  "rocm_deb_package_version": "10.1.0~20260811.bkc.20260818",
  "rocm_rpm_package_version": "10.1.0~20260811.bkc.20260818"
}
```

After merging this and related changes in rockrel we can trigger a real `nightly-bkc` release and watch the versions be set.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
