### PR TITLE
DO NOT REVIEW: CI probe — drop nlohmann-json dep edge

### DIFF
--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -799,7 +799,7 @@ disable_platforms = ["windows"]
 [artifacts.profiler-hub]
 artifact_group = "profiler-core"
 type = "target-neutral"
-artifact_deps = ["core-runtime", "base", "rocprofiler-sdk", "spdlog", "nlohmann-json"]
+artifact_deps = ["core-runtime", "base", "rocprofiler-sdk", "spdlog"]
 feature_name = "PROFILER_HUB"
 feature_group = "PROFILER"
 disable_platforms = ["windows"]

--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -796,6 +796,14 @@ artifact_deps = ["rocprofiler-sdk", "openmpi"]
 feature_group = "PROFILER"
 disable_platforms = ["windows"]
 
+[artifacts.profiler-hub]
+artifact_group = "profiler-core"
+type = "target-neutral"
+artifact_deps = ["core-runtime", "base", "rocprofiler-sdk", "spdlog", "nlohmann-json"]
+feature_name = "PROFILER_HUB"
+feature_group = "PROFILER"
+disable_platforms = ["windows"]
+
 [artifacts.rocprofiler-systems]
 artifact_group = "profiler-apps"
 type = "target-neutral"

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -297,7 +297,7 @@ endif(THEROCK_ENABLE_ROCPROFILER_COMPUTE)
 # that needs it.
 ##############################################################################
 if(THEROCK_ENABLE_PROFILER_HUB)
-  set(_profiler_hub_build_deps therock-nlohmann-json therock-spdlog therock-fmt)
+  set(_profiler_hub_build_deps therock-spdlog therock-fmt)
   if(THEROCK_BUILD_TESTING)
     list(APPEND _profiler_hub_build_deps therock-googletest)
   endif()

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -326,7 +326,6 @@ if(THEROCK_ENABLE_PROFILER_HUB)
     INTERFACE_LINK_DIRS
       lib
   )
-  therock_cmake_subproject_provide_package(profiler-hub profiler-hub lib/cmake/profiler-hub)
   therock_cmake_subproject_activate(profiler-hub)
 
   # Actually run the gtest binary built above instead of only compiling it.
@@ -380,11 +379,10 @@ if(THEROCK_ENABLE_ROCPROFSYS)
     message(STATUS "Detected Python root dirs for rocprofiler-systems: ${_ROCPROFSYS_PYTHON_ROOT_DIRS_STR}")
   endif()
 
-  # rocprofiler-systems' cmake/ProfilerHub.cmake calls find_package(profiler-hub).
-  # When profiler-hub is built as a super-project subproject, TheRock's dependency
-  # provider requires it to be declared as a dep here; when it is not, find_package
-  # falls back to profiler-hub's own sparse checkout. Only declare the dep when the
-  # profiler-hub subproject actually exists.
+  # profiler-hub is built and published as its own artifact above, but is not yet
+  # provided to rocprofiler-systems, which keeps its sparse-checkout fallback in
+  # cmake/ProfilerHub.cmake until profiler-hub is packaged in an immediate follow-on
+  # PR. This dep only orders the two subprojects.
   set(_rocprofsys_profiler_hub_dep "")
   if(THEROCK_ENABLE_PROFILER_HUB)
     set(_rocprofsys_profiler_hub_dep profiler-hub)

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -291,6 +291,70 @@ if(THEROCK_ENABLE_ROCPROFILER_COMPUTE)
 endif(THEROCK_ENABLE_ROCPROFILER_COMPUTE)
 
 ##############################################################################
