### PR TITLE
fix(rccl): enable RocJitsu for staged pretranslation

### DIFF
--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -752,7 +752,10 @@ disable_platforms = ["windows"]
 [artifacts.rccl]
 artifact_group = "comm-libs"
 type = "target-specific"
-artifact_deps = ["core-runtime", "core-hip", "hipify", "rocprofiler-sdk", "core-amdsmi", "openmpi"]
+# RCCL's gfx1250 split artifact includes an install-owned RocJitsu translation
+# cache. Keep the pretranslation toolchain as an explicit staged dependency so
+# configure_stage.py enables ROCJITSU and ROCJITSU_HOTSWAP in comm-libs builds.
+artifact_deps = ["core-runtime", "core-hip", "hipify", "rocprofiler-sdk", "core-amdsmi", "openmpi", "rocjitsu-hotswap"]
 split_databases = ["hotswap_cache"]
 disable_platforms = ["windows"]
 

--- a/build_tools/tests/configure_stage_test.py
+++ b/build_tools/tests/configure_stage_test.py
@@ -12,7 +12,7 @@ from pathlib import Path
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 
 from _therock_utils.build_topology import get_topology
-from configure_stage import generate_cmake_args, get_project_features
+from configure_stage import generate_cmake_args, get_project_features, get_stage_features
 
 
 class ProjectResolutionTest(unittest.TestCase):
@@ -74,6 +74,22 @@ class FeatureOrientedResolutionTest(unittest.TestCase):
         """rocBLAS resolves to BLAS (no override)."""
         features = self.topology.resolve_projects_to_features(["rocBLAS"])
         self.assertIn("BLAS", features)
+
+
+class StageDependencyFeatureTest(unittest.TestCase):
+    """Tests for features enabled through staged artifact dependencies."""
+
+    def setUp(self):
+        self.topology = get_topology()
+
+    def test_comm_libs_enables_rocjitsu_hotswap_for_rccl_pretranslation(self):
+        """The staged RCCL build must include its pretranslation toolchain."""
+        features = get_stage_features(
+            self.topology, "comm-libs", platform_name="linux"
+        )
+
+        self.assertIn("ROCJITSU", features)
+        self.assertIn("ROCJITSU_HOTSWAP", features)
 
 
 class RocmSystemsMappingTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

- make the RCCL artifact explicitly depend on `rocjitsu-hotswap`
- ensure staged `comm-libs` builds bootstrap the RocJitsu pretranslation toolchain
- add a regression test for the generated staged-build feature set

## Problem

The gfx1250 RCCL pretranslation integration from #7460 is conditional on both
`THEROCK_ENABLE_ROCJITSU_HOTSWAP` and `THEROCK_FLAG_KPACK_SPLIT_ARTIFACTS`.

In [RockRel run 32199453871](https://github.com/ROCm/rockrel/actions/runs/32199453871),
the `comm-libs` stage configured with split KPACKs enabled but both RocJitsu
features disabled:

```text
KPACK_SPLIT_ARTIFACTS = ON
ROCJITSU = OFF
ROCJITSU_HOTSWAP = OFF
```

As a result, `rccl-translate` was excluded from the build graph. The stage
still succeeded and published `rccl_lib_gfx1250`, but the KPACK contained only
the original RCCL code objects and no install-owned translation cache.

## Fix

Declare `rocjitsu-hotswap` as an artifact dependency of RCCL. Its transitive
dependency on `rocjitsu` makes both artifacts inbound to staged `comm-libs`
builds, so `configure_stage.py` emits:

```text
-DTHEROCK_ENABLE_ROCJITSU=ON
-DTHEROCK_ENABLE_ROCJITSU_HOTSWAP=ON
```

This activates the existing `rccl-translate` subproject before RCCL's KPACK is
split, without duplicating translation logic in the release workflow.

## Tests

```text
python build_tools/tests/configure_stage_test.py
  Ran 11 tests: PASS (1 skipped)

python -m unittest build_tools.tests.configure_stage_test build_tools.tests.build_topology_test
  Ran 42 tests: PASS (1 skipped)

python build_tools/configure_stage.py --stage comm-libs \
  --dist-amdgpu-families gfx125X-dcgpu --platform linux --oneline
  includes THEROCK_ENABLE_ROCJITSU=ON and THEROCK_ENABLE_ROCJITSU_HOTSWAP=ON
```

The full Windows discovery run reached 581 tests but has 17 environment-only
errors from unavailable optional Python dependencies and Windows symlink
privileges. The focused topology/configuration tests are clean.
