### PR TITLE
Add PreUpload  native linux pkg verification

### DIFF
--- a/.github/workflows/multi_arch_build_native_linux_packages.yml
+++ b/.github/workflows/multi_arch_build_native_linux_packages.yml
@@ -50,6 +50,14 @@ on:
           set it manually.
         type: string
         default: ""
+      skip_pre_upload_build_verify:
+        description: "Skip build package verification between build and simulate install"
+        type: boolean
+        default: false
+      pre_upload_build_pkg_names:
+        description: "Space-separated package.json names for pre-upload build verification"
+        type: string
+        default: "amdrocm-core-sdk"
     outputs:
       package_repository_url:
         description: "Public repository URL for package installation"
@@ -80,6 +88,7 @@ jobs:
       OUTPUT_DIR: output
       ARTIFACTS_DIR: output/artifacts
       PACKAGE_DIST_DIR: output/packages
+      PRE_UPLOAD_REPORT_DIR: output/pre_upload_reports
       RELEASE_TYPE: ${{ inputs.release_type }}
     steps:
       - name: "Quartz - started ${{ env.QUARTZ_WORKFLOW_POSTFIX }}"
@@ -116,7 +125,6 @@ jobs:
           sudo apt-get install -y llvm-20
           sudo apt-get install -y rpm debhelper-compat build-essential
           sudo apt-get install -y dpkg-dev createrepo-c
-          sudo apt-get install -y patchelf
 
       - name: Fetch Artifacts for all GPU families
         run: |
@@ -144,6 +152,22 @@ jobs:
             --pkg-type "${{ inputs.native_package_type }}" \
             --version-suffix "${{ env.ARTIFACT_RUN_ID }}" \
             --build-variant "${{ inputs.build_variant }}"
+
+      - name: Pre-upload build package verification
+        if: ${{ !inputs.skip_pre_upload_build_verify }}
+        id: pre-upload-build-verify
+        run: |
+          mkdir -p "${{ env.PRE_UPLOAD_REPORT_DIR }}"
+          python ./build_tools/packaging/linux/build_package_verify.py \
+            --pkg-type "${{ inputs.native_package_type }}" \
+            --packages-dir "${{ env.PACKAGE_DIST_DIR }}" \
+            --artifacts-dir "${{ env.ARTIFACTS_DIR }}" \
+            --dest-dir "${{ env.PACKAGE_DIST_DIR }}" \
+            --rocm-version "${{ inputs.rocm_version }}" \
+            --version-suffix "${{ env.ARTIFACT_RUN_ID }}" \
+            --pkg-names ${{ inputs.pre_upload_build_pkg_names }} \
+            --report-dir "${{ env.PRE_UPLOAD_REPORT_DIR }}" \
+            --quiet
 
       - name: Simulated install Test
         id: test-packages

--- a/.github/workflows/multi_arch_build_native_linux_packages.yml
+++ b/.github/workflows/multi_arch_build_native_linux_packages.yml
@@ -166,8 +166,7 @@ jobs:
             --rocm-version "${{ inputs.rocm_version }}" \
             --version-suffix "${{ env.ARTIFACT_RUN_ID }}" \
             --pkg-names ${{ inputs.pre_upload_build_pkg_names }} \
-            --report-dir "${{ env.PRE_UPLOAD_REPORT_DIR }}" \
-            --quiet
+            --report-dir "${{ env.PRE_UPLOAD_REPORT_DIR }}"
 
       - name: Simulated install Test
         id: test-packages

--- a/.github/workflows/multi_arch_build_native_linux_packages.yml
+++ b/.github/workflows/multi_arch_build_native_linux_packages.yml
@@ -125,6 +125,7 @@ jobs:
           sudo apt-get install -y llvm-20
           sudo apt-get install -y rpm debhelper-compat build-essential
           sudo apt-get install -y dpkg-dev createrepo-c
+          sudo apt-get install -y patchelf
 
       - name: Fetch Artifacts for all GPU families
         run: |