+# profiler-hub
+# General-purpose, schema-versioned data storage library for profiling and
+# tracing tools, designed to be built and consumed standalone by any tool
+# that needs it.
+##############################################################################
+if(THEROCK_ENABLE_PROFILER_HUB)
+  set(_profiler_hub_build_deps therock-nlohmann-json therock-spdlog therock-fmt)
+  if(THEROCK_BUILD_TESTING)
+    list(APPEND _profiler_hub_build_deps therock-googletest)
+  endif()
+
+  therock_cmake_subproject_declare(profiler-hub
+    # profiler-hub is a pure host C++ library with no GPU/HIP code, so it
+    # does not require any AMDGPU targets to be selected.
+    DISABLE_AMDGPU_TARGETS
+    # Host C++ lib: build with in-tree clang (amd-llvm) so its tests get ASan-linked.
+    COMPILER_TOOLCHAIN amd-llvm
+    EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/profilers/profiler-hub"
+    BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/profiler-hub"
+    BACKGROUND_BUILD
+    CMAKE_ARGS
+      -DPROFILER_HUB_BUILD_TESTS=${THEROCK_BUILD_TESTING}
+      -DPROFILER_HUB_BUILD_BENCHMARKS=OFF
+    CMAKE_INCLUDES
+      therock_explicit_finders.cmake
+    BUILD_DEPS
+      ${_profiler_hub_build_deps}
+    RUNTIME_DEPS
+      rocprofiler-sdk
+      ${THEROCK_BUNDLED_SQLITE3}
+    INTERFACE_INCLUDE_DIRS
+      include
+    INTERFACE_LINK_DIRS
+      lib
+  )
+  therock_cmake_subproject_provide_package(profiler-hub profiler-hub lib/cmake/profiler-hub)
+  therock_cmake_subproject_activate(profiler-hub)
+
+  # Actually run the gtest binary built above instead of only compiling it.
+  therock_cmake_subproject_build_test(profiler-hub
+    COMMAND "${CMAKE_CTEST_COMMAND}" --output-on-failure --no-tests=error
+  )
+
+  therock_test_validate_shared_lib(PATH ${CMAKE_CURRENT_BINARY_DIR}/profiler-hub/dist/lib
+    LIB_NAMES
+      libprofiler-hub.so
+  )
+
+  therock_provide_artifact(profiler-hub
+    TARGET_NEUTRAL
+    DESCRIPTOR artifact-profiler-hub.toml
+    COMPONENTS
+      dbg
+      dev
+      doc
+      lib
+      run
+      test
+    SUBPROJECT_DEPS
+      profiler-hub
+  )
+endif(THEROCK_ENABLE_PROFILER_HUB)
+
+##############################################################################
 # rocprofiler-systems
 ##############################################################################
 if(THEROCK_ENABLE_ROCPROFSYS)
@@ -314,6 +378,16 @@ if(THEROCK_ENABLE_ROCPROFSYS)
     list(JOIN _rocprofsys_detected_python_versions "\;" _ROCPROFSYS_PYTHON_VERSIONS_STR)
     message(STATUS "Detected Python versions for rocprofiler-systems: ${_ROCPROFSYS_PYTHON_VERSIONS_STR}")
     message(STATUS "Detected Python root dirs for rocprofiler-systems: ${_ROCPROFSYS_PYTHON_ROOT_DIRS_STR}")
+  endif()
+
+  # rocprofiler-systems' cmake/ProfilerHub.cmake calls find_package(profiler-hub).
+  # When profiler-hub is built as a super-project subproject, TheRock's dependency
+  # provider requires it to be declared as a dep here; when it is not, find_package
+  # falls back to profiler-hub's own sparse checkout. Only declare the dep when the
+  # profiler-hub subproject actually exists.
+  set(_rocprofsys_profiler_hub_dep "")
+  if(THEROCK_ENABLE_PROFILER_HUB)
+    set(_rocprofsys_profiler_hub_dep profiler-hub)
   endif()
 
   # When libiberty is bundled; otherwise let rocprofiler-systems build its own.
@@ -359,6 +433,7 @@ if(THEROCK_ENABLE_ROCPROFSYS)
       amdsmi
       aqlprofile
       hip-clr
+      ${_rocprofsys_profiler_hub_dep}
       rocprofiler-register
       rocprofiler-sdk
       ${THEROCK_BUNDLED_LIBIBERTY}

--- a/profiler/artifact-profiler-hub.toml
+++ b/profiler/artifact-profiler-hub.toml
@@ -1,0 +1,20 @@
+# profiler-hub
+[components.lib."profiler/profiler-hub/stage"]
+include = [
+  "lib/libprofiler-hub.so*",
+]
+# profiler-hub ships no runtime executables or runtime data files.
+# 'run' has no default include patterns, so it is omitted entirely here
+# rather than declared bare - a bare entry would act as a catch-all and
+# claim the headers/static-lib/cmake files meant for 'dev' (see
+# build_tools/_therock_utils/artifact_builder.py ComponentDefaults("run", ...)).
+# Debug split is handled by the strip step; no extra files belong here.
+[components.dbg."profiler/profiler-hub/stage"]
+[components.dev."profiler/profiler-hub/stage"]
+include = [
+  "include/profiler-hub/**",
+  "lib/libprofiler-hub.a",
+  "lib/cmake/profiler-hub/**",
+]
+[components.doc."profiler/profiler-hub/stage"]
+[components.test."profiler/profiler-hub/stage"]

--- a/profiler/artifact-profiler-hub.toml
+++ b/profiler/artifact-profiler-hub.toml
@@ -3,12 +3,7 @@
 include = [
   "lib/libprofiler-hub.so*",
 ]
