### PR TITLE
[release/bkc] fix RCCL staged RocJitsu pretranslation

### DIFF
--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -750,7 +750,10 @@ disable_platforms = ["windows"]
 [artifacts.rccl]
 artifact_group = "comm-libs"
 type = "target-specific"
-artifact_deps = ["core-runtime", "core-hip", "hipify", "rocprofiler-sdk", "core-amdsmi", "openmpi"]
+# RCCL's gfx1250 split artifact includes an install-owned RocJitsu translation
+# cache. Keep the pretranslation toolchain as an explicit staged dependency so
+# configure_stage.py enables ROCJITSU and ROCJITSU_HOTSWAP in comm-libs builds.
+artifact_deps = ["core-runtime", "core-hip", "hipify", "rocprofiler-sdk", "core-amdsmi", "openmpi", "rocjitsu-hotswap"]
 split_databases = ["hotswap_cache"]
 disable_platforms = ["windows"]
 

--- a/build_tools/tests/configure_stage_test.py
+++ b/build_tools/tests/configure_stage_test.py
@@ -12,7 +12,10 @@ from pathlib import Path
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 
 from _therock_utils.build_topology import get_topology
-from configure_stage import generate_cmake_args, get_project_features
+from configure_stage import (
+    generate_cmake_args,
+    get_project_features,
+)
 
 
 class ProjectResolutionTest(unittest.TestCase):

--- a/comm-libs/CMakeLists.txt
+++ b/comm-libs/CMakeLists.txt
@@ -70,6 +70,7 @@ if(THEROCK_ENABLE_RCCL)
   if(THEROCK_ENABLE_ROCJITSU_HOTSWAP AND THEROCK_FLAG_KPACK_SPLIT_ARTIFACTS)
     therock_cmake_subproject_dist_dir(_rccl_dist_dir rccl)
     therock_cmake_subproject_dist_dir(_rocjitsu_dist_dir rocjitsu)
+    therock_cmake_subproject_dist_dir(_rocjitsu_hotswap_dist_dir rocjitsu-hotswap)
 
     # Generate the install-owned translation tier from RCCL before KPACK splits
     # its fat binary. The splitter then assigns this tree only to gfx1250.
@@ -83,6 +84,7 @@ if(THEROCK_ENABLE_RCCL)
       CMAKE_ARGS
         -DRCCL_ROOT=${_rccl_dist_dir}
         -DROCJITSU_ROOT=${_rocjitsu_dist_dir}
