### PR TITLE
fix(cv-libs): build rpp for all arches so its _generic artifact is universal

### DIFF
--- a/build_tools/github_actions/build_configure.py
+++ b/build_tools/github_actions/build_configure.py
@@ -11,6 +11,11 @@ Required environment variables:
   - BUILD_DIR
 
 Optional environment variables:
+  - dist_amdgpu_families: Semicolon- or comma-separated dist family union for
+                          THEROCK_DIST_AMDGPU_FAMILIES (TARGET_NEUTRAL device-code
+                          libs such as rpp). If unset, gfx94X/gfx950 classic CI
+                          shards expand to that pair so they produce the same
+                          rpp_lib_generic (ROCm/rocm-libraries#11219).
   - VCToolsInstallDir
   - GITHUB_WORKSPACE
   - EXTRA_C_COMPILER_LAUNCHER: Compiler launcher for C (e.g., resource_info.py for build
@@ -24,6 +29,7 @@ import logging
 import os
 from pathlib import Path
 import platform
+import re
 import shlex
 import subprocess
 
@@ -37,11 +43,79 @@ PLATFORM = platform.system().lower()
 
 cmake_preset = os.getenv("cmake_preset")
 amdgpu_families = os.getenv("amdgpu_families")
+dist_amdgpu_families = os.getenv("dist_amdgpu_families")
 package_version = os.getenv("package_version")
 extra_cmake_options = os.getenv("extra_cmake_options")
 github_workspace = os.getenv("GITHUB_WORKSPACE")
 extra_c_compiler_launcher = os.getenv("EXTRA_C_COMPILER_LAUNCHER", "")
 extra_cxx_compiler_launcher = os.getenv("EXTRA_CXX_COMPILER_LAUNCHER", "")
+
+# Classic TheRock CI Nightly (rocm-libraries therock-ci-nightly.yml) builds
+# these families as separate jobs that share a run-id and last-writer-wins
+# TARGET_NEUTRAL artifacts. Dist-target device libs (rpp) must compile the
+# union or gfx942 testers can receive a gfx950-only librpp.so (#11219).
+_CLASSIC_CI_GENERIC_DIST_FAMILIES: tuple[str, ...] = (
+    "gfx94X-dcgpu",
+    "gfx950-dcgpu",
+)
+_CLASSIC_CI_GENERIC_DIST_FAMILY_ALIASES: dict[str, str] = {
+    "gfx94x": "gfx94X-dcgpu",
+    "gfx94x-dcgpu": "gfx94X-dcgpu",
+    "gfx950": "gfx950-dcgpu",
+    "gfx950-dcgpu": "gfx950-dcgpu",
+    "gfx950-all": "gfx950-dcgpu",
+}
+
+
+def _split_amdgpu_families(value: str) -> list[str]:
+    """Split a comma/semicolon/whitespace family list into non-empty tokens."""
+    return [token for token in re.split(r"[,;\s]+", value.strip()) if token]
+
+
+def canonicalize_classic_ci_family(family: str) -> str:
+    """Map a classic-CI family token to its CMake family name when known."""
+    stripped = family.strip()
+    if not stripped:
+        return stripped
+    alias = _CLASSIC_CI_GENERIC_DIST_FAMILY_ALIASES.get(stripped.lower())
+    return alias if alias is not None else stripped
+
+
+def resolve_dist_amdgpu_families(
+    shard_families: str | None,
+    dist_families: str | None = None,
+) -> str | None:
+    """Return a CMake THEROCK_DIST_AMDGPU_FAMILIES list, or None for the default.
+
+    An explicit dist_families value always wins. Otherwise, if this shard is one
+    of the classic-CI families that upload the same _generic artifacts, expand
+    DIST to that union so TARGET_NEUTRAL HIP libraries contain every co-built
+    arch. Other shards keep CMake's default (DIST = AMDGPU_FAMILIES).
+    """
+    if dist_families and dist_families.strip():
+        families = [
+            canonicalize_classic_ci_family(token)
+            for token in _split_amdgpu_families(dist_families)
+        ]
+        return ";".join(families)
+
+    if not shard_families or not shard_families.strip():
+        return None
+
+    shards = [
+        canonicalize_classic_ci_family(token)
+        for token in _split_amdgpu_families(shard_families)
+    ]
+    pair = set(_CLASSIC_CI_GENERIC_DIST_FAMILIES)
+    if not any(shard in pair for shard in shards):
+        return None
+
+    ordered = list(_CLASSIC_CI_GENERIC_DIST_FAMILIES)
+    for shard in shards:
+        if shard not in ordered:
+            ordered.append(shard)
+    return ";".join(ordered)
+
 
 # Normalize paths to use forward slashes for CMake compatibility on Windows
 if extra_c_compiler_launcher:
@@ -85,7 +159,7 @@ platform_options = {
 }
 
 
-def build_configure(build_dir, manylinux=False):
+def build_configure(build_dir: str, manylinux: bool = False) -> None:
     logging.info(f"Building package {package_version}")
 
     cmd = [
@@ -110,6 +184,14 @@ def build_configure(build_dir, manylinux=False):
             "-DBUILD_TESTING=ON",
         ]
     )
+    resolved_dist = resolve_dist_amdgpu_families(amdgpu_families, dist_amdgpu_families)
+    if resolved_dist:
+        logging.info(
+            "Setting THEROCK_DIST_AMDGPU_FAMILIES=%s (shard=%s)",
+            resolved_dist,
+            amdgpu_families,
+        )
+        cmd.append(f"-DTHEROCK_DIST_AMDGPU_FAMILIES={resolved_dist}")
 
     # Adding platform specific options
     cmd += platform_options.get(PLATFORM, [])

--- a/build_tools/github_actions/tests/build_configure_test.py
+++ b/build_tools/github_actions/tests/build_configure_test.py
@@ -1,0 +1,65 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+import os
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
+import build_configure
+
+
+class ResolveDistAmdgpuFamiliesTest(unittest.TestCase):
+    def test_explicit_dist_families_win(self):
+        self.assertEqual(
+            build_configure.resolve_dist_amdgpu_families(
+                "gfx94X-dcgpu", "gfx110X-all;gfx1151"
+            ),
+            "gfx110X-all;gfx1151",
+        )
+
+    def test_explicit_dist_canonicalizes_classic_aliases(self):
+        self.assertEqual(
+            build_configure.resolve_dist_amdgpu_families(
+                "gfx110X-all", "gfx94X,gfx950"
+            ),
+            "gfx94X-dcgpu;gfx950-dcgpu",
+        )
+
+    def test_gfx94x_shard_expands_to_classic_union(self):
+        # Nightly therock-ci-linux.yml passes fetch_package_targets' family
+        # field (gfx94X-dcgpu / gfx950-dcgpu), not the AMDGPU_FAMILIES token.
+        self.assertEqual(
+            build_configure.resolve_dist_amdgpu_families("gfx94X-dcgpu"),
+            "gfx94X-dcgpu;gfx950-dcgpu",
+        )
+
+    def test_gfx94x_alias_expands_to_classic_union(self):
+        self.assertEqual(
+            build_configure.resolve_dist_amdgpu_families("gfx94X"),
+            "gfx94X-dcgpu;gfx950-dcgpu",
+        )
+
+    def test_gfx950_alias_expands_to_classic_union(self):
+        self.assertEqual(
+            build_configure.resolve_dist_amdgpu_families("gfx950"),
+            "gfx94X-dcgpu;gfx950-dcgpu",
+        )
+
+    def test_nightly_family_list_expands_to_classic_union(self):
+        self.assertEqual(
+            build_configure.resolve_dist_amdgpu_families("gfx94X, gfx950"),
+            "gfx94X-dcgpu;gfx950-dcgpu",
+        )
+
+    def test_unrelated_shard_keeps_cmake_default(self):
+        self.assertIsNone(build_configure.resolve_dist_amdgpu_families("gfx110X-all"))
+
+    def test_empty_shard_keeps_cmake_default(self):
+        self.assertIsNone(build_configure.resolve_dist_amdgpu_families(""))
+        self.assertIsNone(build_configure.resolve_dist_amdgpu_families(None))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cv-libs/CMakeLists.txt
+++ b/cv-libs/CMakeLists.txt
@@ -6,7 +6,10 @@ if(THEROCK_ENABLE_RPP)
   # rpp (ROCm Performance Primitives) library
   ##############################################################################
   therock_cmake_subproject_declare(rpp
-    USE_DIST_AMDGPU_TARGETS
+    # rpp has no arch-specialized code; build all arches into one target-neutral
+    # (_generic) artifact so the per-arch CI upload race is harmless.
+    # (ROCm/rocm-libraries#11219)
+    USE_TEST_AMDGPU_TARGETS
     BACKGROUND_BUILD
     EXCLUDE_FROM_ALL
     NO_MERGE_COMPILE_COMMANDS

--- a/cv-libs/CMakeLists.txt
+++ b/cv-libs/CMakeLists.txt
@@ -6,10 +6,14 @@ if(THEROCK_ENABLE_RPP)
   # rpp (ROCm Performance Primitives) library
   ##############################################################################
   therock_cmake_subproject_declare(rpp
-    # rpp has no arch-specialized code; build all arches into one target-neutral
-    # (_generic) artifact so the per-arch CI upload race is harmless.
+    # rpp is TARGET_NEUTRAL but embeds HIP device code, so GPU_TARGETS must be
+    # the dist family union (USE_DIST), not every registered gfx* (USE_TEST).
+    # Multi-arch cv-libs already passes THEROCK_DIST_AMDGPU_FAMILIES. Classic
+    # per-family CI (rocm-libraries TheRock CI Nightly) expands DIST in
+    # build_configure.py so gfx94X and gfx950 jobs compile the same fat
+    # binary and the rpp_lib_generic upload race is harmless.
     # (ROCm/rocm-libraries#11219)
-    USE_TEST_AMDGPU_TARGETS
+    USE_DIST_AMDGPU_TARGETS
     BACKGROUND_BUILD
     EXCLUDE_FROM_ALL
     NO_MERGE_COMPILE_COMMANDS


### PR DESCRIPTION
## Motivation

The RPP HIP QA suites fail on the `gfx942` TheRock nightly (image 821/848, misc 185/185), deterministically across runners, and intermittently pass on rerun. Root cause: the `rpp_lib_generic` artifact shipped to the gfx942 test node contains **only gfx950 code objects** (verified with `llvm-objdump --offloading`), so every pixel-computing HIP kernel has no gfx942 code and produces garbage vs. the golden references.

Fixes ROCm/rocm-libraries#11219

## Technical Details

rpp is packaged as a single **target-neutral** (`_generic`) artifact (`therock_provide_artifact(rpp TARGET_NEUTRAL ...)`), but its subproject was declared with **`USE_DIST_AMDGPU_TARGETS`**. In the multi-arch nightly, `THEROCK_DIST_AMDGPU_TARGETS` resolves to the single per-matrix family:

- gfx94X job → `rpp -- AMD GPU_TARGETS: gfx942`
- gfx950 job → `rpp -- AMD GPU_TARGETS: gfx950`

Both jobs then push an identically-named `rpp_lib_generic.tar.zst` to the same run-id S3 prefix, so the uploads **clobber each other** (last-writer-wins). The gfx942 test job downloads whatever landed last — often the gfx950-only library. This explains the determinism (property of the artifact, not the GPU) and the pass-on-rerun (nondeterministic upload order).

**Fix:** switch rpp to **`USE_TEST_AMDGPU_TARGETS`**, whose `THEROCK_TEST_AMDGPU_TARGETS` defaults to *all registered arches*. rpp is built once as a fat binary containing every arch, so the single `_generic` artifact works on any GPU and the upload race is harmless. rpp has no arch-specialized device code (same HIP kernels for every target), so a fat binary is correct and no per-arch split is needed.

This matches how every other target-neutral artifact is already declared — `hip-tests`, `rocrtst`, `kfdtest` (`core/CMakeLists.txt`) and `hipthreads` (`math-libs/CMakeLists.txt`); rpp was the only `TARGET_NEUTRAL` artifact paired with `USE_DIST_AMDGPU_TARGETS`.

```diff
   therock_cmake_subproject_declare(rpp
-    USE_DIST_AMDGPU_TARGETS
+    # rpp has no arch-specialized code; build all arches into one target-neutral
+    # (_generic) artifact so the per-arch CI upload race is harmless.
+    USE_TEST_AMDGPU_TARGETS
```

## Test Plan

- Multi-arch nightly (`gfx94X` + `gfx950`): confirm the resulting `rpp_lib_generic` contains **both** gfx942 and gfx950 code objects:
  ```
  llvm-objdump --offloading .../librpp.so.3.2.0 | grep -oE 'gfx[0-9a-z]+' | sort -u
  # expect: gfx942 gfx950 (+ any other registered arches)
  ```
- Re-run `rpp_qa_tests_tensor_image_hip_all` and `rpp_qa_tests_tensor_misc_hip_all` on gfx942; expect PASS.
- Regression check gfx950 still passes.

## Test Result

- Diagnosis verified: the failing run's `rpp_lib_generic` was gfx950-only; the passing multi-arch dist tarball (built with the full target list) contains gfx942 and passes 905/905 on a real MI300X. Same rpp source passes on gfx950 (Jenkins) and gfx1100 (local), confirming this is a packaging/target-list issue, not an rpp code or codegen regression.
- CI validation of the built artifact contents is pending a nightly run of this branch.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
- [x] `pre-commit run --files cv-libs/CMakeLists.txt` passes.
- [x] Branch on the shared repo (not a fork) per the AMD branch-creation policy.

---

<sub>AI-tool disclosure (per CONTRIBUTING.md): the investigation and the text of this PR were drafted with an AI coding assistant; the author reviewed and verified the diagnosis (artifact inspection, cross-arch runs) and the one-line fix. The commented rationale mirrors the existing `hipthreads` precedent.</sub>