### PR TITLE
fix(bootstrap): write .prebuilt marker at the subproject stage dir

### DIFF
--- a/build_tools/_therock_utils/artifacts.py
+++ b/build_tools/_therock_utils/artifacts.py
@@ -33,6 +33,38 @@ from .archive_util import open_archive_for_read
 from .pattern_match import PatternMatcher, MatchPredicate
 
 
+# Every subproject stage directory is named "stage": therock_subproject.cmake
+# derives it as "${BINARY_DIR}/${DIR_PREFIX}stage" and DIR_PREFIX is unset for
+# every subproject in the tree.
+STAGE_DIR_NAME = "stage"
+
+
+def prebuilt_marker_relpath(relpath: str) -> str:
+    """Maps an artifact manifest relpath to the bootstrap marker the build reads.
+
+    therock_subproject.cmake looks for the marker beside the subproject's stage
+    directory, as "${_stage_dir}.prebuilt". Almost every artifact descriptor
+    declares its basedir as the stage directory itself, so the marker is simply
+    "<relpath>.prebuilt".
+
+    A descriptor may however declare a basedir *below* its stage directory (e.g.
+    "dctools/rdc/stage/portable-rdc", which scopes the artifact to RDC's
+    INSTALL_DESTINATION). Naming the marker after that basedir yields a path the
+    build never checks, so the subproject is rebuilt from source even though its
+    artifact was fetched and extracted. Truncate at the innermost enclosing
+    "stage" component so such basedirs still mark their enclosing subproject.
+
+    Relpaths whose last component is "stage" (the overwhelming majority) and
+    relpaths with no "stage" component at all (e.g. "math-libs/hipthreads/build")
+    are returned unchanged apart from the suffix.
+    """
+    parts = PurePosixPath(relpath).parts
+    for i in range(len(parts) - 1, -1, -1):
+        if parts[i] == STAGE_DIR_NAME:
+            return str(PurePosixPath(*parts[: i + 1])) + ".prebuilt"
+    return relpath + ".prebuilt"
+
+
 class ArtifactName:
     def __init__(self, name: str, component: str, target_family: str):
         self.name = name

--- a/build_tools/_therock_utils/artifacts.py
+++ b/build_tools/_therock_utils/artifacts.py
@@ -33,38 +33,6 @@ from .archive_util import open_archive_for_read
 from .pattern_match import PatternMatcher, MatchPredicate
 
 
-# Every subproject stage directory is named "stage": therock_subproject.cmake
-# derives it as "${BINARY_DIR}/${DIR_PREFIX}stage" and DIR_PREFIX is unset for
-# every subproject in the tree.
-STAGE_DIR_NAME = "stage"
-
-
-def prebuilt_marker_relpath(relpath: str) -> str:
-    """Maps an artifact manifest relpath to the bootstrap marker the build reads.
-
-    therock_subproject.cmake looks for the marker beside the subproject's stage
-    directory, as "${_stage_dir}.prebuilt". Almost every artifact descriptor
-    declares its basedir as the stage directory itself, so the marker is simply
-    "<relpath>.prebuilt".
-
-    A descriptor may however declare a basedir *below* its stage directory (e.g.
-    "dctools/rdc/stage/portable-rdc", which scopes the artifact to RDC's
-    INSTALL_DESTINATION). Naming the marker after that basedir yields a path the
-    build never checks, so the subproject is rebuilt from source even though its
-    artifact was fetched and extracted. Truncate at the innermost enclosing
-    "stage" component so such basedirs still mark their enclosing subproject.
-
-    Relpaths whose last component is "stage" (the overwhelming majority) and
-    relpaths with no "stage" component at all (e.g. "math-libs/hipthreads/build")
-    are returned unchanged apart from the suffix.
-    """
-    parts = PurePosixPath(relpath).parts
-    for i in range(len(parts) - 1, -1, -1):
-        if parts[i] == STAGE_DIR_NAME:
-            return str(PurePosixPath(*parts[: i + 1])) + ".prebuilt"
-    return relpath + ".prebuilt"
-
-
 class ArtifactName:
     def __init__(self, name: str, component: str, target_family: str):
         self.name = name
@@ -299,3 +267,35 @@ class ArtifactPopulator:
                                 f"Extracting tar artifact archive, encountered file not in manifest: {member}"
                             )
         return all_root_relpaths
