### PR TITLE
fix: Anonymize tar member ownership/mode when repacking rocm sdist

### DIFF
--- a/build_tools/packaging/promote_packages.py
+++ b/build_tools/packaging/promote_packages.py
@@ -958,6 +958,28 @@ def promote_wheel(
     return True
 
 
+def _anonymize_tarinfo(tarinfo: tarfile.TarInfo) -> tarfile.TarInfo:
+    """Strip local-machine identity from a tar member before it is (re-)written.
+
+    `tarfile.TarFile.add()` otherwise stamps each member with whatever
+    uid/gid/uname/gname/mode `os.lstat()` reports for the extracted-to-disk
+    file, i.e. the account (or CI container) that happened to run the
+    promotion, plus its umask. That's not part of the package's actual
+    contents and shouldn't leak into a published release artifact.
+    """
+    if tarinfo.isdir():
+        mode = 0o755
+    elif tarinfo.issym():
+        mode = tarinfo.mode
+    else:
+        mode = 0o755 if tarinfo.mode & 0o111 else 0o644
+    # deep=False: a deep copy would try to pickle-clone whatever internal
+    # references tarfile attaches to TarInfo during traversal (e.g. a handle
+    # back to the open TarFile), which isn't copyable. We only need to
+    # override these top-level scalar fields, so a shallow copy suffices.
+    return tarinfo.replace(uid=0, gid=0, uname="", gname="", mode=mode, deep=False)
+
+
 def promote_targz_sdist(
     filename: pathlib.Path,
     src_version_type: str,
@@ -1039,7 +1061,11 @@ def promote_targz_sdist(
         print(f" {new_archive_name}", end="")
 
         with tarfile.open(f"{base_dir}/{new_archive_name}.tar.gz", "w|gz") as tar:
-            tar.add(tmp_path / f"{new_archive_name}", arcname=new_archive_name)
+            tar.add(
+                tmp_path / f"{new_archive_name}",
+                arcname=new_archive_name,
+                filter=_anonymize_tarinfo,
+            )
 
         print(" ...done")
         print(

--- a/build_tools/packaging/tests/promote_packages_test.py
+++ b/build_tools/packaging/tests/promote_packages_test.py
@@ -52,6 +52,8 @@ import argparse
 import shutil
 import sys
 import os
+import tarfile
+import unittest
 from pathlib import Path
 import tempfile
 from packaging.version import Version
@@ -404,6 +406,90 @@ def getWindowsPackagesLinks() -> tuple[list[tuple[str, str]], Version, Version]:
     )
 
     return url_and_packages, version, expected_version
+
+
+SDIST_OWNERSHIP_PKG_INFO_BODY = """\
+Metadata-Version: 2.1
+Name: rocm
+Version: 7.14.0rc1
+"""
+
+
+def _make_sdist_ownership_source(path: Path) -> None:
+    """Write a synthetic rocm-7.14.0rc1.tar.gz with non-default owner/mode.
+
+    Used by PromoteSdistOwnershipTest below to simulate the tar-member
+    ownership leak reported against promote_targz_sdist() without needing to
+    download a real RC package.
+    """
+    with tempfile.TemporaryDirectory() as staging:
+        root = Path(staging) / "rocm-7.14.0rc1"
+        root.mkdir()
+        (root / "PKG-INFO").write_text(SDIST_OWNERSHIP_PKG_INFO_BODY)
+        (root / "MANIFEST.in").write_text("")
+
+        # promote_targz_sdist() unconditionally rewrites these files in place
+        # to bump the embedded version string, so the fixture must contain them.
+        egg_info = root / "src" / "rocm.egg-info"
+        egg_info.mkdir(parents=True)
+        (egg_info / "requires.txt").write_text("")
+        (egg_info / "PKG-INFO").write_text(SDIST_OWNERSHIP_PKG_INFO_BODY)
+
+        rocm_sdk = root / "src" / "rocm_sdk"
+        rocm_sdk.mkdir(parents=True)
+        (rocm_sdk / "_dist_info.py").write_text("")
+
+        def foreign_owner(tarinfo: tarfile.TarInfo) -> tarfile.TarInfo:
+            # Simulate the observed leak: a real (non-root) account, and
+            # permissive modes (as if extracted under an unrestrictive umask).
+            tarinfo.uid = 1000
+            tarinfo.gid = 1000
+            tarinfo.uname = "arravikum"
+            tarinfo.gname = "arravikum"
+            tarinfo.mode = 0o777 if tarinfo.isdir() else 0o666
+            return tarinfo
+
+        with tarfile.open(path, "w:gz") as tar:
+            tar.add(root, arcname="rocm-7.14.0rc1", filter=foreign_owner)
+
+
+class PromoteSdistOwnershipTest(unittest.TestCase):
+    """Runs without network access and completes in well under a second.
+
+    Unlike the rest of this file (a standalone script invoked directly, see
+    `if __name__ == "__main__"` below), this is a plain unittest.TestCase so
+    it can be picked up by `python -m unittest promote_packages_test`
+    alongside the other lightweight tests in this directory.
+    """
+
+    def test_promoted_sdist_has_no_local_identity_or_permissive_modes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base_dir = Path(tmp)
+            source = base_dir / "rocm-7.14.0rc1.tar.gz"
+            _make_sdist_ownership_source(source)
+
+            self.assertTrue(
+                promote_packages.promote_targz_sdist(source, src_version_type="rc")
+            )
+
+            promoted = base_dir / "rocm-7.14.0.tar.gz"
+            self.assertTrue(promoted.exists())
+
+            with tarfile.open(promoted) as tar:
+                members = tar.getmembers()
+
+            self.assertGreater(len(members), 0)
+            for member in members:
+                self.assertEqual(member.uid, 0)
+                self.assertEqual(member.gid, 0)
+                self.assertEqual(member.uname, "")
+                self.assertEqual(member.gname, "")
+                self.assertNotEqual(member.uid, os.getuid())
+                if member.isdir():
+                    self.assertEqual(member.mode, 0o755)
+                elif member.isreg():
+                    self.assertIn(member.mode, (0o644, 0o755))
+                    self.assertFalse(member.mode & 0o022)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
  ## Motivation

  Issue : #7631

  `promote_targz_sdist()` re-tars the `rocm-<version>.tar.gz` sdist after
  rewriting its embedded version string. `tarfile.TarFile.add()` stamps each
  member with whatever uid/gid/uname/gname/mode `os.lstat()` reports for the
  extracted-to-disk files — i.e. the local account (or CI container) that
  happened to run the promotion, plus its umask. That's not part of the
  package's actual contents and shouldn't end up in a published release
  artifact.

  ## Technical Details
  Add an `_anonymize_tarinfo()` filter callback passed to `tar.add()` in
  `promote_targz_sdist()` (`build_tools/packaging/promote_packages.py`). For
  every member it forces `uid=0`, `gid=0`, `uname=""`, `gname=""`, and a 
  deterministic mode (`0o755` for directories, `0o755`/`0o644` for files based
  on the existing executable bit, unchanged for symlinks).

  ## Test Plan
  
  Added `PromoteSdistOwnershipTest` to the existing
  `build_tools/packaging/tests/promote_packages_test.py` as a
  `unittest.TestCase`, runnable via `python -m unittest promote_packages_test`
  alongside the file's other lightweight tests, without touching its existing
  network-dependent standalone-script behavior. It builds a synthetic sdist
  with a foreign uid/gid/uname/gname and permissive modes, runs
  `promote_targz_sdist()` on it, and asserts every member in the resulting
  archive is normalized.
  
  ## Test Result
  
  `python -m unittest promote_packages_test` passes, including the new
  `PromoteSdistOwnershipTest`.