### PR TITLE
ci(jax): add release v0.11.1, retire v0.10.0, move the PR gate

### DIFF
--- a/.github/workflows/multi_arch_build_linux_jax_wheels_ci.yml
+++ b/.github/workflows/multi_arch_build_linux_jax_wheels_ci.yml
@@ -95,7 +95,7 @@ on:
         required: false
         default: ""
       jax_ref:
-        description: "JAX / rocm-jax release ref (e.g. rocm-jaxlib-v0.10.0, rocm-jaxlib-v0.10.2)."
+        description: "JAX / rocm-jax release ref (e.g. rocm-jaxlib-v0.11.0, rocm-jaxlib-v0.11.1)."
         type: string
         required: true
       rocm_version:

--- a/.github/workflows/test_jax_dockerfile.yml
+++ b/.github/workflows/test_jax_dockerfile.yml
@@ -22,7 +22,7 @@ on:
         required: true
         description: JAX plugin branch to checkout
         type: string
-        default: "rocm-jaxlib-v0.11.0"
+        default: "rocm-jaxlib-v0.11.1"
 
   workflow_call:
     inputs:
@@ -40,7 +40,7 @@ on:
       jax_plugin_branch:
         description: JAX plugin branch to checkout to use for test scripts
         type: string
-        default: "rocm-jaxlib-v0.11.0"
+        default: "rocm-jaxlib-v0.11.1"
 
 permissions:
   contents: read

--- a/.github/workflows/test_linux_jax_wheels.yml
+++ b/.github/workflows/test_linux_jax_wheels.yml
@@ -35,7 +35,7 @@ on:
         description: rocm-jax repository ref/branch to check out
         required: false
         type: string
-        default: "rocm-jaxlib-v0.11.0"
+        default: "rocm-jaxlib-v0.11.1"
       jax_version:
         description: "Base JAX version (e.g. 0.8.2) for installing jax from PyPI. Extracted from built wheels by write_jax_versions.py."
         required: false
@@ -109,7 +109,7 @@ on:
         description: rocm-jax repository ref/branch to check out
         required: false
         type: string
-        default: "rocm-jaxlib-v0.11.0"
+        default: "rocm-jaxlib-v0.11.1"
       jax_version:
         description: "Base JAX version (e.g. 0.8.2). Leave empty to auto-detect from rocm-jax requirements."
         required: false

--- a/.github/workflows/test_multi_arch_linux_jax_wheels.yml
+++ b/.github/workflows/test_multi_arch_linux_jax_wheels.yml
@@ -154,7 +154,7 @@ on:
       jax_ref:
         description: "rocm-jax repository ref/branch to check out"
         type: string
-        default: "rocm-jaxlib-v0.11.0"
+        default: "rocm-jaxlib-v0.11.1"
       jax_version:
         description: "Built JAX version"
         type: string

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -427,8 +427,8 @@ Install JAX with ROCm support using the unified multi-arch index.
 > ROCm 7.x and `jax_rocm10_*` for ROCm 10.x.
 
 ```bash
-# Set the version (currently supported: 0.10.0, 0.10.1, 0.10.2, and 0.11.0)
-JAX_VERSION=0.11.0
+# Set the version (currently supported: 0.10.0, 0.10.1, 0.10.2, 0.11.0, and 0.11.1)
+JAX_VERSION=0.11.1
 
 # 1. Install ROCm (replace device-gfx942 with your GPU)
 pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
@@ -460,8 +460,8 @@ print(jax.devices())
 > `jax_rocm10_plugin` name, so the GPU kernel modules resolve to `None` and no FFI
 > handlers are registered. Symptoms are `'NoneType' object has no attribute ...` and
 > `No FFI handler registered for hipsolver_*`. Those versions predate the upstream fix
-> ([jax-ml/jax#39634](https://github.com/jax-ml/jax/pull/39634)); until a `jaxlib`
-> carrying it ships, teach the installed copy about the new major:
+> ([jax-ml/jax#39634](https://github.com/jax-ml/jax/pull/39634)), which first shipped in
+> `jaxlib` 0.11.1. On an older `jaxlib`, teach the installed copy about the new major:
 >
 > ```bash
 > python external-builds/jax/patch_installed_jax_rocm_plugin_names.py \

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -427,7 +427,7 @@ Install JAX with ROCm support using the unified multi-arch index.
 > ROCm 7.x and `jax_rocm10_*` for ROCm 10.x.
 
 ```bash
-# Set the version (currently supported: 0.10.0, 0.10.1, 0.10.2, 0.11.0, and 0.11.1)
+# Set the version (currently supported: 0.10.1, 0.10.2, 0.11.0, and 0.11.1)
 JAX_VERSION=0.11.1
 
 # 1. Install ROCm (replace device-gfx942 with your GPU)
@@ -456,7 +456,7 @@ print(jax.devices())
 ```
 
 > [!NOTE]
