### PR TITLE
[bkc] Set base-date in version.json to 20260825

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "rocm-version": "10.1.0",
   "release-metadata": {
-    "base-date": ""
+    "base-date": "20260825"
   }
 }


### PR DESCRIPTION
## Motivation

We've cut the next BKC release branch, so this sets up the version.

* Related to https://github.com/ROCm/rockrel/issues/88
* See also https://github.com/ROCm/TheRock/pull/7462

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
