### PR TITLE
Drop rocm meta package self-dependency (#7461)

### DIFF
--- a/build_tools/packaging/python/templates/rocm/setup.py
+++ b/build_tools/packaging/python/templates/rocm/setup.py
@@ -49,11 +49,7 @@ print(
 
 
 TARGET_FAMILY = dist_info.determine_target_family()
-INSTALL_REQUIRES = [
-    pkg.get_dist_package_require(target_family=TARGET_FAMILY)
-    for pkg in dist_info.ALL_PACKAGES.values()
-    if pkg.required
-]
+INSTALL_REQUIRES = dist_info.build_install_requires(target_family=TARGET_FAMILY)
 print(f"install_requires={INSTALL_REQUIRES}")
 EXTRAS_REQUIRE = {
     pkg.logical_name: [pkg.get_dist_package_require(target_family=TARGET_FAMILY)]

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
@@ -365,3 +365,14 @@ def build_per_target_extras() -> "dict[str, list[str]]":
             all_requires.append(req)
         result[f"{pkg.logical_name}-all"] = all_requires
     return result
+
+
+def build_install_requires(target_family: str) -> list[str]:
+    """Builds install_requires for the rocm meta package."""
+    return [
+        pkg.get_dist_package_require(target_family=target_family)
+        for pkg in ALL_PACKAGES.values()
+        # Excludes the meta package itself so the rocm sdist never
+        # declares a Requires-Dist on its own distribution name.
+        if pkg.required and pkg.logical_name != "meta"
+    ]

--- a/build_tools/tests/py_packaging_test.py
+++ b/build_tools/tests/py_packaging_test.py
@@ -822,6 +822,58 @@ class RestrictFamiliesTest(TmpDirTestCase):
         self.assertNotIn("AVAILABLE_TARGET_FAMILIES.clear()", content)
         self.assertNotIn("gfx94X-dcgpu", content)
 
+    def test_dist_info_object_matches_generated_file(self):
+        """params.dist_info (in-memory, built via direct attribute assignment
+        onto the static template) and the _dist_info.py written to disk (built
+        via repr()-encoded source text) must agree on every user-controlled
+        field, so the two initialization paths can't silently drift apart the
+        way they did when a version bug was previously introduced in only one
+        of the two places.
+        """
+        artifact_dir = self.temp_dir / "artifacts"
+        self._add_artifact(artifact_dir, "base", "lib", "gfx942")
+        self._add_artifact(artifact_dir, "base", "lib", "gfx1100")
+        dest_dir = self.temp_dir / "packages"
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        params = Parameters(
+            dest_dir=dest_dir,
+            version="7.0.0",
+            version_suffix="rc1",
+            artifacts=ArtifactCatalog(artifact_dir),
+        )
+
+        ns: dict = {}
+        exec(params.dist_info_contents, ns)
+
+        self.assertEqual(ns["__version__"], params.dist_info.__version__)
+        self.assertEqual(
+            ns["PY_PACKAGE_SUFFIX_NONCE"], params.dist_info.PY_PACKAGE_SUFFIX_NONCE
+        )
+        self.assertEqual(
+            ns["DEFAULT_TARGET_FAMILY"], params.dist_info.DEFAULT_TARGET_FAMILY
+        )
+        self.assertEqual(
+            sorted(ns["AVAILABLE_TARGET_FAMILIES"]),
+            sorted(params.dist_info.AVAILABLE_TARGET_FAMILIES),
+        )
+
+        meta = PopulatedDistPackage(params, logical_name="meta")
+        env = os.environ.copy()
+        env["ROCM_SDK_TARGET_FAMILY"] = "gfx942"
+        subprocess.run(
+            [sys.executable, "setup.py", "egg_info"],
+            cwd=meta.path,
+            env=env,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+
+        pkg_info = (meta.path / "src" / "rocm.egg-info" / "PKG-INFO").read_text()
+        self.assertNotIn("Requires-Dist: rocm==7.0.0\n", pkg_info)
+        self.assertIn("Requires-Dist: rocm-sdk-core==7.0.0\n", pkg_info)
+
 
 # ---------------------------------------------------------------------------
 # Tests for cross-platform family awareness in the rocm sdist


### PR DESCRIPTION
Cherry-picks commit 25e6298 into the ROCm 7.14 release branch. As part of this, backports a scoped packaging test.

---

## Motivation

The rocm sdist should depend on required runtime packages, but it must not emit a Requires-Dist entry for the rocm distribution itself. Keep the meta package registered for package generation and centralize install_requires construction in dist_info so setup.py cannot blindly include the logical meta entry.

JIRA ID: ROCM-29573
Issue #7362

## Technical Details

The regression stays in the generated dist-info test. It now runs egg_info for a materialized rocm package and checks PKG-INFO for rocm-sdk-core without a rocm self dependency.

## Test Plan

- python build_tools/tests/py_packaging_test.py RestrictFamiliesTest
- python build_tools/tests/py_packaging_test.py
- python -m py_compile build_tools/packaging/python/templates/rocm/setup.py build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py build_tools/tests/py_packaging_test.py

## Test Result

- Passed: RestrictFamiliesTest (9 tests)
- Passed: py_packaging_test.py (68 tests)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.

Generated with Codex