### PR TITLE
docs: add GPU detection guide using rocm-bootstrap

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -273,10 +273,7 @@ For more details on using the `rocm-sdk-devel` package to build projects, see
 ##### Supported Python `[device-*]` install extras
 
 For packages which include device-specific code (such as `rocm`, `torch`, and
-`torchvision`), select your GPU using a `[device-*]` install extra from the
-table below. See also the
-[GPU architecture specs](https://rocm.docs.amd.com/en/latest/reference/gpu-arch-specs.html)
-for a full list of supported AMD GPUs.
+`torchvision`), select your GPU using a `[device-*]` install extra.
 
 ###### Detect your GPU automatically
 
@@ -289,6 +286,12 @@ $ pip install rocm-bootstrap
 $ rocm-bootstrap-detect
 gfx1103
 ```
+
+###### GFX target lookup table
+
+If you know your GPU you can also check the table below or the
+[GPU architecture specs](https://rocm.docs.amd.com/en/latest/reference/gpu-arch-specs.html)
+for a full list of supported AMD GPUs.
 
 | Product Name                                         | GFX Target | Device Extra     |
 | ---------------------------------------------------- | ---------- | ---------------- |

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -278,6 +278,30 @@ table below. See also the
 [GPU architecture specs](https://rocm.docs.amd.com/en/latest/reference/gpu-arch-specs.html)
 for a full list of supported AMD GPUs.
 
+###### Detect your GPU automatically
+
+If you don't know your GPU architecture, use the
+[`rocm-bootstrap`](https://pypi.org/project/rocm-bootstrap/) package to detect
+it before installing. `rocm-bootstrap` is a lightweight package with no
+dependencies — it does not require ROCm to be installed and supports both Linux
+and Windows:
+
+```bash
+pip install rocm-bootstrap
+rocm-bootstrap-detect
+```
+
+This prints your GPU's `gfx` target (e.g. `gfx1103`), which you can then use
+with the matching `device-*` extra from the table below:
+
+```bash
+$ rocm-bootstrap-detect
+gfx1103
+
+$ pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+    "rocm[libraries,device-gfx1103]"
+```
+
 | Product Name                                         | GFX Target | Device Extra     |
 | ---------------------------------------------------- | ---------- | ---------------- |
 | *All supported GPUs*                                 | (all)      | `device-all`     |

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -280,26 +280,14 @@ for a full list of supported AMD GPUs.
 
 ###### Detect your GPU automatically
 
-If you don't know your GPU architecture, use the
-[`rocm-bootstrap`](https://pypi.org/project/rocm-bootstrap/) package to detect
-it before installing. `rocm-bootstrap` is a lightweight package with no
-dependencies — it does not require ROCm to be installed and supports both Linux
-and Windows:
+The
+[`rocm-bootstrap`](https://pypi.org/project/rocm-bootstrap/) package can
+detect your GPU's `gfx` target for you:
 
 ```bash
-pip install rocm-bootstrap
-rocm-bootstrap-detect
-```
-
-This prints your GPU's `gfx` target (e.g. `gfx1103`), which you can then use
-with the matching `device-*` extra from the table below:
-
-```bash
+$ pip install rocm-bootstrap
 $ rocm-bootstrap-detect
 gfx1103
-
-$ pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
-    "rocm[libraries,device-gfx1103]"
 ```
 
 | Product Name                                         | GFX Target | Device Extra     |


### PR DESCRIPTION
Adds a Detect your GPU automatically section to RELEASES.md before the device extras table. Shows users how to use rocm-bootstrap-detect to find their GPU architecture before installing ROCm via pip. Tested on Windows 11 with Radeon 780M (gfx1103). Closes #7564