### PR TITLE
Wait for ROCm publishing before PyTorch+JAX release triggers

### DIFF
--- a/.github/workflows/multi_arch_release_linux.yml
+++ b/.github/workflows/multi_arch_release_linux.yml
@@ -270,10 +270,13 @@ jobs:
             }
 
 
-  # TODO: Consider switch pulling ROCm packages from the CDN instead of the artifact
-  #   bucket if the job order is not altered.
+  # The PyTorch release workflow publishes its wheels to the release index, then
+  # tests from that index. Wait for the corresponding ROCm release to be published
+  # before triggering the downstream release.
+  # TODO: Consider pulling ROCm packages from the published release index instead
+  #   of the artifact bucket now that this waits for release bucket publication.
   trigger_release_pytorch_wheels:
-    needs: [build_artifacts, build_python_packages]
+    needs: [build_python_packages, publish_to_release_buckets]
     name: Trigger Release PyTorch Wheels
     if: ${{ inputs.build_pytorch != false && fromJSON(inputs.build_config).build_pytorch == true }}
     runs-on: ubuntu-24.04
@@ -296,8 +299,13 @@ jobs:
               "quartz_tracking_id": "${{ inputs.quartz_tracking_id }}"
             }
 
+  # The JAX release workflow publishes its wheels to the release index, then tests
+  # from that index. Wait for the corresponding ROCm release to be published before
+  # triggering the downstream release.
+  # TODO: Consider pulling ROCm packages from the published release index instead
+  #   of the artifact bucket now that this waits for release bucket publication.
   trigger_release_jax_wheels:
-    needs: [build_artifacts, build_python_packages]
+    needs: [build_python_packages, publish_to_release_buckets]
     name: Trigger Release JAX Wheels
     if: ${{ inputs.build_jax != false && fromJSON(inputs.build_config).build_jax == true }}
     runs-on: ubuntu-24.04

--- a/.github/workflows/multi_arch_release_windows.yml
+++ b/.github/workflows/multi_arch_release_windows.yml
@@ -183,10 +183,13 @@ jobs:
               "quartz_tracking_id": "${{ inputs.quartz_tracking_id }}"
             }
 
-  # TODO: Consider switch pulling ROCm packages from the CDN instead of the artifact
-  #   bucket if the job order is not altered.
+  # The PyTorch release workflow publishes its wheels to the release index, then
+  # tests from that index. Wait for the corresponding ROCm release to be published
+  # before triggering the downstream release.
+  # TODO: Consider pulling ROCm packages from the published release index instead
+  #   of the artifact bucket now that this waits for release bucket publication.
   trigger_release_pytorch_wheels:
-    needs: [build_artifacts, build_python_packages]
+    needs: [build_python_packages, publish_to_release_buckets]
     name: Trigger Release PyTorch Wheels
     if: ${{ inputs.build_pytorch != false && fromJSON(inputs.build_config).build_pytorch == true }}
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Motivation

* Fixes https://github.com/ROCm/TheRock/issues/7584

## Technical Details

The PyTorch and JAX release workflows currently:
1. Build from artifact URLs like `rocm_package_find_links_url: https://therock-nightly-artifacts.s3.amazonaws.com/32539019050-linux/python/index.html`
2. Upload their packages to e.g. `package_index_url=https://nightly.repo.amd.com/rocm/whl-next/`
3. Run tests with the release index that is _expected to already have rocm packages published there_

These jobs should therefore wait until `publish_to_release_buckets` runs. Unfortunately this is going to reduce how much overlap we get out of release jobs due to current bottlenecks in tarball and native package building, but we can optimize that separately from this correctness issue.

## Test Plan

* Dev Linux release: https://github.com/ROCm/TheRock/actions/runs/32760514468 should show the expected ordering
  <img width="1025" height="309" alt="image" src="https://github.com/user-attachments/assets/a1831f60-1e03-44bf-8bea-9f63663294c4" />

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
