### PR TITLE
fix(rocprofiler-sdk): preserve runtime dlopen aliases for rocprofiler

### DIFF
--- a/build_tools/_therock_utils/py_packaging.py
+++ b/build_tools/_therock_utils/py_packaging.py
@@ -392,7 +392,10 @@ class PopulatedDistPackage:
                     # unversioned names at runtime.
                     soname = get_soname(dir_entry.path)
                     if soname:
-                        if soname == dir_entry.name or relpath in runtime_library_aliases:
+                        if (
+                            soname == dir_entry.name
+                            or relpath in runtime_library_aliases
+                        ):
                             self._populate_file(
                                 relpath, dest_path, dir_entry, resolve_src=True
                             )

--- a/build_tools/_therock_utils/py_packaging.py
+++ b/build_tools/_therock_utils/py_packaging.py
@@ -39,12 +39,6 @@ assert DIST_INFO_PATH.exists()
 
 ENABLED_VLOG_LEVEL: int = 5
 
-RUNTIME_DLOPEN_LIBRARY_ALIASES = {
-    "lib/librocprofiler-sdk.so",
-    "lib/librocprofiler-sdk-attach.so",
-    "lib/rocprofiler-sdk/librocprofiler-sdk-tool.so",
-}
-
 
 def log(*args, vlog: int = 0, **kwargs):
     if vlog > ENABLED_VLOG_LEVEL:
