### PR TITLE
fix(packaging): aggregate_deb_metadata.py to fall through to the next compression format on HTTP 403 error

### DIFF
--- a/build_tools/packaging/linux/aggregate_deb_metadata.py
+++ b/build_tools/packaging/linux/aggregate_deb_metadata.py
@@ -138,8 +138,11 @@ def fetch_packages(
             compressed = fetch_bytes(url)
             return decompress(compressed)
         except urllib.error.HTTPError as e:
-            if e.code == 404:
-                print(f"  Not found: {url} — trying next format")
+            # Treat 404 (not found) and 403 (forbidden/not available) as
+            # "this format is not served — try the next one". Some servers
+            # return 403 for non-existent resources instead of 404.
+            if e.code in (403, 404):
+                print(f"  Not found ({e.code}): {url} — trying next format")
                 continue
             raise
 

--- a/build_tools/packaging/linux/tests/aggregate_metadata_test.py
+++ b/build_tools/packaging/linux/tests/aggregate_metadata_test.py
@@ -172,6 +172,24 @@ class TestDebFetchPackages(unittest.TestCase):
             )
         self.assertEqual(result, b"Package: pkg\nVersion: 2.0\n")
 
+    def test_falls_back_to_gz_when_xz_returns_403(self):
+        # Some servers (e.g. repo.amd.com) return 403 Forbidden instead of
+        # 404 for formats they don't serve. We treat 403 the same as 404.
+        gz_data = gzip.compress(b"Package: pkg\nVersion: 3.0\n")
+
+        def side_effect(url):
+            if url.endswith(".xz"):
+                raise self._make_http_error(403)
+            if url.endswith(".bz2"):
+                raise self._make_http_error(404)
+            return gz_data
+
+        with patch.object(deb, "fetch_bytes", side_effect=side_effect):
+            result = deb.fetch_packages(
+                "https://example.com", "dists", "stable", "main", "amd64"
+            )
+        self.assertEqual(result, b"Package: pkg\nVersion: 3.0\n")
+
     def test_falls_back_through_all_to_uncompressed(self):
         raw = b"Package: pkg\nVersion: 3.0\n"
 


### PR DESCRIPTION
## Motivation

When running the aggregate DEB metadata script against `repo.amd.com`,
the script failed with a error:

`ERROR: Failed to fetch Packages.gz from [core] https://repo.amd.com/rocm/packages-multi-arch/ubuntu2404: HTTP Error 403: Forbidden`


The actual sequence was:
1. Script tries `Packages.xz` first (preferred format)
2. Server returns **403 Forbidden** (not 404) for `.xz`
3. Code re-raised the 403 immediately instead of trying the next format
4. `.gz` was never attempted, even though it exists and works

Some servers return 403 for compression formats they don't serve rather
than the more conventional 404. `repo.amd.com` is one such server.

## Technical Details

**`build_tools/packaging/linux/aggregate_deb_metadata.py`**

Changed the HTTP error handling in `fetch_packages()` to treat both
`403` and `404` as "this format is not available — try the next one":

```python
# Before:
if e.code == 404:

# After:
if e.code in (403, 404):
If all formats (.xz, .bz2, .gz, uncompressed) fail, the error is
still propagated correctly.

build_tools/packaging/linux/tests/aggregate_metadata_test.py

Added test_falls_back_to_gz_when_xz_returns_403 to cover the 403
fallback case explicitly.

Note: aggregate_rpm_metadata.py does not need this fix — it fetches
the exact URL from repomd.xml with no format negotiation.

##Test Plan

- Existing 43 unit tests continue to pass
- New test verifies .gz is used when .xz returns 403
- Manual verification: script now successfully fetches from repo.amd.com