### PR TITLE
[ci] Treat skipped jobs as successful for baseline run selection

### DIFF
--- a/build_tools/github_actions/baseline_runs.py
+++ b/build_tools/github_actions/baseline_runs.py
@@ -266,11 +266,16 @@ def is_successful_workflow_run(workflow_run: dict) -> bool:
 
 
 def is_successful_workflow_job(workflow_job: dict) -> bool:
-    """Return True when a workflow job completed successfully."""
-    return (
-        workflow_job.get("status") == "completed"
-        and workflow_job.get("conclusion") == "success"
-    )
+    """Return True when a workflow job completed successfully.
+
+    Some jobs like "Quartz - started" are automatically skipped and can be
+    treated as successful. Note that a CI run that skipped build stages
+    could pass this check but then fail later checks like
+    validate_required_artifacts_available().
+    """
+    return workflow_job.get("status") == "completed" and workflow_job.get(
+        "conclusion"
+    ) in ["success", "skipped"]
 
 
 def query_completed_workflow_runs(

--- a/build_tools/github_actions/tests/baseline_runs_test.py
+++ b/build_tools/github_actions/tests/baseline_runs_test.py
@@ -67,11 +67,7 @@ class BaselineRunsTest(unittest.TestCase):
         )
 
     def test_is_successful_workflow_run(self):
-        self.assertTrue(
-            baseline_runs.is_successful_workflow_run(
-                _workflow_run("1", conclusion="success")
-            )
-        )
+        self.assertTrue(baseline_runs.is_successful_workflow_run(_workflow_run("1")))
         self.assertFalse(
             baseline_runs.is_successful_workflow_run(
                 _workflow_run("1", conclusion="failure")
@@ -89,7 +85,10 @@ class BaselineRunsTest(unittest.TestCase):
         )
         self.assertTrue(
             baseline_runs.is_successful_workflow_job(
-                _workflow_job("Notify", conclusion="skipped")
+                _workflow_job(
+                    "Build Multi-Arch Stages / Quartz - started - build ROCm",
+                    conclusion="skipped",
+                )
             )
         )
         self.assertFalse(
@@ -360,6 +359,14 @@ class BaselineRunsTest(unittest.TestCase):
             workflow_jobs=[
                 _workflow_job("Build Multi-Arch Stages / linux"),
                 _workflow_job("Build Multi-Arch Stages / windows"),
+                _workflow_job(
+                    "Build Multi-Arch Stages / Quartz - started - build ROCm",
+                    conclusion="skipped",
+                ),
+                _workflow_job(
+                    "Build Multi-Arch Stages / Quartz - completed - build ROCm",
+                    conclusion="skipped",
+                ),
                 _workflow_job("Test hip-tests", conclusion="failure"),
             ],
             required_name_substrings=["Build Multi-Arch Stages"],
@@ -371,6 +378,8 @@ class BaselineRunsTest(unittest.TestCase):
             (
                 "Build Multi-Arch Stages / linux",
                 "Build Multi-Arch Stages / windows",
+                "Build Multi-Arch Stages / Quartz - started - build ROCm",
+                "Build Multi-Arch Stages / Quartz - completed - build ROCm",
             ),
         )
         self.assertEqual(job_health.failed_job_names, ())
@@ -383,8 +392,11 @@ class BaselineRunsTest(unittest.TestCase):
                     "Build Multi-Arch Stages / linux",
                     conclusion="failure",
                 ),
-                _workflow_job("Test hip-tests", conclusion="success"),
-                _workflow_job("Notify Quartz Completed", conclusion="skipped"),
+                _workflow_job(
+                    "Build Multi-Arch Stages / Quartz - completed - build ROCm",
+                    conclusion="skipped",
+                ),
+                _workflow_job("Test hip-tests", conclusion="failure"),
             ],
             required_name_substrings=[
                 "Build Multi-Arch Stages",
@@ -393,7 +405,6 @@ class BaselineRunsTest(unittest.TestCase):
         )
 
         self.assertFalse(job_health.is_valid)