-> On ROCm 10, a released `jaxlib` (0.10.0 through 0.11.0) does not know the
+> On ROCm 10, a released `jaxlib` (0.10.1 through 0.11.0) does not know the
 > `jax_rocm10_plugin` name, so the GPU kernel modules resolve to `None` and no FFI
 > handlers are registered. Symptoms are `'NoneType' object has no attribute ...` and
 > `No FFI handler registered for hipsolver_*`. Those versions predate the upstream fix

--- a/build_tools/github_actions/configure_jax_release_matrix.py
+++ b/build_tools/github_actions/configure_jax_release_matrix.py
@@ -53,6 +53,13 @@ JAX_REF_CONFIGS = {
         # JAX dropped Python 3.11 support in 0.11.0.
         "exclude_python_versions": ["3.11"],
     },
+    "rocm-jaxlib-v0.11.1": {
+        "jax_ref": "rocm-jaxlib-v0.11.1",
+        "jax_repository": "ROCm/jax",
+        "gfx_arch": "device-all",
+        # JAX dropped Python 3.11 support in 0.11.0.
+        "exclude_python_versions": ["3.11"],
+    },
 }
 
 # Keep release behavior equivalent to the old generate_jax_matrix(None):
@@ -66,6 +73,7 @@ RELEASE_JAX_REFS = {
         "rocm-jaxlib-v0.10.1",
         "rocm-jaxlib-v0.10.2",
         "rocm-jaxlib-v0.11.0",
+        "rocm-jaxlib-v0.11.1",
     ],
 }
 