+        -DROCJITSU_HOTSWAP_ROOT=${_rocjitsu_hotswap_dist_dir}
         -DROCJITSU_PRETRANSLATE_DRIVER=${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/emulation/rocjitsu/scripts/rocjitsu-pretranslate.py
         -DKPACK_PYTHON_SOURCE=${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/shared/kpack/python
         # TODO: Set ON once RocJitsu supports every RCCL gfx1250 code object.
@@ -95,6 +97,7 @@ if(THEROCK_ENABLE_RCCL)
       BUILD_DEPS
         rccl
         rocjitsu
+        rocjitsu-hotswap
         rocm-kpack
     )
     therock_cmake_subproject_activate(rccl-translate)

--- a/comm-libs/rccl-translate/CMakeLists.txt
+++ b/comm-libs/rccl-translate/CMakeLists.txt
@@ -12,7 +12,12 @@ option(
   OFF
 )
 
-foreach(_required_path RCCL_ROOT ROCJITSU_ROOT KPACK_PYTHON_SOURCE)
+foreach(_required_path
+    RCCL_ROOT
+    ROCJITSU_ROOT
+    ROCJITSU_HOTSWAP_ROOT
+    KPACK_PYTHON_SOURCE
+)
   if(NOT IS_ABSOLUTE "${${_required_path}}")
     message(FATAL_ERROR "${_required_path} must be an absolute path")
   endif()
@@ -33,6 +38,12 @@ find_program(ROCJITSU_PRETRANSLATE_TOOL
 find_program(ROCJITSU_PRETRANSLATE_DRIVER
   NAMES rocjitsu-pretranslate.py
   PATHS "${ROCJITSU_ROOT}/bin"
+  NO_DEFAULT_PATH
+  REQUIRED
+)
+find_library(ROCJITSU_HOTSWAP_TRANSLATOR_LIBRARY
+  NAMES rocjitsu_gfx1250_b0_to_a0
+  PATHS "${ROCJITSU_HOTSWAP_ROOT}/lib"
   NO_DEFAULT_PATH
   REQUIRED
 )
@@ -57,7 +68,9 @@ add_custom_command(
     --gfx-arch gfx1250
     --output-dir "${_unbundled_dir}"
     "${RCCL_LIBRARY}"
-  COMMAND "${Python3_EXECUTABLE}" "${ROCJITSU_PRETRANSLATE_DRIVER}"
+  COMMAND "${CMAKE_COMMAND}" -E env
+    "LD_LIBRARY_PATH=${ROCJITSU_HOTSWAP_ROOT}/lib:${ROCJITSU_ROOT}/lib"
+    "${Python3_EXECUTABLE}" "${ROCJITSU_PRETRANSLATE_DRIVER}"
     --tool "${ROCJITSU_PRETRANSLATE_TOOL}"
     --store-root "${_cache_root}"
     --report-dir "${_report_dir}"
@@ -73,6 +86,7 @@ add_custom_command(
     "${RCCL_LIBRARY}"
     "${ROCJITSU_PRETRANSLATE_TOOL}"
     "${ROCJITSU_PRETRANSLATE_DRIVER}"
+    "${ROCJITSU_HOTSWAP_TRANSLATOR_LIBRARY}"
     "${KPACK_PYTHON_SOURCE}/rocm_kpack/binutils.py"
     "${KPACK_PYTHON_SOURCE}/rocm_kpack/ccob_parser.py"
     "${KPACK_PYTHON_SOURCE}/rocm_kpack/tools/bulk_unbundle.py"

--- a/emulation/CMakeLists.txt
+++ b/emulation/CMakeLists.txt
@@ -42,11 +42,6 @@ if(THEROCK_ENABLE_ROCJITSU)
     LIB_NAMES
       librocjitsu.so
   )
-  therock_test_validate_shared_lib(PATH rocjitsu/dist/lib
-    LIB_NAMES
-      libhsa_hotswap_rocjitsu.so
-  )
-
   therock_provide_artifact(rocjitsu
     TARGET_NEUTRAL
     DESCRIPTOR artifact-rocjitsu.toml
@@ -77,6 +72,11 @@ if(THEROCK_ENABLE_ROCJITSU_HOTSWAP)
   )
 
   therock_cmake_subproject_activate(rocjitsu-hotswap)
+
+  therock_test_validate_shared_lib(PATH rocjitsu-hotswap/dist/lib
+    LIB_NAMES
+      libhsa_hotswap_rocjitsu.so
+  )
 
   therock_provide_artifact(rocjitsu-hotswap
     TARGET_NEUTRAL

--- a/emulation/artifact-rocjitsu.toml
+++ b/emulation/artifact-rocjitsu.toml
@@ -8,5 +8,7 @@ include = [
 [components.dev."emulation/rocjitsu/stage"]
 [components.run."emulation/rocjitsu/stage"]
 include = [
+  "bin/rj_pretranslate",
+  "bin/rocjitsu-pretranslate.py",
   "share/rocjitsu/**",
 ]

--- a/test_tools/therock_consumer_graph.json
+++ b/test_tools/therock_consumer_graph.json
@@ -302,7 +302,9 @@
     ]
   },
   "rocjitsu-hotswap": {
-    "consumers": []
+    "consumers": [
+      "rccl-translate"
+    ]
   },
   "rocjpeg": {
     "consumers": [


### PR DESCRIPTION
## Summary

Cherry-picks the complete change set from #7505 onto `release/bkc/therock-10.1-20260811`:

- enable RocJitsu and its hotswap artifact for staged RCCL pretranslation
- package the RocJitsu pretranslation executable and translator library
- resolve the translator from staged artifacts and provide its runtime library path
- validate the hotswap library from its owning split artifact path

## Validation

- `python -m unittest build_tools.tests.emulation_cmake_test build_tools.tests.configure_stage_test build_tools.tests.artifacts_test` (36 passed, 1 skipped)
- ammar pinned manylinux regression test passed
- ammar `validate_shared_library.py` passed for `rocjitsu-hotswap/dist/lib/libhsa_hotswap_rocjitsu.so`
- focused gfx1250 RCCL pretranslation translated 85/85 code objects
- dev release workflow: https://github.com/ROCm/TheRock/actions/runs/32370067068

Source PR: #7505

This PR is for release-branch validation and should not merge #7505 into `main` as part of this workflow.