### PR TITLE
fix: grammar error in setuptools dependency comment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ python-magic>=0.4.27; platform_system != "Windows"
 PyYAML==6.0.2
 pyzstd>=0.16.0
 # `pkg_resources` has been removed from Setuptools in version 82.0.0
-# but it still a dependency in some environments (issue#3311)
+# but it is still a dependency in some environments (issue#3311)
 setuptools>=80.9.0,<82.0.0
 tomli==2.2.1; python_version <= '3.10'
 pytest-cmake==0.13.0


### PR DESCRIPTION
This PR addresses the following issue in `requirements.txt`: grammar error in setuptools dependency comment.

## Changes
- `requirements.txt`: grammar error in setuptools dependency comment.

## Details
```diff
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-# `pkg_resources` has been removed from Setuptools in version 82.0.0
-# but it still a dependency in some environments (issue#3311)
+# `pkg_resources` has been removed from Setuptools in version 82.0.0
+# but it is still a dependency in some environments (issue#3311)
```

## Tests

> Let me know if you want tests added for this fix or not.