+
+
+# Every subproject stage directory is named "stage": therock_subproject.cmake
+# derives it as "${BINARY_DIR}/${DIR_PREFIX}stage" and DIR_PREFIX is unset for
+# every subproject in the tree.
+STAGE_DIR_NAME = "stage"
+
+
+def prebuilt_marker_relpath(relpath: str) -> str:
+    """Maps an artifact manifest relpath to the bootstrap marker the build reads.
+
+    therock_subproject.cmake looks for the marker beside the subproject's stage
+    directory, as "${_stage_dir}.prebuilt". Almost every artifact descriptor
+    declares its basedir as the stage directory itself, so the marker is simply
+    "<relpath>.prebuilt".
+
+    A descriptor may however declare a basedir *below* its stage directory (e.g.
+    "dctools/rdc/stage/portable-rdc", which scopes the artifact to RDC's
+    INSTALL_DESTINATION). Naming the marker after that basedir yields a path the
+    build never checks, so the subproject is rebuilt from source even though its
+    artifact was fetched and extracted. Truncate at the innermost enclosing
+    "stage" component so such basedirs still mark their enclosing subproject.
+
+    Relpaths whose last component is "stage" (the overwhelming majority) and
+    relpaths with no "stage" component at all (e.g. "math-libs/hipthreads/build")
+    are returned unchanged apart from the suffix.
+    """
+    parts = PurePosixPath(relpath).parts
+    for i in range(len(parts) - 1, -1, -1):
+        if parts[i] == STAGE_DIR_NAME:
+            return str(PurePosixPath(*parts[: i + 1])) + ".prebuilt"
+    return relpath + ".prebuilt"

--- a/build_tools/artifact_manager.py
+++ b/build_tools/artifact_manager.py
@@ -68,7 +68,11 @@ from _therock_utils.artifact_backend import (
     S3Backend,
     create_backend_from_env,
 )
-from _therock_utils.artifacts import ArtifactName, ArtifactPopulator
+from _therock_utils.artifacts import (
+    ArtifactName,
+    ArtifactPopulator,
+    prebuilt_marker_relpath,
+)
 from _therock_utils.hash_util import calculate_hash
 from _therock_utils.workflow_outputs import WorkflowOutputRoot
 
@@ -353,11 +357,12 @@ class BootstrappingPopulator(ArtifactPopulator):
             # Do cleanup while holding lock to prevent race with extraction
             if full_path.exists():
                 rmtree_with_retry(full_path)
-            # Write the ".prebuilt" marker file
-            prebuilt_path = full_path.with_name(full_path.name + ".prebuilt")
+            # Write the ".prebuilt" marker file where the build looks for it.
+            prebuilt_path = self.output_path / prebuilt_marker_relpath(relpath)
             prebuilt_path.parent.mkdir(parents=True, exist_ok=True)
             prebuilt_path.touch()
-            self.created_markers.append(prebuilt_path)
+            if prebuilt_path not in self.created_markers:
+                self.created_markers.append(prebuilt_path)
 
 
 def extract_artifact(request: ExtractRequest) -> Optional[Path]:

--- a/build_tools/buildctl.py
+++ b/build_tools/buildctl.py
@@ -86,7 +86,11 @@ import subprocess
 import sys
 from typing import Optional, Set
 
-from _therock_utils.artifacts import ArtifactPopulator, ArtifactName
+from _therock_utils.artifacts import (
+    ArtifactPopulator,
+    ArtifactName,
+    prebuilt_marker_relpath,
+)
 
 
 def do_enable_disable(args: argparse.Namespace, enable_mode: bool):
@@ -262,11 +266,12 @@ class BootstrappingPopulator(ArtifactPopulator):
         if full_path.exists():
             print(f"CLEANING: {full_path}")
             shutil.rmtree(full_path)
-        # Write the ".prebuilt" marker file
-        prebuilt_path = full_path.with_name(full_path.name + ".prebuilt")
+        # Write the ".prebuilt" marker file where the build looks for it.
+        prebuilt_path = self.output_path / prebuilt_marker_relpath(relpath)
         prebuilt_path.parent.mkdir(parents=True, exist_ok=True)
         prebuilt_path.touch()
-        self.created_markers.append(prebuilt_path)
+        if prebuilt_path not in self.created_markers:
+            self.created_markers.append(prebuilt_path)
 
     def on_artifact_dir(self, artifact_dir: Path):
         print(f"FLATTENING {artifact_dir.name}")

