### PR TITLE
feat(ci): enable ASAN presubmit for external repos without labels

### DIFF
--- a/.github/workflows/setup_multi_arch.yml
+++ b/.github/workflows/setup_multi_arch.yml
@@ -44,6 +44,14 @@ on:
         description: "Workflow run ID to copy prebuilt stage artifacts from."
         type: string
         default: ""
+      baseline_repository:
+        description: >-
+          Repository to search for baseline runs during automatic stage reuse.
+          Defaults to the 'repository' input (THEROCK_REPOSITORY). External repos
+          can set this to their own repo (e.g., github.repository) for
+          workflow_dispatch events to reuse baselines from their own runs.
+        type: string
+        default: ""
       stage_reuse_mode:
         description: >-
           Artifact-reuse mode: "off" disables all reuse, ignores prebuilt_stages
@@ -211,6 +219,7 @@ jobs:
           WINDOWS_TEST_LABELS: ${{ inputs.windows_test_labels }}
           PREBUILT_STAGES: ${{ inputs.prebuilt_stages }}
           BASELINE_RUN_ID: ${{ inputs.baseline_run_id }}
+          BASELINE_REPOSITORY: ${{ inputs.baseline_repository }}
           STAGE_REUSE_MODE: ${{ inputs.stage_reuse_mode }}
           # The checkout commit is used for commit-compatibility checking.
           STAGE_REUSE_CURRENT_SHA: ${{ steps.checkout.outputs.commit }}

--- a/build_tools/github_actions/stage_reuse_decision.py
+++ b/build_tools/github_actions/stage_reuse_decision.py
@@ -548,10 +548,15 @@ def _default_baseline_selector(*, platform: str) -> BaselineSelector:
     extra "passing build" check is needed here.
     """
 
-    # THEROCK_REPOSITORY is set by setup_multi_arch.yml to the repository input
-    # (ROCm/TheRock for external repos, or github.repository for normal runs).
-    github_repository = os.environ.get(
-        "THEROCK_REPOSITORY", os.environ.get("GITHUB_REPOSITORY", "ROCm/TheRock")
+    # BASELINE_REPOSITORY overrides THEROCK_REPOSITORY for baseline lookups.
+    # This allows external repos to specify a different repository for baseline
+    # runs (e.g., their own repo for workflow_dispatch instead of TheRock).
+    #
+    # Priority: BASELINE_REPOSITORY > THEROCK_REPOSITORY > GITHUB_REPOSITORY
+    github_repository = (
+        os.environ.get("BASELINE_REPOSITORY")
+        or os.environ.get("THEROCK_REPOSITORY")
+        or os.environ.get("GITHUB_REPOSITORY", "ROCm/TheRock")
     )
     branch = os.environ.get("STAGE_REUSE_BASELINE_BRANCH", "main")
     workflow_name = os.environ.get("STAGE_REUSE_BASELINE_WORKFLOW", "multi_arch_ci.yml")


### PR DESCRIPTION
rocm-systems and rocm-libraries were initially enabled on presubmit but this conditional caused host-asan to not run. However from discussions, 
- we decided to do [post-submit only for rocm-libraries](https://github.com/ROCm/rocm-libraries/pull/11262) to continue getting signal and able to revert if issue is found. 
    - once rocm-libraries optimizations on multi-arch come into play, we will enable presubmit
- rocm-systems will get presubmit coverage in order to quickly block bad work

Plan here: https://github.com/ROCm/TheRock/issues/6627

Workflow dispatch test run: https://github.com/ROCm/rocm-libraries/actions/runs/33098621491/job/98617005999
@main pin no longer there due to https://github.com/ROCm/rocm-libraries/commit/bdcc4149c853a77b366c58396838f541d72b7710