-        # Note: successful and skipped jobs do _not_ appear in this list.
         self.assertEqual(
             job_health.failed_job_names,
             ("Build Multi-Arch Stages / linux (completed/failure)",),
@@ -465,7 +476,6 @@ class BaselineRunsTest(unittest.TestCase):
     def test_select_baseline_run_skips_run_when_required_build_job_failed(self):
         runs = [
             _workflow_run("failed-build", conclusion="failure"),
-            _workflow_run("safely-skipped", conclusion="skipped"),
             _workflow_run("usable", conclusion="success"),
         ]
         artifacts_by_run_id = {
@@ -480,9 +490,20 @@ class BaselineRunsTest(unittest.TestCase):
         }
         jobs_by_run_id = {
             "failed-build": [
-                _workflow_job("Build Multi-Arch Stages", conclusion="failure")
+                _workflow_job("Build Multi-Arch Stages", conclusion="failure"),
+                _workflow_job(
+                    "Build Multi-Arch Stages / Quartz - completed - build ROCm",
+                    conclusion="skipped",
+                ),
             ],
-            "usable": [_workflow_job("Build Multi-Arch Stages")],
+            "usable": [
+                _workflow_job("Build Multi-Arch Stages"),
+                _workflow_job(
+                    "Build Multi-Arch Stages / Quartz - started - build ROCm",
+                    conclusion="skipped",
+                ),
+                _workflow_job("Test hip-tests", conclusion="failure"),
+            ],
         }
 
         def backend_factory(workflow_run, github_repository, platform):

--- a/build_tools/github_actions/tests/baseline_runs_test.py
+++ b/build_tools/github_actions/tests/baseline_runs_test.py
@@ -67,7 +67,11 @@ class BaselineRunsTest(unittest.TestCase):
         )
 
     def test_is_successful_workflow_run(self):
-        self.assertTrue(baseline_runs.is_successful_workflow_run(_workflow_run("1")))
+        self.assertTrue(
+            baseline_runs.is_successful_workflow_run(
+                _workflow_run("1", conclusion="success")
+            )
+        )
         self.assertFalse(
             baseline_runs.is_successful_workflow_run(
                 _workflow_run("1", conclusion="failure")
@@ -82,6 +86,11 @@ class BaselineRunsTest(unittest.TestCase):
     def test_is_successful_workflow_job(self):
         self.assertTrue(
             baseline_runs.is_successful_workflow_job(_workflow_job("Build"))
+        )
+        self.assertTrue(
+            baseline_runs.is_successful_workflow_job(
+                _workflow_job("Notify", conclusion="skipped")
+            )
         )
         self.assertFalse(
             baseline_runs.is_successful_workflow_job(
@@ -374,7 +383,8 @@ class BaselineRunsTest(unittest.TestCase):
                     "Build Multi-Arch Stages / linux",
                     conclusion="failure",
                 ),
-                _workflow_job("Test hip-tests"),
+                _workflow_job("Test hip-tests", conclusion="success"),
+                _workflow_job("Notify Quartz Completed", conclusion="skipped"),
             ],
             required_name_substrings=[
                 "Build Multi-Arch Stages",
@@ -383,6 +393,7 @@ class BaselineRunsTest(unittest.TestCase):
         )
 
         self.assertFalse(job_health.is_valid)
+        # Note: successful and skipped jobs do _not_ appear in this list.
         self.assertEqual(
             job_health.failed_job_names,
             ("Build Multi-Arch Stages / linux (completed/failure)",),
@@ -454,7 +465,8 @@ class BaselineRunsTest(unittest.TestCase):
     def test_select_baseline_run_skips_run_when_required_build_job_failed(self):
         runs = [
             _workflow_run("failed-build", conclusion="failure"),
-            _workflow_run("usable"),
+            _workflow_run("safely-skipped", conclusion="skipped"),
+            _workflow_run("usable", conclusion="success"),
         ]
         artifacts_by_run_id = {
             "failed-build": [


### PR DESCRIPTION
## Motivation

Workflow runs have been failing to find a baseline run using this logic since Quartz started adding jobs like `Linux::release / Build Multi-Arch Stages / Quartz - started - build ROCm` that are skipped when `vars.NOTIFY_QUARTZ_ENABLED` is not set (it is only set for release workflow runs).

* Follow-up to https://github.com/ROCm/TheRock/pull/6611
* Progress on https://github.com/ROCm/TheRock/issues/3399

For example: https://github.com/ROCm/ROCgdb/actions/runs/32391493179/job/96498546954?pr=295
`INFO baseline_runs: [BASELINE] run 32325085853: required build jobs not healthy (failed=('Windows::release / Build Multi-Arch Stages / Quartz - started - build ROCm (completed/skipped)', 'Linux::release / Build Multi-Arch Stages / Quartz - started - build ROCm (completed/skipped)', 'Windows::release / Build Multi-Arch Stages / Quartz - completed - build ROCm (completed/skipped)', 'Linux::release / Build Multi-Arch Stages / Quartz - completed - build ROCm (completed/skipped)'), missing=()), skipping`

## Technical Details

This allows skipped build jobs to satisfy the check, trusting the `validate_required_artifacts_available()` function call that runs afterwards to validate that a job is a reasonable candidate for artifact reuse.

Baseline run selection currently looks at jobs with `"Build"` in their name so it ignores `"Test"` jobs, but the Quartz jobs are scoped under `"Build"` jobs. We could instead allow-list jobs named `"Quartz"` instead of allowing the `"skipped"` status for any `"Build"` job.

## Test Plan

* Added new unit tests
* I did _not_ trigger real runs of workflows to check the behavior

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