--- a/build_tools/tests/artifact_descriptor_overlap_test.py
+++ b/build_tools/tests/artifact_descriptor_overlap_test.py
@@ -30,11 +30,16 @@ Limitations (cases this test does NOT catch):
 """
 
 import subprocess
+import sys
 import tomllib
 import unittest
 from pathlib import Path
 
 THEROCK_DIR = Path(__file__).resolve().parent.parent.parent
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from _therock_utils.artifacts import STAGE_DIR_NAME, prebuilt_marker_relpath
 
 
 def get_descriptor_paths() -> list[Path]:
@@ -125,6 +130,54 @@ class ArtifactDescriptorOverlapTest(unittest.TestCase):
                 "https://github.com/ROCm/TheRock/issues/3758):\n"
                 + "\n".join(f"  - {e}" for e in errors)
             )
+
+
+class BootstrapMarkerBasedirTest(unittest.TestCase):
+    """Verifies the bootstrap marker derived from each basedir names a stage dir.
+
+    `--bootstrap` writes a ".prebuilt" marker per artifact manifest basedir, and
+    therock_subproject.cmake only ever looks for "${_stage_dir}.prebuilt". A
+    basedir nested below its stage dir (see `dctools/artifact-rdc.toml`) would
+    otherwise produce a marker the build never checks.
+    """
+
+    def test_every_basedir_yields_a_stage_dir_marker(self):
+        descriptors = sorted(get_descriptor_paths())
+        self.assertGreater(
+            len(descriptors),
+            0,
+            f"No artifact descriptors found, check THEROCK_DIR ('{THEROCK_DIR}')",
+        )
+
+        basedirs: set[str] = set()
+        for descriptor_path in descriptors:
+            basedirs |= get_basedirs(descriptor_path)
+
+        # Any basedir whose marker is not simply "<basedir>.prebuilt" must have
+        # been truncated to an enclosing stage dir, never anywhere else.
+        rewritten: dict[str, str] = {}
+        for basedir in sorted(basedirs):
+            marker = prebuilt_marker_relpath(basedir)
+            if marker == basedir + ".prebuilt":
+                continue
+            stage_dir = marker[: -len(".prebuilt")]
+            self.assertTrue(
+                basedir.startswith(stage_dir + "/"),
+                f"Marker for '{basedir}' escaped its own basedir: '{marker}'",
+            )
+            self.assertTrue(
+                stage_dir.endswith("/" + STAGE_DIR_NAME),
+                f"Marker for '{basedir}' does not name a stage dir: '{marker}'",
+            )
+            rewritten[basedir] = marker
+
+        # Only descriptors that declare a basedir below their stage dir are
+        # affected. If this list grows, confirm the new marker is the one the
+        # subproject's stage dir would produce.
+        self.assertEqual(
+            rewritten,
+            {"dctools/rdc/stage/portable-rdc": "dctools/rdc/stage.prebuilt"},
+        )
 
 
 if __name__ == "__main__":

--- a/build_tools/tests/artifact_descriptor_test.py
+++ b/build_tools/tests/artifact_descriptor_test.py
@@ -1,32 +1,36 @@
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-"""Tests validating that artifact descriptors don't have overlapping basedirs.
+"""Whole-tree invariant tests over the artifact-*.toml descriptors.
 
-When two artifact descriptors claim the same stage directory for any component
-type, extracting both artifacts into the same output directory causes file
-collisions.
+These tests are checks on the descriptors themselves rather than on any one
+tool. Each loads every TheRock-owned `artifact-*.toml`, collects the basedirs
+it declares, and asserts a property that must hold across the whole tree.
+Descriptor discovery uses ``git ls-files`` so it does not recursively scan
+generated build trees, caches, or the contents of submodules. Both tracked
+files and non-ignored untracked files are included, so a newly created
+descriptor is checked before it is staged.
 
-This was the root cause of https://github.com/ROCm/TheRock/issues/3758, where
-both `artifact-rocprofiler-sdk.toml` and `artifact-aqlprofile-tests.toml`
-included `profiler/aqlprofile/stage`, causing concurrent extraction to race
-(and fail with "file exists" errors) on overlapping files.
+`ArtifactDescriptorOverlapTest` — each basedir belongs to exactly one
+descriptor. When two descriptors claim the same stage directory for any
+component type, extracting both artifacts into the same output directory
+causes file collisions. This was the root cause of
+https://github.com/ROCm/TheRock/issues/3758, where both
+`artifact-rocprofiler-sdk.toml` and `artifact-aqlprofile-tests.toml` included
+`profiler/aqlprofile/stage`, causing concurrent extraction to race (and fail
+with "file exists" errors) on overlapping files.
 
-This test loads TheRock-owned artifact-*.toml descriptors and checks that each
-stage directory (basedir) belongs to exactly one descriptor. Descriptor
-discovery uses ``git ls-files`` so it does not recursively scan generated build
-trees, caches, or the contents of submodules. Both tracked files and non-ignored
-untracked files are included, so a newly created descriptor is checked before
-it is staged.
+Cases the overlap test does NOT catch: two artifacts with *different* basedirs
+whose installed files collide after flattening (basedir prefix stripped). If
+two subprojects both install a file to the same relative path (e.g.,
+"lib/libfoo.so" or "bin/sequence.yaml") in their respective stage dirs,
+flattening produces duplicate paths even though the basedirs are distinct.
+Current projects avoid this by using unique file names, but it's convention
+rather than enforcement. Catching this requires inspecting actual build output.
 
-Limitations (cases this test does NOT catch):
-  - Two artifacts with *different* basedirs whose installed files collide
-    after flattening (basedir prefix stripped). If two subprojects both
-    install a file to the same relative path (e.g., "lib/libfoo.so" or
-    "bin/sequence.yaml") in their respective stage dirs, flattening produces
-    duplicate paths even though the basedirs are distinct. Current projects
-    avoid this by using unique file names, but it's convention rather than
-    enforcement. Catching this requires inspecting actual build output.
+`BootstrapMarkerBasedirTest` — the bootstrap ".prebuilt" marker derived from
+each basedir names a directory the build actually checks. See
+https://github.com/ROCm/TheRock/issues/7549.
 """
 
 import subprocess

