### PR TITLE
ci: raise setup test environment timeout from 15 to 25 minutes

### DIFF
--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -130,10 +130,10 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: Run setup test environment workflow
-        timeout-minutes: 15
+        timeout-minutes: 25
         env:
           RETRY_THIS_STEP: "true"
-          STEP_TIMEOUT_MINUTES: "15" # should match timeout-minutes specified above at this step
+          STEP_TIMEOUT_MINUTES: "25" # should match timeout-minutes specified above at this step
         uses: './.github/actions/setup_test_environment'
         with:
           ARTIFACT_RUN_ID: ${{ env.ARTIFACT_RUN_ID }}


### PR DESCRIPTION
## Summary

- Raises the `Run setup test environment workflow` step timeout from 15 to 25 minutes in `test_component.yml`
- Updates both `timeout-minutes` and the matching `STEP_TIMEOUT_MINUTES` env var (kept in sync per the existing comment)

The step was observed timing out at 15 minutes (e.g. https://github.com/ROCm/TheRock/actions/runs/32165005832/job/96055002747?pr=7449).

## Test plan

- [x] Confirm the setup test environment step completes within 25 minutes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

@skip-pr-bot