-# profiler-hub ships no runtime executables or runtime data files.
-# 'run' has no default include patterns, so it is omitted entirely here
-# rather than declared bare - a bare entry would act as a catch-all and
-# claim the headers/static-lib/cmake files meant for 'dev' (see
-# build_tools/_therock_utils/artifact_builder.py ComponentDefaults("run", ...)).
-# Debug split is handled by the strip step; no extra files belong here.
+# 'run' omitted rather than declared bare: a bare 'run' is a catch-all and would claim dev's files.
 [components.dbg."profiler/profiler-hub/stage"]
 [components.dev."profiler/profiler-hub/stage"]
 include = [

--- a/test_tools/therock_consumer_graph.json
+++ b/test_tools/therock_consumer_graph.json
@@ -28,6 +28,7 @@
       "kfdtest",
       "libhipcxx",
       "ocl-clr",
+      "profiler-hub",
       "rdc",
       "rocgdb",
       "rocminfo",
@@ -257,6 +258,11 @@
       "hipsparselt"
     ]
   },
+  "profiler-hub": {
+    "consumers": [
+      "rocprofiler-systems"
+    ]
+  },
   "rccl": {
     "consumers": [
       "rccl-tests"
@@ -425,6 +431,7 @@
       "hipblaslt",
       "hipsparselt",
       "miopen",
+      "profiler-hub",
       "rccl",
       "rdc",
       "rocblas",
@@ -596,6 +603,7 @@
     "consumers": [
       "hipblaslt",
       "hipdnn",
+      "profiler-hub",
       "rccl",
       "rocprofiler-systems",
       "rocroller",
@@ -644,6 +652,7 @@
       "miopen",
       "miopenprovider",
       "mxdatagenerator",
+      "profiler-hub",
       "rccl",
       "rocalution",
       "rocblas",
@@ -771,6 +780,7 @@
       "hipkernelprovider",
       "miopen",
       "miopenprovider",
+      "profiler-hub",
       "therock-frugally-deep"
     ]
   },
@@ -796,6 +806,7 @@
     "consumers": [
       "hipblaslt",
       "hipdnn",
+      "profiler-hub",
       "rocprofiler-systems",
       "rocroller"
     ]
@@ -803,6 +814,7 @@
   "therock-sqlite3": {
     "consumers": [
       "miopen",
+      "profiler-hub",
       "rocprofiler-compute",
       "rocprofiler-sdk",
       "rocprofiler-systems",

--- a/test_tools/therock_consumer_graph.json
+++ b/test_tools/therock_consumer_graph.json
@@ -780,7 +780,6 @@
       "hipkernelprovider",
       "miopen",
       "miopenprovider",
-      "profiler-hub",
       "therock-frugally-deep"
     ]
   },
@@ -846,6 +845,7 @@
       "kfdtest",
       "rdc",
       "rocgdb",
+      "rocprofiler-compute",
       "rocr-runtime",
       "therock-elfutils",
       "therock-grpc"

--- a/tests/test_artifact_structure.py
+++ b/tests/test_artifact_structure.py
@@ -74,6 +74,11 @@ KNOWN_UNCOVERED_COMPONENTS: set[tuple[str, str]] = {
     ("hipthreads", "dev"),
     ("hipthreads", "test"),
     ("mirage", "dev"),  # new artifact, no packages yet.
+    ("profiler-hub", "dev"),  # packaging deferred to #7377; remove all five with it.
+    ("profiler-hub", "doc"),
+    ("profiler-hub", "lib"),
+    ("profiler-hub", "run"),
+    ("profiler-hub", "test"),
     ("rocjitsu", "dev"),  # new artifact, no packages yet.
     ("rocprofiler-systems-examples", "test"),
     ("rocrtst", "lib"),

--- a/tests/test_artifact_structure.py
+++ b/tests/test_artifact_structure.py
@@ -74,7 +74,7 @@ KNOWN_UNCOVERED_COMPONENTS: set[tuple[str, str]] = {
     ("hipthreads", "dev"),
     ("hipthreads", "test"),
     ("mirage", "dev"),  # new artifact, no packages yet.
-    ("profiler-hub", "dev"),  # packaging deferred to #7377; remove all five with it.
+    ("profiler-hub", "dev"),  # built, not packaged; the follow-on PR removes all five.
     ("profiler-hub", "doc"),
     ("profiler-hub", "lib"),
     ("profiler-hub", "run"),


### PR DESCRIPTION
Throwaway diagnostic for #7376: #7376's tree with profiler-hub's nlohmann-json dependency edge removed (BUILD_DEPS and artifact_deps), to see whether that clears the Windows math-libs natvis failure. Will be closed once CI reports.