--- a/build_tools/tests/artifact_manager_tool_test.py
+++ b/build_tools/tests/artifact_manager_tool_test.py
@@ -26,6 +26,7 @@ def is_windows():
 
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 
+from _therock_utils.archive_util import open_archive_for_write
 from _therock_utils.artifact_backend import ArtifactBackend, LocalDirectoryBackend
 from _therock_utils.workflow_outputs import WorkflowOutputRoot
 
@@ -1505,6 +1506,118 @@ class ParseTargetFamiliesTest(unittest.TestCase):
         self.assertIn("gfx110X-all", result)
         self.assertIn("gfx1100", result)
         self.assertIn("gfx1101", result)
+
+
+class BootstrapMarkerTest(unittest.TestCase):
+    """End-to-end tests for where bootstrapping writes ".prebuilt" markers.
+
+    Covers both BootstrappingPopulator implementations: artifact_manager.py
+    (CI fetch) and buildctl.py (local bootstrap from an artifacts dir).
+    """
+
+    def setUp(self):
+        # Import here so sys.path is already set up.
+        import artifact_manager
+        import buildctl
+
+        self.populator_factories = {
+            "artifact_manager": artifact_manager.BootstrappingPopulator,
+            "buildctl": buildctl.BootstrappingPopulator,
+        }
+        self.temp_dir = Path(tempfile.mkdtemp(prefix="bootstrap_marker_test_"))
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _make_archive(self, tag: str, basedir: str, relfiles) -> Path:
+        """Write a minimal artifact archive declaring a single manifest basedir."""
+        content_dir = self.temp_dir / "content" / tag
+        for relfile in relfiles:
+            p = content_dir / basedir / relfile
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(relfile)
+        manifest = content_dir / "artifact_manifest.txt"
+        manifest.write_text(basedir + "\n")
+
+        archive_path = self.temp_dir / f"{tag}.tar.xz"
+        with open_archive_for_write(archive_path, "xz") as tf:
+            # artifact_manifest.txt must be the first member.
+            tf.add(str(manifest), arcname="artifact_manifest.txt")
+            for relfile in relfiles:
+                tf.add(
+                    str(content_dir / basedir / relfile),
+                    arcname=f"{basedir}/{relfile}",
+                )
+        return archive_path
+
+    def _bootstrap(self, impl: str, basedir: str, relfiles) -> Path:
+        tag = f"{impl}_lib_generic"
+        archive = self._make_archive(tag, basedir, relfiles)
+        output_dir = self.temp_dir / f"build-{impl}"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        self.populator_factories[impl](output_path=output_dir)(archive)
+        return output_dir
+
+    def test_nested_basedir_marks_enclosing_stage_dir(self):
+        """Regression test for a basedir nested below the subproject stage dir.
+
+        `dctools/artifact-rdc.toml` declares
+        "dctools/rdc/stage/portable-rdc". Naming the marker after that basedir
+        yields "dctools/rdc/stage/portable-rdc.prebuilt", which
+        therock_subproject.cmake never checks, so rdc is rebuilt from source
+        despite its artifact having been fetched and extracted.
+        """
+        for impl in self.populator_factories:
+            with self.subTest(impl=impl):
+                output_dir = self._bootstrap(
+                    impl,
+                    "dctools/rdc/stage/portable-rdc",
+                    ["bin/rdcd", "lib/librdc.so"],
+                )
+                stage_dir = output_dir / "dctools" / "rdc" / "stage"
+
+                # The marker the build looks for: "${_stage_dir}.prebuilt".
+                self.assertTrue(
+                    (output_dir / "dctools" / "rdc" / "stage.prebuilt").exists(),
+                    "Bootstrap marker not created beside the subproject stage dir",
+                )
+                self.assertFalse(
+                    (stage_dir / "portable-rdc.prebuilt").exists(),
+                    "Marker written at a path the build never checks",
+                )
+                # Extraction is unaffected: content still lands in the basedir.
+                self.assertTrue((stage_dir / "portable-rdc" / "bin" / "rdcd").exists())
+                self.assertTrue(
+                    (stage_dir / "portable-rdc" / "lib" / "librdc.so").exists()
+                )
+
+    def test_stage_basedir_marker_unchanged(self):
+        """The ~100 basedirs that are stage dirs keep their existing marker."""
+        for impl in self.populator_factories:
+            with self.subTest(impl=impl):
+                output_dir = self._bootstrap(
+                    impl, "core/ROCR-Runtime/stage", ["lib/libhsa-runtime64.so"]
+                )
+                subproject_dir = output_dir / "core" / "ROCR-Runtime"
+
+                self.assertTrue((subproject_dir / "stage.prebuilt").exists())
+                self.assertTrue(
+                    (subproject_dir / "stage" / "lib" / "libhsa-runtime64.so").exists()
+                )
+
+    def test_basedir_without_stage_component_marker_unchanged(self):
+        """A basedir with no "stage" component is left alone."""
+        for impl in self.populator_factories:
+            with self.subTest(impl=impl):
+                output_dir = self._bootstrap(
+                    impl, "math-libs/hipthreads/build", ["lib/libhipthreads.so"]
+                )
+
+                self.assertTrue(
+                    (
+                        output_dir / "math-libs" / "hipthreads" / "build.prebuilt"
+                    ).exists()
+                )
 
 
 if __name__ == "__main__":

