### PR TITLE
[packaging] Document Python post-release versions

### DIFF
--- a/docs/packaging/versioning.md
+++ b/docs/packaging/versioning.md
@@ -132,22 +132,18 @@ The script produces these versions for each release type:
 
 ### Post releases
 
-Python package versions may add a PEP 440 post-release segment to an existing
-version. For example, the versions are ordered as `7.14.0 < 7.14.0.post1 < 7.14.0.post2 < 7.14.1`. See the official
-[Python packaging guidance for post releases](https://packaging.python.org/en/latest/specifications/version-specifiers/#post-releases)
-for the definition of a post release and guidance on when to use one.
+A post release is a follow-up release of an existing package version, written
+in canonical form with a `.postN` segment. PEP 440 orders it after its base
+version and before the next patch: `7.14.0 < 7.14.0.post1 < 7.14.1`. TheRock's
+scripts do not generate these versions, but we may create one manually in
+exceptional cases to patch an individual Python package. See the official
+[Python packaging guidance](https://packaging.python.org/en/latest/specifications/version-specifiers/#post-releases)
+for what qualifies as a post release.
 
-TheRock's versioning and promotion scripts do not currently generate post
-release versions. We can create and publish them manually as needed in
-exceptional cases, giving us the option to patch an individual Python package
-without creating a new ROCm patch version or republishing unrelated packages.
-
-To preserve that option, TheRock scripts and published packages should tolerate
-post-release segments when comparing versions that are otherwise identical.
-For example, `7.14.0` and `7.14.0.post1` should be compatible, while `7.14.0`
-and `7.14.1` should remain incompatible. Exact dependency pins and runtime
-string comparisons must account for this distinction so a post release of one
-package does not require a coordinated post release of the entire package set.
+Version comparisons in TheRock scripts and published packages should tolerate
+versions that differ only by a post-release segment. For example, `7.14.0` and
+`7.14.0.post1` should be compatible, while `7.14.0` and `7.14.1` should not.
+This lets us patch one package without republishing the entire package set.
 
 ### BKC versions
 
@@ -277,43 +273,24 @@ When working with versions please use these tools and avoid custom parsing
   '1.2.0'
   ```
 
-- The `packaging.specifiers.SpecifierSet` utility:
-  https://packaging.pypa.io/en/stable/specifiers.html
-
-  Use `SpecifierSet` when code needs to apply the same compatibility rules as
-  Python package metadata. A prefix match can express compatibility across a
-  ROCm major/minor release while accepting stable patch and post releases:
+- [`packaging.specifiers.SpecifierSet`](https://packaging.pypa.io/en/stable/specifiers.html)
+  for testing constraints written as
+  [dependency specifiers](https://packaging.python.org/en/latest/specifications/dependency-specifiers/):
 
   ```python
   >>> from packaging.specifiers import SpecifierSet
   >>> from packaging.version import Version
-  >>> compatible_rocm = SpecifierSet("==7.14.*")
-  >>> Version("7.14.0") in compatible_rocm
+  >>> same_minor = SpecifierSet("==7.14.*")
+  >>> Version("7.14.0.post1") in same_minor
   True
-  >>> Version("7.14.0.post1") in compatible_rocm
+  >>> Version("7.15.0") in same_minor
+  False
+  >>> same_major_from_7_14 = SpecifierSet("~=7.14")
+  >>> Version("7.15.0") in same_major_from_7_14
   True
-  >>> Version("7.14.1") in compatible_rocm
-  True
-  >>> Version("7.15.0") in compatible_rocm
+  >>> Version("8.0.0") in same_major_from_7_14
   False
   ```
-
-  Exact equality has different semantics and excludes post releases:
-
-  ```python
-  >>> exact_release = SpecifierSet("==7.14.0")
-  >>> Version("7.14.0") in exact_release
-  True
-  >>> Version("7.14.0.post1") in exact_release
-  False
-  ```
-
-  `SpecifierSet("~=7.14.0")` is another way to accept `7.14.0` or newer
-  versions in the `7.14` series. Prefer `==7.14.*` when the policy is simply
-  "the major and minor components must match"; use `~=` when its lower bound is
-  also part of the compatibility requirement. Pre-releases are excluded by
-  default unless explicitly enabled or otherwise selected according to the
-  standard Python packaging rules.
 
 - Existing Python scripts:
 

--- a/docs/packaging/versioning.md
+++ b/docs/packaging/versioning.md
@@ -133,55 +133,21 @@ The script produces these versions for each release type:
 ### Post releases
 
 Python package versions may add a PEP 440 post-release segment to an existing
-stable version. For example, `7.14.0.post1` is newer than `7.14.0` but older
-than `7.14.1`:
+version. For example, the versions are ordered as `7.14.0 < 7.14.0.post1 < 7.14.0.post2 < 7.14.1`. See the official
+[Python packaging guidance for post releases](https://packaging.python.org/en/latest/specifications/version-specifiers/#post-releases)
+for the definition of a post release and guidance on when to use one.
 
-```text
-7.14.0 < 7.14.0.post1 < 7.14.0.post2 < 7.14.1
-```
+TheRock's versioning and promotion scripts do not currently generate post
+release versions. We can create and publish them manually as needed in
+exceptional cases, giving us the option to patch an individual Python package
+without creating a new ROCm patch version or republishing unrelated packages.
 
-Post releases let us publish a corrected Python distribution derived from a
-stable release without changing the underlying ROCm release number. Suitable
-uses include correcting package metadata, dependency declarations, or other
-Python packaging and publication errors while retaining the stable release's
-native payload. Published distributions are immutable, so a corrected artifact
-must have a new version rather than replacing the file for `7.14.0`.
-
-Post releases should not be used as a substitute for ROCm patch releases. If a
-change fixes ROCm software, changes native binaries, or changes an interface or
-ABI, prefer a new patch release such as `7.14.1`. This follows the
-[Python packaging guidance for post releases](https://packaging.python.org/en/latest/specifications/version-specifiers/#post-releases),
-which strongly discourages using them for maintenance releases containing
-software bug fixes.
-
-TheRock can construct post releases from stable release inputs in a few ways:
-
-- Repackage an unchanged stable payload with corrected Python metadata.
-- Publish a post release of a leaf or selector package when its compatibility
-  constraints allow it to work with the base stable packages.
-- Publish a coordinated post release of all packages in a tightly coupled set
-  when their metadata requires exact matching versions.
-
-Post releases are not currently a regular release type produced by
-`compute_rocm_package_version.py`, and `promote_packages.py --dest-version` does
-not currently accept `.postN`. Creating one therefore requires a purpose-built
-repackaging flow or an extension to the promotion tooling. The resulting
-artifacts must still go through the normal validation and publishing process.
-
-Compatibility must be considered before deciding whether to post-release one
-package or a coordinated set:
-
-- An exact requirement such as `rocm-sdk-device-gfx1100==7.14.0` does not accept
-  `7.14.0.post1`, and the reverse exact requirement does not accept `7.14.0`.
-- Runtime checks based on string equality have the same problem and may reject
-  an otherwise compatible mix of base, patch, and post releases.
-- A major/minor constraint such as `==7.14.*` permits patch and post releases.
-  Use it only at boundaries where that compatibility is an intentional
-  contract. Keep exact pins where packages must be built, tested, and installed
-  as one versioned set.
-- Before publishing, test clean installs as well as upgrades from the base
-  stable version. Check that dependency resolution does not downgrade another
-  SDK package or produce a mixture that the runtime cannot use.
+To preserve that option, TheRock scripts and published packages should tolerate
+post-release segments when comparing versions that are otherwise identical.
+For example, `7.14.0` and `7.14.0.post1` should be compatible, while `7.14.0`
+and `7.14.1` should remain incompatible. Exact dependency pins and runtime
+string comparisons must account for this distinction so a post release of one
+package does not require a coordinated post release of the entire package set.
 
 ### BKC versions
 
@@ -348,13 +314,6 @@ When working with versions please use these tools and avoid custom parsing
   also part of the compatibility requirement. Pre-releases are excluded by
   default unless explicitly enabled or otherwise selected according to the
   standard Python packaging rules.
-
-  The `packaging` project is available to TheRock build and release tooling,
-  but it is not automatically a runtime dependency of every generated package.
-  Do not add a `packaging` import to installed SDK code unless the corresponding
-  distribution declares that dependency. Runtime code without that dependency
-  should use a small, narrowly scoped comparison for the specific version
-  policy it implements.
 
 - Existing Python scripts:
 

--- a/docs/packaging/versioning.md
+++ b/docs/packaging/versioning.md
@@ -130,6 +130,59 @@ The script produces these versions for each release type:
 | dev          | `X.Y.Z.dev0+NNNN`                          | `7.10.0.dev0+efed3c3b10a5cce8578f58f8eb288582c26d18c4`<br>(For commit [`efed3c3`](https://github.com/ROCm/TheRock/commit/efed3c3b10a5cce8578f58f8eb288582c26d18c4)) |
 | dev-bkc      | `X.Y.Z.dev0+NNNN`<br>(same as regular dev) | `10.1.0.dev0+efed3c3b10a5cce8578f58f8eb288582c26d18c4`                                                                                                              |
 
+### Post releases
+
+Python package versions may add a PEP 440 post-release segment to an existing
+stable version. For example, `7.14.0.post1` is newer than `7.14.0` but older
+than `7.14.1`:
+
+```text
+7.14.0 < 7.14.0.post1 < 7.14.0.post2 < 7.14.1
+```
+
+Post releases let us publish a corrected Python distribution derived from a
+stable release without changing the underlying ROCm release number. Suitable
+uses include correcting package metadata, dependency declarations, or other
+Python packaging and publication errors while retaining the stable release's
+native payload. Published distributions are immutable, so a corrected artifact
+must have a new version rather than replacing the file for `7.14.0`.
+
+Post releases should not be used as a substitute for ROCm patch releases. If a
+change fixes ROCm software, changes native binaries, or changes an interface or
+ABI, prefer a new patch release such as `7.14.1`. This follows the
+[Python packaging guidance for post releases](https://packaging.python.org/en/latest/specifications/version-specifiers/#post-releases),
+which strongly discourages using them for maintenance releases containing
+software bug fixes.
+
+TheRock can construct post releases from stable release inputs in a few ways:
+
+- Repackage an unchanged stable payload with corrected Python metadata.
+- Publish a post release of a leaf or selector package when its compatibility
+  constraints allow it to work with the base stable packages.
+- Publish a coordinated post release of all packages in a tightly coupled set
+  when their metadata requires exact matching versions.
+
+Post releases are not currently a regular release type produced by
+`compute_rocm_package_version.py`, and `promote_packages.py --dest-version` does
+not currently accept `.postN`. Creating one therefore requires a purpose-built
+repackaging flow or an extension to the promotion tooling. The resulting
+artifacts must still go through the normal validation and publishing process.
+
+Compatibility must be considered before deciding whether to post-release one
+package or a coordinated set:
+
+- An exact requirement such as `rocm-sdk-device-gfx1100==7.14.0` does not accept
+  `7.14.0.post1`, and the reverse exact requirement does not accept `7.14.0`.
+- Runtime checks based on string equality have the same problem and may reject
+  an otherwise compatible mix of base, patch, and post releases.
+- A major/minor constraint such as `==7.14.*` permits patch and post releases.
+  Use it only at boundaries where that compatibility is an intentional
+  contract. Keep exact pins where packages must be built, tested, and installed
+  as one versioned set.
+- Before publishing, test clean installs as well as upgrades from the base
+  stable version. Check that dependency resolution does not downgrade another
+  SDK package or produce a mixture that the runtime cannot use.
+
 ### BKC versions
 
 For `nightly-bkc`, `BASEDATE` comes from `release-metadata.base-date` in
@@ -257,6 +310,51 @@ When working with versions please use these tools and avoid custom parsing
   >>> v2.base_version
   '1.2.0'
   ```
+
+- The `packaging.specifiers.SpecifierSet` utility:
+  https://packaging.pypa.io/en/stable/specifiers.html
+
+  Use `SpecifierSet` when code needs to apply the same compatibility rules as
+  Python package metadata. A prefix match can express compatibility across a
+  ROCm major/minor release while accepting stable patch and post releases:
+
+  ```python
+  >>> from packaging.specifiers import SpecifierSet
+  >>> from packaging.version import Version
+  >>> compatible_rocm = SpecifierSet("==7.14.*")
+  >>> Version("7.14.0") in compatible_rocm
+  True
+  >>> Version("7.14.0.post1") in compatible_rocm
+  True
+  >>> Version("7.14.1") in compatible_rocm
+  True
+  >>> Version("7.15.0") in compatible_rocm
+  False
+  ```
+
+  Exact equality has different semantics and excludes post releases:
+
+  ```python
+  >>> exact_release = SpecifierSet("==7.14.0")
+  >>> Version("7.14.0") in exact_release
+  True
+  >>> Version("7.14.0.post1") in exact_release
+  False
+  ```
+
+  `SpecifierSet("~=7.14.0")` is another way to accept `7.14.0` or newer
+  versions in the `7.14` series. Prefer `==7.14.*` when the policy is simply
+  "the major and minor components must match"; use `~=` when its lower bound is
+  also part of the compatibility requirement. Pre-releases are excluded by
+  default unless explicitly enabled or otherwise selected according to the
+  standard Python packaging rules.
+
+  The `packaging` project is available to TheRock build and release tooling,
+  but it is not automatically a runtime dependency of every generated package.
+  Do not add a `packaging` import to installed SDK code unless the corresponding
+  distribution declares that dependency. Runtime code without that dependency
+  should use a small, narrowly scoped comparison for the specific version
+  policy it implements.
 
 - Existing Python scripts:
 


### PR DESCRIPTION
## Motivation

We published the Python sdist 'rocm' package version `7.14.0.post1` to resolve https://github.com/ROCm/TheRock/issues/7362. This was our first post-release (https://packaging.python.org/en/latest/specifications/version-specifiers/#post-releases), so this PR adds documentation for what was involved in creating and testing this.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
