### PR TITLE
 fix(comm-libs): skip rccl-translate under sanitizer builds

### DIFF
--- a/comm-libs/CMakeLists.txt
+++ b/comm-libs/CMakeLists.txt
@@ -67,7 +67,12 @@ if(THEROCK_ENABLE_RCCL)
   therock_cmake_subproject_activate(rccl)
   list(APPEND _rccl_subproject_names rccl)
 
-  if(THEROCK_ENABLE_ROCJITSU_HOTSWAP AND THEROCK_FLAG_KPACK_SPLIT_ARTIFACTS)
+  # rccl-translate unbundles gfx1250 device code from librccl.so. Under ASAN,
+  # GPU_TARGETS is filtered to xnack+ arches only (gfx942, gfx950), so gfx1250
+  # is never compiled into librccl.so and the unbundle step fails with
+  # "No code objects for architecture 'gfx1250'".
+  if(THEROCK_ENABLE_ROCJITSU_HOTSWAP AND THEROCK_FLAG_KPACK_SPLIT_ARTIFACTS
+     AND NOT THEROCK_SANITIZER)
     therock_cmake_subproject_dist_dir(_rccl_dist_dir rccl)
     therock_cmake_subproject_dist_dir(_rocjitsu_dist_dir rocjitsu)
     therock_cmake_subproject_dist_dir(_rocjitsu_hotswap_dist_dir rocjitsu-hotswap)


### PR DESCRIPTION
  ## Summary
fixes: https://github.com/ROCm/TheRock/issues/7538
  `rccl-translate` pre-translates RCCL's `gfx1250` device code using RocJitsu, but it assumes `gfx1250` is present in `librccl.so`. Under any   sanitizer build (`ASAN`, `HOST_ASAN`, `TSAN`), `therock_sanitizers.cmake`  rewrites `GPU_TARGETS` to only the `xnack+` variants of `gfx942` and  `gfx950`, so `gfx1250` is never compiled into RCCL. The `bulk_unbundle`
 step then hard-fails:
```
 ValueError: No code objects for architecture 'gfx1250' in librccl.so
```
 This broke the ASAN nightly on 2026-08-21 (run [32431769088](https://github.com/ROCm/rockrel/actions/runs/32431769088/job/96629729073)), introduced by #7505 which activated `rccl-translate` in the build.

## Fix
Add `AND NOT THEROCK_SANITIZER` to the `rccl-translate` activation guard in `comm-libs/CMakeLists.txt`. The translation step is a release-packaging optimization (kpack split artifacts) and has no role in sanitizer builds.

## Changes
- `comm-libs/CMakeLists.txt`: extend the `rccl-translate` guard with  `AND NOT THEROCK_SANITIZER`

## Test Result

  - [x] Verify the ASAN nightly CI passes after this merges (the `Stage - Comm Libs` job should no longer fail on `rccl-translate`)
  - [x] Verify a non-ASAN release build still activates `rccl-translate` when `THEROCK_ENABLE_ROCJITSU_HOTSWAP` and
    `THEROCK_FLAG_KPACK_SPLIT_ARTIFACTS` are set

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
