### PR TITLE
fix(packaging): collapse ".." in devel link targets before use

### DIFF
--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
@@ -196,11 +196,12 @@ def _resolve_link_target(parent: Path, target: str) -> Path:
     os.stat and os.link fail on that string even when the collapsed path is well
     under the limit.
 
-    parent is resolved before joining because collapsing '..' lexically through a
-    symlinked ancestor would name a different file than the OS reaches by walking
-    it, and the devel tarball does extract directory symlinks as-is.
+    resolve() collapses '..' by walking the path rather than lexically, which
+    matters because _lock_and_expand extracts directory symlinks as-is: a
+    lexical collapse through a symlinked ancestor names a different file than
+    the OS reaches.
     """
-    return Path(os.path.normpath(os.path.join(os.path.realpath(parent), target)))
+    return (parent.resolve() / target).resolve()
 
 
 def _devel_link_ok(dest_path: Path, target: str) -> bool:

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
@@ -187,6 +187,22 @@ def _find_tarfile(rocm_sdk_devel_path: Path):
     return tarfile_path, tarfile_mode
 
 
+def _resolve_link_target(parent: Path, target: str) -> Path:
+    """Resolves a relative link target against parent, collapsing any '..'.
+
+    Link targets carry one '..' per component of the file's relpath, so joining
+    one onto parent verbatim yields a string far longer than the file it names.
+    Windows applies MAX_PATH to the path as passed, before '..' is collapsed, so
+    os.stat and os.link fail on that string even when the collapsed path is well
+    under the limit.
+
+    parent is resolved before joining because collapsing '..' lexically through a
+    symlinked ancestor would name a different file than the OS reaches by walking
+    it, and the devel tarball does extract directory symlinks as-is.
+    """
+    return Path(os.path.normpath(os.path.join(os.path.realpath(parent), target)))
+
+
 def _devel_link_ok(dest_path: Path, target: str) -> bool:
     """True if dest_path already exists as a hardlink to its manifest target.
 
@@ -196,7 +212,7 @@ def _devel_link_ok(dest_path: Path, target: str) -> bool:
     if dest_path.is_symlink() or not dest_path.is_file():
         return False
     try:
-        return dest_path.samefile(dest_path.parent / target)
+        return dest_path.samefile(_resolve_link_target(dest_path.parent, target))
     except OSError:
         return False
 
@@ -377,10 +393,11 @@ def _reconcile_device_links(
                     )
                     if _devel_link_ok(dest_path, link["target"]):
                         continue
-                    # Create the parent first so the relative ".." target can be
-                    # resolved through it (the OS cannot traverse a missing dir).
+                    # Create the parent first: hardlink_to needs it to exist.
                     dest_path.parent.mkdir(parents=True, exist_ok=True)
-                    hardlink_target = dest_path.parent / link["target"]
+                    hardlink_target = _resolve_link_target(
+                        dest_path.parent, link["target"]
+                    )
                     if not hardlink_target.is_file():
                         # The target ships in the same wheel as this manifest, so
                         # it should exist; skip defensively if it somehow does not.
