### PR TITLE
ci(rocgdb): add rocgdb-corefile to test policies

### DIFF
--- a/test_tools/test_policies.toml
+++ b/test_tools/test_policies.toml
@@ -49,14 +49,14 @@ test_include = ["rocprofiler-systems-examples"]
 [component.roctracer]
 test_include = ["hip-clr", "rocprofiler-sdk"]
 
-# rocgdb-cpu / rocgdb-gpu are ctest targets of rocgdb, not subprojects, so they
-# are named here rather than derived from the graph.
+# rocgdb-cpu / rocgdb-gpu / rocgdb-corefile are ctest targets of rocgdb, not
+# subprojects, so they are named here rather than derived from the graph.
 
 [component.amd-dbgapi]
-test_include = ["rocgdb-cpu", "rocgdb-gpu"]
+test_include = ["rocgdb-cpu", "rocgdb-gpu", "rocgdb-corefile"]
 
 [component.rocgdb]
-test_include = ["rocgdb-cpu", "rocgdb-gpu"]
+test_include = ["rocgdb-cpu", "rocgdb-gpu", "rocgdb-corefile"]
 
 # --- Math / ML library couplings ----------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds `rocgdb-corefile` as a ctest target alongside `rocgdb-gpu` in `test_tools/test_policies.toml`
- Ensures `rocgdb-corefile` runs whenever `amd-dbgapi` or `rocgdb` components change
- Updates the comment above those entries to mention all three targets

## Test plan

- [x] Verify CI picks up `rocgdb-corefile` in test runs triggered by `rocgdb` or `amd-dbgapi` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

@skip-pr-bot