--- a/build_tools/tests/artifact_manager_tool_test.py
+++ b/build_tools/tests/artifact_manager_tool_test.py
@@ -8,6 +8,7 @@ These tests verify end-to-end behavior of the artifact_manager push/fetch comman
 particularly error handling and exit codes.
 """
 
+import argparse
 import hashlib
 import os
 import platform
@@ -29,6 +30,9 @@ sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 from _therock_utils.archive_util import open_archive_for_write
 from _therock_utils.artifact_backend import ArtifactBackend, LocalDirectoryBackend
 from _therock_utils.workflow_outputs import WorkflowOutputRoot
+
+import artifact_manager
+import buildctl
 
 # Minimal topology TOML for testing push/fetch behavior.
 # Defines two stages: upstream-stage produces artifacts, downstream-stage consumes them.
@@ -264,8 +268,6 @@ class TestPushFailureExitCode(ArtifactManagerTestBase):
     @mock.patch("artifact_manager.create_backend_from_env")
     def test_push_fails_when_all_uploads_fail(self, mock_backend_factory, mock_delay):
         """Test that push exits with code 1 when all uploads fail."""
-        import artifact_manager
-
         failing_backend = FailingBackend(fail_uploads_after=0)
         mock_backend_factory.return_value = failing_backend
 
@@ -295,8 +297,6 @@ class TestPushFailureExitCode(ArtifactManagerTestBase):
     @mock.patch("artifact_manager.create_backend_from_env")
     def test_push_fails_when_some_uploads_fail(self, mock_backend_factory, mock_delay):
         """Test that push exits with code 1 when some (but not all) uploads fail."""
-        import artifact_manager
-
         failing_backend = FailingBackend(
             fail_uploads_after=1, staging_dir=self.staging_dir
         )
@@ -327,8 +327,6 @@ class TestPushFailureExitCode(ArtifactManagerTestBase):
 
     def test_push_succeeds_when_all_uploads_succeed(self):
         """Test that push exits normally (no exception) when all uploads succeed."""
-        import artifact_manager
-
         archive_path = self._create_fake_precompressed_artifact(
             "test-artifact", "lib", "generic"
         )
@@ -371,8 +369,6 @@ class TestPushFailureExitCode(ArtifactManagerTestBase):
 
     def test_push_succeeds_when_precompressed_artifact_is_missing_sha256sum(self):
         """Test that pre-compressed artifacts do not require a sha256sum sidecar."""
-        import artifact_manager
-
         archive_path = self._create_fake_precompressed_artifact(
             "test-artifact", "lib", "generic"
         )
@@ -415,8 +411,6 @@ class TestPushCompressionFailure(ArtifactManagerTestBase):
     @mock.patch("artifact_manager.compress_artifact")
     def test_push_fails_when_compression_fails(self, mock_compress):
         """Test that push exits with code 1 when compression fails."""
-        import artifact_manager
-
         mock_compress.return_value = None
 
         self._create_fake_artifact_dir("test-artifact", "lib", "generic")
@@ -447,8 +441,6 @@ class TestPushStageAll(ArtifactManagerTestBase):
 
     def test_push_all_stages_uploads_all_produced_artifacts(self):
         """Test that --stage all pushes artifacts from every stage."""
-        import artifact_manager
-
         self._create_fake_precompressed_artifact("test-artifact", "lib", "generic")
         self._create_fake_precompressed_artifact("second-artifact", "lib", "generic")
         self._create_fake_precompressed_artifact(
@@ -494,8 +486,6 @@ class TestFetchFailureExitCode(ArtifactManagerTestBase):
     @mock.patch("artifact_manager.create_backend_from_env")
     def test_fetch_fails_when_download_fails(self, mock_backend_factory, mock_delay):
         """Test that fetch exits with code 1 when download fails."""
-        import artifact_manager
-
         self._create_staged_artifact("test-artifact", "lib", "generic")
 
         failing_backend = FailingBackend(
@@ -526,8 +516,6 @@ class TestFetchFailureExitCode(ArtifactManagerTestBase):
     @mock.patch("artifact_manager.extract_artifact")
     def test_fetch_fails_when_extraction_fails(self, mock_extract):
         """Test that fetch exits with code 1 when extraction fails."""
-        import artifact_manager
-
         self._create_staged_artifact("test-artifact", "lib", "generic")
 
         mock_extract.return_value = None
@@ -560,8 +548,6 @@ class TestFetchStageAll(ArtifactManagerTestBase):
 
     def test_fetch_all_fetches_every_artifact(self):
         """Test that --stage all fetches artifacts from every stage."""
-        import artifact_manager
-
         self._create_staged_artifact("test-artifact", "lib", "generic")
         self._create_staged_artifact("second-artifact", "lib", "generic")
         self._create_staged_artifact("downstream-artifact", "lib", "generic")
@@ -601,8 +587,6 @@ class TestFetchStageAll(ArtifactManagerTestBase):
 
     def test_fetch_exclude_components_skips_test_artifacts(self) -> None:
         """Test that --exclude-components filters artifact components including xnack variants."""
-        import artifact_manager
-
         self._create_staged_artifact("test-artifact", "lib", "generic")
         self._create_staged_artifact("test-artifact", "test", "generic")
         self._create_staged_artifact("test-artifact", "test", "gfx942")
@@ -651,8 +635,6 @@ class TestFetchStageAll(ArtifactManagerTestBase):
 
     def test_fetch_exclude_components_rejects_unknown_component(self) -> None:
         """Test that --exclude-components validates component names."""
-        import artifact_manager
-
         self._create_staged_artifact("test-artifact", "lib", "generic")
 
         argv = [
@@ -678,8 +660,6 @@ class TestFetchStageAll(ArtifactManagerTestBase):
 
     def test_fetch_exclude_artifacts_skips_named_artifacts(self) -> None:
         """Test that --exclude-artifacts filters whole artifacts."""
-        import artifact_manager
-
         self._create_staged_artifact("test-artifact", "lib", "generic")
         self._create_staged_artifact("second-artifact", "lib", "generic")
 
@@ -716,8 +696,6 @@ class TestFetchStageAll(ArtifactManagerTestBase):
 
     def test_fetch_exclude_artifacts_rejects_unknown_artifact(self) -> None:
         """Test that --exclude-artifacts validates artifact names."""
-        import artifact_manager
-
         argv = [
             "fetch",
             "--stage",
@@ -745,8 +723,6 @@ class TestFetchAmdgpuTargets(ArtifactManagerTestBase):
 
     def test_fetch_with_amdgpu_targets_finds_individual_target_archives(self):
         """Test that --amdgpu-targets matches individual-target and xnack-suffixed archives."""
-        import artifact_manager
-
         # Stage generic, per-target, and xnack-suffixed artifacts
         self._create_staged_artifact("test-artifact", "lib", "generic")
         self._create_staged_artifact("test-artifact", "lib", "gfx942")
@@ -799,8 +775,6 @@ class TestFetchAmdgpuTargets(ArtifactManagerTestBase):
 
     def test_fetch_with_amdgpu_targets_skips_other_targets(self):
         """Test that --amdgpu-targets doesn't fetch archives for other targets."""