@@ -74,7 +82,7 @@ RELEASE_JAX_REFS = {
 # rather than every release version. Additional refs can be opted in as needed.
 CI_JAX_REFS = {
     "linux": [
-        "rocm-jaxlib-v0.11.0",
+        "rocm-jaxlib-v0.11.1",
     ],
 }
 

--- a/build_tools/github_actions/configure_jax_release_matrix.py
+++ b/build_tools/github_actions/configure_jax_release_matrix.py
@@ -31,11 +31,6 @@ CI_PYTHON_VERSIONS = {
 }
 
 JAX_REF_CONFIGS = {
-    "rocm-jaxlib-v0.10.0": {
-        "jax_ref": "rocm-jaxlib-v0.10.0",
-        "jax_repository": "ROCm/jax",
-        "gfx_arch": "device-all",
-    },
     "rocm-jaxlib-v0.10.1": {
         "jax_ref": "rocm-jaxlib-v0.10.1",
         "jax_repository": "ROCm/jax",
@@ -69,7 +64,6 @@ JAX_REF_CONFIGS = {
 # should differ later.
 RELEASE_JAX_REFS = {
     "linux": [
-        "rocm-jaxlib-v0.10.0",
         "rocm-jaxlib-v0.10.1",
         "rocm-jaxlib-v0.10.2",
         "rocm-jaxlib-v0.11.0",

--- a/build_tools/github_actions/tests/configure_jax_release_matrix_test.py
+++ b/build_tools/github_actions/tests/configure_jax_release_matrix_test.py
@@ -50,14 +50,14 @@ class ConfigureJaxReleaseMatrixTest(unittest.TestCase):
 
     def test_generate_jax_matrix_uses_requested_refs_only(self):
         matrix = m.generate_jax_matrix(
-            jax_refs=["rocm-jaxlib-v0.10.0"],
+            jax_refs=["rocm-jaxlib-v0.10.1"],
             python_versions=["3.12"],
         )
 
         self.assertEqual(len(matrix), 1)
         self.assertEqual(matrix[0]["python_version"], "3.12")
-        self.assertEqual(matrix[0]["jax_ref"], "rocm-jaxlib-v0.10.0")
-        self.assertEqual(matrix[0]["jax_label"], "0.10.0")
+        self.assertEqual(matrix[0]["jax_ref"], "rocm-jaxlib-v0.10.1")
+        self.assertEqual(matrix[0]["jax_label"], "0.10.1")
         self.assertEqual(matrix[0]["jax_repository"], "ROCm/jax")
         self.assertEqual(matrix[0]["gfx_arch"], "device-all")
 

--- a/build_tools/github_actions/tests/configure_jax_release_matrix_test.py
+++ b/build_tools/github_actions/tests/configure_jax_release_matrix_test.py
@@ -107,10 +107,12 @@ class ConfigureJaxReleaseMatrixTest(unittest.TestCase):
         combos = {(row["python_version"], row["jax_ref"]) for row in matrix}
 
         self.assertNotIn(("3.11", "rocm-jaxlib-v0.11.0"), combos)
+        self.assertNotIn(("3.11", "rocm-jaxlib-v0.11.1"), combos)
         # 3.11 is still valid for refs that don't exclude it.
         self.assertIn(("3.11", "rocm-jaxlib-v0.10.2"), combos)
-        # Non-excluded Python versions are still paired with 0.11.0.
+        # Non-excluded Python versions are still paired with the 0.11 refs.
         self.assertIn(("3.12", "rocm-jaxlib-v0.11.0"), combos)
+        self.assertIn(("3.12", "rocm-jaxlib-v0.11.1"), combos)
 
     def test_ci_builds_single_jax_ref(self):
         # CI keeps the runner queues short by building one ref, while still
@@ -120,7 +122,7 @@ class ConfigureJaxReleaseMatrixTest(unittest.TestCase):
             release_type="ci",
             platform="linux",
         )
-        self.assertEqual({row["jax_ref"] for row in matrix}, {"rocm-jaxlib-v0.11.0"})
+        self.assertEqual({row["jax_ref"] for row in matrix}, {"rocm-jaxlib-v0.11.1"})
 
     def test_unknown_release_type_raises(self):
         with self.assertRaises(ValueError):

--- a/external-builds/jax/README.md
+++ b/external-builds/jax/README.md
@@ -57,7 +57,6 @@ Support for JAX is provided via stable release branches from
 | 0.11.0      | ✅ Supported via [ROCm/jax `rocm-jaxlib-v0.11.0`](https://github.com/ROCm/jax/tree/rocm-jaxlib-v0.11.0) | ❌ Not supported |
 | 0.10.2      | ✅ Supported via [ROCm/jax `rocm-jaxlib-v0.10.2`](https://github.com/ROCm/jax/tree/rocm-jaxlib-v0.10.2) | ❌ Not supported |
 | 0.10.1      | ✅ Supported via [ROCm/jax `rocm-jaxlib-v0.10.1`](https://github.com/ROCm/jax/tree/rocm-jaxlib-v0.10.1) | ❌ Not supported |
-| 0.10.0      | ✅ Supported via [ROCm/jax `rocm-jaxlib-v0.10.0`](https://github.com/ROCm/jax/tree/rocm-jaxlib-v0.10.0) | ❌ Not supported |
 
 > [!NOTE]
 > Python 3.11 is not supported for JAX 0.11.0 and later (dropped upstream).
@@ -75,7 +74,7 @@ This repository builds the following ROCm-enabled JAX artifacts:
 - **`jax_rocm<major>_plugin`** (JAX runtime plugin for ROCm)
 
 > [!NOTE]
-> jaxlib is **not built** for supported JAX versions (0.10.0+); it is installed
+> jaxlib is **not built** for supported JAX versions (0.10.1+); it is installed
 > from upstream PyPI (e.g. `pip install jaxlib==0.11.1`). Only
 > **`jax_rocm<major>_pjrt`** and **`jax_rocm<major>_plugin`** are built.
 
@@ -84,7 +83,7 @@ This repository builds the following ROCm-enabled JAX artifacts:
 The [downstream ROCm/jax](https://github.com/ROCm/jax) build instructions
 assume that a stable ROCm version is already installed on the system.
 
-Supported JAX versions (0.10.0+) build against ROCm Python packages installed
+Supported JAX versions (0.10.1+) build against ROCm Python packages installed
 from the TheRock multi-arch Python package index (the manylinux flow).
 
 ### Prerequisites
@@ -109,7 +108,7 @@ from the TheRock multi-arch Python package index (the manylinux flow).
 
 1. Choose your configuration:
 
-   - **JAX version**: e.g. `0.10.0`, `0.10.1`, `0.10.2`, `0.11.0`, or `0.11.1`
+   - **JAX version**: e.g. `0.10.1`, `0.10.2`, `0.11.0`, or `0.11.1`
    - **Python version**: e.g. `3.12`
    - **Package index**: the TheRock multi-arch Python package index.
 

--- a/external-builds/jax/README.md
+++ b/external-builds/jax/README.md
@@ -53,6 +53,7 @@ Support for JAX is provided via stable release branches from
 
 | JAX version | Linux                                                                                                   | Windows          |
 | ----------- | ------------------------------------------------------------------------------------------------------- | ---------------- |
+| 0.11.1      | ✅ Supported via [ROCm/jax `rocm-jaxlib-v0.11.1`](https://github.com/ROCm/jax/tree/rocm-jaxlib-v0.11.1) | ❌ Not supported |
 | 0.11.0      | ✅ Supported via [ROCm/jax `rocm-jaxlib-v0.11.0`](https://github.com/ROCm/jax/tree/rocm-jaxlib-v0.11.0) | ❌ Not supported |
 | 0.10.2      | ✅ Supported via [ROCm/jax `rocm-jaxlib-v0.10.2`](https://github.com/ROCm/jax/tree/rocm-jaxlib-v0.10.2) | ❌ Not supported |
 | 0.10.1      | ✅ Supported via [ROCm/jax `rocm-jaxlib-v0.10.1`](https://github.com/ROCm/jax/tree/rocm-jaxlib-v0.10.1) | ❌ Not supported |
@@ -75,7 +76,7 @@ This repository builds the following ROCm-enabled JAX artifacts:
 
 > [!NOTE]
 > jaxlib is **not built** for supported JAX versions (0.10.0+); it is installed
-> from upstream PyPI (e.g. `pip install jaxlib==0.11.0`). Only
+> from upstream PyPI (e.g. `pip install jaxlib==0.11.1`). Only
 > **`jax_rocm<major>_pjrt`** and **`jax_rocm<major>_plugin`** are built.
 
 ### How building with TheRock differs from upstream
@@ -102,13 +103,13 @@ from the TheRock multi-arch Python package index (the manylinux flow).
    git clone https://github.com/ROCm/jax.git
 
    pushd jax
-   git checkout rocm-jaxlib-v0.11.0
+   git checkout rocm-jaxlib-v0.11.1
    popd
    ```
 
 1. Choose your configuration:
 
-   - **JAX version**: e.g. `0.10.0`, `0.10.1`, `0.10.2`, or `0.11.0`
+   - **JAX version**: e.g. `0.10.0`, `0.10.1`, `0.10.2`, `0.11.0`, or `0.11.1`
    - **Python version**: e.g. `3.12`
    - **Package index**: the TheRock multi-arch Python package index.
 


### PR DESCRIPTION
## Motivation

ROCm/jax cut [`rocm-jaxlib-v0.11.1`](https://github.com/ROCm/jax/tree/rocm-jaxlib-v0.11.1). Add it to the release matrix and promote it to the single ref PR CI builds, and retire the oldest ref so the matrix does not grow without bound — as v0.9.1 was dropped when v0.11.0 landed in #6708.

## Technical Details

`build_tools/github_actions/configure_jax_release_matrix.py`:

- Add `rocm-jaxlib-v0.11.1` to `JAX_REF_CONFIGS` with `exclude_python_versions: ["3.11"]` — v0.11.1 keeps the 3.11 drop (`setup.py` declares `python_requires='>=3.12'`).
- Remove `rocm-jaxlib-v0.10.0` from `JAX_REF_CONFIGS` and `RELEASE_JAX_REFS`. Dropping the config entry too means a workflow input still naming it fails with `Unknown JAX refs` rather than silently building nothing.
- `CI_JAX_REFS` moves v0.11.0 → v0.11.1, still one ref.

Release matrix is now v0.10.1, v0.10.2, v0.11.0, v0.11.1 — 14 rows, down from 18. Python 3.11 coverage is unaffected: v0.10.1 and v0.10.2 still build it.

Workflow `jax_ref` defaults bumped to v0.11.1 so a manual dispatch matches the gate, plus a stale example ref in a `jax_ref` input description. Docs updated in `RELEASES.md` and `external-builds/jax/README.md`.

Nothing else needed changing: `run_jax_tests.py` derives the version from the ref, `create_skip_tests.py` treats a version with no data file as a no-op, and `patch_installed_jax_rocm_plugin_names.py` detects the upstream fix itself.

## Test Plan

Unit tests for the matrix generator and the JAX tooling it feeds, generated-matrix inspection per release type, and `yaml.safe_load` on the edited workflows.

## Test Result

`configure_jax_release_matrix_test`, `jax_skip_tests_test`, `run_jax_tests_test`, `jax_install_scripts_test`, `configure_jax_test_matrix_test`, and the `multi_arch_ci` suite (100) all pass. `dev` generates 14 rows across four refs; `ci` generates one — `rocm-jaxlib-v0.11.1` on py3.12. A request for the retired v0.10.0 raises `Unknown JAX refs`.

This PR's own `build-jax` job is the real check, since it now builds v0.11.1. If that proves unstable, the revert is one line: `CI_JAX_REFS` back to v0.11.0.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
