### PR TITLE
core: gate amdsmi WSL backend on THEROCK_ENABLE_WSL_ROCDXG

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -70,7 +70,9 @@ if(THEROCK_ENABLE_CORE_AMDSMI)
       CMAKE_ARGS
         "-DCMAKE_VERBOSE_MAKEFILE=OFF"
         "-DBUILD_TESTS=${THEROCK_BUILD_TESTING}"
-        "-DENABLE_WSL_BACKEND=ON"
+        # The backend dlopens librocdxg.so, which only exists when the
+        # wsl-rocdxg subproject is built.
+        "-DENABLE_WSL_BACKEND=${THEROCK_ENABLE_WSL_ROCDXG}"
       BUILD_DEPS
         therock-googletest
       RUNTIME_DEPS

--- a/docs/development/wsl_rocdxg.md
+++ b/docs/development/wsl_rocdxg.md
@@ -39,7 +39,9 @@ target-neutral artifact from the `rocm-systems` source set.
 The relevant feature controls are:
 
 - `THEROCK_ENABLE_WSL`: enables the WSL feature group.
-- `THEROCK_ENABLE_WSL_ROCDXG`: enables the ROCDXG component.
+- `THEROCK_ENABLE_WSL_ROCDXG`: enables the ROCDXG component. This also builds
+  amdsmi with `ENABLE_WSL_BACKEND=ON`, since that backend dlopens the
+  `librocdxg.so` produced here.
 
 The `wsl-rocdxg` artifact group depends on `base`, and the artifact depends on
 `core-hip`. This lets the WSL stage bootstrap from the same inbound Linux


### PR DESCRIPTION
## Summary

Follow-up to #7102, which added `-DENABLE_WSL_BACKEND=ON` to the `amdsmi` subproject unconditionally.

TheRock already has a switch for this component, `THEROCK_ENABLE_WSL_ROCDXG` (feature group `WSL`, off in default/CI builds). With the backend forced on, the two disagree:

- Default builds ship an amdsmi WSL backend that `dlopen`s `librocdxg.so`, while the `wsl-rocdxg` subproject that produces that library is not built. The `dlopen` just fails at runtime, so nothing breaks, but the code is dead weight in every default build.
- `ENABLE_WSL_BACKEND=ON` is not dependency-free on the amdsmi side. It has a `FATAL_ERROR` gate requiring `rocr-runtime/libhsakmt/include/hsakmt/rocdxg_smi.h`, resolved through a hardcoded sibling path. That works today only because `rocm-systems` is checked out whole, and it is a build-time dependency default builds should not take on.

This makes the amdsmi flag follow TheRock's existing switch, matching the `-DBUILD_TESTS=${THEROCK_BUILD_TESTING}` pattern on the adjacent line. Turning on `THEROCK_ENABLE_WSL_ROCDXG` now builds both the bridge library and the amdsmi backend that consumes it.

## JIRA ID

ROCM-28065

## Test plan

Verified `THEROCK_ENABLE_WSL_ROCDXG` is a `CACHE BOOL` created by `therock_add_feature`, and that `therock_finalize_features()` (top-level `CMakeLists.txt:277`) runs well before `add_subdirectory(core)` (`CMakeLists.txt:503`), so the variable is in scope at the point of use.

Substitution checked for every state:

| `THEROCK_ENABLE_WSL_ROCDXG` | Emitted argument |
|---|---|
| `OFF` | `-DENABLE_WSL_BACKEND=OFF` |
| `ON` | `-DENABLE_WSL_BACKEND=ON` |
| undefined | `-DENABLE_WSL_BACKEND=` (falsey; amdsmi's `option(... OFF)` default preserved, no error) |

- [x] Default Linux build no longer compiles the WSL backend (restores pre-#7102 artifact content)
- [x] `THEROCK_ENABLE_WSL_ROCDXG=ON` propagates `ENABLE_WSL_BACKEND=ON` to amdsmi
- [x] Windows unaffected (change stays inside the existing `if(NOT WIN32)` guard)
- [x] `pre-commit run --files core/CMakeLists.txt docs/development/wsl_rocdxg.md` passes

For reference, in run 32498518713 the `compiler-runtime` stage built amdsmi with the backend on and `core-amdsmi_lib_generic` grew from 29,896,091 to 30,051,269 bytes (+151 KB) versus `main`. That delta is what default builds stop carrying with this change.