@@ -353,7 +347,10 @@ class PopulatedDistPackage:
         return package_dest_dir
 
     def populate_runtime_files(
-        self, artifacts: ArtifactCatalog
+        self,
+        artifacts: ArtifactCatalog,
+        *,
+        runtime_library_aliases: set[str] | None = None,
     ) -> "PopulatedDistPackage":
         """Populates runtime files in an artifact catalog to the platform directory.
 
@@ -374,6 +371,7 @@ class PopulatedDistPackage:
             # This will be used later to restrict devel packages to only these.
             self.params.runtime_artifact_names.add(an.name)
 
+        runtime_library_aliases = runtime_library_aliases or set()
         package_dest_dir = self.platform_dir
         for relpath, dir_entry in artifacts.pm.matches():
             if self.files.has(relpath):
@@ -381,21 +379,20 @@ class PopulatedDistPackage:
             dest_path = package_dest_dir / relpath
             if dir_entry.is_symlink():
                 # Chase the symlink.
-                self._populate_runtime_symlink(relpath, dest_path, dir_entry)
+                self._populate_runtime_symlink(
+                    relpath, dest_path, dir_entry, runtime_library_aliases
+                )
             else:
                 # Copy the file.
                 file_type = get_file_type(dir_entry)
                 if file_type == "so":
                     # We only populate runtime shared libraries that correspond
-                    # with their soname (or that don't have one). A few
-                    # rocprofiler libraries are dlopened by their unversioned
-                    # names at runtime, so keep those aliases in runtime packages.
+                    # with their soname (or that don't have one). Some callers
+                    # provide explicit aliases for libraries dlopened by their
+                    # unversioned names at runtime.
                     soname = get_soname(dir_entry.path)
                     if soname:
-                        if (
-                            soname == dir_entry.name
-                            or relpath in RUNTIME_DLOPEN_LIBRARY_ALIASES
-                        ):
+                        if soname == dir_entry.name or relpath in runtime_library_aliases:
                             self._populate_file(
                                 relpath, dest_path, dir_entry, resolve_src=True
                             )
@@ -470,7 +467,11 @@ class PopulatedDistPackage:
         )
 
     def _populate_runtime_symlink(
-        self, relpath: str, dest_path: Path, src_entry: os.DirEntry[str]
+        self,
+        relpath: str,
+        dest_path: Path,
+        src_entry: os.DirEntry[str],
+        runtime_library_aliases: set[str],
     ):
         # We can't have any symlinks in a runtime tree.
         # Here is what we do based on what it points to:
@@ -485,7 +486,7 @@ class PopulatedDistPackage:
         file_type = get_file_type(link_target)
         # Case 2: Shared library.
         if file_type == "so" and (soname := get_soname(link_target)):
-            if soname == src_entry.name or relpath in RUNTIME_DLOPEN_LIBRARY_ALIASES:
+            if soname == src_entry.name or relpath in runtime_library_aliases:
                 self._populate_file(relpath, dest_path, src_entry, resolve_src=True)
             else:
                 self.files.soname_aliases[relpath] = soname

--- a/build_tools/_therock_utils/py_packaging.py
+++ b/build_tools/_therock_utils/py_packaging.py
@@ -39,6 +39,12 @@ assert DIST_INFO_PATH.exists()
 
 ENABLED_VLOG_LEVEL: int = 5
 
+RUNTIME_DLOPEN_LIBRARY_ALIASES = {
+    "lib/librocprofiler-sdk.so",
+    "lib/librocprofiler-sdk-attach.so",
+    "lib/rocprofiler-sdk/librocprofiler-sdk-tool.so",
+}
+
 
 def log(*args, vlog: int = 0, **kwargs):
     if vlog > ENABLED_VLOG_LEVEL:
@@ -381,10 +387,15 @@ class PopulatedDistPackage:
                 file_type = get_file_type(dir_entry)
                 if file_type == "so":
                     # We only populate runtime shared libraries that correspond
-                    # with their soname (or that don't have one).
+                    # with their soname (or that don't have one). A few
+                    # rocprofiler libraries are dlopened by their unversioned
+                    # names at runtime, so keep those aliases in runtime packages.
                     soname = get_soname(dir_entry.path)
                     if soname:
-                        if soname == dir_entry.name:
+                        if (
+                            soname == dir_entry.name
+                            or relpath in RUNTIME_DLOPEN_LIBRARY_ALIASES
+                        ):
                             self._populate_file(
                                 relpath, dest_path, dir_entry, resolve_src=True
                             )
@@ -474,7 +485,7 @@ class PopulatedDistPackage:
         file_type = get_file_type(link_target)
         # Case 2: Shared library.
         if file_type == "so" and (soname := get_soname(link_target)):
-            if soname == src_entry.name:
+            if soname == src_entry.name or relpath in RUNTIME_DLOPEN_LIBRARY_ALIASES:
                 self._populate_file(relpath, dest_path, src_entry, resolve_src=True)
             else:
                 self.files.soname_aliases[relpath] = soname

--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -31,6 +31,14 @@ from _therock_utils.cmake_amdgpu_targets import amdgpu_family_map, expand_famili
 from _therock_utils.py_packaging import Parameters, PopulatedDistPackage, build_packages
 
 
+ROCPROFILER_RUNTIME_LIBRARY_ALIASES = {
+    "lib/librocprofiler-sdk.so",
+    "lib/librocprofiler-sdk-attach.so",
+    "lib/librocprofiler-sdk-rocattach.so",
+    "lib/rocprofiler-sdk/librocprofiler-sdk-tool.so",
+}
+
+
 def _amdgpu_families_arg(value: str) -> list[str] | None:
     """Argparse type for --linux/windows-amdgpu-families CLI flags.
 
@@ -254,6 +262,7 @@ def run(args: argparse.Namespace):
                 "share/**/rocprofiler-systems/**",
             ],
         ),
