### PR TITLE
ci: expose multi-arch package toggles

### DIFF
--- a/.github/workflows/multi_arch_ci.yml
+++ b/.github/workflows/multi_arch_ci.yml
@@ -65,6 +65,10 @@ on:
         type: string
         default: ""
         description: "Comma-separated list of changed projects to filter tests (empty = run all tests)"
+      build_python_packages:
+        type: boolean
+        default: true
+        description: "Build ROCm Python packages"
       build_pytorch:
         type: boolean
         default: true
@@ -73,6 +77,10 @@ on:
         type: boolean
         default: true
         description: "Build JAX wheels"
+      build_native_linux:
+        type: boolean
+        default: true
+        description: "Build native Linux packages and run install tests"
   pull_request:
     types:
       - labeled
@@ -109,8 +117,10 @@ jobs:
       stage_reuse_mode: ${{ inputs.stage_reuse_mode || 'dry-run' }}
       stage_reuse_max_age_hours: ${{ inputs.stage_reuse_max_age_hours || '72' }}
       stage_reuse_commit_history: ${{ inputs.stage_reuse_commit_history || '50' }}
+      build_python_packages: ${{ github.event_name != 'workflow_dispatch' || inputs.build_python_packages }}
       build_pytorch: ${{ github.event_name != 'workflow_dispatch' || inputs.build_pytorch }}
       build_jax: ${{ github.event_name != 'workflow_dispatch' || inputs.build_jax }}
+      build_native_linux: ${{ github.event_name != 'workflow_dispatch' || inputs.build_native_linux }}
     secrets: inherit
 
   linux_build_and_test:


### PR DESCRIPTION
## Motivation

Expose existing multi-arch setup controls from the top-level Multi-Arch CI workflow so manual runs and downstream callers can reduce package-related build/test coverage while keeping the core multi-arch artifact pipeline intact. This will be leveraged for initial support of multi-arch CI on repos such as `ROCm/rocm-systems` and `ROCm/rocm-libraries`.

GitHub issue: #3343

## Technical Details

Adds `workflow_dispatch` inputs to `.github/workflows/multi_arch_ci.yml` for:

- `build_python_packages`
- `build_native_linux`

These are passed through to `setup_multi_arch.yml` using the same pattern already used for `build_pytorch` and `build_jax`.

## Test Plan

Validated that `.github/workflows/multi_arch_ci.yml` parses as YAML and checked the resulting diff.

## Test Result

- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/multi_arch_ci.yml').read_text()); print('YAML parsed')"` passed.
- `git diff --check origin/main...HEAD` passed.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.