### PR TITLE
[packaging] Allow post versions to float for device linking

### DIFF
--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
@@ -36,6 +36,7 @@ import json
 import os
 from pathlib import Path
 import platform
+import re
 import shutil
 import sys
 import tarfile
@@ -219,14 +220,9 @@ def _record_has_entries(record_path: Path, names: list[str]) -> bool:
     return all(n in existing for n in names)
 
 
-def _major_minor_version(version: str) -> tuple[int, int] | None:
-    parts = version.split(".", 2)
-    if len(parts) < 2:
-        return None
-    try:
-        return int(parts[0]), int(parts[1])
-    except ValueError:
-        return None
+def _without_post_release(version: str) -> str:
+    """Remove a canonical PEP 440 post-release segment from a version."""
+    return re.sub(r"\.post\d+", "", version, count=1)
 
 
 def _discover_device_link_plans(site_lib_path: Path, expected_version: str):
@@ -250,13 +246,11 @@ def _discover_device_link_plans(site_lib_path: Path, expected_version: str):
         if name != "rocm-sdk-device" and not name.startswith("rocm-sdk-device-"):
             continue
 
-        # The device wheel and the SDK are major/minor version-locked. A
-        # mismatched wheel's link targets may not line up with this devel tree,
-        # so skip it loudly.
-        expected_major_minor = _major_minor_version(expected_version)
-        if (
-            expected_major_minor is None
-            or _major_minor_version(dist.version) != expected_major_minor
+        # The device wheel and the SDK are version-locked except for post-release
+        # segments. Other differences may indicate that the wheel's link targets
+        # do not line up with this devel tree, so skip it loudly.
+        if _without_post_release(dist.version) != _without_post_release(
+            expected_version
         ):
             print(
                 f"WARNING: skipping {name} {dist.version}: does not match "

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
@@ -219,6 +219,16 @@ def _record_has_entries(record_path: Path, names: list[str]) -> bool:
     return all(n in existing for n in names)
 
 
+def _major_minor_version(version: str) -> tuple[int, int] | None:
+    parts = version.split(".", 2)
+    if len(parts) < 2:
+        return None
+    try:
+        return int(parts[0]), int(parts[1])
+    except ValueError:
+        return None
+
+
 def _discover_device_link_plans(site_lib_path: Path, expected_version: str):
     """Find installed rocm-sdk-device-* wheels and their devel-link manifests.
 
@@ -239,15 +249,22 @@ def _discover_device_link_plans(site_lib_path: Path, expected_version: str):
             continue
         if name != "rocm-sdk-device" and not name.startswith("rocm-sdk-device-"):
             continue
-        # The device wheel and the SDK are version-locked. A mismatched wheel's
-        # link targets may not line up with this devel tree, so skip it loudly.
-        if dist.version != expected_version:
+
+        # The device wheel and the SDK are major/minor version-locked. A
+        # mismatched wheel's link targets may not line up with this devel tree,
+        # so skip it loudly.
+        expected_major_minor = _major_minor_version(expected_version)
+        if (
+            expected_major_minor is None
+            or _major_minor_version(dist.version) != expected_major_minor
+        ):
             print(
                 f"WARNING: skipping {name} {dist.version}: does not match "
                 f"rocm-sdk {expected_version}",
                 file=sys.stderr,
             )
             continue
+
         files = dist.files
         if not files:
             continue

--- a/build_tools/tests/devel_reconcile_test.py
+++ b/build_tools/tests/devel_reconcile_test.py
@@ -113,8 +113,10 @@ class ReconcileDeviceLinksTest(unittest.TestCase):
             if line.strip()
         ]
 
-    def _reconcile(self) -> int:
-        return _devel._reconcile_device_links(self.site, self.devel_dir, VERSION)
+    def _reconcile(self, expected_version: str = VERSION) -> int:
+        return _devel._reconcile_device_links(
+            self.site, self.devel_dir, expected_version
+        )
 
     # ----- tests ----------------------------------------------------------
 
@@ -184,9 +186,29 @@ class ReconcileDeviceLinksTest(unittest.TestCase):
             {".kpack/blas_lib_gfx942.kpack": "kpack data"},
             version="9.9.9",
         )
-        # Device wheel version does not match the SDK version -> skip entirely.
+        # Device wheel major/minor does not match the SDK -> skip entirely.
         self.assertEqual(self._reconcile(), 0)
         self.assertFalse((self.devel_dir / ".kpack/blas_lib_gfx942.kpack").exists())
+
+    def test_patch_and_post_versions_reconciled(self):
+        expected_version = "7.14.0.post1"
+        compatible_versions = (
+            ("gfx1100", "7.14.0"),
+            ("gfx1101", "7.14.1"),
+            ("gfx1102", "7.14.2.post3"),
+        )
+
+        for target_family, device_version in compatible_versions:
+            with self.subTest(device_version=device_version):
+                relpath = f".kpack/blas_lib_{target_family}.kpack"
+                self._add_device_wheel(
+                    target_family,
+                    {relpath: "kpack data"},
+                    version=device_version,
+                )
+
+                self.assertEqual(self._reconcile(expected_version), 1)
+                self.assertTrue((self.devel_dir / relpath).is_file())
 
     def test_prune_semantics_record_lists_links(self):
         record = self._add_device_wheel(

--- a/build_tools/tests/devel_reconcile_test.py
+++ b/build_tools/tests/devel_reconcile_test.py
@@ -186,29 +186,66 @@ class ReconcileDeviceLinksTest(unittest.TestCase):
             {".kpack/blas_lib_gfx942.kpack": "kpack data"},
             version="9.9.9",
         )
-        # Device wheel major/minor does not match the SDK -> skip entirely.
+        # Device wheel release does not match the SDK -> skip entirely.
         self.assertEqual(self._reconcile(), 0)
         self.assertFalse((self.devel_dir / ".kpack/blas_lib_gfx942.kpack").exists())
 
-    def test_patch_and_post_versions_reconciled(self):
-        expected_version = "7.14.0.post1"
-        compatible_versions = (
-            ("gfx1100", "7.14.0"),
-            ("gfx1101", "7.14.1"),
-            ("gfx1102", "7.14.2.post3"),
+    def test_post_release_version_reconciled(self):
+        relpath = ".kpack/blas_lib_gfx1100.kpack"
+        self._add_device_wheel(
+            "gfx1100",
+            {relpath: "kpack data"},
+            version="7.14.0",
         )
 
-        for target_family, device_version in compatible_versions:
-            with self.subTest(device_version=device_version):
-                relpath = f".kpack/blas_lib_{target_family}.kpack"
-                self._add_device_wheel(
-                    target_family,
-                    {relpath: "kpack data"},
-                    version=device_version,
+        self.assertEqual(self._reconcile("7.14.0.post1"), 1)
+        self.assertTrue((self.devel_dir / relpath).is_file())
+
+    def test_compatible_version_pairs(self):
+        compatible_versions = (
+            ("7.14.0", "7.14.0"),
+            ("7.14.0", "7.14.0.post1"),
+            ("7.14.0.post1", "7.14.0.post2"),
+            ("7.14.0rc1", "7.14.0rc1.post1"),
+        )
+
+        for device_version, sdk_version in compatible_versions:
+            with self.subTest(
+                device_version=device_version,
+                sdk_version=sdk_version,
+            ):
+                self.assertEqual(
+                    _devel._without_post_release(device_version),
+                    _devel._without_post_release(sdk_version),
                 )
 
-                self.assertEqual(self._reconcile(expected_version), 1)
-                self.assertTrue((self.devel_dir / relpath).is_file())
+    def test_incompatible_version_pairs(self):
+        incompatible_versions = (
+            ("7.14.0", "7.14.1"),
+            ("7.14.0", "7.14.0rc1"),
+            ("7.14.0", "7.14.0.dev1"),
+        )
+
+        for device_version, sdk_version in incompatible_versions:
+            with self.subTest(
+                device_version=device_version,
+                sdk_version=sdk_version,
+            ):
+                self.assertNotEqual(
+                    _devel._without_post_release(device_version),
+                    _devel._without_post_release(sdk_version),
+                )
+
+    def test_patch_version_mismatch_skipped(self):
+        relpath = ".kpack/blas_lib_gfx1100.kpack"
+        self._add_device_wheel(
+            "gfx1100",
+            {relpath: "kpack data"},
+            version="7.14.1",
+        )
+
+        self.assertEqual(self._reconcile("7.14.0.post1"), 0)
+        self.assertFalse((self.devel_dir / relpath).exists())
 
     def test_prune_semantics_record_lists_links(self):
         record = self._add_device_wheel(


### PR DESCRIPTION
## Motivation

Follow-up to https://github.com/ROCm/TheRock/pull/7468 to address part of https://github.com/ROCm/TheRock/issues/7362.

We'd like to publish post releases and patch releases like `7.14.0.post1` or `7.14.1` but there are a few spots in the code that check for exact version matches. This relaxes the code that copies kpack files from device packages into the `_rocm_sdk_devel` folder when running any `rocm-sdk` command to allow post versions but still limit patch versions.

Without this fix, installing `7.14.0.post1` together with devel packages and running `rocm-sdk test` or just commands like `rocm-sdk path --root` will produce a warning and *not copy kpack files*:
```
(3.12.venv) λ rocm-sdk path --cmake
WARNING: skipping rocm-sdk-device-gfx1100 7.14.0: does not match rocm-sdk 7.14.0.post1
D:\scratch\therock\3.12.venv\Lib\site-packages\_rocm_sdk_devel\lib\cmake

(3.12.venv) λ ls -a 3.12.venv\Lib\site-packages\_rocm_sdk_devel
./  ../  .info/  __init__.py  bin/  cmake/  include/  lib/  libexec/  share/
```

## Technical Details

This is a minimal change to allow post versions, not a general fix for patch versions or other local version identifiers.

## Test Plan

* New unit tests
* Apply these changes to installed packages then:
  * Check that tools work:
    ```
    rocm-sdk test
    rocm-sdk path --root
    rocm-sdk path --cmake
    ```
  * Check that `_rocm_sdk_devel\.kpack` has files:
    ```
    (3.12.venv) λ ls -a 3.12.venv\Lib\site-packages\_rocm_sdk_devel
    ./   .devel_reconcile.lock  .kpack/      __pycache__/  cmake/    lib/      share/
    ../  .info/                 __init__.py  bin/          include/  libexec/
    ```
* Local pytorch build:
    ```
    (3.12_test.venv) λ pip freeze
    rocm==rocm-7.14.0.post1
    rocm-sdk-core==7.14.0
    rocm-sdk-devel==7.14.0
    rocm-sdk-device-gfx1100==7.14.0
    rocm-sdk-libraries==7.14.0
    
    (3.12_test.venv) λ python D:/projects/TheRock/external-builds/pytorch/build_prod_wheels.py build --pytorch-dir D:/b/pytorch --no-build-pytorch-audio --no-build-pytorch-vision --pytorch-rocm-arch=gfx1100 --output-dir %HOME%/.therock/pytorch --use-ccache
    ```
    Version loaded:
    ```
    ++ Capture [D:\scratch\therock]$ 'D:\scratch\therock\3.12_test.venv\Scripts\python.exe' -m pip show rocm
    Computing version suffix for installed rocm package: 7.14.0.post1
    Version suffix is: +rocm7.14.0.post1
    
    Using PYTORCH_BUILD_VERSION: 2.13.0+rocm7.14.0.post1
    ```
    Generated `_rocm_init.py` contents:
    ```python
    def initialize():
        import rocm_sdk
        rocm_sdk.initialize_process(
            preload_shortnames=['amd_comgr', 'amdhip64', 'hiprtc', 'hipblas', 'hipfft', 'hiprand', 'hipsparse', 'hipsparselt', 'hipsolver', 'hipblaslt', 'miopen', 'hipdnn', 'rocm-openblas'],
            check_version='7.14.0.post1')
    ```
    Built torch packages initialize and report to expected version:
    ```
    >>> import torch
    >>> torch.__version__
    '2.13.0+rocm7.14.0.post1'
    ```
    Built torch packages pass smoketests:
    ```
    pytest D:\projects\TheRock\external-builds\pytorch\smoke-tests\pytorch_smoke_test.py -vv
    14 passed, 6 skipped in 22.32s
    ```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
