### PR TITLE
build_tools: add per-submodule CI labels for mesa-fork bump PRs

### DIFF
--- a/build_tools/github_actions/bump_automation.py
+++ b/build_tools/github_actions/bump_automation.py
@@ -73,6 +73,10 @@ SUBMODULE_CONFIG = {
         "updater": "submodule-only",
         # We will reuse the rocm-systems token for now.
         "token_key": "systems",
+        # Changes to mesa-fork can run a limited matrix of CI jobs:
+        #   * Build for all gfx archs
+        #   * mesa-fork tests only (no impact on other project builds/tests)
+        "labels": [*COMMON_CI_LABELS, "test:rocdecode", "test:rocjpeg"],
     },
 }
 

--- a/build_tools/github_actions/tests/fetch_test_configurations_test.py
+++ b/build_tools/github_actions/tests/fetch_test_configurations_test.py
@@ -621,6 +621,43 @@ class FetchTestConfigurationsTest(unittest.TestCase):
         self.assertEqual(job_names.count("rocgdb-gpu"), 1)
         self.assertEqual(job_names.count("rocgdb-corefile"), 1)
 
+    # -----------------------
+    # mesa-fork labels
+    # -----------------------
+
+    def test_rocdecode_label_selects_rocdecode_job(self):
+        """test:rocdecode should select the rocdecode job."""
+        with patch.dict(os.environ, {"TEST_LABELS": json.dumps(["test:rocdecode"])}):
+            fetch_test_configurations.run()
+            components = self._get_components()
+
+        names = {job["job_name"] for job in components}
+        self.assertIn("rocdecode", names)
+        self.assertNotIn("rocjpeg", names)
+
+    def test_rocjpeg_label_selects_rocjpeg_job(self):
+        """test:rocjpeg should select the rocjpeg job."""
+        with patch.dict(os.environ, {"TEST_LABELS": json.dumps(["test:rocjpeg"])}):
+            fetch_test_configurations.run()
+            components = self._get_components()
+
+        names = {job["job_name"] for job in components}
+        self.assertIn("rocjpeg", names)
+        self.assertNotIn("rocdecode", names)
+
+    def test_rocdecode_and_rocjpeg_labels_together(self):
+        """test:rocdecode and test:rocjpeg together should select both jobs."""
+        with patch.dict(
+            os.environ,
+            {"TEST_LABELS": json.dumps(["test:rocdecode", "test:rocjpeg"])},
+        ):
+            fetch_test_configurations.run()
+            components = self._get_components()
+
+        names = {job["job_name"] for job in components}
+        self.assertIn("rocdecode", names)
+        self.assertIn("rocjpeg", names)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

Mesa-fork bump PRs now receive `ci:run-all-archs`, `test:rocdecode`, and `test:rocjpeg` labels instead of no labels, limiting CI to the jobs directly exercised by mesa-fork changes. GitHub issue #7497 

## Technical Details

- `bump_automation.py`: adds a `"labels"` entry to the `third-party/sysdeps/linux/amd-mesa/mesa-fork` submodule config. The label list expands `COMMON_CI_LABELS` (`ci:run-all-archs`) and pins the two media-library test jobs (`test:rocdecode`, `test:rocjpeg`) that are directly relevant to mesa-fork changes.
- `fetch_test_configurations_test.py`: adds three tests (using `patch.dict(os.environ)`) verifying that `test:rocdecode` selects only the rocdecode job, `test:rocjpeg` selects only the rocjpeg job, and both labels together select both jobs. Both labels are single-key literals that fall through `TEST_LABEL_GROUPS` unchanged, so no change to `fetch_test_configurations.py` is required.

No functional change to the CI label-expansion logic; this is purely config and test coverage.


## Test Plan

rocdecode and rocjpeg tests should pass.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
