### PR TITLE
feat: add baseline reuse diagnostics

### DIFF
--- a/build_tools/github_actions/baseline_runs.py
+++ b/build_tools/github_actions/baseline_runs.py
@@ -25,6 +25,7 @@ from datetime import datetime, timezone
 import logging
 from pathlib import Path
 import sys
+import time
 from urllib.parse import urlencode, quote
 
 logger = logging.getLogger(__name__)
@@ -771,6 +772,16 @@ def select_baseline_run(
 
     for workflow_run in candidates[:max_runs]:
         run_id = str(workflow_run["id"])
+        candidate_start = time.monotonic()
+
+        logger.info(
+            "[BASELINE] checking candidate: platform=%s run_id=%s head_sha=%s branch=%s",
+            platform,
+            run_id,
+            workflow_run.get("head_sha"),
+            workflow_run.get("head_branch"),
+        )
+
         if run_id in excluded:
             continue
         if not is_completed_workflow_run(workflow_run):
@@ -817,8 +828,23 @@ def select_baseline_run(
                 )
                 continue
 
+        job_lookup_start = time.monotonic()
+
+        workflow_jobs = workflow_jobs_fetcher(
+            workflow_run,
+            github_repository,
+        )
+
+        logger.info(
+            "[BASELINE] candidate run_id=%s platform=%s fetched %d jobs in %.2fs",
+            run_id,
+            platform,
+            len(workflow_jobs),
+            time.monotonic() - job_lookup_start,
+        )
+
         job_health = validate_required_jobs_successful(
-            workflow_jobs=workflow_jobs_fetcher(workflow_run, github_repository),
+            workflow_jobs=workflow_jobs,
             required_name_substrings=required_jobs,
         )
         if not job_health.is_valid:
@@ -831,16 +857,37 @@ def select_baseline_run(
             )
             continue
 
+        artifact_lookup_start = time.monotonic()
+
         backend = backend_factory(workflow_run, github_repository, platform)
+
         availability = validate_required_artifacts_available(
             backend=backend,
             required_artifacts=requirements,
         )
+
+        artifact_lookup_seconds = time.monotonic() - artifact_lookup_start
+
+        logger.info(
+            "[BASELINE] candidate run_id=%s platform=%s artifact_lookup=%.2fs",
+            run_id,
+            platform,
+            artifact_lookup_seconds,
+        )
+
         if not availability.is_valid:
+            missing_families = sorted(
+                {artifact.target_family for artifact in availability.missing_artifacts}
+            )
             logger.info(
-                "Skipping run %s: missing artifacts %s",
+                "[BASELINE] rejecting candidate: platform=%s run_id=%s "
+                "missing_artifact_pairs=%d/%d missing_families=%s total=%.2fs",
+                platform,
                 run_id,
-                availability.missing_artifacts,
+                len(availability.missing_artifacts),
+                len(availability.required_artifacts),
+                missing_families,
+                time.monotonic() - candidate_start,
             )
             continue
 
@@ -848,6 +895,15 @@ def select_baseline_run(
             workflow_run,
             github_repository=github_repository,
             workflow_name=workflow_name,
+        )
+
+        logger.info(
+            "[BASELINE] selected candidate: platform=%s run_id=%s "
+            "required_artifact_pairs=%d total=%.2fs",
+            platform,
+            run_id,
+            len(availability.required_artifacts),
+            time.monotonic() - candidate_start,
         )
 
         return BaselineRun(

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -47,6 +47,7 @@ Outputs (written to GITHUB_OUTPUT):
 
 import enum
 import json
+import logging
 import os
 import sys
 from dataclasses import asdict, dataclass, field, fields, replace
@@ -1449,6 +1450,10 @@ def configure(ci_inputs: CIInputs, git_context: GitContext) -> CIOutputs:
 
 
 def main():
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(message)s",
+    )
     ci_inputs = CIInputs.from_environ()
 
     # Check if this is an external repo build (e.g., rocm-libraries calling TheRock workflows)

--- a/build_tools/github_actions/stage_reuse_decision.py
+++ b/build_tools/github_actions/stage_reuse_decision.py
@@ -275,6 +275,15 @@ def compute_auto_stage_reuse(
     Windows. The report lines are logged before returning.
     """
     platforms = _build_platforms(linux_amdgpu_families, windows_amdgpu_families)
+
+    logger.info(
+        "%s requested platforms=%s linux_families=%s windows_families=%s",
+        LOG_PREFIX,
+        list(platforms),
+        list(linux_amdgpu_families),
+        list(windows_amdgpu_families),
+    )
+
     if not platforms:
         return _log_and_return(
             _empty_result(
@@ -361,6 +370,16 @@ def compute_auto_stage_reuse(
             platform_families,
         )
 
+        logger.info(
+            "%s baseline lookup start: platform=%s required_families=%s "
+            "candidate_stages=%s required_artifact_pairs=%d",
+            LOG_PREFIX,
+            platform,
+            list(platform_families),
+            list(candidates),
+            len(required),
+        )
+
         if baseline_selector is not None:
             selector = baseline_selector
         elif baseline_selector_factory is not None:
@@ -377,6 +396,13 @@ def compute_auto_stage_reuse(
         except GitHubAPIError as exc:
             baseline_error = str(exc)
             baseline = None
+
+        logger.info(
+            "%s baseline lookup result: platform=%s run_id=%s",
+            LOG_PREFIX,
+            platform,
+            baseline.run_id if baseline is not None else "none",
+        )
 
         platform_baseline_run_ids[platform] = (
             baseline.run_id if baseline is not None else None


### PR DESCRIPTION
## Summary

Add diagnostic logging around automatic stage-reuse baseline selection.

This adds visibility into:

- requested platforms and GPU families
- required artifact/family pairs per platform
- each baseline candidate being checked
- workflow job lookup time
- artifact lookup time
- missing GPU families when a candidate is rejected
- the baseline ultimately selected for each platform

Also enables `INFO` logging in `configure_multi_arch_ci.py` so these diagnostics are visible in the Configure CI logs.

## Motivation

Baseline selection can inspect multiple recent workflow runs and take several minutes, but the existing logs do not provide enough information to understand why a candidate was rejected or where the lookup time is being spent.

These diagnostics will help identify cases such as mismatched requested GPU families, missing baseline artifacts, or expensive GitHub API/artifact lookups.