-        import artifact_manager
-
         # Stage artifacts for two different targets
         self._create_staged_artifact("test-artifact", "lib", "generic")
         self._create_staged_artifact("test-artifact", "lib", "gfx942")
@@ -841,8 +815,6 @@ class TestFetchAmdgpuTargets(ArtifactManagerTestBase):
 
     def test_fetch_with_families_and_targets_is_inclusive(self):
         """Test that --amdgpu-families and --amdgpu-targets together fetch both."""
-        import artifact_manager
-
         # Stage family-named and target-named artifacts
         self._create_staged_artifact("test-artifact", "lib", "generic")
         self._create_staged_artifact("test-artifact", "lib", "gfx94X-dcgpu")
@@ -893,8 +865,6 @@ class TestFetchAmdgpuTargets(ArtifactManagerTestBase):
 
     def test_fetch_with_semicolon_separated_families(self):
         """Test that --amdgpu-families accepts semicolon-separated values."""
-        import artifact_manager
-
         # Stage artifacts for two families plus generic
         self._create_staged_artifact("test-artifact", "lib", "generic")
         self._create_staged_artifact("test-artifact", "lib", "gfx94X-dcgpu")
@@ -947,8 +917,6 @@ class TestFetchFlatten(ArtifactManagerTestBase):
 
     def test_fetch_flatten_merges_artifacts_into_single_directory(self):
         """Test that fetch --flatten merges all artifacts into a single directory."""
-        import artifact_manager
-
         # Create two staged artifacts
         self._create_staged_artifact("test-artifact", "lib", "generic")
         self._create_staged_artifact("test-artifact", "run", "generic")
@@ -998,8 +966,6 @@ class TestFetchFlatten(ArtifactManagerTestBase):
 
     def test_fetch_without_flatten_creates_artifact_subdirectories(self):
         """Test that fetch without --flatten creates separate artifact subdirectories."""
