### PR TITLE
[ci] Remove unused HIP version source dependency

### DIFF
--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -226,7 +226,7 @@ source_sets = []  # No submodules - uses vendored/in-tree deps
 description = "Base ROCm infrastructure and CMake tools"
 type = "generic"
 artifact_group_deps = []
-# TODO: rocm-systems included for projects/hip/VERSION (see CMakeLists.txt)
+# rocm-systems provides rocm-core, rocm-smi-lib, and rocprofiler-register.
 source_sets = ["base", "rocm-systems"]
 
 [artifact_groups.core-runtime]
@@ -257,7 +257,7 @@ source_sets = ["compilers"]
 description = "ROCm debug tools"
 type = "generic"
 artifact_group_deps = ["compiler", "third-party-sysdeps"]
-# TODO: rocm-systems included for projects/hip/VERSION (see CMakeLists.txt)
+# rocm-systems provides amd-dbgapi and rocr-debug-agent.
 source_sets = ["debug-tools", "rocm-systems"]
 
 [artifact_groups.hip-runtime]
@@ -288,7 +288,7 @@ source_sets = ["rocm-systems"]
 description = "Math libraries (BLAS, FFT, RAND, etc.)"
 type = "per-arch"  # Built per GPU architecture
 artifact_group_deps = ["hip-runtime", "profiler-core"]
-# TODO: rocm-systems included for projects/hip/VERSION (see CMakeLists.txt)
+# rocm-systems provides shared kpack tooling used to produce kpack artifacts.
 source_sets = ["rocm-libraries", "rocm-systems", "math-libs"]
 
 [artifact_groups.ml-libs]
@@ -301,7 +301,7 @@ source_sets = ["rocm-libraries", "ml-frameworks"]
 description = "Communication libraries"
 type = "generic"
 artifact_group_deps = ["hip-runtime"]
-# TODO: rocm-systems included for projects/hip/VERSION (see CMakeLists.txt)
+# rocm-systems provides RCCL, RCCL tests, ROCm SHMEM, and shared kpack tooling.
 source_sets = ["comm-libs", "rocm-systems"]
 
 [artifact_groups.storage-libs]
@@ -320,7 +320,7 @@ source_sets = ["rocm-systems"]  # rocprofiler-sdk is in rocm-systems
 description = "Data center management tools with minimal dependencies"
 type = "generic"
 artifact_group_deps = ["core-runtime", "core-amdsmi", "profiler-core"]
-# TODO: rocm-systems included for projects/hip/VERSION (see CMakeLists.txt)
+# rocm-systems provides RDC.
 source_sets = ["base", "rocm-systems"]  # RDC uses amdsmi from core-amdsmi
 
 # Future artifact groups
@@ -339,8 +339,7 @@ source_sets = ["rocm-systems"]
 description = "Computer Vision Libraries"
 type = "generic"
 artifact_group_deps = ["third-party-sysdeps", "base", "core-runtime", "hip-runtime"]
-# TODO: rocm-systems included for projects/hip/VERSION (see CMakeLists.txt)
-source_sets = ["rocm-libraries", "rocm-systems"]
+source_sets = ["rocm-libraries"]
 
 [artifact_groups.media-libs]
 description = "Media Libraries"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,23 +186,6 @@ block(PROPAGATE ROCM_MAJOR_VERSION ROCM_MINOR_VERSION ROCM_PATCH_VERSION)
   endif()
 endblock()
 
-# Various things need to be lined up across layers to precisely match the HIP version.
-# The only source of truth for this is from the HIP/VERSION file, so we parse it the
-# same way that clr does. While this *should* generally match the ROCM version, at
-# least from a major/minor perspective, the ROCM version is a "user" version, whereas
-# the HIP version is hardcoded into various places in the code.
-block(SCOPE_FOR VARIABLES PROPAGATE THEROCK_HIP_MAJOR_VERSION THEROCK_HIP_MINOR_VERSION)
-  set(VERSION_PATH "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/hip/VERSION")
-  if(NOT EXISTS "${VERSION_PATH}")
-    message(FATAL_ERROR "Could not find HIP VERSION file: ${VERSION_PATH}")
-  endif()
-  file(STRINGS "${VERSION_PATH}" VERSION_LIST REGEX "^[0-9]+")
-  list(GET VERSION_LIST 0 THEROCK_HIP_MAJOR_VERSION)
-  list(GET VERSION_LIST 1 THEROCK_HIP_MINOR_VERSION)
-  list(GET VERSION_LIST 2 THEROCK_HIP_PATCH_VERSION)
-  message(STATUS "HIP version: ${THEROCK_HIP_MAJOR_VERSION}.${THEROCK_HIP_MINOR_VERSION}.${THEROCK_HIP_PATCH_VERSION}")
-endblock()
-
 ################################################################################
 # Feature flags
 # Project wide flags for controlling the build system.


### PR DESCRIPTION
## Motivation

* Progress on https://github.com/ROCm/TheRock/issues/460
* Follow-up to https://github.com/ROCm/TheRock/pull/4535
* Follow-up to https://github.com/ROCm/TheRock/pull/4730

We no longer use `THEROCK_HIP_MAJOR_VERSION`, `THEROCK_HIP_MINOR_VERSION`, or `THEROCK_HIP_PATCH_VERSION`, so we can drop this code. I then audited which subprojects still need the `rocm-systems` source set (a checkout of the https://github.com/ROCm/rocm-systems repository) and found that we can at least remove it from `cv-libs`. I would like to remove it from `math-libs`, but that still relies on kpack.

## Test Plan

Watch the `cv-libs` build stage on CI (https://github.com/ROCm/TheRock/actions/runs/32530438272/job/96924373440?pr=7560)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.