### PR TITLE
fix(compiler): pin host LLVM_ENABLE_PER_TARGET_RUNTIME_DIR to OFF

### DIFF
--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -116,6 +116,12 @@ if(THEROCK_ENABLE_COMPILER)
       -DOFFLOAD_EXTERNAL_PROJECT_UNIFIED_ROCR=${THEROCK_CONDITION_IS_NON_WINDOWS}
       -DLIBOMPTARGET_EXTERNAL_PROJECT_HSA_PATH=${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rocr-runtime
       -DFLANG_RUNTIME_F128_MATH_LIB=libquadmath
+      # Host runtimes must stay flat in lib/llvm/lib: that is what
+      # INTERFACE_LINK_DIRS and INTERFACE_INSTALL_RPATH_DIRS below point at.
+      # LLVM defaults this ON for Linux, which would move libomp.so et al into
+      # lib/llvm/lib/<host-triple>/, out of every consumer's RUNPATH.
+      -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=OFF
+      # The device runtimes, in contrast, do want the per-target layout.
       -DRUNTIMES_amdgcn-amd-amdhsa_LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=${THEROCK_CONDITION_IS_NON_WINDOWS}
       -DRUNTIMES_amdgcn-amd-amdhsa_LLVM_ENABLE_RUNTIMES=openmp
       # ASAN features.

--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -116,12 +116,7 @@ if(THEROCK_ENABLE_COMPILER)
       -DOFFLOAD_EXTERNAL_PROJECT_UNIFIED_ROCR=${THEROCK_CONDITION_IS_NON_WINDOWS}
       -DLIBOMPTARGET_EXTERNAL_PROJECT_HSA_PATH=${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rocr-runtime
       -DFLANG_RUNTIME_F128_MATH_LIB=libquadmath
-      # Host runtimes must stay flat in lib/llvm/lib: that is what
-      # INTERFACE_LINK_DIRS and INTERFACE_INSTALL_RPATH_DIRS below point at.
-      # LLVM defaults this ON for Linux, which would move libomp.so et al into
-      # lib/llvm/lib/<host-triple>/, out of every consumer's RUNPATH.
       -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=OFF
-      # The device runtimes, in contrast, do want the per-target layout.
       -DRUNTIMES_amdgcn-amd-amdhsa_LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=${THEROCK_CONDITION_IS_NON_WINDOWS}
       -DRUNTIMES_amdgcn-amd-amdhsa_LLVM_ENABLE_RUNTIMES=openmp
       # ASAN features.


### PR DESCRIPTION
Passes `-DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=OFF` for the host triple in the `amd-llvm` subproject's `CMAKE_ARGS`.

The subproject declares its interface directories as a flat host runtime tree — `INSTALL_DESTINATION "lib/llvm"`, `INTERFACE_LINK_DIRS "lib/llvm/lib"`, `INTERFACE_INSTALL_RPATH_DIRS "lib/llvm/lib"` — but never sets the knob that controls whether LLVM actually installs there. Upstream defaults it **ON** for `BSD|Linux|OS390|AIX`, which puts `libomp.so`, `libomptarget`, `libunwind` and `libc++abi` in `lib/llvm/lib/<host-triple>/`, one directory below the RUNPATH TheRock hands its own consumers.

From a shipped 7.12 tree:

```
$ readelf -d bin/rocsparse-test | grep -E 'NEEDED.*omp|RUNPATH'
 (NEEDED)   Shared library: [libomp.so]
 (RUNPATH)  [$ORIGIN/../lib/rocm_sysdeps/lib:$ORIGIN/../lib/llvm/lib:$ORIGIN/../lib]

$ ls lib/llvm/lib/libomp.so
lib/llvm/lib/libomp.so
```

With the default in effect, `rocsparse-test` and rocFFT fail at load with `libomp.so: cannot open shared object file`.

This has not bitten us because `amd-staging` pins the default OFF unconditionally in `llvm/CMakeLists.txt`, right after the platform block. That makes TheRock's install layout depend on a compiler-side patch it does not own — any LLVM branch without the override, including stock upstream, produces a broken dist. The knob is a `CACHE BOOL`, so setting it on the configure line needs no LLVM source change and makes the requirement explicit at the point that relies on it.

Setting it unconditionally is a no-op on Windows, where the upstream default is already OFF.

This is the **host** triple only. `RUNTIMES_amdgcn-amd-amdhsa_LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=ON` — the device runtimes, which TheRock does want per-target — is unchanged; the two now sit adjacent with a comment distinguishing them.

ISSUE ID: #7557