--- a/build_tools/packaging/linux/build_package_verify.py
+++ b/build_tools/packaging/linux/build_package_verify.py
@@ -1,0 +1,558 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Pre-upload Step 1 — verify built packages match ``package.json`` expectations.
+
+After ``build_package.py``, confirms that generated native Linux packages exist on
+disk with the expected variant names and control-field versions. This is the
+**build verification** gate from the pre-upload milestone (Step 1); dependency
+field checks are handled separately by ``pkg_dependency_checker.py`` (Step 2).
+
+Checks per ``package.json`` entry (and each kpack variant):
+
+* **Presence** — expected ``.deb`` / ``.rpm`` file exists under ``--packages-dir``.
+* **Version** — DEB ``Version`` / RPM ``VERSION-RELEASE`` matches ``--rocm-version``
+  and ``--version-suffix`` (same rules as ``deb_package.py`` / ``rpm_package.py``).
+* **Inventory** — optional fail on unexpected extra package files in the output dir.
+
+Example (CI, after build)::
+
+    python3 build_package_verify.py \\
+        --pkg-type deb \\
+        --packages-dir output/packages \\
+        --artifacts-dir output/artifacts \\
+        --dest-dir output/packages \\
+        --rocm-version 7.14.0 \\
+        --version-suffix "${ARTIFACT_RUN_ID}" \\
+        --pkg-names amdrocm-core-sdk \\
+        --report-dir output/pre_upload_reports
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+BUILD_TOOLS_DIR = SCRIPT_DIR.parent.parent
+if str(BUILD_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(BUILD_TOOLS_DIR))
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from packaging_utils import PackageConfig, read_package_json_file  # noqa: E402
+
+import pkg_dependency_checker as checker  # noqa: E402
+
+
+@dataclass
+class VariantBuildCheck:
+    """One expected package variant and whether the built archive matches."""
+
+    base_package: str
+    label: str
+    expected_name: str
+    file_path: Path | None
+    found: bool
+    expected_version: str
+    actual_version: str | None
+    version_ok: bool
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def passed(self) -> bool:
+        return self.found and self.version_ok and not self.errors
+
+
+@dataclass
+class BuildVerifyReport:
+    """Aggregate build verification for one ``package.json`` base name."""
+
+    base_package: str
+    variants: list[VariantBuildCheck] = field(default_factory=list)
+
+    @property
+    def passed(self) -> bool:
+        return all(v.passed for v in self.variants)
+
+
+@dataclass
+class BuildVerifySummary:
+    """Roll-up across all packages checked in one run."""
+
+    packages_requested: list[str]
+    reports: list[BuildVerifyReport]
+    package_files_found: list[str]
+    extra_package_files: list[str] = field(default_factory=list)
+
+    @property
+    def variants_expected(self) -> int:
+        return sum(len(r.variants) for r in self.reports)
+
+    @property
+    def variants_found(self) -> int:
+        return sum(1 for r in self.reports for v in r.variants if v.found)
+
+    @property
+    def variants_passed(self) -> int:
+        return sum(1 for r in self.reports for v in r.variants if v.passed)
+
+    @property
+    def variants_failed(self) -> int:
+        return self.variants_expected - self.variants_passed
+
+    @property
+    def passed(self) -> bool:
+        if self.extra_package_files:
+            return False
+        return self.variants_failed == 0 and all(r.passed for r in self.reports)
+
+    def missing_variants(self) -> list[str]:
+        return [
+            v.expected_name
+            for r in self.reports
+            for v in r.variants
+            if not v.found
+        ]
+
+    def version_failures(self) -> list[str]:
+        return [
+            v.expected_name
+            for r in self.reports
+            for v in r.variants
+            if v.found and not v.version_ok
+        ]
+
+
+def expected_control_version(config: PackageConfig) -> str:
+    """Return the version string written into DEB/RPM control metadata."""
+    if config.pkg_type.lower() == "rpm":
+        release = config.version_suffix or "1"
+        return f"{config.rocm_version}-{release}"
+    version = str(config.rocm_version)
+    if config.version_suffix:
+        version += f"-{config.version_suffix}"
+    return version
+
+
+def read_package_file_version(package_path: Path, pkg_type: str) -> str:
+    """Read ``Version`` (DEB) or ``VERSION-RELEASE`` (RPM) from a package archive."""
+    pkg_type = pkg_type.lower()
+    if pkg_type == "deb":
+        result = checker._run_capture(
+            ["dpkg-deb", "-f", str(package_path), "Version"],
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"dpkg-deb failed for {package_path}: {result.stderr.strip()}",
+            )
+        return result.stdout.strip()
+    result = checker._run_capture(
+        ["rpm", "-qp", "--qf", r"%{VERSION}-%{RELEASE}", str(package_path)],
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"rpm query failed for {package_path}: {result.stderr.strip()}",
+        )
+    return result.stdout.strip()
+
+
+def versions_match(expected: str, actual: str, pkg_type: str) -> bool:
+    """Return True when ``actual`` matches ``expected`` (DEB allows ``~`` vs ``-``)."""
+    if expected == actual:
+        return True
+    if pkg_type.lower() == "deb":
+        normalized_expected = expected.replace("-", "~")
+        normalized_actual = actual.replace("-", "~")
+        return normalized_expected == normalized_actual
+    return False
+
+
+def verify_variant(
+    base_package: str,
+    label: str,
+    expected_name: str,
+    package_files: dict[str, Path],
+    config: PackageConfig,
+    *,
+    check_version: bool,
+) -> VariantBuildCheck:
+    """Verify one expected variant exists and optionally matches version."""
+    expected_version = expected_control_version(config)
+    path = package_files.get(expected_name)
+    found = path is not None
+    actual_version: str | None = None
+    version_ok = not check_version
+    errors: list[str] = []
+
+    if not found:
+        errors.append(f"package file not found for expected name {expected_name!r}")
+    else:
+        if check_version:
+            try:
+                actual_version = read_package_file_version(path, config.pkg_type)
+                version_ok = versions_match(
+                    expected_version, actual_version, config.pkg_type,
+                )
+                if not version_ok:
+                    errors.append(
+                        f"version mismatch: expected {expected_version!r}, "
+                        f"got {actual_version!r}",
+                    )
+            except RuntimeError as exc:
+                version_ok = False
+                errors.append(str(exc))
+
+    return VariantBuildCheck(
+        base_package=base_package,
+        label=label,
+        expected_name=expected_name,
+        file_path=path,
+        found=found,
+        expected_version=expected_version,
+        actual_version=actual_version,
+        version_ok=version_ok,
+        errors=errors,
+    )
+
+
+def verify_package(
+    pkg_name: str,
+    config: PackageConfig,
+    packages_dir: Path,
+    *,
+    check_version: bool,
+) -> BuildVerifyReport:
+    """Verify all build variants for one ``package.json`` package entry."""
+    report = BuildVerifyReport(base_package=pkg_name)
+    package_files = checker.find_package_files(packages_dir, config.pkg_type)
+
+    for label, versioned_pkg, gfx_arch in checker.iter_variant_configs(
+        pkg_name, config,
+    ):
+        expected_name = checker.resolve_installed_name(
+            pkg_name,
+            config,
+            versioned_pkg=versioned_pkg,
+            gfx_arch=gfx_arch,
+        )
+        report.variants.append(
+            verify_variant(
+                pkg_name,
+                label,
+                expected_name,
+                package_files,
+                config,
+                check_version=check_version,
+            ),
+        )
+    return report
+
+
+def collect_extra_package_files(
+    package_files: dict[str, Path],
+    expected_names: set[str],
+) -> list[str]:
+    """Return package stems present on disk but not expected by ``package.json``."""
+    return sorted(name for name in package_files if name not in expected_names)
+
+
+def resolve_pkg_names(
+    args: argparse.Namespace,
+    config: PackageConfig,
+) -> list[str]:
+    """Resolve which ``package.json`` entries to verify."""
+    if args.all_eligible:
+        from build_package import parse_input_package_list
+
+        pkg_list, _skipped = parse_input_package_list(None, config.artifacts_dir)
+        return pkg_list
+    return list(args.pkg_names)
+
+
+def build_summary(
+    packages_requested: list[str],
+    reports: list[BuildVerifyReport],
+    package_files: dict[str, Path],
+    *,
+    fail_on_extra: bool,
+) -> BuildVerifySummary:
+    """Build the run summary including optional extra-file detection."""
+    expected_names = {
+        v.expected_name for r in reports for v in r.variants
+    }
+    extra = collect_extra_package_files(package_files, expected_names)
+    if not fail_on_extra:
+        extra = []
+    return BuildVerifySummary(
+        packages_requested=packages_requested,
+        reports=reports,
+        package_files_found=sorted(package_files.keys()),
+        extra_package_files=extra,
+    )
+
+
+def _variant_to_dict(variant: VariantBuildCheck) -> dict:
+    """Serialize one variant check for JSON output."""
+    return {
+        "base_package": variant.base_package,
+        "label": variant.label,
+        "expected_name": variant.expected_name,
+        "found": variant.found,
+        "file_path": str(variant.file_path) if variant.file_path else None,
+        "expected_version": variant.expected_version,
+        "actual_version": variant.actual_version,
+        "version_ok": variant.version_ok,
+        "passed": variant.passed,
+        "errors": variant.errors,
+    }
+
+
+def format_report_json(summary: BuildVerifySummary) -> str:
+    """Serialize the full build verification report as JSON."""
+    payload = {
+        "passed": summary.passed,
+        "packages_requested": summary.packages_requested,
+        "variants_expected": summary.variants_expected,
+        "variants_found": summary.variants_found,
+        "variants_passed": summary.variants_passed,
+        "variants_failed": summary.variants_failed,
+        "missing_variants": summary.missing_variants(),
+        "version_failures": summary.version_failures(),
+        "package_files_found": summary.package_files_found,
+        "extra_package_files": summary.extra_package_files,
+        "reports": [
+            {
+                "base_package": report.base_package,
+                "passed": report.passed,
+                "variants": [_variant_to_dict(v) for v in report.variants],
+            }
+            for report in summary.reports
+        ],
+    }
+    return json.dumps(payload, indent=2)
+
+
+def format_report_text(summary: BuildVerifySummary) -> str:
+    """Build a plain-text build status report for logs or ``build_status_report.txt``."""
+    lines: list[str] = []
+    overall = "PASS" if summary.passed else "FAIL"
+    lines.append("ROCm build package verification report (Step 1)")
+    lines.append("=" * 72)
+    lines.append(f"Overall result: {overall}")
+    lines.append(f"Packages requested: {', '.join(summary.packages_requested)}")
+    lines.append(
+        f"Variants: {summary.variants_expected} expected, "
+        f"{summary.variants_found} found, "
+        f"{summary.variants_passed} passed, "
+        f"{summary.variants_failed} failed",
+    )
+    lines.append(f"Package files on disk: {len(summary.package_files_found)}")
+    lines.append("")
+
+    for report in summary.reports:
+        lines.append(f"Package (package.json): {report.base_package}")
+        for variant in report.variants:
+            status = "PASS" if variant.passed else "FAIL"
+            found = "yes" if variant.found else "no"
+            lines.append(f"  [{status}] {variant.label}")
+            lines.append(f"         expected name: {variant.expected_name}")
+            lines.append(f"         file found: {found}")
+            if variant.file_path:
+                lines.append(f"         path: {variant.file_path}")
+            if variant.actual_version is not None:
+                lines.append(
+                    f"         version: {variant.actual_version} "
+                    f"(expected {variant.expected_version})",
+                )
+            for err in variant.errors:
+                lines.append(f"         error: {err}")
+        lines.append("")
+
+    if summary.missing_variants():
+        lines.append(f"Missing variants: {summary.missing_variants()}")
+    if summary.version_failures():
+        lines.append(f"Version failures: {summary.version_failures()}")
+    if summary.extra_package_files:
+        lines.append(f"Unexpected extra packages: {summary.extra_package_files}")
+    return "\n".join(lines)
+
+
+def write_report_files(summary: BuildVerifySummary, report_dir: Path) -> None:
+    """Write ``build_status_report.txt`` and ``build_status_report.json``."""
+    report_dir.mkdir(parents=True, exist_ok=True)
+    text_path = report_dir / "build_status_report.txt"
+    json_path = report_dir / "build_status_report.json"
+    text_path.write_text(format_report_text(summary) + "\n", encoding="utf-8")
+    json_path.write_text(format_report_json(summary) + "\n", encoding="utf-8")
+    print(f"Build report written to: {text_path}")
+    print(f"Build report written to: {json_path}")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments for ``build_package_verify``."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Verify built native Linux packages match package.json variant names "
+            "and control-field versions (pre-upload Step 1)."
+        ),
+    )
+    parser.add_argument(
+        "--pkg-type",
+        required=True,
+        choices=("deb", "rpm", "DEB", "RPM"),
+        help="Package format (deb or rpm)",
+    )
+    parser.add_argument(
+        "--packages-dir",
+        type=Path,
+        required=True,
+        help="Directory containing built .deb or .rpm files",
+    )
+    parser.add_argument(
+        "--artifacts-dir",
+        type=Path,
+        required=True,
+        help="Artifact tree for kpack/gfx-arch detection",
+    )
+    parser.add_argument(
+        "--dest-dir",
+        type=Path,
+        default=Path("/tmp/rocm-build-verify"),
+        help="Placeholder dest dir for PackageConfig (matches build_package)",
+    )
+    parser.add_argument(
+        "--rocm-version",
+        required=True,
+        help="ROCm release version used when packages were built",
+    )
+    parser.add_argument(
+        "--version-suffix",
+        default="",
+        help="Build version suffix (e.g. CI run id)",
+    )
+    parser.add_argument(
+        "--install-prefix",
+        default="/opt/rocm/core",
+        help="Install prefix recorded in PackageConfig",
+    )
+    parser.add_argument(
+        "--target",
+        nargs="+",
+        default=[],
+        help="GPU targets for kpack (auto-detected from artifacts if omitted)",
+    )
+    parser.add_argument(
+        "--enable-kpack",
+        action="store_true",
+        help="Use kpack variant rules (auto-detected from manifest if omitted)",
+    )
+    parser.add_argument(
+        "--rpath-pkg",
+        action="store_true",
+        help="Package was built with --rpath-pkg",
+    )
+    parser.add_argument(
+        "--pkg-names",
+        nargs="+",
+        default=["amdrocm-core-sdk"],
+        help="package.json base names to verify (ignored if --all-eligible)",
+    )
+    parser.add_argument(
+        "--all-eligible",
+        action="store_true",
+        help="Verify every package.json entry eligible for the artifact dir",
+    )
+    parser.add_argument(
+        "--no-version-check",
+        action="store_true",
+        help="Skip control-field version verification (presence only)",
+    )
+    parser.add_argument(
+        "--fail-on-extra",
+        action="store_true",
+        help="Fail when unexpected package files exist in packages-dir",
+    )
+    parser.add_argument(
+        "--report-dir",
+        type=Path,
+        metavar="DIR",
+        help="Write build_status_report.txt and .json under DIR",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress verbose packaging_utils debug prints",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry: verify built packages, write report, return exit code."""
+    args = parse_args(argv)
+    checker._suppress_packaging_noise(args.quiet)
+
+    packages_dir = args.packages_dir.expanduser().resolve()
+    if not packages_dir.is_dir():
+        print(f"Error: packages directory not found: {packages_dir}", file=sys.stderr)
+        return 2
+
+    read_package_json_file()
+    try:
+        config = checker.build_checker_config(args)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        pkg_names = resolve_pkg_names(args, config)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    if not pkg_names:
+        print("Error: no packages to verify", file=sys.stderr)
+        return 2
+
+    check_version = not args.no_version_check
+    reports = [
+        verify_package(name, config, packages_dir, check_version=check_version)
+        for name in pkg_names
+    ]
+    package_files = checker.find_package_files(packages_dir, config.pkg_type)
+    summary = build_summary(
+        pkg_names,
+        reports,
+        package_files,
+        fail_on_extra=args.fail_on_extra,
+    )
+
+    print(format_report_text(summary))
+
+    if args.report_dir is not None:
+        write_report_files(summary, args.report_dir.expanduser())
+
+    if not summary.passed:
+        print(
+            f"\nBuild verification failed: "
+            f"{summary.variants_failed} variant(s), "
+            f"{len(summary.extra_package_files)} extra file(s).",
+            file=sys.stderr,
+        )
+        return 1
+    print("\nBuild verification passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+
+# Epilog
+# -----
+# Step 1 (this module): names + versions of built archives vs package.json variants.
+# Step 2 (pkg_dependency_checker.py): Depends/Requires vs package.json rules.
+# Step 3 (native_linux_package_install_test.py --test-type simulate): installability.

--- a/build_tools/packaging/linux/build_package_verify.py
+++ b/build_tools/packaging/linux/build_package_verify.py
@@ -1,57 +1,131 @@
 #!/usr/bin/env python3
+
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-"""Pre-upload Step 1 — verify built packages match ``package.json`` expectations.
+"""Verify built native Linux packages against ``package.json``.
 
-After ``build_package.py``, confirms that generated native Linux packages exist on
-disk with the expected variant names and control-field versions. This is the
-**build verification** gate from the pre-upload milestone (Step 1); dependency
-field checks are handled separately by ``pkg_dependency_checker.py`` (Step 2).
+Runs after ``build_package.py`` and before simulated install or upload. Inspects
+already-built ``.deb``/``.rpm`` files only; it does not build or modify packages.
+For each requested entry, derives expected variant names from ``package.json`` and
+the same CLI flags used at build time, then confirms files exist in
+``--packages-dir`` and optionally checks control-field versions against
+``--rocm-version`` and ``--version-suffix``.
 
-Checks per ``package.json`` entry (and each kpack variant):
+Writes ``build_status_report.txt`` and ``build_status_report.json`` when
+``--report-dir`` is set.
 
-* **Presence** — expected ``.deb`` / ``.rpm`` file exists under ``--packages-dir``.
-* **Version** — DEB ``Version`` / RPM ``VERSION-RELEASE`` matches ``--rocm-version``
-  and ``--version-suffix`` (same rules as ``deb_package.py`` / ``rpm_package.py``).
-* **Inventory** — optional fail on unexpected extra package files in the output dir.
+```
+# Standard CI pre-upload verification (deb):
+./build_tools/packaging/linux/build_package_verify.py \\
+    --pkg-type deb \\
+    --packages-dir output/packages \\
+    --artifacts-dir output/artifacts \\
+    --dest-dir output/packages \\
+    --rocm-version 7.15.0 \\
+    --version-suffix 28484694006 \\
+    --pkg-names amdrocm-core-sdk \\
+    --report-dir output/pre_upload_reports
+```
 
-Example (CI, after build)::
+``--version-suffix``: CI run ID appended to the DEB/RPM version field
+  (e.g. ``7.15.0-28484694006`` for DEB, release ``28484694006`` for RPM).
+  Does not affect the package name or install prefix.
 
-    python3 build_package_verify.py \\
-        --pkg-type deb \\
-        --packages-dir output/packages \\
-        --artifacts-dir output/artifacts \\
-        --dest-dir output/packages \\
-        --rocm-version 7.14.0 \\
-        --version-suffix "${ARTIFACT_RUN_ID}" \\
-        --pkg-names amdrocm-core-sdk \\
-        --report-dir output/pre_upload_reports
+``--build-variant``: Build type that modifies both the package name and
+  install prefix. Currently supports ``asan``.
 """
-
-from __future__ import annotations
 
 import argparse
 import json
+import subprocess
 import sys
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 
-SCRIPT_DIR = Path(__file__).resolve().parent
-BUILD_TOOLS_DIR = SCRIPT_DIR.parent.parent
-if str(BUILD_TOOLS_DIR) not in sys.path:
-    sys.path.insert(0, str(BUILD_TOOLS_DIR))
-if str(SCRIPT_DIR) not in sys.path:
-    sys.path.insert(0, str(SCRIPT_DIR))
+from build_package import (
+    DEFAULT_INSTALL_PREFIX,
+    create_package_config,
+    parse_input_package_list,
+)
+from packaging_utils import (
+    GFX_HOST,
+    GFX_META,
+    PackageConfig,
+    get_package_info,
+    is_gfxarch_package,
+    is_meta_package,
+    read_package_json_file,
+    update_package_name,
+)
+from _therock_utils.log_utils import TheRockLogger, configure_logging
 
-from packaging_utils import PackageConfig, read_package_json_file  # noqa: E402
+logger = TheRockLogger(__name__)
 
-import pkg_dependency_checker as checker  # noqa: E402
+_CLI_EXAMPLES_EPILOG = """
+Examples:
+ # CI pre-upload verification (matches multi_arch_build_native_linux_packages.yml)
+ ./build_tools/packaging/linux/build_package_verify.py \\
+   --pkg-type deb \\
+   --packages-dir output/packages \\
+   --artifacts-dir output/artifacts \\
+   --dest-dir output/packages \\
+   --rocm-version 7.15.0 \\
+   --version-suffix 28484694006 \\
+   --pkg-names amdrocm-core-sdk \\
+   --report-dir output/pre_upload_reports
+
+ # Kpack multi-arch build with explicit GPU targets
+ ./build_tools/packaging/linux/build_package_verify.py \\
+   --pkg-type deb \\
+   --packages-dir output/packages \\
+   --artifacts-dir output/artifacts \\
+   --dest-dir output/packages \\
+   --rocm-version 7.15.0 \\
+   --version-suffix 28484694006 \\
+   --enable-kpack \\
+   --target gfx1100 gfx942 \\
+   --pkg-names amdrocm-core-sdk \\
+   --report-dir output/pre_upload_reports
+
+ # ASAN build variant (package name and install prefix must match build_package.py)
+ ./build_tools/packaging/linux/build_package_verify.py \\
+   --pkg-type deb \\
+   --packages-dir output/packages \\
+   --artifacts-dir output/artifacts \\
+   --dest-dir output/packages \\
+   --rocm-version 7.15.0 \\
+   --version-suffix 28484694006 \\
+   --build-variant asan \\
+   --pkg-names amdrocm-core-sdk \\
+   --report-dir output/pre_upload_reports
+
+ # RPM verification with unexpected-file detection
+ ./build_tools/packaging/linux/build_package_verify.py \\
+   --pkg-type rpm \\
+   --packages-dir output/packages \\
+   --artifacts-dir output/artifacts \\
+   --dest-dir output/packages \\
+   --rocm-version 7.15.0 \\
+   --version-suffix 28484694006 \\
+   --pkg-names amdrocm-core-sdk \\
+   --fail-on-extra \\
+   --report-dir output/pre_upload_reports
+
+ # Presence-only check (skip control-field version comparison)
+ ./build_tools/packaging/linux/build_package_verify.py \\
+   --pkg-type deb \\
+   --packages-dir output/packages \\
+   --artifacts-dir output/artifacts \\
+   --rocm-version 7.15.0 \\
+   --pkg-names amdrocm-core-sdk \\
+   --no-version-check
+"""
 
 
 @dataclass
 class VariantBuildCheck:
-    """One expected package variant and whether the built archive matches."""
+    """Verification result for one package variant."""
 
     base_package: str
     label: str
@@ -65,24 +139,26 @@ class VariantBuildCheck:
 
     @property
     def passed(self) -> bool:
+        """True when the variant file exists and version checks succeed."""
         return self.found and self.version_ok and not self.errors
 
 
 @dataclass
 class BuildVerifyReport:
-    """Aggregate build verification for one ``package.json`` base name."""
+    """Verification results for all variants of one ``package.json`` entry."""
 
     base_package: str
     variants: list[VariantBuildCheck] = field(default_factory=list)
 
     @property
     def passed(self) -> bool:
+        """True when every variant in this report passed."""
         return all(v.passed for v in self.variants)
 
 
 @dataclass
 class BuildVerifySummary:
-    """Roll-up across all packages checked in one run."""
+    """Aggregate verification outcome across all requested packages."""
 
     packages_requested: list[str]
     reports: list[BuildVerifyReport]
@@ -91,32 +167,39 @@ class BuildVerifySummary:
 
     @property
     def variants_expected(self) -> int:
+        """Total variant count across all package reports."""
         return sum(len(r.variants) for r in self.reports)
 
     @property
     def variants_found(self) -> int:
+        """Variants whose expected package file exists on disk."""
         return sum(1 for r in self.reports for v in r.variants if v.found)
 
     @property
     def variants_passed(self) -> int:
+        """Variants that passed presence and version checks."""
         return sum(1 for r in self.reports for v in r.variants if v.passed)
 
     @property
     def variants_failed(self) -> int:
+        """Variants that failed or were not found."""
         return self.variants_expected - self.variants_passed
 
     @property
     def passed(self) -> bool:
+        """True when no variant failed and no unexpected package files were flagged."""
         if self.extra_package_files:
             return False
         return self.variants_failed == 0 and all(r.passed for r in self.reports)
 
     def missing_variants(self) -> list[str]:
+        """Expected installed package names with no matching file on disk."""
         return [
             v.expected_name for r in self.reports for v in r.variants if not v.found
         ]
 
     def version_failures(self) -> list[str]:
+        """Expected installed package names whose control-field version mismatched."""
         return [
             v.expected_name
             for r in self.reports
@@ -125,8 +208,174 @@ class BuildVerifySummary:
         ]
 
 
+@dataclass(frozen=True)
+class PackageVariantSpec:
+    """One expected package variant derived from ``package.json`` and build flags.
+
+    Attributes:
+        label: Human-readable variant name (e.g. ``host``, ``meta``, ``device-gfx1100``).
+        versioned_pkg: Whether the ROCm version appears in the installed package name.
+        gfx_arch: Gfx-arch token for kpack routing (``GFX_HOST``, ``GFX_META``, or device arch).
+    """
+
+    label: str
+    versioned_pkg: bool
+    gfx_arch: str
+
+
+def iter_package_variant_specs(
+    pkg_name: str,
+    config: PackageConfig,
+) -> list[PackageVariantSpec]:
+    """Enumerate expected variants using the same routing as ``build_package_variants``.
+
+    Read-only helper for verification: mirrors how ``build_package.py`` splits a
+    ``package.json`` entry into variant names without building anything.
+
+    Parameters:
+        pkg_name: ``package.json`` base name.
+        config: Build configuration (kpack mode, gfx targets, etc.).
+
+    Returns:
+        Ordered list of variant specifications to check on disk.
+    """
+    pkg_info = get_package_info(pkg_name)
+    specs: list[PackageVariantSpec] = []
+
+    if config.enable_kpack:
+        if is_gfxarch_package(pkg_info, config.enable_kpack, config.artifacts_dir):
+            if not is_meta_package(pkg_info):
+                specs.append(
+                    PackageVariantSpec(
+                        label="host",
+                        versioned_pkg=True,
+                        gfx_arch=GFX_HOST,
+                    )
+                )
+            for device_arch in config.gfxarch_list:
+                specs.append(
+                    PackageVariantSpec(
+                        label=f"device-{device_arch}",
+                        versioned_pkg=True,
+                        gfx_arch=device_arch,
+                    )
+                )
+            specs.append(
+                PackageVariantSpec(
+                    label="meta",
+                    versioned_pkg=True,
+                    gfx_arch=GFX_META,
+                )
+            )
+            specs.append(
+                PackageVariantSpec(
+                    label="non-versioned",
+                    versioned_pkg=False,
+                    gfx_arch=GFX_META,
+                )
+            )
+        else:
+            specs.append(
+                PackageVariantSpec(
+                    label="versioned",
+                    versioned_pkg=True,
+                    gfx_arch="",
+                )
+            )
+            specs.append(
+                PackageVariantSpec(
+                    label="non-versioned",
+                    versioned_pkg=False,
+                    gfx_arch="",
+                )
+            )
+    else:
+        specs.append(
+            PackageVariantSpec(
+                label="versioned",
+                versioned_pkg=True,
+                gfx_arch=config.gfx_arch,
+            )
+        )
+        specs.append(
+            PackageVariantSpec(
+                label="non-versioned",
+                versioned_pkg=False,
+                gfx_arch=config.gfx_arch,
+            )
+        )
+
+    return specs
+
+
+def _run_capture(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    """Run a subprocess and capture stdout/stderr without raising on failure."""
+    return subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+
+def resolve_installed_name(
+    pkg_name: str,
+    config: PackageConfig,
+    *,
+    versioned_pkg: bool,
+    gfx_arch: str,
+) -> str:
+    """Compute the on-disk package stem for one variant.
+
+    Applies the same ``update_package_name`` rules as ``build_package.py`` for
+    versioned vs non-versioned packages and gfx-arch suffixes.
+
+    Parameters:
+        pkg_name: Base name from ``package.json``.
+        config: Shared build configuration.
+        versioned_pkg: Whether this variant includes the ROCm version in its name.
+        gfx_arch: Gfx-arch token for kpack variants (``GFX_HOST``, ``GFX_META``, etc.).
+
+    Returns:
+        Package stem without ``.deb``/``.rpm`` extension (e.g. ``amdrocm-core-sdk7.15``).
+    """
+    local_config = replace(
+        config,
+        versioned_pkg=versioned_pkg,
+        gfx_arch=gfx_arch,
+    )
+    return update_package_name(pkg_name, local_config)
+
+
+def find_package_files(packages_dir: Path, pkg_type: str) -> dict[str, Path]:
+    """Index built package files in ``packages_dir`` by installed package stem.
+
+    Parameters:
+        packages_dir: Directory containing built ``.deb`` or ``.rpm`` files.
+        pkg_type: ``deb`` or ``rpm`` (case-insensitive).
+
+    Returns:
+        Mapping from package stem (filename without extension) to file path.
+    """
+    ext = ".deb" if pkg_type.lower() == "deb" else ".rpm"
+    package_files: dict[str, Path] = {}
+    for path in sorted(packages_dir.iterdir()):
+        if not path.is_file():
+            continue
+        if not path.name.lower().endswith(ext):
+            continue
+        # Stem matches the installed package name used by dpkg/rpm metadata.
+        package_files[path.name[: -len(ext)]] = path
+    return package_files
+
+
 def expected_control_version(config: PackageConfig) -> str:
-    """Return the version string written into DEB/RPM control metadata."""
+    """Build the version string expected in DEB/RPM control metadata.
+
+    DEB uses ``rocm_version`` plus optional ``version_suffix`` as the debian
+    revision. RPM combines ``VERSION-RELEASE`` where release defaults to ``1``.
+
+    Parameters:
+        config: Shared build configuration.
+
+    Returns:
+        Expected version string for comparison with ``dpkg-deb -f`` or ``rpm -qp``.
+    """
     if config.pkg_type.lower() == "rpm":
         release = config.version_suffix or "1"
         return f"{config.rocm_version}-{release}"
@@ -137,10 +386,21 @@ def expected_control_version(config: PackageConfig) -> str:
 
 
 def read_package_file_version(package_path: Path, pkg_type: str) -> str:
-    """Read ``Version`` (DEB) or ``VERSION-RELEASE`` (RPM) from a package archive."""
+    """Read the version field from a built package file.
+
+    Parameters:
+        package_path: Path to a ``.deb`` or ``.rpm`` file.
+        pkg_type: ``deb`` or ``rpm`` (case-insensitive).
+
+    Returns:
+        Version string from package metadata.
+
+    Raises:
+        RuntimeError: When ``dpkg-deb`` or ``rpm`` query fails.
+    """
     pkg_type = pkg_type.lower()
     if pkg_type == "deb":
-        result = checker._run_capture(
+        result = _run_capture(
             ["dpkg-deb", "-f", str(package_path), "Version"],
         )
         if result.returncode != 0:
@@ -148,7 +408,7 @@ def read_package_file_version(package_path: Path, pkg_type: str) -> str:
                 f"dpkg-deb failed for {package_path}: {result.stderr.strip()}",
             )
         return result.stdout.strip()
-    result = checker._run_capture(
+    result = _run_capture(
         ["rpm", "-qp", "--qf", r"%{VERSION}-%{RELEASE}", str(package_path)],
     )
     if result.returncode != 0:
@@ -159,10 +419,23 @@ def read_package_file_version(package_path: Path, pkg_type: str) -> str:
 
 
 def versions_match(expected: str, actual: str, pkg_type: str) -> bool:
-    """Return True when ``actual`` matches ``expected`` (DEB allows ``~`` vs ``-``)."""
+    """Compare expected and actual control-field version strings.
+
+    DEB allows ``~`` as an alternative separator to ``-`` in version revisions;
+    RPM requires an exact match.
+
+    Parameters:
+        expected: Version derived from ``--rocm-version`` and ``--version-suffix``.
+        actual: Version read from the built package file.
+        pkg_type: ``deb`` or ``rpm`` (case-insensitive).
+
+    Returns:
+        True when the versions are equivalent for the given package format.
+    """
     if expected == actual:
         return True
     if pkg_type.lower() == "deb":
+        # Debian revision may use ~ where we encoded - in the expected string.
         normalized_expected = expected.replace("-", "~")
         normalized_actual = actual.replace("-", "~")
         return normalized_expected == normalized_actual
@@ -178,7 +451,19 @@ def verify_variant(
     *,
     check_version: bool,
 ) -> VariantBuildCheck:
-    """Verify one expected variant exists and optionally matches version."""
+    """Verify one variant: file presence and optional control-field version.
+
+    Parameters:
+        base_package: ``package.json`` base name.
+        label: Human-readable variant label (e.g. ``meta``, ``device-gfx1100``).
+        expected_name: Installed package stem expected on disk.
+        package_files: Index from ``find_package_files``.
+        config: Shared build configuration.
+        check_version: When False, skip ``dpkg-deb``/``rpm`` version queries.
+
+    Returns:
+        Per-variant check result with error details on failure.
+    """
     expected_version = expected_control_version(config)
     path = package_files.get(expected_name)
     found = path is not None
@@ -188,23 +473,22 @@ def verify_variant(
 
     if not found:
         errors.append(f"package file not found for expected name {expected_name!r}")
-    else:
-        if check_version:
-            try:
-                actual_version = read_package_file_version(path, config.pkg_type)
-                version_ok = versions_match(
-                    expected_version,
-                    actual_version,
-                    config.pkg_type,
+    elif check_version:
+        try:
+            actual_version = read_package_file_version(path, config.pkg_type)
+            version_ok = versions_match(
+                expected_version,
+                actual_version,
+                config.pkg_type,
+            )
+            if not version_ok:
+                errors.append(
+                    f"version mismatch: expected {expected_version!r}, "
+                    f"got {actual_version!r}",
                 )
-                if not version_ok:
-                    errors.append(
-                        f"version mismatch: expected {expected_version!r}, "
-                        f"got {actual_version!r}",
-                    )
-            except RuntimeError as exc:
-                version_ok = False
-                errors.append(str(exc))
+        except RuntimeError as exc:
+            version_ok = False
+            errors.append(str(exc))
 
     return VariantBuildCheck(
         base_package=base_package,
@@ -226,24 +510,31 @@ def verify_package(
     *,
     check_version: bool,
 ) -> BuildVerifyReport:
-    """Verify all build variants for one ``package.json`` package entry."""
-    report = BuildVerifyReport(base_package=pkg_name)
-    package_files = checker.find_package_files(packages_dir, config.pkg_type)
+    """Verify all variants ``build_package.py`` would produce for one package.
 
-    for label, versioned_pkg, gfx_arch in checker.iter_variant_configs(
-        pkg_name,
-        config,
-    ):
-        expected_name = checker.resolve_installed_name(
+    Parameters:
+        pkg_name: ``package.json`` base name.
+        config: Shared build configuration (kpack routing, gfx targets, etc.).
+        packages_dir: Directory containing built package files.
+        check_version: When False, verify presence only.
+
+    Returns:
+        Report with one ``VariantBuildCheck`` per expected variant.
+    """
+    report = BuildVerifyReport(base_package=pkg_name)
+    package_files = find_package_files(packages_dir, config.pkg_type)
+
+    for spec in iter_package_variant_specs(pkg_name, config):
+        expected_name = resolve_installed_name(
             pkg_name,
             config,
-            versioned_pkg=versioned_pkg,
-            gfx_arch=gfx_arch,
+            versioned_pkg=spec.versioned_pkg,
+            gfx_arch=spec.gfx_arch,
         )
         report.variants.append(
             verify_variant(
                 pkg_name,
-                label,
+                spec.label,
                 expected_name,
                 package_files,
                 config,
@@ -257,7 +548,15 @@ def collect_extra_package_files(
     package_files: dict[str, Path],
     expected_names: set[str],
 ) -> list[str]:
-    """Return package stems present on disk but not expected by ``package.json``."""
+    """List package stems present on disk but not expected by any variant.
+
+    Parameters:
+        package_files: Index from ``find_package_files``.
+        expected_names: Installed package stems derived from variant enumeration.
+
+    Returns:
+        Sorted list of unexpected package stems.
+    """
     return sorted(name for name in package_files if name not in expected_names)
 
 
@@ -265,10 +564,19 @@ def resolve_pkg_names(
     args: argparse.Namespace,
     config: PackageConfig,
 ) -> list[str]:
-    """Resolve which ``package.json`` entries to verify."""
-    if args.all_eligible:
-        from build_package import parse_input_package_list
+    """Resolve the package list from CLI flags.
 
+    Parameters:
+        args: Parsed command-line arguments.
+        config: Shared build configuration (used for ``--all-eligible`` filtering).
+
+    Returns:
+        ``package.json`` base names to verify.
+
+    Raises:
+        ValueError: Propagated from ``parse_input_package_list`` on invalid input.
+    """
+    if args.all_eligible:
         pkg_list, _skipped = parse_input_package_list(None, config.artifacts_dir)
         return pkg_list
     return list(args.pkg_names)
@@ -281,7 +589,17 @@ def build_summary(
     *,
     fail_on_extra: bool,
 ) -> BuildVerifySummary:
-    """Build the run summary including optional extra-file detection."""
+    """Assemble the aggregate verification summary.
+
+    Parameters:
+        packages_requested: Base names passed on the command line.
+        reports: Per-package verification reports.
+        package_files: Full index of files in ``--packages-dir``.
+        fail_on_extra: When False, unexpected files are ignored for pass/fail.
+
+    Returns:
+        Summary used for console output and report files.
+    """
     expected_names = {v.expected_name for r in reports for v in r.variants}
     extra = collect_extra_package_files(package_files, expected_names)
     if not fail_on_extra:
@@ -294,8 +612,8 @@ def build_summary(
     )
 
 
-def _variant_to_dict(variant: VariantBuildCheck) -> dict:
-    """Serialize one variant check for JSON output."""
+def _variant_to_dict(variant: VariantBuildCheck) -> dict[str, object]:
+    """Serialize one variant check for JSON report output."""
     return {
         "base_package": variant.base_package,
         "label": variant.label,
@@ -311,7 +629,14 @@ def _variant_to_dict(variant: VariantBuildCheck) -> dict:
 
 
 def format_report_json(summary: BuildVerifySummary) -> str:
-    """Serialize the full build verification report as JSON."""
+    """Format the verification summary as indented JSON.
+
+    Parameters:
+        summary: Aggregate verification outcome.
+
+    Returns:
+        JSON string suitable for ``build_status_report.json``.
+    """
     payload = {
         "passed": summary.passed,
         "packages_requested": summary.packages_requested,
@@ -336,10 +661,17 @@ def format_report_json(summary: BuildVerifySummary) -> str:
 
 
 def format_report_text(summary: BuildVerifySummary) -> str:
-    """Build a plain-text build status report for logs or ``build_status_report.txt``."""
+    """Format the verification summary as human-readable text.
+
+    Parameters:
+        summary: Aggregate verification outcome.
+
+    Returns:
+        Multi-line report for console output and ``build_status_report.txt``.
+    """
     lines: list[str] = []
     overall = "PASS" if summary.passed else "FAIL"
-    lines.append("ROCm build package verification report (Step 1)")
+    lines.append("ROCm build package verification report")
     lines.append("=" * 72)
     lines.append(f"Overall result: {overall}")
     lines.append(f"Packages requested: {', '.join(summary.packages_requested)}")
@@ -381,29 +713,56 @@ def format_report_text(summary: BuildVerifySummary) -> str:
 
 
 def write_report_files(summary: BuildVerifySummary, report_dir: Path) -> None:
-    """Write ``build_status_report.txt`` and ``build_status_report.json``."""
+    """Write text and JSON verification reports under ``report_dir``.
+
+    Parameters:
+        summary: Aggregate verification outcome.
+        report_dir: Output directory (created if missing).
+
+    Raises:
+        FileNotFoundError: When either report file is missing after write.
+    """
     report_dir.mkdir(parents=True, exist_ok=True)
     text_path = report_dir / "build_status_report.txt"
     json_path = report_dir / "build_status_report.json"
     text_path.write_text(format_report_text(summary) + "\n", encoding="utf-8")
     json_path.write_text(format_report_json(summary) + "\n", encoding="utf-8")
-    print(f"Build report written to: {text_path}")
-    print(f"Build report written to: {json_path}")
+    if not text_path.is_file():
+        raise FileNotFoundError(f"Failed to write report: {text_path}")
+    if not json_path.is_file():
+        raise FileNotFoundError(f"Failed to write report: {json_path}")
+    logger.info(f"Build report written to: {text_path}")
+    logger.info(f"Build report written to: {json_path}")
 
 
-def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    """Parse CLI arguments for ``build_package_verify``."""
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Parameters:
+        argv: Argument list (typically ``sys.argv[1:]``).
+
+    Returns:
+        Parsed namespace for ``run()``.
+    """
     parser = argparse.ArgumentParser(
         description=(
             "Verify built native Linux packages match package.json variant names "
-            "and control-field versions (pre-upload Step 1)."
+            "and control-field versions."
         ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=_CLI_EXAMPLES_EPILOG,
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable verbose output (DEBUG level logging)",
     )
     parser.add_argument(
         "--pkg-type",
         required=True,
         choices=("deb", "rpm", "DEB", "RPM"),
-        help="Package format (deb or rpm)",
+        help="Choose the package format to be verified: DEB or RPM",
     )
     parser.add_argument(
         "--packages-dir",
@@ -430,13 +789,21 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--version-suffix",
+        type=str,
+        nargs="?",
         default="",
-        help="Build version suffix (e.g. CI run id)",
+        help=(
+            "Release identifier appended to the package version field in DEB/RPM "
+            "metadata (e.g. a CI run ID like '28484694006'). "
+            "For DEB this becomes the debian revision (e.g. '7.15.0-28484694006'); "
+            "for RPM this sets the release field. "
+            "Does not affect the package name or install prefix."
+        ),
     )
     parser.add_argument(
         "--install-prefix",
-        default="/opt/rocm/core",
-        help="Install prefix recorded in PackageConfig",
+        default=DEFAULT_INSTALL_PREFIX,
+        help="Base directory where package will be installed",
     )
     parser.add_argument(
         "--target",
@@ -447,12 +814,21 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--enable-kpack",
         action="store_true",
-        help="Use kpack variant rules (auto-detected from manifest if omitted)",
+        help="Enable multi-architecture package generation",
     )
     parser.add_argument(
-        "--rpath-pkg",
+        "--runpath-pkg",
         action="store_true",
-        help="Package was built with --rpath-pkg",
+        help="Keep RUNPATH in binaries (by default, RUNPATH is converted to RPATH)",
+    )
+    parser.add_argument(
+        "--build-variant",
+        default="",
+        help=(
+            "Build variant (e.g. 'asan'). When set to 'asan', the install prefix "
+            "becomes DEFAULT_INSTALL_PREFIX-asan-MAJOR.MINOR "
+            "(e.g. /opt/rocm/core-asan-7.15)."
+        ),
     )
     parser.add_argument(
         "--pkg-names",
@@ -481,39 +857,38 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         metavar="DIR",
         help="Write build_status_report.txt and .json under DIR",
     )
-    parser.add_argument(
-        "--quiet",
-        action="store_true",
-        help="Suppress verbose packaging_utils debug prints",
-    )
     return parser.parse_args(argv)
 
 
-def main(argv: list[str] | None = None) -> int:
-    """CLI entry: verify built packages, write report, return exit code."""
-    args = parse_args(argv)
-    checker._suppress_packaging_noise(args.quiet)
+def run(args: argparse.Namespace) -> int:
+    """Execute build package verification.
 
+    Parameters:
+        args: Parsed command-line arguments.
+
+    Returns:
+        0 on success, 1 when verification failed, 2 on usage or configuration errors.
+    """
     packages_dir = args.packages_dir.expanduser().resolve()
     if not packages_dir.is_dir():
-        print(f"Error: packages directory not found: {packages_dir}", file=sys.stderr)
+        logger.error(f"packages directory not found: {packages_dir}")
         return 2
 
     read_package_json_file()
     try:
-        config = checker.build_checker_config(args)
+        config = create_package_config(args)
     except ValueError as exc:
-        print(f"Error: {exc}", file=sys.stderr)
+        logger.error(f"{exc}")
         return 2
 
     try:
         pkg_names = resolve_pkg_names(args, config)
     except ValueError as exc:
-        print(f"Error: {exc}", file=sys.stderr)
+        logger.error(f"{exc}")
         return 2
 
     if not pkg_names:
-        print("Error: no packages to verify", file=sys.stderr)
+        logger.error("no packages to verify")
         return 2
 
     check_version = not args.no_version_check
@@ -521,7 +896,7 @@ def main(argv: list[str] | None = None) -> int:
         verify_package(name, config, packages_dir, check_version=check_version)
         for name in pkg_names
     ]
-    package_files = checker.find_package_files(packages_dir, config.pkg_type)
+    package_files = find_package_files(packages_dir, config.pkg_type)
     summary = build_summary(
         pkg_names,
         reports,
@@ -535,22 +910,21 @@ def main(argv: list[str] | None = None) -> int:
         write_report_files(summary, args.report_dir.expanduser())
 
     if not summary.passed:
-        print(
-            f"\nBuild verification failed: "
-            f"{summary.variants_failed} variant(s), "
-            f"{len(summary.extra_package_files)} extra file(s).",
-            file=sys.stderr,
+        logger.error(
+            f"Build verification failed: {summary.variants_failed} variant(s), "
+            f"{len(summary.extra_package_files)} extra file(s)",
         )
         return 1
-    print("\nBuild verification passed.")
+    logger.info("Build verification passed.")
     return 0
 
 
-if __name__ == "__main__":
-    sys.exit(main())
+def main(argv: list[str]) -> int:
+    """Program entry point: parse arguments, configure logging, and run verification."""
+    args = parse_args(argv)
+    configure_logging(verbose=args.verbose)
+    return run(args)
 
-# Epilog
-# -----
-# Step 1 (this module): names + versions of built archives vs package.json variants.
-# Step 2 (pkg_dependency_checker.py): Depends/Requires vs package.json rules.
-# Step 3 (native_linux_package_install_test.py --test-type simulate): installability.
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/build_tools/packaging/linux/build_package_verify.py
+++ b/build_tools/packaging/linux/build_package_verify.py
@@ -113,10 +113,7 @@ class BuildVerifySummary:
 
     def missing_variants(self) -> list[str]:
         return [
-            v.expected_name
-            for r in self.reports
-            for v in r.variants
-            if not v.found
+            v.expected_name for r in self.reports for v in r.variants if not v.found
         ]
 
     def version_failures(self) -> list[str]:
@@ -196,7 +193,9 @@ def verify_variant(
             try:
                 actual_version = read_package_file_version(path, config.pkg_type)
                 version_ok = versions_match(
-                    expected_version, actual_version, config.pkg_type,
+                    expected_version,
+                    actual_version,
+                    config.pkg_type,
                 )
                 if not version_ok:
                     errors.append(
@@ -232,7 +231,8 @@ def verify_package(
     package_files = checker.find_package_files(packages_dir, config.pkg_type)
 
     for label, versioned_pkg, gfx_arch in checker.iter_variant_configs(
-        pkg_name, config,
+        pkg_name,
+        config,
     ):
         expected_name = checker.resolve_installed_name(
             pkg_name,
@@ -282,9 +282,7 @@ def build_summary(
     fail_on_extra: bool,
 ) -> BuildVerifySummary:
     """Build the run summary including optional extra-file detection."""
-    expected_names = {
-        v.expected_name for r in reports for v in r.variants
-    }
+    expected_names = {v.expected_name for r in reports for v in r.variants}
     extra = collect_extra_package_files(package_files, expected_names)
     if not fail_on_extra:
         extra = []

--- a/build_tools/packaging/linux/build_package_verify.py
+++ b/build_tools/packaging/linux/build_package_verify.py
@@ -342,15 +342,52 @@ def resolve_installed_name(
     return update_package_name(pkg_name, local_config)
 
 
+def read_package_file_name(package_path: Path, pkg_type: str) -> str:
+    """Read the installed package name from a built ``.deb`` or ``.rpm`` file.
+
+    DEB filenames use ``{name}_{version}_{arch}.deb`` and RPM filenames use
+    ``{name}-{version}-{release}.{arch}.rpm``, so the metadata name must be
+    queried rather than derived from the filename alone.
+
+    Parameters:
+        package_path: Path to a built package file.
+        pkg_type: ``deb`` or ``rpm`` (case-insensitive).
+
+    Returns:
+        Package name from control metadata (``Package`` / ``NAME``).
+
+    Raises:
+        RuntimeError: When ``dpkg-deb`` or ``rpm`` query fails.
+    """
+    pkg_type = pkg_type.lower()
+    if pkg_type == "deb":
+        result = _run_capture(
+            ["dpkg-deb", "-f", str(package_path), "Package"],
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"dpkg-deb failed for {package_path}: {result.stderr.strip()}",
+            )
+        return result.stdout.strip()
+    result = _run_capture(
+        ["rpm", "-qp", "--qf", r"%{NAME}", str(package_path)],
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"rpm query failed for {package_path}: {result.stderr.strip()}",
+        )
+    return result.stdout.strip()
+
+
 def find_package_files(packages_dir: Path, pkg_type: str) -> dict[str, Path]:
-    """Index built package files in ``packages_dir`` by installed package stem.
+    """Index built package files in ``packages_dir`` by installed package name.
 
     Parameters:
         packages_dir: Directory containing built ``.deb`` or ``.rpm`` files.
         pkg_type: ``deb`` or ``rpm`` (case-insensitive).
 
     Returns:
-        Mapping from package stem (filename without extension) to file path.
+        Mapping from metadata package name to file path.
     """
     ext = ".deb" if pkg_type.lower() == "deb" else ".rpm"
     package_files: dict[str, Path] = {}
@@ -359,8 +396,12 @@ def find_package_files(packages_dir: Path, pkg_type: str) -> dict[str, Path]:
             continue
         if not path.name.lower().endswith(ext):
             continue
-        # Stem matches the installed package name used by dpkg/rpm metadata.
-        package_files[path.name[: -len(ext)]] = path
+        try:
+            name = read_package_file_name(path, pkg_type)
+        except RuntimeError as exc:
+            logger.warning(f"Skipping {path.name}: {exc}")
+            continue
+        package_files[name] = path
     return package_files
 
 

--- a/build_tools/packaging/linux/tests/build_package_verify_test.py
+++ b/build_tools/packaging/linux/tests/build_package_verify_test.py
@@ -167,7 +167,9 @@ class ExtraFilesTest(unittest.TestCase):
 class BuildSummaryTest(unittest.TestCase):
     """``BuildVerifySummary`` aggregation and pass/fail."""
 
-    def _variant(self, name: str, *, found: bool, version_ok: bool) -> verify.VariantBuildCheck:
+    def _variant(
+        self, name: str, *, found: bool, version_ok: bool
+    ) -> verify.VariantBuildCheck:
         return verify.VariantBuildCheck(
             base_package="amdrocm-core-sdk",
             label="main",
@@ -183,7 +185,9 @@ class BuildSummaryTest(unittest.TestCase):
     def test_all_passed(self):
         report = verify.BuildVerifyReport(
             base_package="amdrocm-core-sdk",
-            variants=[self._variant("amdrocm-core-sdk7.14", found=True, version_ok=True)],
+            variants=[
+                self._variant("amdrocm-core-sdk7.14", found=True, version_ok=True)
+            ],
         )
         summary = verify.build_summary(
             ["amdrocm-core-sdk"],
@@ -197,7 +201,9 @@ class BuildSummaryTest(unittest.TestCase):
     def test_missing_variant_fails(self):
         report = verify.BuildVerifyReport(
             base_package="amdrocm-core-sdk",
-            variants=[self._variant("amdrocm-core-sdk7.14", found=False, version_ok=False)],
+            variants=[
+                self._variant("amdrocm-core-sdk7.14", found=False, version_ok=False)
+            ],
         )
         summary = verify.build_summary(
             ["amdrocm-core-sdk"],
@@ -211,7 +217,9 @@ class BuildSummaryTest(unittest.TestCase):
     def test_extra_files_fail_when_enabled(self):
         report = verify.BuildVerifyReport(
             base_package="amdrocm-core-sdk",
-            variants=[self._variant("amdrocm-core-sdk7.14", found=True, version_ok=True)],
+            variants=[
+                self._variant("amdrocm-core-sdk7.14", found=True, version_ok=True)
+            ],
         )
         summary = verify.build_summary(
             ["amdrocm-core-sdk"],

--- a/build_tools/packaging/linux/tests/build_package_verify_test.py
+++ b/build_tools/packaging/linux/tests/build_package_verify_test.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for ``build_package_verify.py`` (pre-upload Step 1).
+
+Run (Python 3.10+)::
+
+    python3 -m unittest build_tools.packaging.linux.tests.build_package_verify_test -v
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+_LINUX_DIR = Path(__file__).resolve().parent.parent
+if str(_LINUX_DIR) not in sys.path:
+    sys.path.insert(0, str(_LINUX_DIR))
+
+import build_package_verify as verify  # noqa: E402
+from packaging_utils import PackageConfig  # noqa: E402
+
+
+class ExpectedControlVersionTest(unittest.TestCase):
+    """``expected_control_version`` matches deb/rpm packaging rules."""
+
+    def test_deb_version_with_suffix(self):
+        cfg = PackageConfig(
+            artifacts_dir=Path("/tmp"),
+            dest_dir=Path("/tmp/out"),
+            pkg_type="deb",
+            rocm_version="7.14.0",
+            version_suffix="12345",
+            install_prefix="/opt/rocm/core",
+            gfx_arch="",
+        )
+        self.assertEqual(verify.expected_control_version(cfg), "7.14.0-12345")
+
+    def test_deb_version_without_suffix(self):
+        cfg = PackageConfig(
+            artifacts_dir=Path("/tmp"),
+            dest_dir=Path("/tmp/out"),
+            pkg_type="deb",
+            rocm_version="7.14.0",
+            version_suffix="",
+            install_prefix="/opt/rocm/core",
+            gfx_arch="",
+        )
+        self.assertEqual(verify.expected_control_version(cfg), "7.14.0")
+
+    def test_rpm_version_release(self):
+        cfg = PackageConfig(
+            artifacts_dir=Path("/tmp"),
+            dest_dir=Path("/tmp/out"),
+            pkg_type="rpm",
+            rocm_version="7.14.0",
+            version_suffix="12345",
+            install_prefix="/opt/rocm/core",
+            gfx_arch="",
+        )
+        self.assertEqual(verify.expected_control_version(cfg), "7.14.0-12345")
+
+    def test_rpm_default_release(self):
+        cfg = PackageConfig(
+            artifacts_dir=Path("/tmp"),
+            dest_dir=Path("/tmp/out"),
+            pkg_type="rpm",
+            rocm_version="7.14.0",
+            version_suffix="",
+            install_prefix="/opt/rocm/core",
+            gfx_arch="",
+        )
+        self.assertEqual(verify.expected_control_version(cfg), "7.14.0-1")
+
+
+class VersionsMatchTest(unittest.TestCase):
+    """``versions_match`` tolerates DEB ``~`` vs ``-`` normalization."""
+
+    def test_exact_match(self):
+        self.assertTrue(verify.versions_match("7.14.0-1", "7.14.0-1", "deb"))
+
+    def test_deb_tilde_normalization(self):
+        self.assertTrue(verify.versions_match("7.14.0-12345", "7.14.0~12345", "deb"))
+
+    def test_rpm_no_tilde_normalization(self):
+        self.assertFalse(verify.versions_match("7.14.0-12345", "7.14.0~12345", "rpm"))
+
+
+class VerifyVariantTest(unittest.TestCase):
+    """``verify_variant`` presence and version checks."""
+
+    def setUp(self):
+        self.config = PackageConfig(
+            artifacts_dir=Path("/tmp"),
+            dest_dir=Path("/tmp/out"),
+            pkg_type="deb",
+            rocm_version="7.14.0",
+            version_suffix="daily",
+            install_prefix="/opt/rocm/core",
+            gfx_arch="",
+        )
+
+    def test_missing_package_fails(self):
+        result = verify.verify_variant(
+            "amdrocm-core-sdk",
+            "main",
+            "amdrocm-core-sdk7.14",
+            {},
+            self.config,
+            check_version=True,
+        )
+        self.assertFalse(result.found)
+        self.assertFalse(result.passed)
+        self.assertIn("not found", result.errors[0])
+
+    @patch.object(verify, "read_package_file_version", return_value="7.14.0~daily")
+    def test_found_with_matching_version_passes(self, _mock_read):
+        path = Path("/tmp/pkg.deb")
+        files = {"amdrocm-core-sdk7.14": path}
+        result = verify.verify_variant(
+            "amdrocm-core-sdk",
+            "main",
+            "amdrocm-core-sdk7.14",
+            files,
+            self.config,
+            check_version=True,
+        )
+        self.assertTrue(result.found)
+        self.assertTrue(result.version_ok)
+        self.assertTrue(result.passed)
+
+    @patch.object(verify, "read_package_file_version", return_value="7.14.0~wrong")
+    def test_version_mismatch_fails(self, _mock_read):
+        path = Path("/tmp/pkg.deb")
+        files = {"amdrocm-core-sdk7.14": path}
+        result = verify.verify_variant(
+            "amdrocm-core-sdk",
+            "main",
+            "amdrocm-core-sdk7.14",
+            files,
+            self.config,
+            check_version=True,
+        )
+        self.assertTrue(result.found)
+        self.assertFalse(result.version_ok)
+        self.assertFalse(result.passed)
+
+
+class ExtraFilesTest(unittest.TestCase):
+    """Unexpected package file detection."""
+
+    def test_collect_extra_package_files(self):
+        files = {
+            "amdrocm-core-sdk7.14": Path("/tmp/a.deb"),
+            "unexpected-pkg7.14": Path("/tmp/b.deb"),
+        }
+        expected = {"amdrocm-core-sdk7.14"}
+        extra = verify.collect_extra_package_files(files, expected)
+        self.assertEqual(extra, ["unexpected-pkg7.14"])
+
+
+class BuildSummaryTest(unittest.TestCase):
+    """``BuildVerifySummary`` aggregation and pass/fail."""
+
+    def _variant(self, name: str, *, found: bool, version_ok: bool) -> verify.VariantBuildCheck:
+        return verify.VariantBuildCheck(
+            base_package="amdrocm-core-sdk",
+            label="main",
+            expected_name=name,
+            file_path=Path("/tmp/x.deb") if found else None,
+            found=found,
+            expected_version="7.14.0-daily",
+            actual_version="7.14.0~daily" if found else None,
+            version_ok=version_ok,
+            errors=[] if found and version_ok else ["err"],
+        )
+
+    def test_all_passed(self):
+        report = verify.BuildVerifyReport(
+            base_package="amdrocm-core-sdk",
+            variants=[self._variant("amdrocm-core-sdk7.14", found=True, version_ok=True)],
+        )
+        summary = verify.build_summary(
+            ["amdrocm-core-sdk"],
+            [report],
+            {"amdrocm-core-sdk7.14": Path("/tmp/x.deb")},
+            fail_on_extra=False,
+        )
+        self.assertTrue(summary.passed)
+        self.assertEqual(summary.variants_passed, 1)
+
+    def test_missing_variant_fails(self):
+        report = verify.BuildVerifyReport(
+            base_package="amdrocm-core-sdk",
+            variants=[self._variant("amdrocm-core-sdk7.14", found=False, version_ok=False)],
+        )
+        summary = verify.build_summary(
+            ["amdrocm-core-sdk"],
+            [report],
+            {},
+            fail_on_extra=False,
+        )
+        self.assertFalse(summary.passed)
+        self.assertEqual(summary.missing_variants(), ["amdrocm-core-sdk7.14"])
+
+    def test_extra_files_fail_when_enabled(self):
+        report = verify.BuildVerifyReport(
+            base_package="amdrocm-core-sdk",
+            variants=[self._variant("amdrocm-core-sdk7.14", found=True, version_ok=True)],
+        )
+        summary = verify.build_summary(
+            ["amdrocm-core-sdk"],
+            [report],
+            {
+                "amdrocm-core-sdk7.14": Path("/tmp/x.deb"),
+                "extra7.14": Path("/tmp/y.deb"),
+            },
+            fail_on_extra=True,
+        )
+        self.assertFalse(summary.passed)
+        self.assertEqual(summary.extra_package_files, ["extra7.14"])
+
+
+class ReportFormatTest(unittest.TestCase):
+    """JSON and text report serialization."""
+
+    def test_json_roundtrip_fields(self):
+        variant = verify.VariantBuildCheck(
+            base_package="amdrocm-core-sdk",
+            label="main",
+            expected_name="amdrocm-core-sdk7.14",
+            file_path=Path("/tmp/x.deb"),
+            found=True,
+            expected_version="7.14.0-daily",
+            actual_version="7.14.0~daily",
+            version_ok=True,
+        )
+        report = verify.BuildVerifyReport(
+            base_package="amdrocm-core-sdk",
+            variants=[variant],
+        )
+        summary = verify.BuildVerifySummary(
+            packages_requested=["amdrocm-core-sdk"],
+            reports=[report],
+            package_files_found=["amdrocm-core-sdk7.14"],
+        )
+        payload = json.loads(verify.format_report_json(summary))
+        self.assertTrue(payload["passed"])
+        self.assertEqual(payload["variants_expected"], 1)
+        text = verify.format_report_text(summary)
+        self.assertIn("ROCm build package verification report", text)
+
+    def test_text_contains_pass(self):
+        variant = verify.VariantBuildCheck(
+            base_package="amdrocm-core-sdk",
+            label="main",
+            expected_name="amdrocm-core-sdk7.14",
+            file_path=Path("/tmp/x.deb"),
+            found=True,
+            expected_version="7.14.0-daily",
+            actual_version="7.14.0~daily",
+            version_ok=True,
+        )
+        report = verify.BuildVerifyReport(
+            base_package="amdrocm-core-sdk",
+            variants=[variant],
+        )
+        summary = verify.BuildVerifySummary(
+            packages_requested=["amdrocm-core-sdk"],
+            reports=[report],
+            package_files_found=["amdrocm-core-sdk7.14"],
+        )
+        text = verify.format_report_text(summary)
+        self.assertIn("Overall result: PASS", text)
+        self.assertIn("amdrocm-core-sdk7.14", text)
+
+
+class WriteReportFilesTest(unittest.TestCase):
+    """``write_report_files`` creates txt and json under report dir."""
+
+    def test_writes_both_reports(self):
+        variant = verify.VariantBuildCheck(
+            base_package="amdrocm-core-sdk",
+            label="main",
+            expected_name="amdrocm-core-sdk7.14",
+            file_path=Path("/tmp/x.deb"),
+            found=True,
+            expected_version="7.14.0-daily",
+            actual_version="7.14.0~daily",
+            version_ok=True,
+        )
+        report = verify.BuildVerifyReport(
+            base_package="amdrocm-core-sdk",
+            variants=[variant],
+        )
+        summary = verify.BuildVerifySummary(
+            packages_requested=["amdrocm-core-sdk"],
+            reports=[report],
+            package_files_found=["amdrocm-core-sdk7.14"],
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            report_dir = Path(tmp)
+            verify.write_report_files(summary, report_dir)
+            self.assertTrue((report_dir / "build_status_report.txt").is_file())
+            self.assertTrue((report_dir / "build_status_report.json").is_file())
+            payload = json.loads(
+                (report_dir / "build_status_report.json").read_text(encoding="utf-8"),
+            )
+            self.assertTrue(payload["passed"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/build_tools/packaging/linux/tests/build_package_verify_test.py
+++ b/build_tools/packaging/linux/tests/build_package_verify_test.py
@@ -2,33 +2,102 @@
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-"""Unit tests for ``build_package_verify.py`` (pre-upload Step 1).
+"""Unit tests for ``build_package_verify.py``.
 
-Run (Python 3.10+)::
+Run::
 
-    python3 -m unittest build_tools.packaging.linux.tests.build_package_verify_test -v
+    python3.12 -m unittest build_tools.packaging.linux.tests.build_package_verify_test -v
 """
-
-from __future__ import annotations
 
 import json
 import sys
 import tempfile
 import unittest
+from argparse import Namespace
 from pathlib import Path
 from unittest.mock import patch
 
-_LINUX_DIR = Path(__file__).resolve().parent.parent
-if str(_LINUX_DIR) not in sys.path:
-    sys.path.insert(0, str(_LINUX_DIR))
+THIS_SCRIPT_DIR = Path(__file__).resolve().parent
+LINUX_DIR = THIS_SCRIPT_DIR.parent
+BUILD_TOOLS_DIR = LINUX_DIR.parent.parent
 
+TEST_ROCM_VERSION = "7.14.0"
+TEST_VERSION_SUFFIX = "daily"
+TEST_INSTALL_PREFIX = "/opt/rocm/core"
+TEST_GFX_TARGET = "gfx1100"
+TEST_GFX_TARGET_ALT = "gfx942"
+TEST_PKG_TYPE_DEB = "deb"
+
+PKG_CORE_SDK = "amdrocm-core-sdk"
+PKG_DEVELOPER_TOOLS = "amdrocm-developer-tools"
+PKG_FFT = "amdrocm-fft"
+
+
+def _setup_import_path() -> None:
+    for path in (BUILD_TOOLS_DIR, LINUX_DIR):
+        path_str = str(path)
+        if path_str not in sys.path:
+            sys.path.insert(0, path_str)
+
+
+_setup_import_path()
+
+import build_package  # noqa: E402
 import build_package_verify as verify  # noqa: E402
-from packaging_utils import PackageConfig  # noqa: E402
+from packaging_utils import (  # noqa: E402
+    GFX_META,
+    PackageConfig,
+    get_package_info,
+    is_gfxarch_package,
+)
+
+
+def _args(tmp: Path, **overrides: object) -> Namespace:
+    artifacts = tmp / "artifacts"
+    artifacts.mkdir(parents=True, exist_ok=True)
+    defaults: dict[str, object] = {
+        "artifacts_dir": artifacts,
+        "dest_dir": tmp / "output",
+        "target": [TEST_GFX_TARGET, TEST_GFX_TARGET_ALT],
+        "pkg_type": TEST_PKG_TYPE_DEB,
+        "rocm_version": TEST_ROCM_VERSION,
+        "version_suffix": TEST_VERSION_SUFFIX,
+        "install_prefix": TEST_INSTALL_PREFIX,
+        "runpath_pkg": False,
+        "enable_kpack": False,
+        "build_variant": "",
+    }
+    defaults.update(overrides)
+    return Namespace(**defaults)
+
+
+def _write_kpack_manifest(artifacts_dir: Path) -> None:
+    manifest_dir = artifacts_dir / "pkg"
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    (manifest_dir / "therock_manifest.json").write_text(
+        json.dumps({"flags": {"KPACK_SPLIT_ARTIFACTS": True}}),
+        encoding="utf-8",
+    )
+
+
+def _kpack_config(tmp: Path, **overrides: object) -> PackageConfig:
+    root = Path(tmp)
+    _write_kpack_manifest(root / "artifacts")
+    return build_package.create_package_config(
+        _args(root, enable_kpack=True, **overrides),
+    )
+
+
+class BuildPackageVerifyTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self._temp_context = tempfile.TemporaryDirectory()
+        self.temp_dir = Path(self._temp_context.name)
+
+    def tearDown(self) -> None:
+        self._temp_context.cleanup()
 
 
 class ExpectedControlVersionTest(unittest.TestCase):
-    """``expected_control_version`` matches deb/rpm packaging rules."""
-
     def test_deb_version_with_suffix(self):
         cfg = PackageConfig(
             artifacts_dir=Path("/tmp"),
@@ -79,8 +148,6 @@ class ExpectedControlVersionTest(unittest.TestCase):
 
 
 class VersionsMatchTest(unittest.TestCase):
-    """``versions_match`` tolerates DEB ``~`` vs ``-`` normalization."""
-
     def test_exact_match(self):
         self.assertTrue(verify.versions_match("7.14.0-1", "7.14.0-1", "deb"))
 
@@ -91,9 +158,55 @@ class VersionsMatchTest(unittest.TestCase):
         self.assertFalse(verify.versions_match("7.14.0-12345", "7.14.0~12345", "rpm"))
 
 
-class VerifyVariantTest(unittest.TestCase):
-    """``verify_variant`` presence and version checks."""
+class IterPackageVariantSpecsRoutingTest(BuildPackageVerifyTestCase):
+    def test_core_sdk_kpack_lists_meta_and_device_variants(self):
+        cfg = _kpack_config(self.temp_dir)
+        labels = [
+            spec.label
+            for spec in verify.iter_package_variant_specs(PKG_CORE_SDK, cfg)
+        ]
+        self.assertIn("meta", labels)
+        self.assertIn("non-versioned", labels)
+        self.assertIn(f"device-{TEST_GFX_TARGET}", labels)
+        self.assertNotIn("host", labels)
 
+    def test_developer_tools_kpack_lists_simple_variants(self):
+        cfg = _kpack_config(self.temp_dir)
+        labels = [
+            spec.label
+            for spec in verify.iter_package_variant_specs(
+                PKG_DEVELOPER_TOOLS, cfg
+            )
+        ]
+        self.assertEqual(labels, ["versioned", "non-versioned"])
+
+    def test_fft_without_gfx_artifacts_lists_simple_variants(self):
+        cfg = _kpack_config(self.temp_dir)
+        pkg_info = get_package_info(PKG_FFT)
+        self.assertFalse(
+            is_gfxarch_package(
+                pkg_info=pkg_info,
+                enable_kpack=True,
+                artifacts_dir=cfg.artifacts_dir,
+            ),
+        )
+        labels = [
+            spec.label
+            for spec in verify.iter_package_variant_specs(PKG_FFT, cfg)
+        ]
+        self.assertEqual(labels, ["versioned", "non-versioned"])
+
+    def test_gfx_meta_variant_uses_meta_arch_suffix(self):
+        cfg = _kpack_config(self.temp_dir)
+        meta_variants = [
+            (spec.versioned_pkg, spec.gfx_arch)
+            for spec in verify.iter_package_variant_specs(PKG_CORE_SDK, cfg)
+            if spec.label == "meta"
+        ]
+        self.assertEqual(meta_variants, [(True, GFX_META)])
+
+
+class VerifyVariantTest(unittest.TestCase):
     def setUp(self):
         self.config = PackageConfig(
             artifacts_dir=Path("/tmp"),
@@ -107,7 +220,7 @@ class VerifyVariantTest(unittest.TestCase):
 
     def test_missing_package_fails(self):
         result = verify.verify_variant(
-            "amdrocm-core-sdk",
+            PKG_CORE_SDK,
             "main",
             "amdrocm-core-sdk7.14",
             {},
@@ -123,7 +236,7 @@ class VerifyVariantTest(unittest.TestCase):
         path = Path("/tmp/pkg.deb")
         files = {"amdrocm-core-sdk7.14": path}
         result = verify.verify_variant(
-            "amdrocm-core-sdk",
+            PKG_CORE_SDK,
             "main",
             "amdrocm-core-sdk7.14",
             files,
@@ -139,7 +252,7 @@ class VerifyVariantTest(unittest.TestCase):
         path = Path("/tmp/pkg.deb")
         files = {"amdrocm-core-sdk7.14": path}
         result = verify.verify_variant(
-            "amdrocm-core-sdk",
+            PKG_CORE_SDK,
             "main",
             "amdrocm-core-sdk7.14",
             files,
@@ -152,8 +265,6 @@ class VerifyVariantTest(unittest.TestCase):
 
 
 class ExtraFilesTest(unittest.TestCase):
-    """Unexpected package file detection."""
-
     def test_collect_extra_package_files(self):
         files = {
             "amdrocm-core-sdk7.14": Path("/tmp/a.deb"),
@@ -165,13 +276,11 @@ class ExtraFilesTest(unittest.TestCase):
 
 
 class BuildSummaryTest(unittest.TestCase):
-    """``BuildVerifySummary`` aggregation and pass/fail."""
-
     def _variant(
         self, name: str, *, found: bool, version_ok: bool
     ) -> verify.VariantBuildCheck:
         return verify.VariantBuildCheck(
-            base_package="amdrocm-core-sdk",
+            base_package=PKG_CORE_SDK,
             label="main",
             expected_name=name,
             file_path=Path("/tmp/x.deb") if found else None,
@@ -184,13 +293,13 @@ class BuildSummaryTest(unittest.TestCase):
 
     def test_all_passed(self):
         report = verify.BuildVerifyReport(
-            base_package="amdrocm-core-sdk",
+            base_package=PKG_CORE_SDK,
             variants=[
                 self._variant("amdrocm-core-sdk7.14", found=True, version_ok=True)
             ],
         )
         summary = verify.build_summary(
-            ["amdrocm-core-sdk"],
+            [PKG_CORE_SDK],
             [report],
             {"amdrocm-core-sdk7.14": Path("/tmp/x.deb")},
             fail_on_extra=False,
@@ -200,13 +309,13 @@ class BuildSummaryTest(unittest.TestCase):
 
     def test_missing_variant_fails(self):
         report = verify.BuildVerifyReport(
-            base_package="amdrocm-core-sdk",
+            base_package=PKG_CORE_SDK,
             variants=[
                 self._variant("amdrocm-core-sdk7.14", found=False, version_ok=False)
             ],
         )
         summary = verify.build_summary(
-            ["amdrocm-core-sdk"],
+            [PKG_CORE_SDK],
             [report],
             {},
             fail_on_extra=False,
@@ -216,13 +325,13 @@ class BuildSummaryTest(unittest.TestCase):
 
     def test_extra_files_fail_when_enabled(self):
         report = verify.BuildVerifyReport(
-            base_package="amdrocm-core-sdk",
+            base_package=PKG_CORE_SDK,
             variants=[
                 self._variant("amdrocm-core-sdk7.14", found=True, version_ok=True)
             ],
         )
         summary = verify.build_summary(
-            ["amdrocm-core-sdk"],
+            [PKG_CORE_SDK],
             [report],
             {
                 "amdrocm-core-sdk7.14": Path("/tmp/x.deb"),
@@ -235,11 +344,9 @@ class BuildSummaryTest(unittest.TestCase):
 
 
 class ReportFormatTest(unittest.TestCase):
-    """JSON and text report serialization."""
-
     def test_json_roundtrip_fields(self):
         variant = verify.VariantBuildCheck(
-            base_package="amdrocm-core-sdk",
+            base_package=PKG_CORE_SDK,
             label="main",
             expected_name="amdrocm-core-sdk7.14",
             file_path=Path("/tmp/x.deb"),
@@ -249,11 +356,11 @@ class ReportFormatTest(unittest.TestCase):
             version_ok=True,
         )
         report = verify.BuildVerifyReport(
-            base_package="amdrocm-core-sdk",
+            base_package=PKG_CORE_SDK,
             variants=[variant],
         )
         summary = verify.BuildVerifySummary(
-            packages_requested=["amdrocm-core-sdk"],
+            packages_requested=[PKG_CORE_SDK],
             reports=[report],
             package_files_found=["amdrocm-core-sdk7.14"],
         )
@@ -265,7 +372,7 @@ class ReportFormatTest(unittest.TestCase):
 
     def test_text_contains_pass(self):
         variant = verify.VariantBuildCheck(
-            base_package="amdrocm-core-sdk",
+            base_package=PKG_CORE_SDK,
             label="main",
             expected_name="amdrocm-core-sdk7.14",
             file_path=Path("/tmp/x.deb"),
@@ -275,11 +382,11 @@ class ReportFormatTest(unittest.TestCase):
             version_ok=True,
         )
         report = verify.BuildVerifyReport(
-            base_package="amdrocm-core-sdk",
+            base_package=PKG_CORE_SDK,
             variants=[variant],
         )
         summary = verify.BuildVerifySummary(
-            packages_requested=["amdrocm-core-sdk"],
+            packages_requested=[PKG_CORE_SDK],
             reports=[report],
             package_files_found=["amdrocm-core-sdk7.14"],
         )
@@ -289,11 +396,9 @@ class ReportFormatTest(unittest.TestCase):
 
 
 class WriteReportFilesTest(unittest.TestCase):
-    """``write_report_files`` creates txt and json under report dir."""
-
     def test_writes_both_reports(self):
         variant = verify.VariantBuildCheck(
-            base_package="amdrocm-core-sdk",
+            base_package=PKG_CORE_SDK,
             label="main",
             expected_name="amdrocm-core-sdk7.14",
             file_path=Path("/tmp/x.deb"),
@@ -303,11 +408,11 @@ class WriteReportFilesTest(unittest.TestCase):
             version_ok=True,
         )
         report = verify.BuildVerifyReport(
-            base_package="amdrocm-core-sdk",
+            base_package=PKG_CORE_SDK,
             variants=[variant],
         )
         summary = verify.BuildVerifySummary(
-            packages_requested=["amdrocm-core-sdk"],
+            packages_requested=[PKG_CORE_SDK],
             reports=[report],
             package_files_found=["amdrocm-core-sdk7.14"],
         )

--- a/build_tools/packaging/linux/tests/build_package_verify_test.py
+++ b/build_tools/packaging/linux/tests/build_package_verify_test.py
@@ -162,8 +162,7 @@ class IterPackageVariantSpecsRoutingTest(BuildPackageVerifyTestCase):
     def test_core_sdk_kpack_lists_meta_and_device_variants(self):
         cfg = _kpack_config(self.temp_dir)
         labels = [
-            spec.label
-            for spec in verify.iter_package_variant_specs(PKG_CORE_SDK, cfg)
+            spec.label for spec in verify.iter_package_variant_specs(PKG_CORE_SDK, cfg)
         ]
         self.assertIn("meta", labels)
         self.assertIn("non-versioned", labels)
@@ -174,9 +173,7 @@ class IterPackageVariantSpecsRoutingTest(BuildPackageVerifyTestCase):
         cfg = _kpack_config(self.temp_dir)
         labels = [
             spec.label
-            for spec in verify.iter_package_variant_specs(
-                PKG_DEVELOPER_TOOLS, cfg
-            )
+            for spec in verify.iter_package_variant_specs(PKG_DEVELOPER_TOOLS, cfg)
         ]
         self.assertEqual(labels, ["versioned", "non-versioned"])
 
@@ -191,8 +188,7 @@ class IterPackageVariantSpecsRoutingTest(BuildPackageVerifyTestCase):
             ),
         )
         labels = [
-            spec.label
-            for spec in verify.iter_package_variant_specs(PKG_FFT, cfg)
+            spec.label for spec in verify.iter_package_variant_specs(PKG_FFT, cfg)
         ]
         self.assertEqual(labels, ["versioned", "non-versioned"])
 

--- a/build_tools/packaging/linux/tests/build_package_verify_test.py
+++ b/build_tools/packaging/linux/tests/build_package_verify_test.py
@@ -202,6 +202,50 @@ class IterPackageVariantSpecsRoutingTest(BuildPackageVerifyTestCase):
         self.assertEqual(meta_variants, [(True, GFX_META)])
 
 
+class FindPackageFilesTest(unittest.TestCase):
+    @patch.object(verify, "read_package_file_name")
+    def test_indexes_rpm_by_metadata_name(self, mock_read_name):
+        with tempfile.TemporaryDirectory() as tmp:
+            packages_dir = Path(tmp)
+            device_rpm = (
+                packages_dir
+                / "amdrocm-core-sdk10.2-gfx1100-10.2.0~daily-12345.x86_64.rpm"
+            )
+            meta_rpm = (
+                packages_dir / "amdrocm-core-sdk10.2-10.2.0~daily-12345.x86_64.rpm"
+            )
+            device_rpm.write_bytes(b"rpm")
+            meta_rpm.write_bytes(b"rpm")
+
+            def name_for(path: Path, pkg_type: str) -> str:
+                if "gfx1100" in path.name:
+                    return "amdrocm-core-sdk10.2-gfx1100"
+                return "amdrocm-core-sdk10.2"
+
+            mock_read_name.side_effect = name_for
+            index = verify.find_package_files(packages_dir, "rpm")
+
+        self.assertEqual(
+            index["amdrocm-core-sdk10.2-gfx1100"],
+            device_rpm,
+        )
+        self.assertEqual(index["amdrocm-core-sdk10.2"], meta_rpm)
+
+    @patch.object(verify, "read_package_file_name")
+    def test_indexes_deb_by_metadata_name(self, mock_read_name):
+        with tempfile.TemporaryDirectory() as tmp:
+            packages_dir = Path(tmp)
+            deb_path = (
+                packages_dir / "amdrocm-core-sdk10.2_10.2.0~daily-12345_amd64.deb"
+            )
+            deb_path.write_bytes(b"deb")
+            mock_read_name.return_value = "amdrocm-core-sdk10.2"
+            index = verify.find_package_files(packages_dir, "deb")
+
+        self.assertEqual(index["amdrocm-core-sdk10.2"], deb_path)
+        mock_read_name.assert_called_once_with(deb_path, "deb")
+
+
 class VerifyVariantTest(unittest.TestCase):
     def setUp(self):
         self.config = PackageConfig(


### PR DESCRIPTION
## Motivation

This pull request introduces a pre-upload build package verification step to the multi-architecture native Linux package build workflow and adds comprehensive unit tests for the verification logic. The main goal is to ensure that built packages are present and have correct versions before proceeding to simulated installation, improving package quality and reliability.

Part of https://github.com/ROCm/TheRock/issues/7028
ISSUE ID :  https://github.com/ROCm/TheRock/issues/7028

## Technical Details

Adds pre-upload **build package verification** (`build_package_verify.py`) to the native Linux packaging workflow. The step runs after `build_package.py` and before simulate-install/upload to confirm built `.deb`/`.rpm` files match `package.json` expectations.

- **New verifier CLI** reuses `build_package` routing (`create_package_config`, `update_package_name`, kpack/gfx-arch variant enumeration) to check each expected variant exists and has the correct control-field version (`rocm_version` + `version_suffix`).
- **Metadata-based indexing** via `dpkg-deb` / `rpm -qp` (not filename stems), so lookups work when hundreds of packages are on disk (e.g. gfx-arch variants like `amdrocm-core-sdk7.15-gfx1100`).
- **Scalable `--verify-type` tiers** aligned with install-test aliases: `smoke` (default, `amdrocm-core-sdk`), `sanity` (core metapackages), `full` (all eligible); `off`/`skip` disables the step.
- **Minimal reporting:** human-readable summary always printed to stdout; optional `--report-dir` writes a single compact `build_status_report.json` (counts + `failed_variants` only — no full file lists or duplicate formats).
- **CI wiring** in `multi_arch_build_native_linux_packages.yml`: new `pre_upload_build_verify_type` input (default `smoke`), verify step (passes `--build-variant` for ASAN builds), and artifact upload of the JSON report on `always()`.


## Test Plan

- [x] `python3.12 -m unittest build_tools.packaging.linux.tests.build_package_verify_test -v` (30 tests)
- [ ] CI: `multi_arch_build_native_linux_packages` smoke verify passes for deb and rpm
- [ ] On failure: job fails at verify step; `pre-upload-build-verify-*` artifact contains `build_status_report.json`
- [ ] Stdout in verify step log shows human-readable pass/fail summary

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