-        import artifact_manager
-
         self._create_staged_artifact("test-artifact", "lib", "generic")
 
         argv = [
@@ -1043,8 +1009,6 @@ class TestFetchFlatten(ArtifactManagerTestBase):
 
     def test_flatten_and_bootstrap_are_mutually_exclusive(self):
         """Test that --flatten and --bootstrap cannot be used together."""
-        import artifact_manager
-
         self._create_staged_artifact("test-artifact", "lib", "generic")
 
         argv = [
@@ -1084,8 +1048,6 @@ class TestFetchDownloadCache(ArtifactManagerTestBase):
         reached, so the failing backend won't cause errors. If the cache
         check is removed, the second fetch hits the FailingBackend and fails.
         """
-        import artifact_manager
-
         self._create_staged_artifact("test-artifact", "lib", "generic")
 
         cache_dir = Path(self.temp_dir) / "shared-cache"
@@ -1159,8 +1121,6 @@ class TestCopy(ArtifactManagerTestBase):
         self, extra_argv=None, source_run_id="source-run", dest_run_id="dest-run"
     ):
         """Run the copy command with standard arguments."""
-        import artifact_manager
-
         argv = [
             "copy",
             "--source-run-id",
@@ -1299,8 +1259,6 @@ class TestCopy(ArtifactManagerTestBase):
         self, mock_dest_factory, mock_source_factory, mock_delay
     ):
         """Test that copy exits with code 1 when artifact copy fails."""
-        import artifact_manager
-
         # Source backend has the artifact
         source_backend = LocalDirectoryBackend(
             staging_dir=self.staging_dir,
@@ -1341,8 +1299,6 @@ class TestCopy(ArtifactManagerTestBase):
 
     def test_copy_invalid_stage_exits_with_error(self):
         """Test that copy exits with code 1 for invalid stage name."""
-        import artifact_manager
-
         argv = [
             "copy",
             "--source-run-id",
@@ -1366,8 +1322,6 @@ class TestCopy(ArtifactManagerTestBase):
 
     def test_copy_missing_source_run_id_exits_with_error(self):
         """Test that copy exits with code 2 (argparse) when --source-run-id is missing."""
-        import artifact_manager
-
         argv = [
             "copy",
             "--stage",
@@ -1388,8 +1342,6 @@ class TestCopy(ArtifactManagerTestBase):
     @mock.patch("artifact_manager._delay_for_retry")
     def test_copy_multiple_stages(self, mock_delay):
         """Test that copy with comma-separated stages copies artifacts from all stages."""
-        import artifact_manager
-
         self._create_source_artifact("test-artifact", "lib", "generic")
         self._create_staged_artifact(
             "second-artifact", "lib", "generic", run_id="source-run"
@@ -1431,10 +1383,7 @@ class ParseTargetFamiliesTest(unittest.TestCase):
     """Unit tests for artifact_manager.parse_target_families."""
 
     def setUp(self):
-        # Import here so sys.path is already set up.
-        import artifact_manager as am
-
-        self.am = am
+        self.am = artifact_manager
 
     def _make_args(
         self,
@@ -1443,8 +1392,6 @@ class ParseTargetFamiliesTest(unittest.TestCase):
         generic_only: bool = False,
         expand_family_to_targets: bool = False,
     ):
-        import argparse
-
         return argparse.Namespace(
             amdgpu_families=amdgpu_families,
             amdgpu_targets=amdgpu_targets,
@@ -1516,10 +1463,6 @@ class BootstrapMarkerTest(unittest.TestCase):
     """
 
     def setUp(self):
-        # Import here so sys.path is already set up.
-        import artifact_manager
-        import buildctl
-
         self.populator_factories = {
             "artifact_manager": artifact_manager.BootstrappingPopulator,
             "buildctl": buildctl.BootstrappingPopulator,

--- a/build_tools/tests/artifacts_test.py
+++ b/build_tools/tests/artifacts_test.py
@@ -11,7 +11,7 @@ import sys
 
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 
-from _therock_utils.artifacts import ArtifactName
+from _therock_utils.artifacts import ArtifactName, prebuilt_marker_relpath
 import _therock_utils.artifact_builder as builder
 
 
@@ -626,6 +626,53 @@ class ComponentScannerTest(TmpDirTestCase):
             builder.ArtifactDescriptor.load_toml_file(
                 self.temp_dir / "descriptor.toml", artifact_name=""
             )
+
+
+class PrebuiltMarkerRelpathTest(unittest.TestCase):
+    """Tests for prebuilt_marker_relpath.
+
+    therock_subproject.cmake looks for the bootstrap marker at
+    "${_stage_dir}.prebuilt", so the marker must be named after the subproject
+    stage directory, not after the artifact basedir (which may be nested below
+    it).
+    """
+
+    def testStageBasedirUnchanged(self):
+        # The common case: the basedir is the stage dir itself.
+        self.assertEqual(
+            prebuilt_marker_relpath("core/ROCR-Runtime/stage"),
+            "core/ROCR-Runtime/stage.prebuilt",
+        )
+        self.assertEqual(
+            prebuilt_marker_relpath("math-libs/BLAS/hipBLASLt/stage"),
+            "math-libs/BLAS/hipBLASLt/stage.prebuilt",
+        )
+        # A stage dir may itself be nested below a build dir.
+        self.assertEqual(
+            prebuilt_marker_relpath("third-party/openmpi/build/stage"),
+            "third-party/openmpi/build/stage.prebuilt",
+        )
+
+    def testBasedirWithoutStageComponentUnchanged(self):
+        # Some descriptors declare a build dir as a basedir. There is no stage
+        # dir to attribute it to, so the behavior must be unchanged.
+        self.assertEqual(
+            prebuilt_marker_relpath("math-libs/hipthreads/build"),
+            "math-libs/hipthreads/build.prebuilt",
+        )
+
+    def testBasedirNestedBelowStageTruncates(self):
+        # A basedir below the stage dir must still mark the enclosing stage dir.
+        self.assertEqual(
+            prebuilt_marker_relpath("dctools/rdc/stage/portable-rdc"),
+            "dctools/rdc/stage.prebuilt",
+        )
+
+    def testInnermostStageComponentWins(self):
+        self.assertEqual(
+            prebuilt_marker_relpath("a/stage/b/stage/c/d"),
+            "a/stage/b/stage.prebuilt",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #7549

## Problem

`--bootstrap` writes the `.prebuilt` marker at a path the build never checks when an artifact's basedir is nested below its subproject's stage directory. The subproject then reconfigures, rebuilds and reinstalls from source despite its artifact having been fetched and extracted correctly, with no warning.

- `BootstrappingPopulator.on_first_relpath` named the marker after the artifact manifest relpath: `full_path.with_name(full_path.name + ".prebuilt")`.
- `cmake/therock_subproject.cmake` (lines 929 and 1218) only ever looks for `set(_prebuilt_file "${_stage_dir}.prebuilt")`.
- `dctools/artifact-rdc.toml` declares its basedir as `dctools/rdc/stage/portable-rdc`, so bootstrap produced `dctools/rdc/stage/portable-rdc.prebuilt` while the build looked for `dctools/rdc/stage.prebuilt`.

`dctools/rdc` is the only subproject with this layout today.

## Fix

Derive the marker from the innermost enclosing `stage` path component of the manifest relpath, falling back to the relpath itself.

Stage directories are always named `stage`: `therock_subproject.cmake` builds them as `${ARG_BINARY_DIR}/${ARG_DIR_PREFIX}stage`, and `DIR_PREFIX` is not set by any subproject in the tree. Where the basedir *is* the stage dir — every other descriptor — the search terminates on the last component and the result is byte-identical to the old behavior. Where the relpath has no `stage` component at all (`math-libs/hipthreads/build`, `math-libs/libhipcxx/build`), it falls through unchanged. Extraction paths and the cleanup `rmtree` are untouched; only the marker moves.

The same logic was duplicated in `buildctl.py`'s local bootstrap path, which had the identical bug, so it is factored into `_therock_utils/artifacts.py` and both call sites use it.

## Why not change the descriptor instead

The issue also suggested declaring the basedir as `dctools/rdc/stage` and scoping the component entries with `portable-rdc/**` globs. That is a silent, user-visible regression, because `ArtifactPopulator` derives flattened paths by stripping exactly the manifest relpath prefix:

```python
prefix_relpath += "/"
if member_name.startswith(prefix_relpath):
    scoped_path = member_name[len(prefix_relpath):]
```

Verified by running the populator both ways over an equivalent archive:

| basedir | `flatten=True` output | `flatten=False` output |
|---|---|---|
| `dctools/rdc/stage/portable-rdc` (today) | `bin/rdcd`, `lib/librdc.so` | `dctools/rdc/stage/portable-rdc/...` |
| `dctools/rdc/stage` | `portable-rdc/bin/rdcd`, `portable-rdc/lib/librdc.so` | `dctools/rdc/stage/portable-rdc/...` |

So the basedir is exactly what makes RDC's `INSTALL_DESTINATION portable-rdc/` "flattened away", as `dctools/CMakeLists.txt` notes. Re-rooting it would move every RDC file under `portable-rdc/` in flattened output — which feeds `--flatten` fetches, `install_rocm_from_artifacts.py --flatten` and `build_tarballs.py` — and would invalidate RDC's `INSTALL_RPATH_EXECUTABLE_DIR bin` / `INSTALL_RPATH_LIBRARY_DIR lib`, which are declared relative to the flattened location. The descriptor is correct as written; the marker derivation was wrong.

## Tests

- `artifacts_test.py::PrebuiltMarkerRelpathTest` — unit tests of the derivation: stage basedirs, a stage dir nested under a build dir (`third-party/openmpi/build/stage`), a basedir with no `stage` component, the nested rdc case, and innermost-wins.
- `artifact_descriptor_overlap_test.py::BootstrapMarkerBasedirTest` — enumerates every basedir declared by every descriptor in the tree (reusing the existing `git ls-files` discovery) and asserts the derived marker is either unchanged or an enclosing stage dir of that same basedir. Exactly one basedir changes: rdc's.
- `artifact_manager_tool_test.py::BootstrapMarkerTest` — end-to-end, bootstrapping real archives through both `artifact_manager.BootstrappingPopulator` and `buildctl.BootstrappingPopulator`, asserting the marker the build reads is created, the unreachable one is not, and content still extracts to the basedir. The nested case fails on the parent commit for both implementations; the two non-nested cases pass on the parent commit, confirming they are genuine no-op guards.

Full `build_tools/tests/` suite: 762 passed / 6 skipped on the parent commit, 770 passed / 6 skipped with this change. No pre-existing failures.
