### PR TITLE
Add BKC aggregate Python index stream

### DIFF
--- a/build_tools/packaging/python/aggregate_index.py
+++ b/build_tools/packaging/python/aggregate_index.py
@@ -88,7 +88,7 @@ from yaml.constructor import ConstructorError
 from yaml.nodes import MappingNode
 
 
-MANIFEST_SCHEMA_VERSION = 2
+MANIFEST_SCHEMA_VERSION = 3
 ROUTES_SCHEMA_VERSION = 2
 VALIDATION_SCHEMA_VERSION = 2
 SUPPORTED_PUBLIC_BASE = "/rocm/whl-next"
@@ -156,9 +156,10 @@ class PackageOwnership:
 
 @dataclasses.dataclass(frozen=True)
 class StreamConfig:
-    """Known streams and the default package stream set."""
+    """Known streams, named groups, and the default package stream set."""
 
     known: tuple[str, ...]
+    groups: dict[str, frozenset[str]]
     default: frozenset[str]
 
 
@@ -818,21 +819,46 @@ def parse_ownership_manifest(
 
 def _parse_stream_config(data: object, context: str) -> StreamConfig:
     stream_config = _require_mapping(data, context)
-    _require_keys(stream_config, {"known", "default"}, context)
+    _require_keys(stream_config, {"known", "groups", "default"}, context)
     known = _parse_stream_list(stream_config["known"], f"{context}.known")
-    default = frozenset(
-        _parse_stream_list(stream_config["default"], f"{context}.default")
+    groups = _parse_stream_groups(
+        stream_config["groups"], frozenset(known), f"{context}.groups"
     )
-    unknown_defaults = sorted(default - set(known))
-    if unknown_defaults:
+    default_group = _require_str(stream_config["default"], f"{context}.default")
+    _validate_stream_group_name(default_group, f"{context}.default")
+    if default_group not in groups:
         raise ManifestError(
-            f"{context}.default contains unknown stream(s): "
-            f"{', '.join(unknown_defaults)}"
+            f"{context}.default contains unknown stream group {default_group!r}"
         )
     return StreamConfig(
         known=tuple(known),
-        default=default,
+        groups=groups,
+        default=groups[default_group],
     )
+
+
+def _parse_stream_groups(
+    data: object,
+    known_streams: frozenset[str],
+    context: str,
+) -> dict[str, frozenset[str]]:
+    group_items = _require_mapping(data, context)
+    if not group_items:
+        raise ManifestError(f"{context} must not be empty")
+
+    groups: dict[str, frozenset[str]] = {}
+    for raw_group_name, raw_streams in group_items.items():
+        group_name = _require_str(raw_group_name, f"{context} key")
+        _validate_stream_group_name(group_name, f"{context}.{group_name}")
+        streams = frozenset(_parse_stream_list(raw_streams, f"{context}.{group_name}"))
+        unknown_streams = sorted(streams - known_streams)
+        if unknown_streams:
+            raise ManifestError(
+                f"{context}.{group_name} contains unknown stream(s): "
+                f"{', '.join(unknown_streams)}"
+            )
+        groups[group_name] = streams
+    return groups
 
 
 def _parse_stream_list(data: object, context: str) -> list[str]:
@@ -895,7 +921,7 @@ def _parse_python_index(
             package_config,
             {"owner_path"},
             f"{context}.packages.{package_name}",
-            optional_keys={"streams"},
+            optional_keys={"stream_group", "streams"},
         )
         owner_path = _require_str(
             package_config["owner_path"],
@@ -929,7 +955,24 @@ def _parse_package_streams(
     stream_config: StreamConfig,
     context: str,
 ) -> frozenset[str]:
-    if "streams" not in package_config:
+    has_stream_group = "stream_group" in package_config
+    has_streams = "streams" in package_config
+    if has_stream_group and has_streams:
+        raise ManifestError(
+            f"{context} must not contain both 'stream_group' and 'streams'"
+        )
+    if has_stream_group:
+        group_name = _require_str(
+            package_config["stream_group"], f"{context}.stream_group"
+        )
+        _validate_stream_group_name(group_name, f"{context}.stream_group")
+        if group_name not in stream_config.groups:
+            raise ManifestError(
+                f"{context}.stream_group contains unknown stream group "
+                f"{group_name!r}"
+            )
+        return stream_config.groups[group_name]
+    if not has_streams:
         return stream_config.default
     streams = frozenset(
         _parse_stream_list(package_config["streams"], f"{context}.streams")
@@ -955,6 +998,14 @@ def _validate_manifest_stream(
 
 def _validate_stream_name(stream: str, context: str) -> None:
     if not _STREAM_RE.fullmatch(stream):
+        raise ManifestError(
+            f"{context} must start with lowercase alphanumeric and contain only "
+            "lowercase alphanumeric, '_', or '-'"
+        )
+
+
+def _validate_stream_group_name(group_name: str, context: str) -> None:
+    if not _STREAM_RE.fullmatch(group_name):
         raise ManifestError(
             f"{context} must start with lowercase alphanumeric and contain only "
             "lowercase alphanumeric, '_', or '-'"
@@ -1285,8 +1336,8 @@ def main(argv: list[str]) -> int:
     generate_parser.add_argument(
         "--stream",
         required=True,
-        help="Concrete stream to generate, such as dev, nightly, rc, stable, "
-        "or stable-staging",
+        help="Concrete stream to generate, such as dev, nightly, rc, bkc, "
+        "stable, or stable-staging",
     )
     generate_parser.add_argument(
         "--content-root",
@@ -1316,8 +1367,8 @@ def main(argv: list[str]) -> int:
     content_parser.add_argument(
         "--stream",
         required=True,
-        help="Concrete stream to validate, such as dev, nightly, rc, stable, "
-        "or stable-staging",
+        help="Concrete stream to validate, such as dev, nightly, rc, bkc, "
+        "stable, or stable-staging",
     )
     content_parser.add_argument(
         "--content-root",

--- a/build_tools/packaging/python/rocm_whl_next_ownership.yaml
+++ b/build_tools/packaging/python/rocm_whl_next_ownership.yaml
@@ -5,21 +5,35 @@
 # /rocm/whl-next Python index. Owner paths are public paths relative to /rocm
 # and must not include hostnames, buckets, release streams, or storage-internal
 # prefixes.
-schema_version: 2
+schema_version: 3
 
 streams:
+  # Packages use the default group unless they select a stream_group or provide
+  # an exact streams list.
   known:
     - dev
     - nightly
     - rc
+    - bkc
     - stable
     - stable-staging
-  default:
-    - dev
-    - nightly
-    - rc
-    - stable
-    - stable-staging
+  groups:
+    all-except-bkc:
+      - dev
+      - nightly
+      - rc
+      - stable
+      - stable-staging
+    all:
+      - dev
+      - nightly
+      - rc
+      - bkc
+      - stable
+      - stable-staging
+  # BKC is opt-in per package because its target-specific package set is
+  # currently limited to gfx1250.
+  default: all-except-bkc
 
 python_indexes:
   - public_base: /rocm/whl-next
@@ -72,6 +86,7 @@ python_indexes:
         owner_path: pytorch/whl-next
       amd-torch-device-gfx1250:
         owner_path: pytorch/whl-next
+        stream_group: all
       amd-torch-device-gfx900:
         owner_path: pytorch/whl-next
         streams:
@@ -137,6 +152,7 @@ python_indexes:
         owner_path: pytorch/whl-next
       amd-torchvision-device-gfx1250:
         owner_path: pytorch/whl-next
+        stream_group: all
       amd-torchvision-device-gfx900:
         owner_path: pytorch/whl-next
         streams:
@@ -162,36 +178,50 @@ python_indexes:
         owner_path: pytorch/whl-next
       apex:
         owner_path: pytorch/whl-next
+        stream_group: all
       filelock:
         owner_path: core/whl-next
+        stream_group: all
       fsspec:
         owner_path: core/whl-next
+        stream_group: all
       jax-rocm10-pjrt:
         owner_path: jax/whl-next
       jax-rocm10-plugin:
         owner_path: jax/whl-next
       jinja2:
         owner_path: core/whl-next
+        stream_group: all
       markupsafe:
         owner_path: core/whl-next
+        stream_group: all
       mpmath:
         owner_path: core/whl-next
+        stream_group: all
       networkx:
         owner_path: core/whl-next
+        stream_group: all
       numpy:
         owner_path: core/whl-next
+        stream_group: all
       pillow:
         owner_path: core/whl-next
+        stream_group: all
       rocm:
         owner_path: core/whl-next
+        stream_group: all
       rocm-bootstrap:
         owner_path: core/whl-next
+        stream_group: all
       rocm-profiler:
         owner_path: core/whl-next
+        stream_group: all
       rocm-sdk-core:
         owner_path: core/whl-next
+        stream_group: all
       rocm-sdk-devel:
         owner_path: core/whl-next
+        stream_group: all
       rocm-sdk-device-gfx1010:
         owner_path: core/whl-next
       rocm-sdk-device-gfx1011:
@@ -234,6 +264,7 @@ python_indexes:
         owner_path: core/whl-next
       rocm-sdk-device-gfx1250:
         owner_path: core/whl-next
+        stream_group: all
       rocm-sdk-device-gfx900:
         owner_path: core/whl-next
         streams:
@@ -259,17 +290,25 @@ python_indexes:
         owner_path: core/whl-next
       rocm-sdk-libraries:
         owner_path: core/whl-next
+        stream_group: all
       setuptools:
         owner_path: core/whl-next
+        stream_group: all
       sympy:
         owner_path: core/whl-next
+        stream_group: all
       torch:
         owner_path: pytorch/whl-next
+        stream_group: all
       torchaudio:
         owner_path: pytorch/whl-next
+        stream_group: all
       torchvision:
         owner_path: pytorch/whl-next
+        stream_group: all
       triton:
         owner_path: pytorch/whl-next
+        stream_group: all
       typing-extensions:
         owner_path: core/whl-next
+        stream_group: all

--- a/build_tools/packaging/python/tests/aggregate_index_test.py
+++ b/build_tools/packaging/python/tests/aggregate_index_test.py
@@ -31,7 +31,8 @@ def _valid_manifest() -> dict[str, object]:
         "schema_version": MANIFEST_SCHEMA_VERSION,
         "streams": {
             "known": ["dev", "nightly", "rc", "stable", "stable-staging"],
-            "default": ["dev", "nightly", "rc", "stable", "stable-staging"],
+            "groups": {"all": ["dev", "nightly", "rc", "stable", "stable-staging"]},
+            "default": "all",
         },
         "python_indexes": [
             {
@@ -44,6 +45,14 @@ def _valid_manifest() -> dict[str, object]:
                 },
             }
         ],
+    }
+
+
+def _single_stream_config() -> dict[str, object]:
+    return {
+        "known": ["nightly"],
+        "groups": {"all": ["nightly"]},
+        "default": "all",
     }
 
 
@@ -135,6 +144,7 @@ def test_checked_in_manifest_loads() -> None:
         "dev",
         "nightly",
         "rc",
+        "bkc",
         "stable",
         "stable-staging",
     )
@@ -143,6 +153,27 @@ def test_checked_in_manifest_loads() -> None:
     assert index.packages["jax-rocm10-plugin"].owner_path == "jax/whl-next"
     assert index.packages["rocm-sdk-core"].owner_path == "core/whl-next"
     assert index.packages["torch"].owner_path == "pytorch/whl-next"
+
+
+def test_checked_in_manifest_bkc_contains_only_gfx1250_targets() -> None:
+    manifest_path = Path(__file__).parents[1] / "rocm_whl_next_ownership.yaml"
+    manifest = load_ownership_manifest(manifest_path)
+    index = manifest.python_indexes[0]
+    target_package_marker = "-device-gfx"
+    expected_bkc_target_packages = {
+        "amd-torch-device-gfx1250",
+        "amd-torchvision-device-gfx1250",
+        "rocm-sdk-device-gfx1250",
+    }
+    expected_bkc_packages = {
+        package_name
+        for package_name in index.packages
+        if target_package_marker not in package_name
+        and not package_name.startswith("jax-")
+    } | expected_bkc_target_packages
+
+    assert set(index.active_packages("bkc")) == expected_bkc_packages
+    assert index.owner_paths("bkc") == {"core/whl-next", "pytorch/whl-next"}
 
 
 def test_checked_in_manifest_uses_known_owner_paths() -> None:
@@ -856,7 +887,7 @@ python_indexes: []
     assert exit_code == 1
     assert captured.out == ""
     assert captured.err.startswith("error: ")
-    assert "schema_version must be 2" in captured.err
+    assert "schema_version must be 3" in captured.err
     assert "Traceback" not in captured.err
 
 
@@ -914,10 +945,12 @@ def test_main_reports_index_validation_errors_without_traceback(
     manifest_path = tmp_path / "ownership.yaml"
     manifest_path.write_text(
         """
-schema_version: 2
+schema_version: 3
 streams:
   known: [nightly]
-  default: [nightly]
+  groups:
+    all: [nightly]
+  default: all
 python_indexes:
   - public_base: /rocm/whl-next
     packages:
@@ -1090,15 +1123,15 @@ def test_validate_product_indexes_rejects_empty_package_page(
         (
             {
                 "schema_version": 1,
-                "streams": {"known": ["nightly"], "default": ["nightly"]},
+                "streams": _single_stream_config(),
                 "python_indexes": [],
             },
-            "schema_version must be 2",
+            "schema_version must be 3",
         ),
         (
             {
                 "schema_version": True,
-                "streams": {"known": ["nightly"], "default": ["nightly"]},
+                "streams": _single_stream_config(),
                 "python_indexes": [],
             },
             "schema_version must be an integer",
@@ -1106,7 +1139,7 @@ def test_validate_product_indexes_rejects_empty_package_page(
         (
             {
                 "schema_version": MANIFEST_SCHEMA_VERSION,
-                "streams": {"known": ["nightly"], "default": ["nightly"]},
+                "streams": _single_stream_config(),
                 "python_indexes": [],
             },
             "exactly one /rocm/whl-next index",
@@ -1114,7 +1147,7 @@ def test_validate_product_indexes_rejects_empty_package_page(
         (
             {
                 "schema_version": MANIFEST_SCHEMA_VERSION,
-                "streams": {"known": ["nightly"], "default": ["nightly"]},
+                "streams": _single_stream_config(),
                 "python_indexes": [
                     {
                         "public_base": "/rocm/whl-next",
@@ -1134,23 +1167,57 @@ def test_rejects_malformed_top_level_data(data: object, match: str) -> None:
 @pytest.mark.parametrize(
     "streams, match",
     [
-        ({"known": [], "default": ["nightly"]}, "known must not be empty"),
-        ({"known": ["nightly"], "default": []}, "default must not be empty"),
         (
-            {"known": ["nightly", "nightly"], "default": ["nightly"]},
+            {"known": [], "groups": {"all": ["nightly"]}, "default": "all"},
+            "known must not be empty",
+        ),
+        (
+            {"known": ["nightly"], "groups": {}, "default": "all"},
+            "groups must not be empty",
+        ),
+        (
+            {"known": ["nightly"], "groups": {"all": []}, "default": "all"},
+            "groups.all must not be empty",
+        ),
+        (
+            {
+                "known": ["nightly", "nightly"],
+                "groups": {"all": ["nightly"]},
+                "default": "all",
+            },
             "duplicate stream",
         ),
         (
-            {"known": ["Nightly"], "default": ["Nightly"]},
+            {
+                "known": ["Nightly"],
+                "groups": {"all": ["Nightly"]},
+                "default": "all",
+            },
             "lowercase alphanumeric",
         ),
         (
-            {"known": ["release.1"], "default": ["release.1"]},
+            {
+                "known": ["nightly"],
+                "groups": {"release.1": ["nightly"]},
+                "default": "release.1",
+            },
             "lowercase alphanumeric",
         ),
         (
-            {"known": ["nightly"], "default": ["nightly", "rc"]},
+            {
+                "known": ["nightly"],
+                "groups": {"all": ["nightly", "rc"]},
+                "default": "all",
+            },
             "unknown stream",
+        ),
+        (
+            {
+                "known": ["nightly"],
+                "groups": {"all": ["nightly"]},
+                "default": "missing",
+            },
+            "unknown stream group",
         ),
     ],
 )
@@ -1177,7 +1244,71 @@ def test_rejects_unknown_package_stream() -> None:
         parse_ownership_manifest(data)
 
 
-def test_rejects_patterns_key_in_schema_v2() -> None:
+def test_package_stream_group_expands_to_group_streams() -> None:
+    data = _valid_manifest()
+    stream_config = data["streams"]
+    assert isinstance(stream_config, dict)
+    known_streams = stream_config["known"]
+    assert isinstance(known_streams, list)
+    known_streams.append("bkc")
+    groups = stream_config["groups"]
+    assert isinstance(groups, dict)
+    groups["all-with-bkc"] = [
+        "dev",
+        "nightly",
+        "rc",
+        "bkc",
+        "stable",
+        "stable-staging",
+    ]
+    index = data["python_indexes"][0]
+    assert isinstance(index, dict)
+    packages = index["packages"]
+    assert isinstance(packages, dict)
+    packages["torch"] = {
+        "owner_path": "pytorch/whl-next",
+        "stream_group": "all-with-bkc",
+    }
+
+    manifest = parse_ownership_manifest(data)
+
+    assert manifest.python_indexes[0].packages["torch"].streams == frozenset(
+        {"dev", "nightly", "rc", "bkc", "stable", "stable-staging"}
+    )
+
+
+def test_rejects_unknown_package_stream_group() -> None:
+    data = _valid_manifest()
+    index = data["python_indexes"][0]
+    assert isinstance(index, dict)
+    packages = index["packages"]
+    assert isinstance(packages, dict)
+    packages["torch"] = {
+        "owner_path": "pytorch/whl-next",
+        "stream_group": "unknown",
+    }
+
+    with pytest.raises(ManifestError, match="unknown stream group"):
+        parse_ownership_manifest(data)
+
+
+def test_rejects_package_stream_group_with_exact_streams() -> None:
+    data = _valid_manifest()
+    index = data["python_indexes"][0]
+    assert isinstance(index, dict)
+    packages = index["packages"]
+    assert isinstance(packages, dict)
+    packages["torch"] = {
+        "owner_path": "pytorch/whl-next",
+        "stream_group": "all",
+        "streams": ["nightly"],
+    }
+
+    with pytest.raises(ManifestError, match="must not contain both"):
+        parse_ownership_manifest(data)
+
+
+def test_rejects_patterns_key_in_schema_v3() -> None:
     data = _valid_manifest()
     index = data["python_indexes"][0]
     assert isinstance(index, dict)


### PR DESCRIPTION
## Motivation

Add named stream groups to manifest schema v3 so BKC membership can be opt-in without duplicating normal stream lists across every shared package.

Related to https://github.com/ROCm/rockrel/issues/88.

## Technical Details

Expose target-neutral Core and PyTorch packages in BKC together with only the gfx1250 device packages. Keep JAX and all other GPU targets out of the BKC aggregate index. Route and validation output schemas remain unchanged.

## Test Plan

- python -m pytest -q -p no:cacheprovider build_tools/packaging/python/tests/aggregate_index_test.py
- python build_tools/packaging/python/aggregate_index.py validate-manifest --manifest build_tools/packaging/python/rocm_whl_next_ownership.yaml
- Generate the BKC aggregate route output and inspect its schema, owners, and route count

## Test Result

- Passed: aggregate_index_test.py (87 tests)
- Passed: validate-manifest
- Passed: BKC route schema v2 with 25 Core/PyTorch routes

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.

Generated with Codex
