### PR TITLE
ci: add helper to discard unusable Python tool cache entries

### DIFF
--- a/build_tools/github_actions/clean_python_toolcache.py
+++ b/build_tools/github_actions/clean_python_toolcache.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+"""Remove tool cache Python entries whose interpreter no longer runs.
+
+`actions/setup-python` reuses an entry as soon as its directory and the sibling
+`<arch>.complete` marker exist, without ever executing the interpreter. A
+partially populated entry is therefore reported as a successful setup and only
+surfaces later, typically as `pip: cannot execute: required file not found`.
+Removing such an entry makes the action provision a fresh one instead.
+"""
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def find_interpreter(arch_dir: Path) -> Path:
+    # Mirrors the `python-path` output of actions/setup-python, which is the
+    # interpreter the later steps run.
+    if sys.platform == "win32":
+        return arch_dir / "python.exe"
+    return arch_dir / "bin" / "python"
+
+
+def is_usable(arch_dir: Path) -> bool:
+    interpreter = find_interpreter(arch_dir)
+    if not interpreter.exists():
+        return False
+
+    env = dict(os.environ)
+    # The published interpreters carry an RPATH pointing at the tool cache root
+    # of the image they were built for, which need not exist here.
+    env["LD_LIBRARY_PATH"] = os.pathsep.join(
+        p for p in [os.fspath(arch_dir / "lib"), env.get("LD_LIBRARY_PATH", "")] if p
+    )
+
+    try:
+        result = subprocess.run(
+            [os.fspath(interpreter), "-m", "pip", "--version"],
+            capture_output=True,
+            env=env,
+            timeout=120,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0
+
+
+def clean_toolcache(toolcache_root: Path, version: str) -> list[Path]:
+    version_root = toolcache_root / "Python"
+    if not version_root.is_dir():
+        return []
+
+    removed = []
+    for version_dir in sorted(version_root.glob(f"{version}.*")):
+        for arch_dir in sorted(p for p in version_dir.iterdir() if p.is_dir()):
+            if is_usable(arch_dir):
+                continue
+            print(f"Removing unusable Python tool cache entry {arch_dir}")
+            shutil.rmtree(arch_dir, ignore_errors=True)
+            arch_dir.with_name(f"{arch_dir.name}.complete").unlink(missing_ok=True)
+            removed.append(arch_dir)
+    return removed
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("version", help="Python feature version, e.g. 3.12")
+    args = parser.parse_args(argv)
+
+    toolcache_root = os.environ.get("AGENT_TOOLSDIRECTORY") or os.environ.get(
+        "RUNNER_TOOL_CACHE"
+    )
+    if not toolcache_root:
+        print("No tool cache configured, nothing to check")
+        return 0
+
+    removed = clean_toolcache(Path(toolcache_root), args.version)
+    if removed:
+        runner = os.environ.get("RUNNER_NAME", "unknown")
+        print(
+            f"::warning::Removed {len(removed)} unusable Python tool cache "
+            f"entry/entries on runner '{runner}'; they will be provisioned again."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/build_tools/github_actions/tests/clean_python_toolcache_test.py
+++ b/build_tools/github_actions/tests/clean_python_toolcache_test.py
@@ -1,0 +1,97 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+import os
+import stat
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
+import clean_python_toolcache
+
+
+def make_entry(toolcache: Path, version: str = "3.12.12", arch: str = "x64") -> Path:
+    arch_dir = toolcache / "Python" / version / arch
+    (arch_dir / "bin").mkdir(parents=True)
+    (arch_dir / "lib").mkdir()
+    (arch_dir.parent / f"{arch}.complete").touch()
+    return arch_dir
+
+
+def write_interpreter(arch_dir: Path, body: str, name: str = "python") -> Path:
+    interpreter = arch_dir / "bin" / name
+    interpreter.write_text(f"#!/bin/sh\n{body}\n")
+    interpreter.chmod(interpreter.stat().st_mode | stat.S_IEXEC)
+    return interpreter
+
+
+@unittest.skipIf(sys.platform == "win32", "POSIX interpreter layout")
+class CleanPythonToolcacheTest(unittest.TestCase):
+    """Tests for clean_python_toolcache.clean_toolcache."""
+
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.toolcache = Path(tmp.name)
+
+    def assert_removed(self, arch_dir: Path):
+        self.assertFalse(arch_dir.exists())
+        self.assertFalse(arch_dir.with_name(f"{arch_dir.name}.complete").exists())
+
+    def test_working_entry_is_kept(self):
+        arch_dir = make_entry(self.toolcache)
+        write_interpreter(arch_dir, "exit 0")
+
+        self.assertEqual(
+            clean_python_toolcache.clean_toolcache(self.toolcache, "3.12"), []
+        )
+        self.assertTrue(arch_dir.is_dir())
+        self.assertTrue(arch_dir.with_name("x64.complete").exists())
+
+    def test_entry_missing_interpreter_is_removed(self):
+        arch_dir = make_entry(self.toolcache)
+
+        removed = clean_python_toolcache.clean_toolcache(self.toolcache, "3.12")
+
+        self.assertEqual(removed, [arch_dir])
+        self.assert_removed(arch_dir)
+
+    def test_python3_alone_does_not_keep_the_entry(self):
+        # setup-python hands out `bin/python`; a surviving `bin/python3` must not
+        # mask its absence.
+        arch_dir = make_entry(self.toolcache)
+        write_interpreter(arch_dir, "exit 0", name="python3")
+
+        removed = clean_python_toolcache.clean_toolcache(self.toolcache, "3.12")
+
+        self.assertEqual(removed, [arch_dir])
+        self.assert_removed(arch_dir)
+
+    def test_entry_without_working_pip_is_removed(self):
+        arch_dir = make_entry(self.toolcache)
+        write_interpreter(arch_dir, "exit 1")
+
+        removed = clean_python_toolcache.clean_toolcache(self.toolcache, "3.12")
+
+        self.assertEqual(removed, [arch_dir])
+        self.assert_removed(arch_dir)
+
+    def test_other_feature_versions_are_untouched(self):
+        other = make_entry(self.toolcache, version="3.11.9")
+
+        self.assertEqual(
+            clean_python_toolcache.clean_toolcache(self.toolcache, "3.12"), []
+        )
+        self.assertTrue(other.is_dir())
+
+    def test_missing_toolcache_is_not_an_error(self):
+        self.assertEqual(
+            clean_python_toolcache.clean_toolcache(self.toolcache / "absent", "3.12"),
+            [],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
actions/setup-python reuses a tool cache entry as soon as its directory and the sibling `<arch>.complete` marker exist, without ever executing the interpreter, so a partially populated entry is reported as a successful setup and only fails later as `pip: cannot execute: required file not found`.

Add a helper that removes entries whose interpreter cannot run pip, so the action provisions a fresh copy instead.

Contributes to #7370

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

<!-- Most pull requests should be associated with at least one GitHub issue -->

<!-- GitHub issue: https://github.com/ROCm/TheRock/issues/1234 -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
