### PR TITLE
Update release docs for repo.amd.com streams

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,7 +6,7 @@ Continuous Integration (CI) build/test workflows as well as release artifacts as
 part of Continuous Delivery (CD) nightly releases.
 
 <!-- TODO: mention other release channels, link to release notes, etc.
-       stable: https://repo.amd.com/rocm/
+       stable: https://stable.repo.amd.com/rocm/
        https://rocm.docs.amd.com/en/7.12.0-preview/index.html
        https://rocm.docs.amd.com/en/7.13.0-preview/index.html
 -->
@@ -101,12 +101,29 @@ Key differences from
 
 ## Installing multi-arch releases
 
+> [!IMPORTANT]
+> The `repo.amd.com` layout documented below starts with ROCm 10.1 nightly
+> releases and ROCm 10.0 stable releases. Earlier releases remain in the
+> [legacy multi-arch release locations](docs/packaging/legacy_multi_arch_releases.md).
+> In particular, ROCm 7.14 nightlies and the ROCm 10.0.0 release candidates
+> are only available from the legacy indexes.
+
+Current releases use these stream-specific locations:
+
+| Release channel | Python aggregate index                      | ROCm Core tarballs                              | ROCm Core native packages                        |
+| --------------- | ------------------------------------------- | ----------------------------------------------- | ------------------------------------------------ |
+| Stable          | https://stable.repo.amd.com/rocm/whl-next/  | https://stable.repo.amd.com/rocm/core/tarball/  | https://stable.repo.amd.com/rocm/core/packages/  |
+| Nightly         | https://nightly.repo.amd.com/rocm/whl-next/ | https://nightly.repo.amd.com/rocm/core/tarball/ | https://nightly.repo.amd.com/rocm/core/packages/ |
+| Prerelease      | https://rc.repo.amd.com/rocm/whl-next/      | https://rc.repo.amd.com/rocm/core/tarball/      | https://rc.repo.amd.com/rocm/core/packages/      |
+| BKC             | https://bkc.repo.amd.com/rocm/whl-next/     | https://bkc.repo.amd.com/rocm/core/tarball/     | https://bkc.repo.amd.com/rocm/core/packages/     |
+| Development     | https://dev.repo.amd.com/rocm/whl-next/     | https://dev.repo.amd.com/rocm/core/tarball/     | https://dev.repo.amd.com/rocm/core/packages/     |
+
 ### Installing multi-arch Python packages
 
 Nightly releases of ROCm and framework Python packages are published to a
