### PR TITLE
fix(ci):add `asan-debug` and `host-asan-debug` build variants to ASAN-capable GPU families

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -238,7 +238,7 @@ amdgpu_family_info_matrix_presubmit = {
             # Individual GPU target(s) on the test runner, for fetching split artifacts.
             # TODO(#3444): ASAN variants may need xnack suffix expansion (e.g. gfx942:xnack+).
             "fetch-gfx-targets": ["gfx942"],
-            "build_variants": ["release", "asan", "host-asan", "tsan"],
+            "build_variants": ["release", "asan", "asan-debug", "host-asan", "host-asan-debug", "tsan"],
         }
     },
     "gfx110x": {
@@ -326,7 +326,7 @@ amdgpu_family_info_matrix_postsubmit = {
             "test-runs-on-multi-gpu": "linux-gfx950-8gpu-ccs-ossci-rocm",
             "family": "gfx950-dcgpu",
             "fetch-gfx-targets": ["gfx950"],
-            "build_variants": ["release", "asan", "tsan"],
+            "build_variants": ["release", "asan", "asan-debug", "tsan"],
             # Only run tests on submodule bumps (builds always run)
             "submodule_bump_tests_only": True,
         }

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -238,7 +238,14 @@ amdgpu_family_info_matrix_presubmit = {
             # Individual GPU target(s) on the test runner, for fetching split artifacts.
             # TODO(#3444): ASAN variants may need xnack suffix expansion (e.g. gfx942:xnack+).
             "fetch-gfx-targets": ["gfx942"],
-            "build_variants": ["release", "asan", "asan-debug", "host-asan", "host-asan-debug", "tsan"],
+            "build_variants": [
+                "release",
+                "asan",
+                "asan-debug",
+                "host-asan",
+                "host-asan-debug",
+                "tsan"
+            ],
         }
     },
     "gfx110x": {

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -244,7 +244,7 @@ amdgpu_family_info_matrix_presubmit = {
                 "asan-debug",
                 "host-asan",
                 "host-asan-debug",
-                "tsan"
+                "tsan",
             ],
         }
     },


### PR DESCRIPTION
## Motivation
- Add `asan-debug` and `host-asan-debug` to the `build_variants` list for `gfx94X-dcgpu` and `gfx950-dcgpu` in `amdgpu_family_matrix.py`

ISSUE ID : https://github.com/ROCm/TheRock/issues/7614

## Context
 Commit a30607a introduced two new CMake presets (`linux-release-asan-debug`, `linux-release-host-asan-debug`) and registered `asan-debug`/`host-asan-debug`  as valid entries in `all_build_variants`. It also switched the rockrel nightly ASAN workflow to use `build_variant: asan-debug`.
However, the per-family `build_variants` lists were not updated, so `configure_multi_arch_ci.py` logged "does not support variant asan-debug on linux, skipping" for every GPU family, producing an empty `linux_build_config` and causing all Linux jobs in the nightly ASAN workflow to be skipped.

## Test plan  
- [ ] Verify rockrel nightly ASAN workflow (`Multi-Arch Release ASAN`) no longer skips Linux jobs
  - Test run: https://github.com/ROCm/rockrel/actions/runs/32835632531 --> **Inprogress**

## Submission Checklist
- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
