### PR TITLE
ci: add timing instrumentation to stage-reuse baseline selection

### DIFF
--- a/.github/workflows/setup_multi_arch.yml
+++ b/.github/workflows/setup_multi_arch.yml
@@ -61,6 +61,14 @@ on:
           Automatic stage reuse: number of recent branch commits to fetch for ancestry. default: "50"
         type: string
         default: "50"
+      stage_reuse_current_sha:
+        description: >-
+          Override the commit SHA used for stage-reuse ancestry checking. When
+          set, this value is used instead of the SHA resolved from the ref
+          checkout. Useful when the checked-out ref is a diagnostic/instrumented
+          branch whose tip is not in the baseline branch history.
+        type: string
+        default: ""
       build_python_packages:
         description: "Build ROCm Python packages (rocm-sdk, rocm-profiler, etc.)."
         type: boolean
@@ -206,7 +214,9 @@ jobs:
           BASELINE_RUN_ID: ${{ inputs.baseline_run_id }}
           STAGE_REUSE_MODE: ${{ inputs.stage_reuse_mode }}
           # The checkout commit is used for commit-compatibility checking.
-          STAGE_REUSE_CURRENT_SHA: ${{ steps.checkout.outputs.commit }}
+          # stage_reuse_current_sha overrides this when the checked-out ref is
+          # an instrumented/diagnostic branch not in the baseline history.
+          STAGE_REUSE_CURRENT_SHA: ${{ inputs.stage_reuse_current_sha || steps.checkout.outputs.commit }}
           STAGE_REUSE_MAX_AGE_HOURS: ${{ inputs.stage_reuse_max_age_hours }}
           STAGE_REUSE_COMMIT_HISTORY: ${{ inputs.stage_reuse_commit_history }}
           # For baseline run selection, use repository input (defaults to GITHUB_REPOSITORY).

--- a/.github/workflows/setup_multi_arch.yml
+++ b/.github/workflows/setup_multi_arch.yml
@@ -220,6 +220,8 @@ jobs:
           # External repo family overrides allow callers to add/modify GPU family configs
           # (e.g., adding test runners for architectures not enabled in TheRock's default config)
           EXTERNAL_FAMILY_OVERRIDES: ${{ inputs.external_repo != '' && toJSON(fromJSON(inputs.external_repo).family_overrides) || '' }}
+          # Enable INFO-level logging so [BASELINE]/[STAGE-REUSE]/[TIMING] lines appear in CI output.
+          PYTHONLOGLEVEL: INFO
         run: python ./build_tools/github_actions/configure_multi_arch_ci.py
 
       # Note: Other scripts treat "dev releases" and "CI builds" differently.

--- a/build_tools/github_actions/baseline_runs.py
+++ b/build_tools/github_actions/baseline_runs.py
@@ -25,6 +25,7 @@ from datetime import datetime, timezone
 import logging
 from pathlib import Path
 import sys
+import time
 from urllib.parse import urlencode, quote
 
 logger = logging.getLogger(__name__)
@@ -753,6 +754,7 @@ def select_baseline_run(
             )
     check_recency = max_age_hours is not None
 
+    _t_candidates = time.monotonic()
     candidates = (
         list(workflow_runs)
         if workflow_runs is not None
@@ -763,12 +765,26 @@ def select_baseline_run(
             max_runs=max_runs,
         )
     )
+    logger.info(
+        "[BASELINE] query_completed_workflow_runs(repo=%s, workflow=%s, branch=%s, max=%d): %.2fs -> %d runs",
+        github_repository, workflow_name, branch, max_runs,
+        time.monotonic() - _t_candidates, len(candidates),
+    )
 
+    _t_loop_start = time.monotonic()
+    _runs_checked = 0
     for workflow_run in candidates[:max_runs]:
         run_id = str(workflow_run["id"])
+        _runs_checked += 1
+        _t_run = time.monotonic()
         if run_id in excluded:
+            logger.info("[BASELINE] run %s: excluded, skipping", run_id)
             continue
         if not is_completed_workflow_run(workflow_run):
