### PR TITLE
Apply amd-mesa version script per meson target, not project-wide

### DIFF
--- a/third-party/sysdeps/linux/amd-mesa/CMakeLists.txt
+++ b/third-party/sysdeps/linux/amd-mesa/CMakeLists.txt
@@ -65,7 +65,7 @@ add_custom_target(
     # Step 1: Initial meson setup to download libva-2.22.0 subproject
     # This is required before patching because patch_source.sh modifies files in the libva subproject
     "${CMAKE_COMMAND}" -E env
-      "LDFLAGS=-Wl,-rpath='$$ORIGIN' -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/version.lds"
+      "LDFLAGS=-Wl,-rpath='$$ORIGIN'"
       "CC=${_meson_cc}"
       "CXX=${_meson_cxx}"
       --
@@ -111,7 +111,7 @@ add_custom_target(
     # Step 3: Reconfigure meson to build from patched source
     # This ensures the build system uses the modified source files
     "${CMAKE_COMMAND}" -E env
-      "LDFLAGS=-Wl,-rpath='$$ORIGIN' -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/version.lds"
+      "LDFLAGS=-Wl,-rpath='$$ORIGIN'"
       "CC=${_meson_cc}"
       "CXX=${_meson_cxx}"
       --

--- a/third-party/sysdeps/linux/amd-mesa/patch_source.sh
+++ b/third-party/sysdeps/linux/amd-mesa/patch_source.sh
@@ -5,7 +5,9 @@
 set -e
 
 SOURCE_DIR="${1:?Source directory must be given}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 VA_MESON_BUILD="$SOURCE_DIR/src/gallium/targets/va/meson.build"
+VERSION_LDS="$SCRIPT_DIR/version.lds"
 
 # Detect the libva subproject directory without hardcoding the version number.
 LIBVA_SUBPROJECT_DIR="$(echo "$SOURCE_DIR"/subprojects/libva-[0-9]*/)"
@@ -30,6 +32,43 @@ sed -i -E "/shared_library\(/,/\)/ s/'va',/'rocm_sysdeps_va',/" "$LIBVA_MESON_BU
 
 # Replace 'va-drm' library name with 'rocm_sysdeps_va-drm' in libva meson.build
 sed -i -E "/shared_library\(/,/\)/ s/'va-drm',/'rocm_sysdeps_va-drm',/" "$LIBVA_MESON_BUILD"
+
+# Apply symbol versioning to the library targets instead of to the whole project.
+# Passing -Wl,--version-script via LDFLAGS applies it to every link in the
+# project, and meson duplicates such arguments in its compiler sanity check
+# (1.12.0), which ld rejects with "duplicate version tag". Per-target link_args
+# are not duplicated and are the correct scope for a version script anyway.
+#
+# Unlike the other meson sysdeps, two of these targets already carry a version
+# script of their own, so the sysdeps script has to be merged with care:
+#
+#   * The gallium VA megadriver uses mesa's va.sym, which is an *anonymous*
+#     version node. ld refuses to combine an anonymous node with the named
+#     AMDROCM_SYSDEPS_1.0 node ("anonymous version tag cannot be combined with
+#     other version tags"), so va.sym is replaced rather than appended to.
+#     This is a no-op in practice: with version.lds on LDFLAGS, mesa's own
+#     with_ld_version_script probe fails ("duplicate expression `*'", because
+#     build-support/conftest.map and version.lds both match `*`), so va.sym is
+#     already silently disabled today. Dropping it here keeps the linked result
+#     identical while making the behaviour explicit instead of accidental.
+#   * libva's va.syms uses named nodes and no `*` wildcard, so it coexists with
+#     AMDROCM_SYSDEPS_1.0 and is appended to rather than replaced.
+sed -i "\|^  va_link_args += \['-Wl,--version-script', join_paths(meson.current_build_dir(), 'va.sym')\]$|d" "$VA_MESON_BUILD"
+sed -i "s|^va_link_args = \[\]$|va_link_args = ['-Wl,--version-script=$VERSION_LDS']|" "$VA_MESON_BUILD"
+sed -i "s|^  link_args : libva_link_args,$|  link_args : [libva_link_args, '-Wl,--version-script=$VERSION_LDS'],|" "$LIBVA_MESON_BUILD"
+sed -i "/^  libva_drm = shared_library($/,/^  libva_drm_dep = declare_dependency($/ s|^\([[:space:]]*\)install : true,|\1link_args : ['-Wl,--version-script=$VERSION_LDS'],\n\1install : true,|" "$LIBVA_MESON_BUILD"
+
+# The VA megadriver must end up with exactly one version script, and both libva
+# targets must have picked one up. A silent sed miss here would ship unversioned
+# libraries, so fail loudly instead.
+if [[ "$(grep -c -- "--version-script" "$VA_MESON_BUILD")" != "1" ]]; then
+  echo "ERROR: Expected exactly one --version-script in $VA_MESON_BUILD" >&2
+  exit 1
+fi
+if [[ "$(grep -c -- "--version-script=$VERSION_LDS" "$LIBVA_MESON_BUILD")" != "2" ]]; then
+  echo "ERROR: Failed to patch both libva targets in $LIBVA_MESON_BUILD with --version-script" >&2
+  exit 1
+fi
 
 # Remove libva from pkg.generate block and add explicit name/libraries to override automatic detection
 sed -i "/pkg\.generate(libva,/,/version:/ s/pkg\.generate(libva,/pkg.generate(/" "$LIBVA_PKGCONFIG_MESON_BUILD"


### PR DESCRIPTION
## Motivation

ISSUE ID : https://github.com/ROCm/TheRock/issues/7488

Fixes #7488. Follow-on to #7287, which fixed the same meson 1.12.0 regression for `libdrm`
and `libpciaccess` but deliberately left `amd-mesa` out. Original report: #7286.

With `-DTHEROCK_ENABLE_SYSDEPS_AMD_MESA=ON` and a freshly resolved `requirements.txt`
(`meson>=1.7.0` → meson 1.12.0), `therock-amd-mesa` aborts in meson's compiler sanity check,
before any mesa source is parsed:

```
meson.build:4:0: ERROR: Compiler gcc cannot compile programs.
```

The real error is only in `meson-logs/meson-log.txt`, and note that the LDFLAGS appear twice:

```
Sanity check compiler command line: cc ... -D_FILE_OFFSET_BITS=64 \
  '-Wl,-rpath=$ORIGIN' -Wl,--version-script=.../version.lds \
  '-Wl,-rpath=$ORIGIN' -Wl,--version-script=.../version.lds
Sanity check compile stderr:
/usr/bin/ld: duplicate version tag `AMDROCM_SYSDEPS_1.0'
```

CI does not catch this because `dockerfiles/build_manylinux_x86_64.Dockerfile` pre-installs
`meson==1.7.0`, which already satisfies the `>=1.7.0` floor, so pip never upgrades.

## Technical Details

`amd-mesa` passed `-Wl,--version-script=.../version.lds` through the `LDFLAGS` environment
variable to both `meson setup` invocations (`CMakeLists.txt` lines 68 and 114), so it applied
to every link in the project. meson 1.12.0 duplicates user-supplied link args in its sanity
check, and a repeated `--version-script` naming the same tag is not idempotent.

The fix is the same shape as #7287 — move the version script onto the `shared_library()`
targets via `patch_source.sh`, which already rewrites these `meson.build` files to rename the
libraries — but **a blind port of #7287 breaks this build**, so the merge is done per target.

### Why a naive port fails

Two of the three targets already carry a version script:

| target | defined in | own version script | combines with `AMDROCM_SYSDEPS_1.0`? |
|---|---|---|---|
| `gallium_drv_video` | `src/gallium/targets/va/meson.build` | `va.sym` — an **anonymous** version node | **no** — `ld: anonymous version tag cannot be combined with other version tags` |
| `va` | libva subproject `va/meson.build` | `libva.syms` — named nodes, no `*` wildcard | yes |
| `va-drm` | libva subproject `va/meson.build` | none | yes |

The subtle part is *why* the megadriver links today. Mesa gates `va.sym` behind a
`with_ld_version_script` probe that link-tests `build-support/conftest.map`. That probe
inherits the environment `LDFLAGS`, so it actually tests `conftest.map` **and** `version.lds`
together — and since both use the `*` wildcard, `ld` rejects it:

```
Checking if "version-script" links: NO
/usr/bin/ld: duplicate expression `*' in version information
```

So `with_ld_version_script` is silently **false** today and mesa's `va.sym` is never applied.
Take `version.lds` off `LDFLAGS` and the probe starts passing, `va.sym` comes back, and the
link fails with the anonymous-tag error.

This PR therefore **replaces** `va.sym` on the megadriver rather than appending to it, and
**appends** alongside `libva.syms` on `va` / `va-drm`. That reproduces today's linked output
exactly, while making the behaviour explicit instead of a side effect of a flag that is being
removed. The verification below confirms the resulting binaries are unchanged.

### `radeonsi_drv_video`

`therock_test_validate_shared_lib` checks four names, but there are only three link targets.
`radeonsi_drv_video.so` is not a `shared_library()` — it is a symlink to the megadriver,
produced by a `custom_target` (`ln -sf`) plus mesa's `install_megadrivers` script. It needs no
`link_args`, and inherits versioning because it *is* the same file. `libgallium_drv_video.so`,
`libva.so` and `libva-drm.so` are likewise symlinks created by `patch_install.sh`. I confirmed
the installed tree contains no other shared library, so nothing else silently loses versioning.

`-Wl,-rpath='$$ORIGIN'` stays on `LDFLAGS`; repeating it is harmless.

### Scope — anything else affected?

I audited every sysdep for this pattern. Only meson-configured sysdeps can hit it:

- `libdrm`, `libpciaccess` — meson, already fixed by #7287.
- `amd-mesa` — meson, fixed here. **This was the last one.**
- `util-linux` — meson, but never puts a version script on `LDFLAGS`; upstream already wires
  its `.sym` files in via per-target `link_args`.
- `expat`, `gmp`, `hwloc`, `mpfr`, `ncurses` — autotools `./configure`, not meson.
- `bzip2`, `sqlite3`, `zstd` — CMake. `libcap` — patched Makefile.

## Test Plan

Built the `amd-mesa` sysdep from source on Ubuntu 24.04 by replaying the `add_custom_target`
command list by hand (copy sources → `meson setup` → `patch_source.sh` → `meson setup
--reconfigure` → `meson compile` → `DESTDIR= meson install` → `patch_install.sh`), with the
verbatim `-D...` option list from `CMakeLists.txt`.

TheRock's own `libdrm` sysdep has to be built first: mesa requires libdrm >= 2.4.133 and
Ubuntu 24.04 ships 2.4.125.

Compared, against an unmodified `main` baseline:

1. `meson setup` under meson 1.12.0 — previously the reported failure.
2. `meson compile` under both meson 1.11.2 and 1.12.0.
3. `readelf --version-info` on all three real libraries.
4. `readelf --dyn-syms` exported-symbol sets (including `@@VERSION` tags) diffed against
   baseline, to prove the fix is ABI-neutral.
5. The four symlinks `therock_test_validate_shared_lib` loads.

## Test Result

Built three times from the same tree: **baseline** = unmodified `main` with meson 1.11.2;
**fixed11 / fixed12** = this branch with meson 1.11.2 / 1.12.0.

| | baseline (main) | this branch |
|---|---|---|
| `meson setup`, meson 1.11.2 | pass | pass |
| `meson setup`, **meson 1.12.0** | **FAIL** — `Compiler gcc cannot compile programs` / `ld: duplicate version tag 'AMDROCM_SYSDEPS_1.0'` | **pass** |
| `meson compile`, 1.11.2 / 1.12.0 | pass / n/a | pass / pass |
| mesa `Checking if "version-script" links` | `NO` | `YES` |

The probe flipping `NO` → `YES` is the trap described above: mesa's `va.sym` becomes active
again once `version.lds` leaves `LDFLAGS`. Because `patch_source.sh` now removes `va.sym` from
the megadriver, the link still succeeds and the output is unchanged. Without that removal the
build fails with `ld: anonymous version tag cannot be combined with other version tags` — I
hit exactly that before arriving at this patch.

`readelf --version-info` on this branch, meson 1.12.0 (identical for 1.11.2 and for baseline):

```
librocm_sysdeps_gallium_drv_video.so
  000000: Rev: 1  Flags: BASE  Index: 1  Cnt: 1  Name: librocm_sysdeps_gallium_drv_video.so
  0x001c: Rev: 1  Flags: none  Index: 2  Cnt: 1  Name: AMDROCM_SYSDEPS_1.0

librocm_sysdeps_va.so.2.2200.0
  000000: Rev: 1  Flags: BASE  Index: 1  Cnt: 1  Name: librocm_sysdeps_va.so.2
  0x001c: Rev: 1  Flags: none  Index: 2  Cnt: 1  Name: VA_API_0.32.0
  0x0038: Rev: 1  Flags: none  Index: 3  Cnt: 2  Name: VA_API_0.33.0
  0x0054: Parent 1: VA_API_0.32.0
  0x005c: Rev: 1  Flags: none  Index: 4  Cnt: 1  Name: AMDROCM_SYSDEPS_1.0

librocm_sysdeps_va-drm.so.2.2200.0
  000000: Rev: 1  Flags: BASE  Index: 1  Cnt: 1  Name: librocm_sysdeps_va-drm.so.2
  0x001c: Rev: 1  Flags: none  Index: 2  Cnt: 1  Name: AMDROCM_SYSDEPS_1.0
```

libva's own `VA_API_0.32.0` / `VA_API_0.33.0` nodes are preserved — that was the main risk of
attaching `AMDROCM_SYSDEPS_1.0` to a target that already had a version script.

**ABI-neutral.** Diffing baseline against both fixed builds:

- `.gnu.version_d` (definitions) and `.gnu.version_r` (needs): identical for all three libraries.
- Exported dynamic symbols including their `@@VERSION` tags: identical — 768 / 93 / 2 symbols.
- Only byte-level difference anywhere is `.debug_line_str` (306 → 305 bytes), from the build
  directory name differing in length.

All four symlinks that `therock_test_validate_shared_lib` loads are present:

```
libgallium_drv_video.so -> librocm_sysdeps_gallium_drv_video.so
radeonsi_drv_video.so   -> librocm_sysdeps_gallium_drv_video.so
libva.so                -> librocm_sysdeps_va.so.2
libva-drm.so            -> librocm_sysdeps_va-drm.so.2
```

Not run: PR CI, and no GPU/runtime test — this is a link-time packaging change with no device
impact, and the binaries are bit-identical apart from a debug string table.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.

---

<sub>This change was developed with AI assistance (Claude). The root-cause analysis, the
meson/ld behaviour, the source builds and the before/after binary comparisons were executed
and verified by me, and I am accountable for the contribution.</sub>
