### PR TITLE
fix(ci): hip-tests exclude Unit_hipVoteSync_All on gfx125X-dcgpu 

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_hiptests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiptests.py
@@ -93,6 +93,8 @@ TEST_TO_IGNORE = {
             # ROCM-29275: SDMA COPY_SWAP hangs the GPU on gfx1250 (rocm-systems#9923).
             "Unit_hipMemcpyBatchAsync_Swap",
             "Unit_hipMemcpyBatchAsync_P2P_Swap",
+            # TODO(#7499): Re-enable test once crash issue is resolved.
+            "Unit_hipVoteSync_All",
         ]
     },
 }


### PR DESCRIPTION
Test crashes machines on gfx125X-dcgpu architecture. Excluding until the root cause is investigated and fixed.

ISSUE ID: #7499