### PR TITLE
docs(debug-tools): update test script references to installed paths

### DIFF
--- a/debug-tools/README.md
+++ b/debug-tools/README.md
@@ -422,13 +422,20 @@ Common TSAN_OPTIONS:
 
 ### Testing Debug-Tools
 
-TheRock provides test scripts for ROCgdb and ROCr Debug Agent. Both scripts
-work with locally-built ROCm trees or downloaded nightly tarballs from
+Test scripts for ROCgdb and ROCr Debug Agent are owned by their respective
+upstream repositories and installed into the ROCm tree as part of the build:
+
+- ROCgdb: source of truth is
+  [ROCm/ROCgdb `.github/scripts/test_rocgdb.py`](https://github.com/ROCm/ROCgdb/blob/amd-staging/.github/scripts/test_rocgdb.py),
+  installed to `tests/rocgdb/test_rocgdb.py`
+- ROCr Debug Agent: source of truth is
+  [ROCm/rocm-systems `projects/rocr-debug-agent/.github/scripts/test_rocr-debug-agent.py`](https://github.com/ROCm/rocm-systems/blob/develop/projects/rocr-debug-agent/.github/scripts/test_rocr-debug-agent.py),
+  installed to `tests/rocm-debug-agent/test_rocr-debug-agent.py`
+
+Both scripts work with locally-built ROCm trees or downloaded nightly tarballs from
 
 - https://nightly.repo.amd.com/rocm/core/tarball/ or
 - https://rocm.nightlies.amd.com/.
-
-**Scripts location:** `build_tools/github_actions/test_executable_scripts/`
 
 #### Setup
 
@@ -451,7 +458,7 @@ For container testing, use the testing container described in [Container Environ
 **ROCgdb:**
 
 ```bash
-python3 build_tools/github_actions/test_executable_scripts/test_rocgdb.py
+python3 ${OUTPUT_ARTIFACTS_DIR}/tests/rocgdb/test_rocgdb.py
 ```
 
 The script runs the GDB test suite against ROCgdb using both GCC and LLVM compilers. By default it will run the gdb.rocm and gdb.dwarf2 test categories.
@@ -459,7 +466,7 @@ The script runs the GDB test suite against ROCgdb using both GCC and LLVM compil
 **ROCr Debug Agent:**
 
 ```bash
-python3 build_tools/github_actions/test_executable_scripts/test_rocr-debug-agent.py
+python3 ${OUTPUT_ARTIFACTS_DIR}/tests/rocm-debug-agent/test_rocr-debug-agent.py
 ```
 
 The script includes automatic retry logic for flaky GPU-dependent tests.


### PR DESCRIPTION
## Summary

- Removes references to the old `build_tools/github_actions/test_executable_scripts/` location for the ROCgdb and ROCr Debug Agent test scripts
- Adds links to the upstream source of truth for each script (ROCm/ROCgdb and ROCm/rocm-systems)
- Updates the run commands to use the installed paths under `${OUTPUT_ARTIFACTS_DIR}/tests/rocgdb/` and `${OUTPUT_ARTIFACTS_DIR}/tests/rocm-debug-agent/`, which is where the build places them

## Test plan

- [x] Verify the installed paths match what `debug-tools/rocgdb/CMakeLists.txt` and `rocm-systems/projects/rocr-debug-agent/test/CMakeLists.txt` install to (`tests/rocgdb/` and `tests/rocm-debug-agent/` respectively)
- [x] Doc-only change; no code paths affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)