### PR TITLE
feat(ci): add lock_test_labels input to prevent PR labels from extending test scope

### DIFF
--- a/.github/workflows/setup_multi_arch.yml
+++ b/.github/workflows/setup_multi_arch.yml
@@ -73,6 +73,12 @@ on:
         description: "Build JAX wheels."
         type: boolean
         default: false
+      lock_test_labels:
+        description: >-
+          Treat the caller's test labels as the complete test scope: PR 'test:*'
+          labels are ignored instead of extending the matrix.
+        type: boolean
+        default: false
       python_version:
         description: "Single Python version for wheel builds; empty uses the default matrix."
         type: string
@@ -197,6 +203,7 @@ jobs:
           BUILD_PYTHON_PACKAGES: ${{ inputs.build_python_packages }}
           BUILD_PYTORCH: ${{ inputs.build_pytorch }}
           BUILD_JAX: ${{ inputs.build_jax }}
+          LOCK_TEST_LABELS: ${{ inputs.lock_test_labels }}
           PYTHON_VERSION: ${{ inputs.python_version }}
           LINUX_AMDGPU_FAMILIES: ${{ inputs.linux_amdgpu_families }}
           WINDOWS_AMDGPU_FAMILIES: ${{ inputs.windows_amdgpu_families }}

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -147,6 +147,11 @@ class CIInputs:
     build_jax: bool = False
     python_versions: list[str] = field(default_factory=list)
 
+    # When set, PR 'test:*' labels do not extend the caller-supplied test
+    # labels. Callers that pin an exact test scope use this so a label cannot
+    # widen the matrix beyond what the build produced.
+    lock_test_labels: bool = False
+
     # PR labels (from event payload for pull_request events)
     pr_labels: list[str] = field(default_factory=list)
 
@@ -208,6 +213,7 @@ class CIInputs:
         )
         build_pytorch = os.environ.get("BUILD_PYTORCH", "true").lower() != "false"
         build_jax = os.environ.get("BUILD_JAX", "false").lower() != "false"
+        lock_test_labels = os.environ.get("LOCK_TEST_LABELS", "false").lower() == "true"
         python_version = os.environ.get("PYTHON_VERSION", "").strip()
 
         pr_labels: list[str] = []
@@ -237,7 +243,11 @@ class CIInputs:
         # Test labels come from two sources:
         # 1. LINUX/WINDOWS_TEST_LABELS env vars (workflow_dispatch inputs)
         # 2. PR test:* labels (apply to both platforms)
+        # lock_test_labels drops source 2 so the caller's scope is authoritative.
         pr_test_labels = [label for label in pr_labels if label.startswith("test:")]
+        if lock_test_labels and pr_test_labels:
+            print(f"  lock_test_labels set: ignoring PR test labels {pr_test_labels}")
+            pr_test_labels = []
         linux_test_labels = (
             _parse_comma_list(os.environ.get("LINUX_TEST_LABELS", "")) + pr_test_labels
         )
@@ -257,6 +267,7 @@ class CIInputs:
             build_pytorch=build_pytorch,
             build_jax=build_jax,
             python_versions=[python_version] if python_version else [],
+            lock_test_labels=lock_test_labels,
             pr_labels=pr_labels,
             linux_amdgpu_families=_parse_comma_list(
                 os.environ.get("LINUX_AMDGPU_FAMILIES", "")
@@ -823,6 +834,10 @@ def _has_test_labels(ci_inputs: CIInputs) -> bool:
     ]
     if linux_tests or windows_tests:
         return True
+    if ci_inputs.lock_test_labels:
+        # PR test labels were already dropped from the caller's scope; they
+        # must not escalate test_type either.
+        return False
     return any(label.startswith("test:") for label in ci_inputs.pr_labels)
 
 

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -209,6 +209,24 @@ class TestCIInputsFromEnviron(unittest.TestCase):
         self.assertEqual(inputs.linux_test_labels, ["test:rccl", "test:rocprim"])
         self.assertEqual(inputs.windows_test_labels, ["test:rccl", "test:rocprim"])
 
+    def test_lock_test_labels_ignores_pr_test_labels(self):
+        """lock_test_labels prevents PR test:* labels from extending scope."""
+        inputs = _run_from_environ(
+            event_name="pull_request",
+            event_payload={
+                "pull_request": {
+                    "labels": [
+                        {"name": "test:rccl", "id": 1},
+                        {"name": "test:rocprim", "id": 2},
+                    ]
+                }
+            },
+            extra_env={"LOCK_TEST_LABELS": "true"},
+        )
+        # PR test labels should be dropped when lock_test_labels is set
+        self.assertEqual(inputs.linux_test_labels, [])
+        self.assertEqual(inputs.windows_test_labels, [])
+
     def test_push_reads_before_sha(self):
         """Push events use event.before as the diff base."""
         inputs = _run_from_environ(


### PR DESCRIPTION
 When a workflow caller specifies exact test labels (e.g., linux_test_labels="test:clr"),
  they expect exactly that test scope. Without lock_test_labels, PR labels like
  test:rocblas would extend the matrix to also run rocblas tests, even if the
  build didn't produce rocblas artifacts.

  Setting lock_test_labels=true:
  - Drops PR test:* labels during input parsing (with diagnostic print)
  - Prevents test_type escalation to "full" from ignored PR labels

  This is useful for narrow-scope workflows (e.g., ASAN presubmit) where the
  test scope must match the limited build output.

JIRA ID: https://github.com/ROCm/TheRock/issues/7202