### PR TITLE
ci(rocgdb): Improve wall clock time for rocgdb-* tests

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -357,13 +357,13 @@ test_matrix = {
     "rocgdb-cpu": {
         **_rocgdb_common,
         "job_name": "rocgdb-cpu",
-        "test_script": "python ./build/tests/rocgdb/test_rocgdb.py --tests gdb.dwarf2",
+        "test_script": "python ./build/tests/rocgdb/test_rocgdb.py --parallel -f 0.25 --tests gdb.dwarf2",
         "linux_cpu_runner": True,
     },
     "rocgdb-gpu": {
         **_rocgdb_common,
         "job_name": "rocgdb-gpu",
-        "test_script": "python ./build/tests/rocgdb/test_rocgdb.py --tests gdb.rocm",
+        "test_script": "python ./build/tests/rocgdb/test_rocgdb.py --parallel -f 0.25 --toolchain llvm --tests gdb.rocm",
     },
     # Corefile tests require specific hardware support (GPU core dump capable runners).
     # test_runner is pre-pinned so the family-based runner selection loop skips it.
@@ -371,7 +371,7 @@ test_matrix = {
         **_rocgdb_common,
         "job_name": "rocgdb-corefile",
         "test_script": (
-            "python ./build/tests/rocgdb/test_rocgdb.py --tests"
+            "python ./build/tests/rocgdb/test_rocgdb.py --parallel -f 0.25 --toolchain llvm --tests"
             " gdb.rocm/corefile.exp"
             " gdb.rocm/core-no-read-special-files.exp"
             " gdb.rocm/gcore-after-attach.exp"


### PR DESCRIPTION
Pass `--parallel -f 0.25` to all three rocgdb test jobs so tests run in parallel using 25% of the available cores on the machine. Also pass `--toolchain llvm` to `rocgdb-gpu` and `rocgdb-corefile` to restrict runs to the LLVM toolchain, which is the compiler used for GPU code paths.

I expect the rocgdb-cpu jobs to get a reasonable speed up due to parallel compilations/runs. The wall clock time for rocgdb-gpu/rocgdb-corefile tests will be slashed in half at least, plus additional reduction from parallel compilations.

@skip-pr-bot