+            logger.info(
+                "[BASELINE] run %s: status=%s (not completed), skipping",
+                run_id, workflow_run.get("status"),
+            )
             continue
 
         # Cheap, local checks (recency, commit ancestry) run before the
@@ -782,8 +798,8 @@ def select_baseline_run(
             )
             if not run_recency.is_valid:
                 logger.info(
-                    "Skipping run %s: too old or not date-parseable "
-                    "(age_hours=%s, max_age_hours=%s)",
+                    "[BASELINE] run %s: too old or not date-parseable "
+                    "(age_hours=%s, max_age_hours=%s), skipping",
                     run_id,
                     run_recency.age_hours,
                     run_recency.max_age_hours,
@@ -794,8 +810,7 @@ def select_baseline_run(
         if check_commit:
             candidate_head_sha = (workflow_run.get("head_sha", "") or "").strip()
             if not candidate_head_sha:
-                # A run without a head_sha cannot be confirmed compatible.
-                logger.info("Skipping run %s: no head_sha to compare", run_id)
+                logger.info("[BASELINE] run %s: no head_sha to compare, skipping", run_id)
                 continue
             commit_compatibility = validate_commit_compatibility(
                 candidate_head_sha=candidate_head_sha,
@@ -804,7 +819,7 @@ def select_baseline_run(
             )
             if not commit_compatibility.is_valid:
                 logger.info(
-                    "Skipping run %s: commit %s is %s relative to current %s",
+                    "[BASELINE] run %s: commit %s is %s relative to current %s, skipping",
                     run_id,
                     candidate_head_sha,
                     commit_compatibility.relationship,
@@ -812,32 +827,51 @@ def select_baseline_run(
                 )
                 continue
 
+        _t_jobs = time.monotonic()
+        fetched_jobs = workflow_jobs_fetcher(workflow_run, github_repository)
+        _jobs_elapsed = time.monotonic() - _t_jobs
+        logger.info(
+            "[BASELINE] run %s: query_workflow_run_jobs: %.2fs, %d jobs",
+            run_id, _jobs_elapsed, len(fetched_jobs),
+        )
         job_health = validate_required_jobs_successful(
-            workflow_jobs=workflow_jobs_fetcher(workflow_run, github_repository),
+            workflow_jobs=fetched_jobs,
             required_name_substrings=required_jobs,
         )
         if not job_health.is_valid:
             logger.info(
-                "Skipping run %s: required build jobs not healthy "
-                "(failed=%s, missing=%s)",
+                "[BASELINE] run %s: required build jobs not healthy "
+                "(failed=%s, missing=%s), skipping",
                 run_id,
                 job_health.failed_job_names,
                 job_health.missing_name_substrings,
             )
             continue
 
+        _t_artifacts = time.monotonic()
         backend = backend_factory(workflow_run, github_repository, platform)
         availability = validate_required_artifacts_available(
             backend=backend,
             required_artifacts=requirements,
         )
+        _artifacts_elapsed = time.monotonic() - _t_artifacts
+        logger.info(
+            "[BASELINE] run %s: validate_required_artifacts_available: %.2fs, valid=%s",
+            run_id, _artifacts_elapsed, availability.is_valid,
+        )
         if not availability.is_valid:
             logger.info(
-                "Skipping run %s: missing artifacts %s",
+                "[BASELINE] run %s: missing artifacts %s, skipping",
                 run_id,
                 availability.missing_artifacts,
             )
             continue
+
+        logger.info(
+            "[BASELINE] run %s: SELECTED after %.2fs (total loop so far: %.2fs, %d runs checked)",
+            run_id, time.monotonic() - _t_run,
+            time.monotonic() - _t_loop_start, _runs_checked,
+        )
 
         source_ref = create_workflow_run_summary(
             workflow_run,
@@ -854,4 +888,8 @@ def select_baseline_run(
             run_recency=run_recency,
         )
 
+    logger.info(
+        "[BASELINE] no baseline found after checking %d runs in %.2fs",
+        _runs_checked, time.monotonic() - _t_loop_start,
+    )
     return None

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -49,6 +49,7 @@ import enum
 import json
 import os
 import sys
+import time
 from dataclasses import asdict, dataclass, field, fields, replace
 from pathlib import Path
 
@@ -923,12 +924,14 @@ def decide_jobs(
     # their builds and copies artifacts instead. The platforms and families to
     # verify come straight from the resolved target selection.
 
+    _t_stage_reuse = time.monotonic()
     auto_stage_reuse = compute_auto_stage_reuse(
         changed_files=git_context.changed_files,
         mode=StageReuseMode.from_environ(),
         linux_amdgpu_families=targets.linux_families,
         windows_amdgpu_families=targets.windows_families,
     )
+    print(f"[TIMING] compute_auto_stage_reuse: {time.monotonic() - _t_stage_reuse:.2f}s")
 
     baseline_repository = ci_inputs.baseline_repository
     baseline_run_id = ci_inputs.baseline_run_id
@@ -1482,9 +1485,23 @@ def main():
         # a "prior commit" to compare against.
         git_context = GitContext.empty()
 
+    _t_configure = time.monotonic()
     outputs = configure(ci_inputs, git_context)
+    print(f"[TIMING] configure(): {time.monotonic() - _t_configure:.2f}s")
+
+    _t_write = time.monotonic()
     write_outputs(ci_inputs=ci_inputs, outputs=outputs)
+    print(f"[TIMING] write_outputs(): {time.monotonic() - _t_write:.2f}s")
+
+    print(f"[TIMING] total main(): {time.monotonic() - _t_main:.2f}s")
 
 
 if __name__ == "__main__":
+    import logging as _logging
+    _log_level = os.environ.get("PYTHONLOGLEVEL", "WARNING").upper()
+    _logging.basicConfig(
+        level=getattr(_logging, _log_level, _logging.WARNING),
+        format="%(levelname)s %(name)s: %(message)s",
+    )
+    _t_main = time.monotonic()
     main()

--- a/build_tools/github_actions/stage_reuse_decision.py
+++ b/build_tools/github_actions/stage_reuse_decision.py
@@ -55,6 +55,7 @@ import os
 import logging
 import functools
 import sys
+import time
 import baseline_runs
 import github_actions_api
 from pathlib import Path
@@ -373,7 +374,13 @@ def compute_auto_stage_reuse(
         # Configuration errors (e.g. a bad required-artifacts request) indicate
         # a bug and must surface, so they are left to propagate.
         try:
+            _t_sel = time.monotonic()
             baseline = selector(required)
+            logger.info(
+                "%s select_baseline_run(platform=%s): %.2fs -> run_id=%s",
+                LOG_PREFIX, platform, time.monotonic() - _t_sel,
+                baseline.run_id if baseline is not None else None,
+            )
         except GitHubAPIError as exc:
             baseline_error = str(exc)
             baseline = None
@@ -535,10 +542,16 @@ def _default_baseline_selector(*, platform: str) -> BaselineSelector:
     effective_commit_sha = current_commit_sha
     if current_commit_sha is not None:
         try:
+            _t0 = time.monotonic()
             ordered_commit_shas = github_actions_api.gha_query_recent_branch_commits(
                 github_repository_name=github_repository,
                 branch=branch,
                 max_count=history_count,
+            )
+            logger.info(
+                "%s gha_query_recent_branch_commits(%s, branch=%s, max_count=%d): %.2fs, %d commits",
+                LOG_PREFIX, github_repository, branch, history_count,
+                time.monotonic() - _t0, len(ordered_commit_shas),
             )
         except GitHubAPIError as exc:
             if is_external_repo:


### PR DESCRIPTION
## Summary

- Add `[TIMING]`, `[BASELINE]`, and `[STAGE-REUSE]` INFO-level logs to `configure_multi_arch_ci.py`, `baseline_runs.py`, and `stage_reuse_decision.py` to pinpoint where the 4+ minute "Configuring CI options" step spends its time
- Enable `PYTHONLOGLEVEL=INFO` on the configure step in `setup_multi_arch.yml` so the logs surface in CI output
- Covers: commit history fetch, per-platform baseline selection, per-candidate job listing, artifact availability check, and end-to-end totals

**Do not merge** — diagnostic branch only; to be reverted once the bottleneck is identified and fixed.