### PR TITLE
ci: prerelease release builds use local ccache only (no remote reads) (#7249)

### DIFF
--- a/build_tools/setup_ccache.py
+++ b/build_tools/setup_ccache.py
@@ -75,6 +75,20 @@ def _log(msg: str):
     print(f"[setup_ccache] {msg}", file=sys.stderr)
 
 
+def _config_value(lines: list[str], key: str) -> str | None:
+    """Returns the value assigned to `key` in generated config `lines`, if any.
+
+    Splits on the first '=' and strips surrounding whitespace, matching how
+    ccache itself parses the file, so a readback cannot disagree with the
+    setting ccache will actually load.
+    """
+    for line in lines:
+        name, sep, value = line.partition("=")
+        if sep and name.strip() == key:
+            return value.strip()
+    return None
+
+
 def gen_config(dir: Path, compiler_check_file: Path, args: argparse.Namespace):
     lines = []
 
@@ -139,6 +153,17 @@ def gen_config(dir: Path, compiler_check_file: Path, args: argparse.Namespace):
     #   use the appropriate compilation flags that ccache understands. See
     #   https://ccache.dev/manual/4.7.html#_precompiled_headers for details.
     lines.append(f"sloppiness = include_file_ctime,pch_defines,time_macros")
+
+    # Summarize the effective cache mode on one line, read back out of the
+    # generated config rather than inferred from the selected preset. Readers
+    # and CI log scrapers can then confirm what was actually written.
+    remote_storage = _config_value(lines, "remote_storage")
+    cache_dir = _config_value(lines, "cache_dir")
+    _log(
+        f"Cache mode: release_type={args.release_type or '(unset)'} "
+        f"preset={config_preset} remote={remote_storage or 'disabled'} "
+        f"local={cache_dir or 'disabled'}"
+    )
 
     # End with blank line.
     lines.append("")
@@ -255,8 +280,9 @@ def main(argv: list[str]):
     preset_group.add_argument(
         "--release-type",
         type=str,
-        choices=["ci", "dev", "nightly", "prerelease"],
-        help='Shorthand for --config-preset: "ci" and "dev" map to github-oss-dev, '
+        choices=["ci", "dev", "dev-bkc", "nightly", "nightly-bkc", "prerelease"],
+        help='Shorthand for --config-preset: "ci", "dev", and "dev-bkc" map '
+        'to github-oss-dev; "nightly-bkc" and "prerelease" map to local; '
         "others map to github-oss-release.",
     )
 
@@ -264,6 +290,8 @@ def main(argv: list[str]):
     if args.release_type is not None:
         if args.release_type in ("ci", "dev"):
             args.config_preset = "github-oss-dev"
+        elif args.release_type in ("nightly-bkc", "prerelease"):
+            args.config_preset = "local"
         else:
             args.config_preset = "github-oss-release"
     run(args)

--- a/build_tools/tests/setup_ccache_test.py
+++ b/build_tools/tests/setup_ccache_test.py
@@ -1,0 +1,104 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for setup_ccache.py config generation.
+
+The prerelease build is what actually ships, so these tests pin down which
+release types read from the shared remote cache and which are restricted to the
+local cache only.
+"""
+
+from pathlib import Path
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
+
+import setup_ccache
+
+
+class GenConfigTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp_dir = Path(tempfile.mkdtemp())
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
+
+    def gen_config(self, *extra_args: str) -> dict[str, str]:
+        """Runs the tool and returns the generated ccache.conf as a dict."""
+        ccache_dir = self.tmp_dir / ".ccache"
+        setup_ccache.main(
+            [
+                "--dir",
+                os.fspath(ccache_dir),
+                "--log-dir",
+                os.fspath(self.tmp_dir / "logs"),
+                "--no-reset-stats",
+                "--init",
+                *extra_args,
+            ]
+        )
+        config = {}
+        for line in (ccache_dir / "ccache.conf").read_text().splitlines():
+            if not line.strip():
+                continue
+            key, _, value = line.partition(" = ")
+            config[key] = value
+        return config
+
+    def test_prerelease_is_local_only(self):
+        """Shipped builds must not be able to read from the remote cache."""
+        config = self.gen_config("--release-type", "prerelease")
+        self.assertNotIn("remote_storage", config)
+        self.assertIn("cache_dir", config)
+
+    def test_nightly_bkc_is_local_only(self):
+        config = self.gen_config("--release-type", "nightly-bkc")
+        self.assertNotIn("remote_storage", config)
+        self.assertIn("cache_dir", config)
+
+    def test_nightly_uses_release_remote_cache(self):
+        config = self.gen_config("--release-type", "nightly")
+        self.assertEqual(config["remote_storage"], setup_ccache.CACHE_SRV_REL)
+
+    def test_dev_uses_dev_remote_cache(self):
+        config = self.gen_config("--release-type", "dev")
+        self.assertEqual(config["remote_storage"], setup_ccache.CACHE_SRV_DEV)
+
+    def test_dev_bkc_uses_dev_remote_cache(self):
+        config = self.gen_config("--release-type", "dev-bkc")
+        self.assertEqual(config["remote_storage"], setup_ccache.CACHE_SRV_DEV)
+
+    def test_local_path_is_honored_for_prerelease(self):
+        local_path = self.tmp_dir / "cache"
+        config = self.gen_config(
+            "--release-type",
+            "prerelease",
+            "--local-path",
+            os.fspath(local_path),
+        )
+        self.assertEqual(config["cache_dir"], os.fspath(local_path))
+
+    def test_explicit_local_preset_is_local_only(self):
+        config = self.gen_config("--config-preset=local")
+        self.assertNotIn("remote_storage", config)
+        self.assertIn("cache_dir", config)
+
+
+class ConfigValueTest(unittest.TestCase):
+    def test_parses_like_ccache(self):
+        lines = ["remote_storage  =  http://host:8080|connect-timeout=50"]
+        self.assertEqual(
+            setup_ccache._config_value(lines, "remote_storage"),
+            "http://host:8080|connect-timeout=50",
+        )
+
+    def test_missing_key_returns_none(self):
+        self.assertIsNone(setup_ccache._config_value(["max_size = 10G"], "cache_dir"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/development/ccache_troubleshooting.md
+++ b/docs/development/ccache_troubleshooting.md
@@ -86,6 +86,33 @@ on Windows). The namespace isolates entries to some extent, but be aware
 of cross-repo pollution — entries from one repo may share manifests with
 another if they compile the same source files with compatible flags.
 
+### Release builds use the local cache only (no remote)
+
+Prerelease (release-candidate) and `nightly-bkc` builds use only the local
+cache. The `--release-type prerelease` and `--release-type nightly-bkc` options
+automatically select the `local` config preset. Users can select the same
+local-only behavior explicitly with `--config-preset=local`.
+
+Stable releases are a repackage of the prerelease artifacts and reading only
+from the local cache guards against cache poisoning attacks. The local cache is
+kept because some builds (notably Windows) need at least a local cache for
+performance and runner stability.
+
+Expect zero remote hits in prerelease and `nightly-bkc` "Report" steps; local
+hits are expected and fine. Nightly, `dev-bkc`, `dev`, and `ci` builds are
+unaffected and continue to use a shared remote cache.
+
+> [!TIP]
+> To confirm which cache a run actually used, look for the `Cache mode` line in
+> the "Setup ccache" step. It is read back from the generated `ccache.conf`, so
+> it reports what was written rather than only the requested options:
+>
+> ```text
+> [setup_ccache] Cache mode: release_type=prerelease preset=local remote=disabled local=/.../ccache
+> [setup_ccache] Cache mode: release_type=nightly-bkc preset=local remote=disabled local=/.../ccache
+> [setup_ccache] Cache mode: release_type=nightly preset=github-oss-release remote=http://bazelremote-svc-rel...:8080|layout=bazel|connect-timeout=50 local=/.../ccache
+> ```
+
 ## Downloading and inspecting CI logs
 
 ### Finding a workflow run


### PR DESCRIPTION
Cherry-picks commit 9273e0c into the ROCm 10.0 release branch.

---

## Motivation

Stable releases are a repackage of the **prerelease** release-candidate build, so the prerelease compile is what actually ships. Those objects should never come from a **remote** cache hit to eliminate cache poisoning risks.

* Background: #7248
* Design discussion: #7259

## Technical Details

Prerelease builds use the **local cache only** (remote disabled): zero remote hits, but the local cache still works normally (reads + writes).

- `build_tools/setup_ccache.py`: now maps `nightly-bkc` and `prerelease` values of `--release-type` to `--config-preset=local`

### Why local-only (not recache or full-disable)

- **Keep the local cache**: local hits are fine, and some builds (notably Windows) need at least a local cache for performance and runner stability - without one we have seen runners exhaust resources and fail.
- `recache` was rejected: it forces *local* misses too, defeating the local cache Windows needs.
- Full-disable was rejected: it removes the local cache and changes build-config parity with nightly/CI.

## Test Plan

- `build_tools/tests/setup_ccache_test.py` (new): pins which release types read the shared remote cache and which are local-only, plus both failure modes above.
- Local: run the tool as each workflow does for `ci` / `dev` / `nightly` / `prerelease` and compare the emitted config.
- Owner dispatch: a `prerelease` run shows zero remote hits (local hits fine) in each stage's "Report" step and still builds artifacts; a `dev` / `nightly` run is unchanged.

## Test Result

CI on this branch, all 9 new tests passing on both platforms:

| Check | Result |
| --- | --- |
| [Unit Tests ::
ubuntu-24.04](https://github.com/ROCm/TheRock/actions/runs/32395965820/job/96512731944) | pass - 9/9 `setup_ccache_test.py` |
| [Unit Tests ::
windows-2022](https://github.com/ROCm/TheRock/actions/runs/32395965820/job/96512731634) | pass - 9/9 `setup_ccache_test.py` |
|
[pre-commit](https://github.com/ROCm/TheRock/actions/runs/32395965889/job/96512732019) | pass (black, mdformat, actionlint) |

Windows coverage matters here, not just for parity: `IS_WINDOWS` selects a different `compiler_check` mode, and Windows is the platform whose local-cache requirement is the reason this is local-only rather than a full disable.

`Cache mode` output from running the tool exactly as each workflow invokes it - only `prerelease` loses the remote, and it keeps its local cache:

```text
[setup_ccache] Cache mode: release_type=ci         preset=github-oss-dev     remote=http://bazelremote-svc.bazelremote-ns...:8080|layout=bazel|connect-timeout=50      local=/tmp/ccache/ci/cache
[setup_ccache] Cache mode: release_type=dev        preset=github-oss-dev     remote=http://bazelremote-svc.bazelremote-ns...:8080|layout=bazel|connect-timeout=50      local=/tmp/ccache/dev/cache
[setup_ccache] Cache mode: release_type=nightly    preset=github-oss-release remote=http://bazelremote-svc-rel.bazelremote-ns...:8080|layout=bazel|connect-timeout=50  local=/tmp/ccache/nightly/cache
[setup_ccache] Cache mode: release_type=prerelease preset=github-oss-release remote=disabled (--no-remote-cache)                                                       local=/tmp/ccache/prerelease/cache
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.

---------