### PR TITLE
[bkc] Cherry-pick "comm-libs: pretranslate RCCL gfx1250 hotswap cache (#7460)"

### DIFF
--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -751,6 +751,7 @@ disable_platforms = ["windows"]
 artifact_group = "comm-libs"
 type = "target-specific"
 artifact_deps = ["core-runtime", "core-hip", "hipify", "rocprofiler-sdk", "core-amdsmi", "openmpi"]
+split_databases = ["hotswap_cache"]
 disable_platforms = ["windows"]
 
 [artifacts.rocshmem]

--- a/cmake/therock_artifacts.cmake
+++ b/cmake/therock_artifacts.cmake
@@ -238,6 +238,7 @@ function(therock_provide_artifact slice_name)
   # When splitting is enabled, run split_artifacts.py on each component
   if(_should_split)
     set(_split_tool "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/shared/kpack/python/rocm_kpack/tools/split_artifacts.py")
+    set(_split_database_handlers "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/shared/kpack/python/rocm_kpack/database_handlers.py")
     set(_bundler_path "${THEROCK_BINARY_DIR}/compiler/amd-llvm/dist/lib/llvm/bin/clang-offload-bundler")
     set(_split_manifest_files)
     set(_split_component_dirs)
@@ -275,6 +276,7 @@ function(therock_provide_artifact slice_name)
         DEPENDS
           "${_unsplit_manifest}"
           "${_split_tool}"
+          "${_split_database_handlers}"
         VERBATIM
       )
     endforeach()

--- a/comm-libs/CMakeLists.txt
+++ b/comm-libs/CMakeLists.txt
@@ -67,6 +67,40 @@ if(THEROCK_ENABLE_RCCL)
   therock_cmake_subproject_activate(rccl)
   list(APPEND _rccl_subproject_names rccl)
 