-unified index at https://rocm.nightlies.amd.com/whl-multi-arch/.
-
-<!-- TODO: mention https://repo.amd.com/rocm/whl-multi-arch/ release channel too -->
+unified aggregate index at https://nightly.repo.amd.com/rocm/whl-next/. The
+aggregate index includes packages from ROCm Core, PyTorch, and JAX so
+dependencies can resolve across products.
 
 > [!TIP]
 > We highly recommend working within a [Python virtual environment](https://docs.python.org/3/library/venv.html):
@@ -149,19 +166,19 @@ and then running an install command such as:
 
 ```bash
 # Single device (replace device-gfx942 with your GPU):
-pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+pip install --index-url https://nightly.repo.amd.com/rocm/whl-next/ \
     "rocm[libraries,device-gfx942]"
 
 # Also install the 'devel' package:
-pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+pip install --index-url https://nightly.repo.amd.com/rocm/whl-next/ \
     "rocm[libraries,devel,device-gfx942]"
 
 # Multiple devices (e.g. for a Dockerfile used by both MI300X and MI355X):
-pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+pip install --index-url https://nightly.repo.amd.com/rocm/whl-next/ \
     "rocm[libraries,device-gfx942,device-gfx950]"
 
 # All supported devices:
-pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+pip install --index-url https://nightly.repo.amd.com/rocm/whl-next/ \
     "rocm[libraries,device-all]"
 ```
 
@@ -184,10 +201,10 @@ environment:
 
 ```bash
 pip freeze | grep rocm
-# rocm==7.15.0a20260630
-# rocm-sdk-core==7.15.0a20260630
-# rocm-sdk-device-gfx1100==7.15.0a20260630
-# rocm-sdk-libraries==7.15.0a20260630
+# rocm==10.1.0a20260823
+# rocm-sdk-core==10.1.0a20260823
+# rocm-sdk-device-gfx1100==10.1.0a20260823
+# rocm-sdk-libraries==10.1.0a20260823
 ```
 
 You should also see various tools on your `PATH` and in the `bin` directory:
@@ -351,17 +368,17 @@ Select your GPU target using the `[device-*]` extras from the
 
 ```bash
 # Single device (replace device-gfx942 with your GPU):
-pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+pip install --index-url https://nightly.repo.amd.com/rocm/whl-next/ \
     "torch[device-gfx942]" "torchvision[device-gfx942]" torchaudio
 
 # Multiple devices (e.g. for a Dockerfile used by both MI300X and MI355X):
-pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+pip install --index-url https://nightly.repo.amd.com/rocm/whl-next/ \
     "torch[device-gfx942,device-gfx950]" \
     "torchvision[device-gfx942,device-gfx950]" \
     torchaudio
 
 # All supported devices:
-pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+pip install --index-url https://nightly.repo.amd.com/rocm/whl-next/ \
     "torch[device-all]" "torchvision[device-all]" torchaudio
 
 # Optional additional packages on Linux:
@@ -375,13 +392,13 @@ pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
 > install ROCm separately:
 >
 > ```bash
-> pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+> pip install --index-url https://nightly.repo.amd.com/rocm/whl-next/ \
 >     "torch[device-gfx1100]"
 >
 > pip freeze  # with approximate download sizes:
-> # rocm-sdk-core==7.13.0a...              ~700 MB
-> # rocm-sdk-libraries==7.13.0a...         ~100 MB  (host code, shared across GPUs)
-> # rocm-sdk-device-gfx1100==7.13.0a...     ~50 MB  (only gfx1100 device code)
+> # rocm-sdk-core==10.1.0a...              ~700 MB
+> # rocm-sdk-libraries==10.1.0a...         ~100 MB  (host code, shared across GPUs)
+> # rocm-sdk-device-gfx1100==10.1.0a...     ~50 MB  (only gfx1100 device code)
 > # torch==2.11.0+rocm...                  ~100 MB  (host code, shared across GPUs)
 > # amd-torch-device-gfx1100==2.11.0+...    ~50 MB  (only gfx1100 device code)
 > # Total:                                 ~1.1 GB
@@ -431,14 +448,14 @@ Install JAX with ROCm support using the unified multi-arch index.
 JAX_VERSION=0.11.1
 
 # 1. Install ROCm (replace device-gfx942 with your GPU)
-pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+pip install --index-url https://nightly.repo.amd.com/rocm/whl-next/ \
     "rocm[libraries,device-gfx942]"
 
 # 2. Install JAX ROCm wheels
 # Use the ROCm major version the wheels were built against: 7 for ROCm 7.x, 10
 # for ROCm 10.x.
-ROCM_MAJOR=7
-pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+ROCM_MAJOR=10
+pip install --index-url https://nightly.repo.amd.com/rocm/whl-next/ \
     "jax_rocm${ROCM_MAJOR}_plugin==${JAX_VERSION}" \
     "jax_rocm${ROCM_MAJOR}_pjrt==${JAX_VERSION}"
 
@@ -495,25 +512,25 @@ Multi-arch native packages use a simplified package model compared to the
 > [!TIP]
 > To find the latest available release, browse the index pages:
 >
-> - **Debian packages**: https://rocm.nightlies.amd.com/packages-multi-arch/deb/
-> - **RPM packages**: https://rocm.nightlies.amd.com/packages-multi-arch/rpm/
+> - **Debian packages**: https://nightly.repo.amd.com/rocm/core/packages/deb/
+> - **RPM packages**: https://nightly.repo.amd.com/rocm/core/packages/rpm/
 >
 > Look for directories in the format `YYYYMMDD-<action-run-id>`
-> (e.g., `20260701-28484694006`) and use the latest in the commands below.
+> (e.g., `20260823-12345678`) and use the latest in the commands below.
 
 ##### Installing on Debian-based systems (Ubuntu, Debian, etc.)
 
 ```bash
 # Step 1: Find the latest release from
-#         https://rocm.nightlies.amd.com/packages-multi-arch/deb/
-#         Look for directories like "20260701-28484694006"
+#         https://nightly.repo.amd.com/rocm/core/packages/deb/
+#         Look for directories like "20260823-12345678"
 # Step 2: Set the variable below
-export RELEASE_ID=20260701-28484694006  # Replace with the latest date-runid
+export RELEASE_ID=20260823-12345678  # Replace with the latest date-runid
 
 # Step 3: Add repository and install
 sudo apt update
 sudo apt install -y ca-certificates
-echo "deb [trusted=yes] https://rocm.nightlies.amd.com/packages-multi-arch/deb/${RELEASE_ID} stable main" \
+echo "deb [trusted=yes] https://nightly.repo.amd.com/rocm/core/packages/deb/${RELEASE_ID} stable main" \
   | sudo tee /etc/apt/sources.list.d/rocm-multiarch-nightly.list
 sudo apt update
 
@@ -527,17 +544,17 @@ sudo apt install amdrocm-core-sdk
 
 ```bash
 # Step 1: Find the latest release from
-#         https://rocm.nightlies.amd.com/packages-multi-arch/rpm/
-#         Look for directories like "20260701-28484694006"
+#         https://nightly.repo.amd.com/rocm/core/packages/rpm/
+#         Look for directories like "20260823-12345678"
 # Step 2: Set the variable below
-export RELEASE_ID=20260701-28484694006  # Replace with the latest date-runid
+export RELEASE_ID=20260823-12345678  # Replace with the latest date-runid
 
 # Step 3: Add repository and install
 sudo dnf install -y ca-certificates
 sudo tee /etc/yum.repos.d/rocm-multiarch-nightly.repo <<EOF
 [rocm-multiarch-nightly]
 name=ROCm Multi-Arch Nightly Repository
-baseurl=https://rocm.nightlies.amd.com/packages-multi-arch/rpm/${RELEASE_ID}/x86_64
+baseurl=https://nightly.repo.amd.com/rocm/core/packages/rpm/${RELEASE_ID}/x86_64
 enabled=1
 gpgcheck=0
 priority=50
@@ -606,13 +623,13 @@ such as setting environment variables.
 Multi-arch tarballs separate GPU-specific kernel code into a `.kpack/`
 directory. Two variants are available:
 
-- **Per-family multi-arch tarballs** (e.g. `therock-dist-linux-gfx110X-all-7.13.0a20260430.tar.gz`)
+- **Per-family multi-arch tarballs** (e.g. `therock-dist-linux-gfx110X-all-10.1.0a20260823.tar.gz`)
   that include `.kpack` files only for one family.
-- **Full multi-arch tarball** (e.g. `therock-dist-linux-multiarch-7.13.0a20260430.tar.gz`)
+- **Full multi-arch tarball** (e.g. `therock-dist-linux-multiarch-10.1.0a20260823.tar.gz`)
   that include `.kpack` files for all supported targets.
 
 Browse and download tarballs from
-https://rocm.nightlies.amd.com/tarball-multi-arch/.
+https://nightly.repo.amd.com/rocm/core/tarball/.
 
 To download and extract:
 
@@ -620,10 +637,10 @@ To download and extract:
 mkdir therock-tarball && cd therock-tarball
 
 # Per-family (smaller, one GPU family):
-wget https://rocm.nightlies.amd.com/tarball-multi-arch/therock-dist-linux-gfx110X-all-7.13.0a20260430.tar.gz
+wget https://nightly.repo.amd.com/rocm/core/tarball/therock-dist-linux-gfx110X-all-10.1.0a20260823.tar.gz
 
 # Or multiarch (all GPUs):
-wget https://rocm.nightlies.amd.com/tarball-multi-arch/therock-dist-linux-multiarch-7.13.0a20260430.tar.gz
+wget https://nightly.repo.amd.com/rocm/core/tarball/therock-dist-linux-multiarch-10.1.0a20260823.tar.gz
 
 mkdir install && tar -xf *.tar.gz -C install
 ```
@@ -698,37 +715,37 @@ distributions.
 
 ```bash
 # Step 1: Find the latest release from
-#         https://rocm.nightlies.amd.com/packages-asan/deb/
-#         Look for directories like "20260714-29296019987"
+#         https://nightly.repo.amd.com/rocm/core/packages-asan/deb/
+#         Look for directories like "20260823-12345678"
 # Step 2: Set the variable below
-export RELEASE_ID=20260714-29296019987  # replace with the latest date-runid
+export RELEASE_ID=20260823-12345678  # replace with the latest date-runid
 
 # Step 3: Add repository and install
-echo "deb [trusted=yes] https://rocm.nightlies.amd.com/packages-asan/deb/${RELEASE_ID} stable main" \
+echo "deb [trusted=yes] https://nightly.repo.amd.com/rocm/core/packages-asan/deb/${RELEASE_ID} stable main" \
   | sudo tee /etc/apt/sources.list.d/rocm-asan-nightly.list
 sudo apt update
 
 # Install all supported GPU architectures (larger download):
 sudo apt install amdrocm
 # Or install for a specific GPU architecture only (smaller download, recommended):
-sudo apt install amdrocm7.15-gfx942   # MI300X / MI300A
-sudo apt install amdrocm7.15-gfx950   # MI350X
+sudo apt install amdrocm10.1-gfx942   # MI300X / MI300A
+sudo apt install amdrocm10.1-gfx950   # MI350X
 ```
 
 ##### RPM-based systems (RHEL, SLES, AlmaLinux, etc.)
 
 ```bash
 # Step 1: Find the latest release from
-#         https://rocm.nightlies.amd.com/packages-asan/rpm/
-#         Look for directories like "20260714-29296019987"
+#         https://nightly.repo.amd.com/rocm/core/packages-asan/rpm/
+#         Look for directories like "20260823-12345678"
 # Step 2: Set the variable below
-export RELEASE_ID=20260714-29296019987  # replace with the latest date-runid
+export RELEASE_ID=20260823-12345678  # replace with the latest date-runid
 
 # Step 3: Add repository and install
 sudo tee /etc/yum.repos.d/rocm-asan-nightly.repo <<EOF
 [rocm-asan-nightly]
 name=ROCm ASAN Nightly Repository
-baseurl=https://rocm.nightlies.amd.com/packages-asan/rpm/${RELEASE_ID}/x86_64
+baseurl=https://nightly.repo.amd.com/rocm/core/packages-asan/rpm/${RELEASE_ID}/x86_64
 enabled=1
 gpgcheck=0
 priority=50
@@ -739,18 +756,19 @@ sudo dnf clean all
 # Install all supported GPU architectures (larger download):
 sudo dnf install amdrocm
 # Or install for a specific GPU architecture only (smaller download, recommended):
-sudo dnf install amdrocm7.15-gfx942   # MI300X / MI300A
-sudo dnf install amdrocm7.15-gfx950   # MI350X
+sudo dnf install amdrocm10.1-gfx942   # MI300X / MI300A
+sudo dnf install amdrocm10.1-gfx950   # MI350X
 ```
 
 #### Installing via tarball
 
-Browse https://rocm.nightlies.amd.com/tarball-asan/ for the latest available
-release and set `ROCM_VERSION` accordingly (e.g. `7.15.0a20260714`).
+Browse https://nightly.repo.amd.com/rocm/core/tarball-asan/ for the latest
+available release and set `ROCM_VERSION` accordingly (e.g.
+`10.1.0a20260823`).
 
 ```bash
-export ROCM_VERSION=7.15.0a20260714   # replace with the latest from the link above
-export ASAN_TARBALL_BASE_URL=https://rocm.nightlies.amd.com/asan/tarball/
+export ROCM_VERSION=10.1.0a20260823   # replace with the latest from the link above
+export ASAN_TARBALL_BASE_URL=https://nightly.repo.amd.com/rocm/core/tarball-asan/
 ```
 
 Download the tarball that matches your GPU family:

--- a/build_tools/packaging/linux/README-aggregate-repo.txt
+++ b/build_tools/packaging/linux/README-aggregate-repo.txt
@@ -46,7 +46,7 @@ Sources are passed as --source arguments (repeatable, no limit on count).
 DEB — merge ROCm nightly + RVS:
 
   python aggregate_deb_metadata.py \
-    --source "core,https://repo.amd.com/rocm/packages-multi-arch/ubuntu2404,dists,pool/core" \
+    --source "core,https://nightly.repo.amd.com/rocm/core/packages/deb/20260823-12345678,dists,pool/core" \
     --source "rvs,https://d22tya8uodfbu6.cloudfront.net/nightly/rvs/deb,flat,pool/rvs" \
     --output-dir /tmp/deb-metadata \
     --suite stable \
@@ -61,7 +61,7 @@ DEB — merge ROCm nightly + RVS:
 RPM — merge ROCm nightly + RVS:
 
   python aggregate_rpm_metadata.py \
-    --source "core,https://repo.amd.com/rocm/packages-multi-arch/rhel10/x86_64,core" \
+    --source "core,https://nightly.repo.amd.com/rocm/core/packages/rpm/20260823-12345678/x86_64,core" \
     --source "rvs,https://d22tya8uodfbu6.cloudfront.net/nightly/rvs/rpm,rvs" \
     --output-dir /tmp/rpm-metadata
 
@@ -88,7 +88,7 @@ Requires boto3 and AWS credentials with s3:PutObject on the output bucket.
 Upload the generated metadata by adding --output-bucket:
 
   python aggregate_deb_metadata.py \
-    --source "core,https://repo.amd.com/rocm/packages-multi-arch/ubuntu2404,dists,pool/core" \
+    --source "core,https://nightly.repo.amd.com/rocm/core/packages/deb/20260823-12345678,dists,pool/core" \
     --source "rvs,https://d22tya8uodfbu6.cloudfront.net/nightly/rvs/deb,flat,pool/rvs" \
     --output-bucket therock-deb-rpm-test \
     --output-prefix metadata/deb \
@@ -102,7 +102,7 @@ Upload the generated metadata by adding --output-bucket:
     therock-deb-rpm-test/metadata/deb/dists/stable/main/binary-amd64/Packages.gz
 
   python aggregate_rpm_metadata.py \
-    --source "core,https://repo.amd.com/rocm/packages-multi-arch/rhel10/x86_64,core" \
+    --source "core,https://nightly.repo.amd.com/rocm/core/packages/rpm/20260823-12345678/x86_64,core" \
     --source "rvs,https://d22tya8uodfbu6.cloudfront.net/nightly/rvs/rpm,rvs" \
     --output-bucket therock-deb-rpm-test \
     --output-prefix metadata/rpm
@@ -117,8 +117,8 @@ locally and upload in a single run.
 
 Step 3: Set Up CloudFront
 --------------------------
-Add cache behaviors to the repo.amd.com CloudFront distribution. List them
-most-specific first (CloudFront matches top-down).
+Add cache behaviors to the nightly.repo.amd.com CloudFront distribution. List
+them most-specific first (CloudFront matches top-down).
 
 DEB (ubuntu2404):
 
@@ -152,7 +152,7 @@ Step 4: User Setup
 
 Ubuntu/Debian:
 
-  echo "deb [trusted=yes] https://repo.amd.com/rocm/metadata/ubuntu2404 stable main" \
+  echo "deb [trusted=yes] https://nightly.repo.amd.com/rocm/metadata/ubuntu2404 stable main" \
     | sudo tee /etc/apt/sources.list.d/amdrocm-aggregate.list
   sudo apt update
   sudo apt install amdrocm7-rvs
@@ -162,7 +162,7 @@ RHEL/AlmaLinux:
   sudo tee /etc/yum.repos.d/amdrocm-aggregate.repo <<EOF
   [amdrocm-aggregate]
   name=AMD ROCm Aggregate
-  baseurl=https://repo.amd.com/rocm/metadata/rhel10/x86_64
+  baseurl=https://nightly.repo.amd.com/rocm/metadata/rhel10/x86_64
   enabled=1
   gpgcheck=0
   repo_gpgcheck=0
@@ -182,7 +182,7 @@ DEB — produces Release.gpg (detached) + InRelease (clearsigned):
   python aggregate_deb_metadata.py ... --sign-key <KEY_ID>
 
   Client setup (no [trusted=yes] needed):
-  echo "deb [signed-by=/etc/apt/keyrings/amdrocm.gpg] https://repo.amd.com/rocm/metadata/ubuntu2404 stable main" \
+  echo "deb [signed-by=/etc/apt/keyrings/amdrocm.gpg] https://nightly.repo.amd.com/rocm/metadata/ubuntu2404 stable main" \
     | sudo tee /etc/apt/sources.list.d/amdrocm-aggregate.list
 
 RPM — produces repomd.xml.asc (detached):
@@ -191,4 +191,4 @@ RPM — produces repomd.xml.asc (detached):
 
   Client .repo file additions:
     repo_gpgcheck=1
-    gpgkey=https://repo.amd.com/rocm/rocm.gpg.key
+    gpgkey=https://nightly.repo.amd.com/rocm/rocm.gpg.key

--- a/build_tools/packaging/linux/aggregate_deb_metadata.py
+++ b/build_tools/packaging/linux/aggregate_deb_metadata.py
@@ -19,7 +19,7 @@ Limitations:
 
 Usage:
     python aggregate_deb_metadata.py \\
-        --source "core,https://repo.amd.com/rocm/packages-multi-arch/ubuntu2404,dists,pool/core" \\
+        --source "core,https://nightly.repo.amd.com/rocm/core/packages/deb/20260823-12345678,dists,pool/core" \\
         --source "rvs,https://d22tya8uodfbu6.cloudfront.net/nightly/rvs/deb,flat,pool/rvs" \\
         [--output-dir /tmp/deb-metadata] \\
         [--output-bucket therock-deb-rpm-test] \\

--- a/build_tools/packaging/linux/aggregate_rpm_metadata.py
+++ b/build_tools/packaging/linux/aggregate_rpm_metadata.py
@@ -11,7 +11,7 @@ and/or uploads to S3.
 
 Usage:
     python aggregate_rpm_metadata.py \\
-        --source "core,https://repo.amd.com/rocm/packages-multi-arch/rhel10/x86_64,core" \\
+        --source "core,https://nightly.repo.amd.com/rocm/core/packages/rpm/20260823-12345678/x86_64,core" \\
         --source "rvs,https://d22tya8uodfbu6.cloudfront.net/nightly/rvs/rpm,rvs" \\
         [--output-dir /tmp/rpm-metadata] \\
         [--output-bucket therock-deb-rpm-test] \\

--- a/build_tools/third_party/s3_management/README.md
+++ b/build_tools/third_party/s3_management/README.md
@@ -1,5 +1,11 @@
 # s3_management
 
+> [!NOTE]
+> These tools manage the legacy per-family Python release buckets and indexes.
+> Current structured product indexes are generated server-side. See
+> [Legacy per-family releases](/docs/packaging/legacy_per_family_releases.md)
+> for the URLs managed here.
+
 ## Overview
 
 These scripts are forked from https://github.com/pytorch/test-infra/tree/main/s3_management.
@@ -22,7 +28,7 @@ Each bucket has `v2` and `v2-staging` top level folders at the moment. This may
 evolve with `v3` in the future. Within each folder there are subfolders for
 each index we publish, currently corresponding to each GPU family that we
 build releases for. See these other pages for more details:
-* [Index page listing in `RELEASES.md`](https://github.com/ROCm/TheRock/blob/main/RELEASES.md#index-page-listing)
+* [Legacy per-family release index pages](/docs/packaging/legacy_per_family_releases.md#index-page-listing)
 * [Gating releases with Pytorch tests in `external-builds/pytorch/README.md`](/external-builds/pytorch/README.md#gating-releases-with-pytorch-tests)
 
 The user-facing URLs can be used with `pip install --index-url`. For example:

--- a/debug-tools/README.md
+++ b/debug-tools/README.md
@@ -424,6 +424,7 @@ Common TSAN_OPTIONS:
 
 TheRock provides test scripts for ROCgdb and ROCr Debug Agent. Both scripts
 work with locally-built ROCm trees or downloaded nightly tarballs from
+
 - https://nightly.repo.amd.com/rocm/core/tarball/ or
 - https://rocm.nightlies.amd.com/.
 

--- a/debug-tools/README.md
+++ b/debug-tools/README.md
@@ -424,8 +424,8 @@ Common TSAN_OPTIONS:
 
 TheRock provides test scripts for ROCgdb and ROCr Debug Agent. Both scripts
 work with locally-built ROCm trees or downloaded nightly tarballs from
-* https://nightly.repo.amd.com/rocm/core/tarball/ or
-* https://rocm.nightlies.amd.com/.
+- https://nightly.repo.amd.com/rocm/core/tarball/ or
+- https://rocm.nightlies.amd.com/.
 
 **Scripts location:** `build_tools/github_actions/test_executable_scripts/`
 

--- a/debug-tools/README.md
+++ b/debug-tools/README.md
@@ -424,7 +424,8 @@ Common TSAN_OPTIONS:
 
 TheRock provides test scripts for ROCgdb and ROCr Debug Agent. Both scripts
 work with locally-built ROCm trees or downloaded nightly tarballs from
-https://nightly.repo.amd.com/rocm/core/tarball/.
+* https://nightly.repo.amd.com/rocm/core/tarball/ or
+* https://rocm.nightlies.amd.com/.
 
 **Scripts location:** `build_tools/github_actions/test_executable_scripts/`
 

--- a/debug-tools/README.md
+++ b/debug-tools/README.md
@@ -422,7 +422,9 @@ Common TSAN_OPTIONS:
 
 ### Testing Debug-Tools
 
-TheRock provides test scripts for ROCgdb and ROCr Debug Agent. Both scripts work with locally-built ROCm trees or downloaded nightly tarballs from https://rocm.nightlies.amd.com/.
+TheRock provides test scripts for ROCgdb and ROCr Debug Agent. Both scripts
+work with locally-built ROCm trees or downloaded nightly tarballs from
+https://nightly.repo.amd.com/rocm/core/tarball/.
 
 **Scripts location:** `build_tools/github_actions/test_executable_scripts/`
 

--- a/docs/development/github_actions_debugging.md
+++ b/docs/development/github_actions_debugging.md
@@ -31,8 +31,9 @@ which
 1. Uploads the built packages to a release index
 1. Runs tests on the packages
 
-This should be performed using a "dev" release using the `therock-dev-python` S3
-bucket and the package index https://rocm.devreleases.amd.com/.
+This should be performed using a "dev" release. Intermediate artifacts use the
+`therock-dev-artifacts` S3 bucket and published packages use the aggregate
+index https://dev.repo.amd.com/rocm/whl-next/.
 
 Follow these steps:
 

--- a/docs/development/installing_artifacts.md
+++ b/docs/development/installing_artifacts.md
@@ -145,8 +145,9 @@ python build_tools/find_artifacts_for_commit.py \
 TheRock provides two types of release tarballs:
 
 The installer reads published release tarballs directly from the matching S3
-release bucket. The public multi-arch indices below let users browse available
-versions and manually download tarballs.
+release bucket. The public Core tarball indexes below let users browse
+available versions and manually download tarballs. Earlier releases remain in
+the [legacy multi-arch release locations](../packaging/legacy_multi_arch_releases.md).
 
 ##### Nightly Tarballs
 
@@ -154,23 +155,23 @@ Nightly tarballs are built daily and follow the naming pattern: `MAJOR.MINOR.aYY
 
 **To find and use a nightly release:**
 
-1. Visit the [nightly multi-arch tarball index](https://rocm.nightlies.amd.com/tarball-multi-arch/)
+1. Visit the [nightly Core tarball index](https://nightly.repo.amd.com/rocm/core/tarball/)
 1. Look for files matching your GPU family. Files are named: `therock-dist-linux-{GPU_FAMILY}-{VERSION}.tar.gz`
-   - Example: `therock-dist-linux-gfx110X-all-7.11.0a20251124.tar.gz`
+   - Example: `therock-dist-linux-gfx110X-all-10.1.0a20260823.tar.gz`
 1. Extract the version from the filename (the part after the last hyphen, before `.tar.gz`)
-   - In the example above, the version is: `7.11.0a20251124`
+   - In the example above, the version is: `10.1.0a20260823`
 1. Use this version string with `--release`:
    ```bash
    python build_tools/install_rocm_from_artifacts.py \
-       --release 7.11.0a20251124 \
+       --release 10.1.0a20260823 \
        --amdgpu-family gfx110X-all
    ```
 
 **Version format:** `X.Y.ZaYYYYMMDD`
 
-- `X.Y.Z` = ROCm version (e.g., `7.11.0`)
+- `X.Y.Z` = ROCm version (e.g., `10.1.0`)
 - `a` = alpha version
-- `YYYYMMDD` = build date (e.g., `20251124` = November 24, 2025)
+- `YYYYMMDD` = build date (e.g., `20260823` = August 23, 2026)
 
 ##### Dev Tarballs
 
@@ -178,21 +179,21 @@ Dev tarballs are built from specific commits and follow the naming pattern: `MAJ
 
 **To find and use a dev release:**
 
-1. Visit the [dev multi-arch tarball index](https://rocm.devreleases.amd.com/tarball-multi-arch/)
+1. Visit the [dev Core tarball index](https://dev.repo.amd.com/rocm/core/tarball/)
 1. Look for files matching your GPU family. Files are named: `therock-dist-linux-{GPU_FAMILY}-{VERSION}.tar.gz`
-   - Example: `therock-dist-linux-gfx94X-dcgpu-6.4.0.dev0+8f6cdfc0d95845f4ca5a46de59d58894972a29a9.tar.gz`
+   - Example: `therock-dist-linux-gfx94X-dcgpu-10.1.0.dev0+8f6cdfc0d95845f4ca5a46de59d58894972a29a9.tar.gz`
 1. Extract the version from the filename (the part after the last hyphen, before `.tar.gz`)
-   - In the example above, the version is: `6.4.0.dev0+8f6cdfc0d95845f4ca5a46de59d58894972a29a9`
+   - In the example above, the version is: `10.1.0.dev0+8f6cdfc0d95845f4ca5a46de59d58894972a29a9`
 1. Use this version string with `--release`:
    ```bash
    python build_tools/install_rocm_from_artifacts.py \
-       --release 6.4.0.dev0+8f6cdfc0d95845f4ca5a46de59d58894972a29a9 \
+       --release 10.1.0.dev0+8f6cdfc0d95845f4ca5a46de59d58894972a29a9 \
        --amdgpu-family gfx94X-dcgpu
    ```
 
 **Version format:** `X.Y.Z.dev0+{HASH}`
 
-- `X.Y.Z` = ROCm version (e.g., `6.4.0`)
+- `X.Y.Z` = ROCm version (e.g., `10.1.0`)
 - `dev0` = development build indicator
 - `{HASH}` = full Git commit hash (40 characters)
 

--- a/docs/development/s3_buckets.md
+++ b/docs/development/s3_buckets.md
@@ -9,7 +9,7 @@ and explains the authentication needed to upload to them.
 - [Authentication](#authentication)
 - [Bucket inventory](#bucket-inventory)
   - [CI buckets](#ci-buckets): `therock-ci-artifacts`, `therock-ci-artifacts-external`
-  - [Release buckets](#release-buckets): `therock-{dev,nightly,prerelease,release}-{artifacts,packages,python,tarball}`
+  - [Release buckets](#release-buckets): artifact handoff and `repo.amd.com` product buckets
   - [Build system buckets](#build-system-buckets): `rocm-third-party-deps`
   - [Cache buckets](#cache-buckets): `therock-pytorch-sccache-*`
   - [Legacy buckets](#legacy-buckets): `therock-artifacts`, `therock-artifacts-external`
@@ -51,6 +51,19 @@ jobs:
       # ... upload steps that use the credentials ...
 ```
 
+Final publication to the `repo.amd.com` product buckets uses a separate role
+in account `324352301041`. Use
+[`configure_aws_product_publication_credentials`](/.github/actions/configure_aws_product_publication_credentials/action.yml)
+with the product name. The role and bucket follow these patterns:
+
+```text
+arn:aws:iam::324352301041:role/therock-repo-<stream>-<product>
+therock-repo-amd-<stream>-<product>
+```
+
+Artifact credentials and product-publication credentials are intentionally
+separate. Do not use product credentials for intermediate artifact uploads.
+
 **Platform-specific details:**
 
 - **Linux containers** mount runner credentials via
@@ -87,22 +100,55 @@ upload to this bucket and do not need `aws-actions/configure-aws-credentials`.
 
 ### Release buckets
 
-Each release type (`dev`, `nightly`, `prerelease`, `release`) has a matching
-set of buckets.
+Release publication has two stages:
 
-The `dev-bkc` and `nightly-bkc` release types currently use the existing `dev`
-and `nightly` buckets, IAM roles, and CDN indexes, respectively. A dedicated
-BKC bucket and index may be added in the future.
+1. Build workflows upload intermediate outputs to an artifact bucket in
+   account `692859939525`.
+1. Release workflows copy final outputs into product buckets in account
+   `324352301041`, which are served through the stream-specific
+   `repo.amd.com` domains.
 
-The `dev`, `nightly`, and `prerelease` types are accessed via
-the `therock-{release_type}` IAM role while stable `release` buckets are
-manually promoted from prereleases via IAM user policies (see
-[`how_to_do_release.md`](/build_tools/packaging/how_to_do_release.md)).
+Internal release types map to public streams as follows:
 
-Python, tarball, and native package buckets are fronted by CloudFront CDNs.
-Developer-facing documentation and manual installs should use the CDN URLs;
-CI may read the backing S3 buckets directly to avoid CloudFront data-transfer
-charges.
+| Internal release type    | Public stream |
+| ------------------------ | ------------- |
+| `dev`                    | `dev`         |
+| `nightly`                | `nightly`     |
+| `prerelease`             | `rc`          |
+| `dev-bkc`, `nightly-bkc` | `bkc`         |
+
+#### Product release buckets
+
+`<stream>` is one of `dev`, `nightly`, `rc`, or `bkc`.
+
+| Bucket pattern                      | Contents                                                 | Object prefixes                                                        |
+| ----------------------------------- | -------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `therock-repo-amd-<stream>-core`    | ROCm Core Python packages, tarballs, and native packages | `v5/rocm/core/{whl-next,tarball,tarball-asan,packages,packages-asan}/` |
+| `therock-repo-amd-<stream>-pytorch` | PyTorch Python packages                                  | `v5/rocm/pytorch/whl-next/`                                            |
+| `therock-repo-amd-<stream>-jax`     | JAX Python packages                                      | `v5/rocm/jax/whl-next/`                                                |
+
+Public downloads use the matching stream hostname and omit the internal `v5`
+prefix. For example, nightly Core tarballs are at
+https://nightly.repo.amd.com/rocm/core/tarball/ and nightly native packages
+are under https://nightly.repo.amd.com/rocm/core/packages/.
+
+Pip installs must use the aggregate index, such as
+https://nightly.repo.amd.com/rocm/whl-next/. Product-local Python indexes are
+publication and indexer inputs, not self-contained install entry points.
+
+Stable releases are manually promoted and served from
+https://stable.repo.amd.com/rocm/. The new layout begins with ROCm 10.1
+nightlies and ROCm 10.0 stable releases. Older releases remain in the
+[legacy multi-arch release locations](../packaging/legacy_multi_arch_releases.md).
+
+#### Artifact and legacy release buckets
+
+Artifact buckets remain the handoff point between build and release workflows.
+The separate `packages`, `python`, and `tarball` buckets below contain releases
+published with the legacy layout and remain available for historical releases.
+Developer-facing current-release documentation should use the
+stream-specific `repo.amd.com` URLs above. CI may read artifact S3 URLs
+directly when consuming intermediate build outputs.
 
 | Bucket                                                                                   | Contents        | IAM role             | CDN                                                                                                                                                                                     |
 | ---------------------------------------------------------------------------------------- | --------------- | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/packaging/legacy_multi_arch_releases.md
+++ b/docs/packaging/legacy_multi_arch_releases.md
@@ -1,0 +1,57 @@
+# Legacy multi-arch releases
+
+> [!CAUTION]
+> This page documents historical multi-arch release locations. Current
+> releases use the stream-specific `repo.amd.com` locations documented in
+> [RELEASES.md](/RELEASES.md).
+
+Releases published before the `repo.amd.com` product layout remain at their
+original URLs. They are not mirrored into the new indexes, so use the URL that
+matches the ROCm version you need.
+
+The legacy locations apply to:
+
+- nightly releases through ROCm 7.14;
+- ROCm 10.0.0 release candidates; and
+- stable releases before ROCm 10.0.
+
+## Legacy release locations
+
+| Release channel | Python aggregate index                           | ROCm Core tarballs                                   | ROCm Core native packages                             |
+| --------------- | ------------------------------------------------ | ---------------------------------------------------- | ----------------------------------------------------- |
+| Nightly         | https://rocm.nightlies.amd.com/whl-multi-arch/   | https://rocm.nightlies.amd.com/tarball-multi-arch/   | https://rocm.nightlies.amd.com/packages-multi-arch/   |
+| Prerelease      | https://rocm.prereleases.amd.com/whl-multi-arch/ | https://rocm.prereleases.amd.com/tarball-multi-arch/ | https://rocm.prereleases.amd.com/packages-multi-arch/ |
+| Stable          | https://repo.amd.com/rocm/whl-multi-arch/        | https://repo.amd.com/rocm/tarball-multi-arch/        | https://repo.amd.com/rocm/packages-multi-arch/        |
+
+## Installing legacy Python packages
+
+Use the aggregate index for the release channel. For example, install a ROCm
+7.14 nightly with support for `gfx942` from the legacy nightly index:
+
+```bash
+pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+    "rocm[libraries,devel,device-gfx942]"
+```
+
+## Downloading legacy tarballs
+
+Browse the tarball index for the release channel and select the file matching
+the required ROCm version and GPU family. For example, ROCm 10.0.0 release
+candidate tarballs remain under:
+
+```text
+https://rocm.prereleases.amd.com/tarball-multi-arch/
+```
+
+## Installing legacy native packages
+
+The native package parent contains the distribution-specific DEB and RPM
+repositories for each channel. For example, prerelease repositories remain
+under:
+
+```text
+https://rocm.prereleases.amd.com/packages-multi-arch/
+```
+
+The older GPU-family-specific layouts are documented separately in
+[Legacy per-family releases](legacy_per_family_releases.md).

--- a/docs/packaging/legacy_per_family_releases.md
+++ b/docs/packaging/legacy_per_family_releases.md
@@ -7,6 +7,9 @@
 > This page documents historical per-family releases while they are still
 > available but *no new per-family releases will be generated and previous*
 > *per-family releases may be deleted as file retention policies take effect*.
+> The legacy release domains and paths on this page are intentional. Historical
+> artifacts remain at their original URLs and are not mirrored into the current
+> `repo.amd.com` product layout.
 
 Per-family releases use **GPU-family-specific index URLs** - you choose the
 index URL that matches your GPU family, and all packages for that family are

--- a/docs/packaging/native_packaging.md
+++ b/docs/packaging/native_packaging.md
@@ -96,25 +96,25 @@ The following table shows the S3 bucket configuration and public repository URLs
 ### Current Multi-Arch Release Packages
 
 Final multi-arch release packages are published under the ROCm Core product
-hierarchy. The `dev`, `nightly`, and BKC streams retain each run under a
+hierarchy. This layout starts with ROCm 10.1 nightlies and ROCm 10.0 stable
+releases. Earlier releases remain in the
+[legacy multi-arch release locations](legacy_multi_arch_releases.md).
+
+The `dev`, `nightly`, and BKC streams retain each run under a
 `YYYYMMDD-<run-id>` directory. Prerelease publication updates the fixed `rc`
 repository prefix.
 
-| Release type                 | Final bucket                    | S3 prefix                                          | Public repository parent                                       |
-| ---------------------------- | ------------------------------- | -------------------------------------------------- | -------------------------------------------------------------- |
-| **dev**                      | `therock-repo-amd-dev-core`     | `v5/rocm/core/packages/{deb,rpm}/<date>-<run-id>/` | `https://dev.repo.amd.com/rocm/core/packages/{deb,rpm}/`       |
-| **nightly**                  | `therock-repo-amd-nightly-core` | `v5/rocm/core/packages/{deb,rpm}/<date>-<run-id>/` | `https://nightly.repo.amd.com/rocm/core/packages/{deb,rpm}/`   |
-| **prerelease**               | `therock-repo-amd-rc-core`      | `v5/rocm/core/packages/{deb,rpm}/`                 | `https://rc.repo.amd.com/rocm/core/packages/<os-profile>/`     |
-| **dev-bkc**, **nightly-bkc** | `therock-repo-amd-bkc-core`     | `v5/rocm/core/packages/{deb,rpm}/<date>-<run-id>/` | `https://bkc.repo.amd.com/rocm/core/packages/{deb,rpm}/`       |
-| **release**                  | Manually promoted               | `v5/rocm/core/packages/{deb,rpm}/`                 | `https://stable.repo.amd.com/rocm/core/packages/<os-profile>/` |
+| Release type                 | Final bucket                    | S3 prefix                                          | Public repository parent                                        |
+| ---------------------------- | ------------------------------- | -------------------------------------------------- | --------------------------------------------------------------- |
+| **dev**                      | `therock-repo-amd-dev-core`     | `v5/rocm/core/packages/{deb,rpm}/<date>-<run-id>/` | `https://dev.repo.amd.com/rocm/core/packages/<os-profile>/`     |
+| **nightly**                  | `therock-repo-amd-nightly-core` | `v5/rocm/core/packages/{deb,rpm}/<date>-<run-id>/` | `https://nightly.repo.amd.com/rocm/core/packages/<os-profile>/` |
+| **prerelease**               | `therock-repo-amd-rc-core`      | `v5/rocm/core/packages/{deb,rpm}/`                 | `https://rc.repo.amd.com/rocm/core/packages/<os-profile>/`      |
+| **dev-bkc**, **nightly-bkc** | `therock-repo-amd-bkc-core`     | `v5/rocm/core/packages/{deb,rpm}/<date>-<run-id>/` | `https://bkc.repo.amd.com/rocm/core/packages/<os-profile>/`     |
+| **release**                  | Manually promoted               | `v5/rocm/core/packages/{deb,rpm}/`                 | `https://stable.repo.amd.com/rocm/core/packages/<os-profile>/`  |
 
 ASAN package repositories use the parallel `packages-asan` parent. RPM
 repository URLs append `x86_64/` below the selected run directory or OS
 profile.
-
-The new layout starts with ROCm 10.1 nightlies and ROCm 10.0 stable releases.
-Earlier releases remain in the
-[legacy multi-arch release locations](legacy_multi_arch_releases.md).
 
 ### Legacy GFX-Specific Package Publication
 

--- a/docs/packaging/native_packaging.md
+++ b/docs/packaging/native_packaging.md
@@ -93,7 +93,34 @@ Optional Fields
 
 The following table shows the S3 bucket configuration and public repository URLs for each release type. This configuration is used by `build_tools/packaging/linux/get_s3_config.py` and `build_tools/packaging/linux/upload_package_repo.py`.
 
-### GFX Specific Packages
+### Current Multi-Arch Release Packages
+
+Final multi-arch release packages are published under the ROCm Core product
+hierarchy. The `dev`, `nightly`, and BKC streams retain each run under a
+`YYYYMMDD-<run-id>` directory. Prerelease publication updates the fixed `rc`
+repository prefix.
+
+| Release type                 | Final bucket                    | S3 prefix                                          | Public repository parent                                       |
+| ---------------------------- | ------------------------------- | -------------------------------------------------- | -------------------------------------------------------------- |
+| **dev**                      | `therock-repo-amd-dev-core`     | `v5/rocm/core/packages/{deb,rpm}/<date>-<run-id>/` | `https://dev.repo.amd.com/rocm/core/packages/{deb,rpm}/`       |
+| **nightly**                  | `therock-repo-amd-nightly-core` | `v5/rocm/core/packages/{deb,rpm}/<date>-<run-id>/` | `https://nightly.repo.amd.com/rocm/core/packages/{deb,rpm}/`   |
+| **prerelease**               | `therock-repo-amd-rc-core`      | `v5/rocm/core/packages/{deb,rpm}/`                 | `https://rc.repo.amd.com/rocm/core/packages/<os-profile>/`     |
+| **dev-bkc**, **nightly-bkc** | `therock-repo-amd-bkc-core`     | `v5/rocm/core/packages/{deb,rpm}/<date>-<run-id>/` | `https://bkc.repo.amd.com/rocm/core/packages/{deb,rpm}/`       |
+| **release**                  | Manually promoted               | `v5/rocm/core/packages/{deb,rpm}/`                 | `https://stable.repo.amd.com/rocm/core/packages/<os-profile>/` |
+
+ASAN package repositories use the parallel `packages-asan` parent. RPM
+repository URLs append `x86_64/` below the selected run directory or OS
+profile.
+
+The new layout starts with ROCm 10.1 nightlies and ROCm 10.0 stable releases.
+Earlier releases remain in the
+[legacy multi-arch release locations](legacy_multi_arch_releases.md).
+
+### Legacy GFX-Specific Package Publication
+
+The table below documents the legacy per-family publication layout. These URLs
+remain valid for historical releases and must not be rewritten to the current
+product layout.
 
 | Release Type                       | S3 Bucket                       | S3 Prefix                                                                                                         | DEB Install URL                                                                                                      | RPM Install URL                                                                                                              |
 | ---------------------------------- | ------------------------------- | ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
@@ -104,10 +131,12 @@ The following table shows the S3 bucket configuration and public repository URLs
 | **ci** (ROCm/TheRock)<br>*DEFAULT* | `therock-ci-artifacts`          | `{artifact_id}-{platform}/packages/{pkg_type}`<br>Example: `12345678-linux/packages/deb`                          | `https://therock-ci-artifacts.s3.us-east-2.amazonaws.com/{artifact_id}-{platform}/packages/deb`                      | `https://therock-ci-artifacts.s3.us-east-2.amazonaws.com/{artifact_id}-{platform}/packages/rpm/x86_64/`                      |
 | **ci** (Fork/External)             | `therock-ci-artifacts-external` | `{repo_name}/{artifact_id}-{platform}/packages/{pkg_type}`<br>Example: `someone-fork/12345678-linux/packages/deb` | `https://therock-ci-artifacts-external.s3.us-east-2.amazonaws.com/{repo_name}/{artifact_id}-{platform}/packages/deb` | `https://therock-ci-artifacts-external.s3.us-east-2.amazonaws.com/{repo_name}/{artifact_id}-{platform}/packages/rpm/x86_64/` |
 
-### Multi-Arch Packages
+### Multi-Arch Artifact Handoff
 
-For dev/nightly/prerelease/release builds, multi-arch packages are uploaded to a separate artifacts bucket.
-For CI builds (default, fork, external), the same bucket and prefix as GFX arch packages are used.
+Before final publication, multi-arch packages are uploaded to a separate
+artifact bucket. For CI builds (default, fork, external), the same bucket and
+prefix as GFX-specific packages are used. These artifact locations remain
+unchanged by the final `repo.amd.com` product layout.
 
 | Release Type                       | Multi-Arch S3 Bucket            | Multi-Arch S3 Prefix                                                                                              |
 | ---------------------------------- | ------------------------------- | ----------------------------------------------------------------------------------------------------------------- |

--- a/docs/packaging/versioning.md
+++ b/docs/packaging/versioning.md
@@ -69,24 +69,28 @@ Most users are expected to use stable releases, but several other distribution
 channels are also available and may be of interest to project developers,
 users who want early previews of upcoming releases, and QA/test team members.
 
-| Distribution channel | Base URL                          | Source of builds                                                                                                                                                                                             |
-| -------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| stable releases      | https://repo.amd.com/rocm/        | Manually promoted prereleases                                                                                                                                                                                |
-| prereleases          | https://rocm.prereleases.amd.com/ | Manually triggered workflows in [rockrel](https://github.com/ROCm/rockrel)                                                                                                                                   |
-| nightly releases     | https://rocm.nightlies.amd.com/   | Scheduled workflows in [rockrel](https://github.com/ROCm/rockrel)                                                                                                                                            |
-| BKC releases         | TBD                               | Workflows in [rockrel](https://github.com/ROCm/rockrel)                                                                                                                                                      |
-| dev releases         | https://rocm.devreleases.amd.com/ | Manually triggered test workflows in [TheRock](https://github.com/ROCm/TheRock) and [rockrel](https://github.com/ROCm/rockrel)                                                                               |
-| dev builds           | No central index                  | Local builds and per-commit workflows in [TheRock](https://github.com/ROCm/TheRock),<br>[rocm-libraries](https://github.com/ROCm/rocm-libraries), [rocm-systems](https://github.com/ROCm/rocm-systems), etc. |
+| Distribution channel | Base URL                           | Source of builds                                                                                                                                                                                             |
+| -------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| stable releases      | https://stable.repo.amd.com/rocm/  | Manually promoted prereleases                                                                                                                                                                                |
+| prereleases          | https://rc.repo.amd.com/rocm/      | Manually triggered workflows in [rockrel](https://github.com/ROCm/rockrel)                                                                                                                                   |
+| nightly releases     | https://nightly.repo.amd.com/rocm/ | Scheduled workflows in [rockrel](https://github.com/ROCm/rockrel)                                                                                                                                            |
+| BKC releases         | https://bkc.repo.amd.com/rocm/     | Workflows in [rockrel](https://github.com/ROCm/rockrel)                                                                                                                                                      |
+| dev releases         | https://dev.repo.amd.com/rocm/     | Manually triggered test workflows in [TheRock](https://github.com/ROCm/TheRock) and [rockrel](https://github.com/ROCm/rockrel)                                                                               |
+| dev builds           | No central index                   | Local builds and per-commit workflows in [TheRock](https://github.com/ROCm/TheRock),<br>[rocm-libraries](https://github.com/ROCm/rocm-libraries), [rocm-systems](https://github.com/ROCm/rocm-systems), etc. |
 
-Each distribution channel is currently hosted on a separate release index that
-can be passed to package managers like `pip` (see
-[RELEASES.md - Installing releases using pip](../../RELEASES.md#installing-releases-using-pip)
+Each distribution channel has an aggregate Python index that can be passed to
+package managers like `pip` (see
+[RELEASES.md - Installing multi-arch Python packages](../../RELEASES.md#installing-multi-arch-python-packages)
 for details). For example:
 
 ```bash
-pip install --index-url=https://rocm.nightlies.amd.com/whl-multi-arch/ rocm
-pip install --index-url=https://rocm.devreleases.amd.com/whl-multi-arch/ rocm
+pip install --index-url=https://nightly.repo.amd.com/rocm/whl-next/ rocm
+pip install --index-url=https://dev.repo.amd.com/rocm/whl-next/ rocm
 ```
+
+The new layout starts with ROCm 10.1 nightlies and ROCm 10.0 stable releases.
+Earlier releases remain in the
+[legacy multi-arch release locations](legacy_multi_arch_releases.md).
 
 With the exception of "dev releases", each distribution channel only contains
 release artifacts of the matching release type. The "dev releases" channel

--- a/external-builds/jax/README.md
+++ b/external-builds/jax/README.md
@@ -301,10 +301,10 @@ ROCm 7 wheels need none of this.
 
 ### Gating releases with JAX tests
 
-Successful builds publish JAX wheels to the nightly multi-arch Python package
+Successful builds publish JAX wheels to the nightly aggregate Python package
 index:
 
-<https://rocm.nightlies.amd.com/whl-multi-arch/>
+<https://nightly.repo.amd.com/rocm/whl-next/>
 
 The published wheels are validated by the JAX test workflow as part of the
 nightly release process before being made available for use.

--- a/external-builds/jax/install_jax_wheels.py
+++ b/external-builds/jax/install_jax_wheels.py
@@ -17,7 +17,7 @@ Installs are retried via build_tools/setup_venv.py.
 Example usage:
 
     python install_jax_wheels.py \\
-        --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \\
+        --index-url https://nightly.repo.amd.com/rocm/whl-next/ \\
         --plugin-package jax_rocm10_plugin --pjrt-package jax_rocm10_pjrt \\
         --plugin-version 0.11.0 --pjrt-version 0.11.0 --jax-version 0.11.0
 """

--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -184,7 +184,7 @@ mix/match build steps.
 
   ```bash
   python build_prod_wheels.py build \
-    --install-rocm --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+    --install-rocm --index-url https://nightly.repo.amd.com/rocm/whl-next/ \
     --rocm-extras device-gfx1100 \
     --pytorch-rocm-arch gfx1100 \
     --output-dir $HOME/tmp/pyout
@@ -194,7 +194,7 @@ mix/match build steps.
 
   ```batch
   python build_prod_wheels.py build ^
-    --install-rocm --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ ^
+    --install-rocm --index-url https://nightly.repo.amd.com/rocm/whl-next/ ^
     --rocm-extras device-gfx1100 ^
     --pytorch-rocm-arch gfx1100 ^
     --pytorch-dir C:/b/pytorch ^
@@ -311,8 +311,8 @@ https://rocm.nightlies.amd.com/v2/. If no runner is available, promotion is
 blocked by default. Set `bypass_tests_for_releases=true` for exceptional
 cases under [`amdgpu_family_matrix.py`](/build_tools/github_actions/amdgpu_family_matrix.py).
 
-**Multi-arch releases**: Wheels are published directly to
-https://rocm.nightlies.amd.com/whl-multi-arch/ without a staging step.
+**Multi-arch releases**: Wheels are published to the product bucket and served
+through https://nightly.repo.amd.com/rocm/whl-next/ without a staging step.
 Tests run post-publish as a signal (visible on
 https://therock-hud-dev.amd.com/), not as a gate. This avoids
 pip resolution issues that would arise if shared host `torch` wheel and
@@ -333,7 +333,7 @@ use `device-all` when the environment must support every published target.
 
   ```bash
   build_prod_wheels.py
-      --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+      --index-url https://nightly.repo.amd.com/rocm/whl-next/ \
       --rocm-extras device-gfx942 \
       install-rocm
   ```
@@ -341,14 +341,14 @@ use `device-all` when the environment must support every published target.
 - Manually installing from a release index:
 
   ```bash
-  # From therock-nightly-python
+  # From the nightly aggregate index
   python -m pip install \
-    --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+    --index-url https://nightly.repo.amd.com/rocm/whl-next/ \
     "rocm[libraries,devel,device-gfx942]"
 
-  # OR from therock-dev-python
+  # OR from the dev aggregate index
   python -m pip install \
-    --index-url https://rocm.devreleases.amd.com/whl-multi-arch/ \
+    --index-url https://dev.repo.amd.com/rocm/whl-next/ \
     "rocm[libraries,devel,device-gfx942]"
   ```
 

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -59,16 +59,16 @@ You can also install in the same invocation as build by passing `--install-rocm`
 to the build sub-command (useful for docker invocations).
 
 ```
-# For therock-nightly-python
+# For the nightly aggregate index
 build_prod_wheels.py \
     install-rocm \
-    --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+    --index-url https://nightly.repo.amd.com/rocm/whl-next/ \
     --rocm-extras device-gfx942
 
-# For therock-dev-python (unstable but useful for testing outside of prod)
+# For the dev aggregate index (unstable but useful for testing outside of prod)
 build_prod_wheels.py \
     install-rocm \
-    --index-url https://rocm.devreleases.amd.com/whl-multi-arch/ \
+    --index-url https://dev.repo.amd.com/rocm/whl-next/ \
     --rocm-extras device-gfx942
 ```
 
@@ -134,7 +134,7 @@ versions):
     build \
         --install-rocm \
         --pip-cache-dir /therock/output/pip_cache \
-        --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+        --index-url https://nightly.repo.amd.com/rocm/whl-next/ \
         --rocm-extras device-gfx942 \
         --pytorch-rocm-arch gfx942 \
         --clean \

--- a/external-builds/uccl/README.md
+++ b/external-builds/uccl/README.md
@@ -51,7 +51,7 @@ Example:
 python uccl_repo.py checkout
 python build_prod_wheels.py --output-dir outputs \
   --python-version 3.12 \
-  --index-url https://rocm.prereleases.amd.com/whl/gfx94X-dcgpu
+  --index-url https://rc.repo.amd.com/rocm/whl-next/
 ```
 
 The build script has optional arguments for the name of the directory
@@ -64,7 +64,7 @@ The resulting wheel can then be installed like so:
 ```bash
 python3.12 -m venv venv
 . venv/bin/activate
-pip install --extra-index-url https://rocm.prereleases.amd.com/whl/gfx94X-dcgpu \
+pip install --extra-index-url https://rc.repo.amd.com/rocm/whl-next/ \
   uccl-0.0.1.post4-py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl[rocm]
 ```
 

--- a/external-builds/uccl/build_prod_wheels.py
+++ b/external-builds/uccl/build_prod_wheels.py
@@ -30,7 +30,7 @@ Typical usage to build:
 # On Linux, using the default path for the repository:
 python build_prod_wheels.py \
     --output-dir $HOME/tmp/pyout \
-    --index-url https://rocm.prereleases.amd.com/whl/gfx94X-dcgpu
+    --index-url https://rc.repo.amd.com/rocm/whl-next/
 ```
 
 ## Building Linux portable wheels


### PR DESCRIPTION
## Motivation

Documents the new stable, nightly, prerelease, BKC, and development repo.amd.com locations, accompanying #7547. Updates installation examples and adds a legacy release guide covering the old multi-arch indexes.

Related to #6950

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.

Generated with Codex