@@ -442,7 +459,9 @@ def _lock_and_expand(
                             # copies instead of symlinks, at the cost of disk space.
                             parent_path.mkdir(parents=True, exist_ok=True)
                             symlink_target = ti.linkname
-                            hardlink_target = dest_path.parent / symlink_target
+                            hardlink_target = _resolve_link_target(
+                                parent_path, symlink_target
+                            )
                             # On Linux, preserve symlinks in top-level bin/ directory
                             PRESERVE_SYMLINKS = [
                                 "amdclang",

--- a/build_tools/tests/devel_reconcile_test.py
+++ b/build_tools/tests/devel_reconcile_test.py
@@ -19,6 +19,7 @@ import os
 import sys
 import tempfile
 import unittest
+import unittest.mock
 from pathlib import Path, PurePosixPath
 
 # Import the runtime module straight from the package template source tree.
@@ -337,6 +338,45 @@ class ReconcileDeviceLinksTest(unittest.TestCase):
         self._reconcile()
         self.assertTrue(dest.samefile(src))
         self.assertEqual(dest.read_text(), "real kpack")
+
+    def test_no_uncollapsed_parent_refs_reach_the_filesystem(self):
+        # Manifest link targets lead with one ".." per relpath component, so a
+        # verbatim join names the right file with a much longer string. Windows
+        # applies MAX_PATH before collapsing "..", so such a path fails to stat
+        # even though the file is present, and the device file is silently
+        # dropped from the devel tree. Assert on the paths themselves rather
+        # than on a length, so this holds on Linux CI too.
+        self._add_device_wheel(
+            "gfx942",
+            {
+                ".kpack/blas_lib_gfx942.kpack": "kpack data",
+                "lib/rocblas/library/Foo_gfx942.co": "kernel object",
+            },
+        )
+
+        seen: list[str] = []
+        real_stat = os.stat
+
+        def recording_stat(path, *args, **kwargs):
+            seen.append(str(path))
+            return real_stat(path, *args, **kwargs)
+
+        with unittest.mock.patch("os.stat", recording_stat):
+            # Twice: the first pass creates the links and exercises
+            # _reconcile_device_links, the second takes the steady-state route
+            # through _devel_link_ok. They resolve the target separately.
+            self._reconcile()
+            self._reconcile()
+
+        self.assertTrue(seen, "os.stat was not intercepted, so nothing was checked")
+        offenders = [p for p in seen if ".." in Path(p).parts]
+        self.assertFalse(
+            offenders,
+            msg=(
+                "link targets must be collapsed before use; these reached the "
+                f"filesystem with '..' intact: {offenders[:3]}"
+            ),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

On Windows, `rocm-sdk init` does not link some per-ISA device files into the expanded devel tree. It reports no error, so the only thing that catches it is `testLibrariesMirroredIntoDevel`.

`_reconcile_device_links` joins the manifest's relative target onto the destination's parent without collapsing the `..` segments, one per relpath component, so the string is far longer than the file it names. For gfx1200 in `C:\Users\rocm\.venv`, the code stats 261 characters for a 200-character file. Windows applies MAX_PATH before collapsing `..`, so `Path.is_file()` returns `False` and the following `continue` drops the file.

Rebuilding that string for all 396 entries in the published gfx1200 manifest partitions them exactly against the reported failures. The 340 at 259 characters or fewer are linked, and the 56 at 261 to 263 are not.

Which files cross depends on install path length, not on the wheels, which is why CI fails and most developer machines do not. The CI site-packages path is 75 characters against 37 for the install in the report.

Fixes #7537. The CI failures in #7369 are this bug.

## Technical Details

`_devel.py` gains `_resolve_link_target()`, which resolves the parent then collapses the join. All three sites that build this string now go through it: `_devel_link_ok()` at `:199`, `_reconcile_device_links()` at `:383` and `_lock_and_expand()` at `:445`.

Only `_reconcile_device_links` causes the reported failure. `_lock_and_expand` builds the identical string with about 40 characters of headroom, which is not a margin worth keeping.

`resolve()` collapses `..` by walking the path rather than lexically. That matters because `_lock_and_expand()` extracts directory symlinks as-is, so an ancestor can be a symlink, and a lexical collapse through one names a different file than the OS reaches. The resolution runs once per link on every reconcile, including the fast path, and costs about 15 ms per 396 links. That path is `rocm-sdk init`, `path` and `test`; the compiler trampolines return the expanded tree without reconciling, so a build hot path is not affected.

Two things deliberately stay. `dest_path.symlink_to(symlink_target)` in the preserve-symlinks branch keeps its relative target, because that symlink is meant to be relative. The `continue` below still swallows the failure silently, which is why this went unnoticed for eight weeks, but changing it is a behaviour change for its own PR.

The comment above the `mkdir` described a `..` traversal that no longer happens. It now states the remaining reason, which is that `hardlink_to` needs the parent to exist.

## Test Plan

- **Regression test.** One new case in `devel_reconcile_test.py` asserts that no path reaching the filesystem during a reconcile carries an uncollapsed `..`. It patches `os.stat` rather than calling `_resolve_link_target()` directly, so it covers all three call sites and any added later.
- **Negative control.** Run that case against `HEAD`'s `_devel.py` to confirm it fails, then against the change to confirm it passes.
- **Test hardening.** The case reconciles twice, because `_reconcile_device_links` and `_devel_link_ok` resolve the target separately and only the second runs in steady state. It also asserts the recording is non-empty, so it fails rather than passing silently if `os.stat` stops being the interception point.
- **Full suite.** `pytest` from `build_tools` in a `python:3.12-slim` container against both trees, comparing failure names rather than counts. `requirements-test.txt` is at the repo root, not in `build_tools`, or nothing collects.
- **End to end against real data.** Drive the real `_reconcile_device_links()` against the published `rocm_sdk_device_gfx1200-10.0.0a20260729` manifest, padding the install prefix so Linux `PATH_MAX` falls where MAX_PATH does on the reported install.
- **Real Windows.** Run `rocm-sdk test` before and after the change on a Windows 11 machine with long path support disabled.
- **Lint.** `pre-commit` over the changed files, with Black at the pinned 25.11.0.

## Test Result

| Check | Result |
|---|---|
| Regression test | Pass. `devel_reconcile_test` collects 14 cases including the new one. |
| Negative control | Pass. The new case fails against the parent commit's `_devel.py` and passes with the change. |
| Test hardening | Pass. Instrumenting the case shows it reaching both sites, `_reconcile_device_links` on the first pass and `_devel_link_ok` on the second, and recording 273 `os.stat` calls, so the assertion is not vacuous. |
| Full suite | **No new failures.** 1891 passed / 40 skipped / 6 failed, against 1890 / 40 / 7 before the change. The only difference is the new case. `scan_tools` 31 passed and `test_tools` 49 passed. |
| End to end against real data | 340 linked and 56 dropped before the change, 396 linked and 0 dropped after. The 56 dropped are the same 56 the reported failure names. |
| Real Windows | Pass. `rocm-sdk test` fails with the 56 files before the change and passes after, and the devel tree gains all 282 gfx1200 hipBLASLt files as hardlinks. |
| Lint | Pass. `pre-commit` runs clean over both files, Black at the pinned 25.11.0 reformats nothing. |

CI confirms this on the platform where the bug occurs. The Windows job `Test Python (gfx110X-all, windows-gfx110X-gpu-rocm, 3.12, native)` passes on this PR. That is the job linked from #7369, where it previously reported 384 missing files. It installs wheels built by this run into a 75 character site-packages path, which is the prefix that triggers the failure, and `testLibrariesMirroredIntoDevel` now passes with no occurrence of "libraries file(s) missing from devel" anywhere in the log.

The 6 remaining failures pre-date this change and are unrelated to it: one in `artifact_descriptor_overlap_test`, four in `compute_rocm_package_version_test` and one in `jax_install_scripts_test`. They are identical before and after.

**Not covered.** The Windows CI legs on this PR are the only check that runs on a runner. The manual Windows verification used a single machine and a single install path.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