+  if(THEROCK_ENABLE_ROCJITSU_HOTSWAP AND THEROCK_FLAG_KPACK_SPLIT_ARTIFACTS)
+    therock_cmake_subproject_dist_dir(_rccl_dist_dir rccl)
+    therock_cmake_subproject_dist_dir(_rocjitsu_dist_dir rocjitsu)
+
+    # Generate the install-owned translation tier from RCCL before KPACK splits
+    # its fat binary. The splitter then assigns this tree only to gfx1250.
+    therock_cmake_subproject_declare(rccl-translate
+      DISABLE_AMDGPU_TARGETS
+      NO_MERGE_COMPILE_COMMANDS
+      BACKGROUND_BUILD
+      FPRINT_SOURCE_HASH
+      EXTERNAL_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/rccl-translate"
+      BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rccl-translate"
+      CMAKE_ARGS
+        -DRCCL_ROOT=${_rccl_dist_dir}
+        -DROCJITSU_ROOT=${_rocjitsu_dist_dir}
+        -DROCJITSU_PRETRANSLATE_DRIVER=${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/emulation/rocjitsu/scripts/rocjitsu-pretranslate.py
+        -DKPACK_PYTHON_SOURCE=${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/shared/kpack/python
+        # TODO: Set ON once RocJitsu supports every RCCL gfx1250 code object.
+        -DRCCL_TRANSLATE_FAIL_ON_SKIPPED=OFF
+      EXTRA_DEPENDS
+        ${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/emulation/rocjitsu/scripts/rocjitsu-pretranslate.py
+        ${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/shared/kpack/python/rocm_kpack/binutils.py
+        ${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/shared/kpack/python/rocm_kpack/ccob_parser.py
+        ${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/shared/kpack/python/rocm_kpack/tools/bulk_unbundle.py
+      BUILD_DEPS
+        rccl
+        rocjitsu
+        rocm-kpack
+    )
+    therock_cmake_subproject_activate(rccl-translate)
+    list(APPEND _rccl_subproject_names rccl-translate)
+  endif()
+
   if(THEROCK_BUILD_TESTING)
 
     set(_rccl_tests_optional_deps)

--- a/comm-libs/artifact-rccl.toml
+++ b/comm-libs/artifact-rccl.toml
@@ -23,3 +23,11 @@ include = [
   "bin/**",
 ]
 optional = true
+
+# rccl-translate (present only for gfx1250 hotswap builds)
+[components.lib."comm-libs/rccl-translate/stage"]
+default_patterns = false
+include = [
+  "share/rocjitsu/translations/**",
+]
+optional = true

--- a/comm-libs/rccl-translate/CMakeLists.txt
+++ b/comm-libs/rccl-translate/CMakeLists.txt
@@ -1,0 +1,87 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+cmake_minimum_required(VERSION 3.25)
+project(rccl-translate LANGUAGES NONE)
+
+find_package(Python3 3.9 COMPONENTS Interpreter REQUIRED)
+
+option(
+  RCCL_TRANSLATE_FAIL_ON_SKIPPED
+  "Fail when RocJitsu rejects a discovered RCCL code object"
+  OFF
+)
+
+foreach(_required_path RCCL_ROOT ROCJITSU_ROOT KPACK_PYTHON_SOURCE)
+  if(NOT IS_ABSOLUTE "${${_required_path}}")
+    message(FATAL_ERROR "${_required_path} must be an absolute path")
+  endif()
+endforeach()
+
+find_library(RCCL_LIBRARY
+  NAMES rccl
+  PATHS "${RCCL_ROOT}/lib"
+  NO_DEFAULT_PATH
+  REQUIRED
+)
+find_program(ROCJITSU_PRETRANSLATE_TOOL
+  NAMES rj_pretranslate
+  PATHS "${ROCJITSU_ROOT}/bin"
+  NO_DEFAULT_PATH
+  REQUIRED
+)
+find_program(ROCJITSU_PRETRANSLATE_DRIVER
+  NAMES rocjitsu-pretranslate.py
+  PATHS "${ROCJITSU_ROOT}/bin"
+  NO_DEFAULT_PATH
+  REQUIRED
+)
+
+set(_unbundled_dir "${CMAKE_CURRENT_BINARY_DIR}/unbundled")
+set(_cache_root "${CMAKE_CURRENT_BINARY_DIR}/cache")
+set(_report_dir "${CMAKE_CURRENT_BINARY_DIR}/report")
+set(_temporary_root "${CMAKE_CURRENT_BINARY_DIR}/temporary")
+set(_translation_stamp "${CMAKE_CURRENT_BINARY_DIR}/translation.stamp")
+set(_strict_args)
+if(RCCL_TRANSLATE_FAIL_ON_SKIPPED)
+  list(APPEND _strict_args --fail-on-skipped)
+endif()
+
+add_custom_command(
+  OUTPUT "${_translation_stamp}"
+  COMMENT "Pre-translating RCCL gfx1250 device code"
+  COMMAND "${CMAKE_COMMAND}" -E rm -rf
+    "${_unbundled_dir}" "${_cache_root}" "${_report_dir}" "${_temporary_root}"
+  COMMAND "${CMAKE_COMMAND}" -E env "PYTHONPATH=${KPACK_PYTHON_SOURCE}"
+    "${Python3_EXECUTABLE}" -m rocm_kpack.tools.bulk_unbundle
+    --gfx-arch gfx1250
+    --output-dir "${_unbundled_dir}"
+    "${RCCL_LIBRARY}"
+  COMMAND "${Python3_EXECUTABLE}" "${ROCJITSU_PRETRANSLATE_DRIVER}"
+    --tool "${ROCJITSU_PRETRANSLATE_TOOL}"
+    --store-root "${_cache_root}"
+    --report-dir "${_report_dir}"
+    --temporary-root "${_temporary_root}"
+    --target gfx1250
+    --skip-kpack
+    --skip-compressed
+    --portable
+    ${_strict_args}
+    "${_unbundled_dir}"
+  COMMAND "${CMAKE_COMMAND}" -E touch "${_translation_stamp}"
+  DEPENDS
+    "${RCCL_LIBRARY}"
+    "${ROCJITSU_PRETRANSLATE_TOOL}"
+    "${ROCJITSU_PRETRANSLATE_DRIVER}"
+    "${KPACK_PYTHON_SOURCE}/rocm_kpack/binutils.py"
+    "${KPACK_PYTHON_SOURCE}/rocm_kpack/ccob_parser.py"
+    "${KPACK_PYTHON_SOURCE}/rocm_kpack/tools/bulk_unbundle.py"
+  VERBATIM
+)
+
+add_custom_target(rccl-translate-cache ALL DEPENDS "${_translation_stamp}")
+
+install(
+  DIRECTORY "${_cache_root}/"
+  DESTINATION share/rocjitsu/translations
+)

--- a/test_tools/therock_consumer_graph.json
+++ b/test_tools/therock_consumer_graph.json
@@ -255,10 +255,14 @@
   },
   "rccl": {
     "consumers": [
-      "rccl-tests"
+      "rccl-tests",
+      "rccl-translate"
     ]
   },
   "rccl-tests": {
+    "consumers": []
+  },
+  "rccl-translate": {
     "consumers": []
   },
   "rdc": {
@@ -293,6 +297,7 @@
   },
   "rocjitsu": {
     "consumers": [
+      "rccl-translate",
       "rocjitsu-hotswap"
     ]
   },
@@ -363,7 +368,8 @@
   "rocm-kpack": {
     "consumers": [
       "hip-clr",
-      "hipkernelprovider"
+      "hipkernelprovider",
+      "rccl-translate"
     ]
   },
   "rocm_smi_lib": {


### PR DESCRIPTION
This cherry-picks https://github.com/ROCm/TheRock/pull/7460 onto the BKC release branch (context: https://github.com/ROCm/rockrel/issues/88).

The prerequisite code from https://github.com/ROCm/rocm-systems/pull/10037 is already present on the release branch via https://github.com/ROCm/rocm-systems/commit/21c9da4674a9281f86076064a326b88a4882d1aa.