### PR TITLE
ci(rocgdb): mark rocgdb-gpu and rocgdb-corefile as expected failures

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -398,6 +398,7 @@ test_matrix = {
     "rocgdb-gpu": {
         **_rocgdb_common,
         "job_name": "rocgdb-gpu",
+        "expect_failure": True,
         "test_script": "python ./build/tests/rocgdb/test_rocgdb.py --parallel -f 0.25 --toolchain llvm --tests gdb.rocm",
     },
     # Corefile tests require specific hardware support (GPU core dump capable runners).
@@ -407,6 +408,7 @@ test_matrix = {
     "rocgdb-corefile": {
         **_rocgdb_common,
         "job_name": "rocgdb-corefile",
+        "expect_failure": True,
         "test_script": (
             "python ./build/tests/rocgdb/test_rocgdb.py --parallel -f 0.25 --toolchain llvm --tests"
             " gdb.rocm/corefile.exp"


### PR DESCRIPTION
## Summary

- Adds `expect_failure: True` to `rocgdb-gpu` and `rocgdb-corefile` in `fetch_test_configurations.py`.
- An unexpected compiler bump has caused these tests to fail consistently, blocking PRs. This makes them non-blocking while keeping results visible in CI.
- Uses the existing `expect_failure` mechanism already wired in `test_component.yml` (job gets an `(xfail)` label in the UI and `continue-on-error` is set).

ISSUE ID: https://github.com/ROCm/TheRock/issues/7626

**These should be restored to blocking as soon as the underlying compiler/debug-tools issue is resolved.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)