### PR TITLE
fix(rocprofiler-compute): rename the torch trace gtest RPATH origin target

### DIFF
--- a/profiler/post_hook_rocprofiler-compute.cmake
+++ b/profiler/post_hook_rocprofiler-compute.cmake
@@ -8,7 +8,7 @@ foreach(_test_target
         test-rocprofiler-compute-tool
         test-pc-sampling-collector
         test-compression
-        test-roctx-recordfn)
+        test-torch-trace-collector)
   if(TARGET ${_test_target})
     set_target_properties(${_test_target} PROPERTIES
       THEROCK_INSTALL_RPATH_ORIGIN libexec/rocprofiler-compute/tests


### PR DESCRIPTION
rocm-systems renames the `roctx_recordfn` module and its gtest to
`torch_trace_collector` in ROCm/rocm-systems#8552.

The target name here is matched by `if(TARGET ...)`, so the stale name does not
fail the build. It just stops applying `THEROCK_INSTALL_RPATH_ORIGIN` to the
renamed test, which would leave it with incorrect relative RPATH entries.

This lands before ROCm/rocm-systems#8552, which is blocked on the TheRock ref
bump that picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)