+        runtime_library_aliases=ROCPROFILER_RUNTIME_LIBRARY_ALIASES,
     )
 
     profiler_artifacts = params.filter_artifacts(

--- a/build_tools/tests/py_packaging_test.py
+++ b/build_tools/tests/py_packaging_test.py
@@ -21,6 +21,7 @@ import sys
 
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 
+import _therock_utils.py_packaging as py_packaging
 from _therock_utils.artifacts import ArtifactCatalog
 from _therock_utils.py_packaging import Parameters, PopulatedDistPackage, PopulatedFiles
 from build_python_packages import validate_kpack_split_target_completeness
@@ -231,6 +232,65 @@ class MultiArchPackagingTest(TmpDirTestCase):
 
         self.assertEqual(len(params.populated_packages), 1)
         self.assertIs(params.populated_packages[0], lib)
+
+    def test_runtime_library_aliases_are_materialized_selectively(self):
+        """Allowlisted unversioned .so aliases stay in runtime; normal ones do not."""
+        artifact_dir = self.temp_dir / "artifacts"
+        self._add_artifact(
+            artifact_dir,
+            "base",
+            "lib",
+            "generic",
+            {
+                "lib/libkeep.so.1": "keep runtime library",
+                "lib/libdrop.so.1": "drop runtime library",
+            },
+        )
+        stage = artifact_dir / "base_lib_generic" / "stage"
+        (stage / "lib" / "libkeep.so").symlink_to("libkeep.so.1")
+        (stage / "lib" / "libdrop.so").symlink_to("libdrop.so.1")
+
+        params = self._make_params(artifact_dir)
+        core = PopulatedDistPackage(params, logical_name="core")
+
+        original_get_file_type = py_packaging.get_file_type
+        original_get_soname = py_packaging.get_soname
+        original_extend_rpath = PopulatedDistPackage._extend_rpath
+        original_normalize_rpath = PopulatedDistPackage._normalize_rpath
+
+        def fake_get_file_type(path_or_entry):
+            path = Path(getattr(path_or_entry, "path", path_or_entry))
+            if path.name.startswith(("libkeep.so", "libdrop.so")):
+                return "so"
+            return original_get_file_type(path_or_entry)
+
+        def fake_get_soname(path):
+            return Path(path).name
+
+        try:
+            py_packaging.get_file_type = fake_get_file_type
+            py_packaging.get_soname = fake_get_soname
+            PopulatedDistPackage._extend_rpath = lambda *args, **kwargs: None
+            PopulatedDistPackage._normalize_rpath = lambda *args, **kwargs: None
+
+            core.populate_runtime_files(
+                params.filter_artifacts(lambda an: an.name == "base"),
+                runtime_library_aliases={"lib/libkeep.so"},
+            )
+        finally:
+            py_packaging.get_file_type = original_get_file_type
+            py_packaging.get_soname = original_get_soname
+            PopulatedDistPackage._extend_rpath = original_extend_rpath
+            PopulatedDistPackage._normalize_rpath = original_normalize_rpath
+
+        self.assertTrue(core.files.has("lib/libkeep.so.1"))
+        self.assertTrue(core.files.has("lib/libkeep.so"))
+        self.assertTrue((core.platform_dir / "lib" / "libkeep.so").exists())
+
+        self.assertTrue(core.files.has("lib/libdrop.so.1"))
+        self.assertFalse(core.files.has("lib/libdrop.so"))
+        self.assertEqual(core.files.soname_aliases["lib/libdrop.so"], "libdrop.so.1")
+        self.assertFalse((core.platform_dir / "lib" / "libdrop.so").exists())
 
     def test_find_populated_searches_across_packages(self):
         """_find_populated locates a file regardless of which package owns it."""


### PR DESCRIPTION
## Motivation
`rocprofv3 --attach` fails for PyTorch/JAX/Triton-style wheel workloads because the `_rocm_sdk_core` runtime package drops unversioned rocprofiler `.so` aliases that are used by runtime `dlopen()` paths. As a result, `librocprofiler-register` cannot load `librocprofiler-sdk-attach.so` from the core runtime tree, so attach fails with "no `rocp-bg-attach` listener is created".

JIRA ID : AIPROFSDK-1027

## Technical Details

- Add a `runtime_library_aliases` option to `PopulatedDistPackage.populate_runtime_files()` so selected unversioned shared-library aliases can be materialized into runtime wheels.
- Keep the generic runtime packaging rule unchanged by default: non-SONAME aliases still stay out of runtime packages unless explicitly allowlisted.
- Pass a rocprofiler-specific alias list from `build_python_packages.py`:
  - `lib/librocprofiler-sdk.so`
  - `lib/librocprofiler-sdk-attach.so`
  - `lib/librocprofiler-sdk-rocattach.so`
  - `lib/rocprofiler-sdk/librocprofiler-sdk-tool.so`
- Add a regression test proving allowlisted aliases are materialized while normal non-allowlisted aliases continue to be deferred.

## Test Plan

Add new unit test `test_runtime_library_aliases_are_materialized_selectively` to verify that an allowlisted .so library gets materialized into the runtime package while a normal non-allowlisted libraries continues to behave exactly as before.

## Test Result

New unit test passes in CI.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
