### PR TITLE
fix(dockerfiles): follow the nightly repo move to nightly.repo.amd.com

### DIFF
--- a/dockerfiles/install_rocm_packages.sh
+++ b/dockerfiles/install_rocm_packages.sh
@@ -16,8 +16,8 @@
 #   VERSION          - Full version string (e.g., 7.13.0a20260322, 7.11.0)
 #   AMDGPU_FAMILY    - AMD GPU family (e.g., gfx110x, gfx94x, gfx110X-all)
 #                      Special value: 'multi-arch' installs the meta-package from
-#                      AMD's packages-multi-arch repository, which supports all
-#                      GPU families in a single image.
+#                      AMD's multi-arch repository, which supports all GPU
+#                      families in a single image.
 #   RELEASE_TYPE     - Release type: nightlies (default), prereleases, stable
 #
 # Examples:
@@ -35,12 +35,18 @@ AMDGPU_FAMILY="${2:?Error: AMDGPU_FAMILY is required}"
 RELEASE_TYPE="${3:-nightlies}"
 
 # Multi-arch mode: AMDGPU_FAMILY=multi-arch picks the meta-package that supports
-# all GPU families, sourced from AMD's packages-multi-arch repositories.
+# all GPU families, sourced from AMD's multi-arch repositories.
 if [ "$AMDGPU_FAMILY" = "multi-arch" ]; then
     MULTI_ARCH=1
 else
     MULTI_ARCH=0
 fi
+
+# Roots of the nightly package repositories.
+NIGHTLY_MULTI_ARCH_BASE_URL="https://nightly.repo.amd.com/rocm/core/packages"
+# Per-family nightlies are the legacy layout and were never migrated off the
+# retired host, which stopped publishing in 2026.
+NIGHTLY_PER_FAMILY_BASE_URL="https://rocm.nightlies.amd.com"
 
 # ---------------------------------------------------------------------------
 # Helper: extract MAJOR.MINOR from VERSION (e.g., 7.13.0a20260322 → 7.13)
@@ -149,8 +155,8 @@ resolve_nightly_build_dir() {
         exit 1
     fi
 
-    local listing_url="https://rocm.nightlies.amd.com/${repo_type}/"
-    [ "$multi_arch" = "1" ] && listing_url="https://rocm.nightlies.amd.com/packages-multi-arch/${repo_type}/"
+    local listing_url="${NIGHTLY_PER_FAMILY_BASE_URL}/${repo_type}/"
+    [ "$multi_arch" = "1" ] && listing_url="${NIGHTLY_MULTI_ARCH_BASE_URL}/${repo_type}/"
     echo "Searching for nightly build directory matching date ${date_str}..." >&2
 
     local build_dir
@@ -160,6 +166,8 @@ resolve_nightly_build_dir() {
     if [ -z "$build_dir" ]; then
         echo "Error: No nightly build found for date ${date_str}" >&2
         echo "Check available builds at: ${listing_url}" >&2
+        echo "Nightly runs are pruned after a few days, so an older date may" >&2
+        echo "simply have aged off." >&2
         exit 1
     fi
 
@@ -170,10 +178,6 @@ resolve_nightly_build_dir() {
 
 # ---------------------------------------------------------------------------
 # Helper: build the repo base URL
-#
-# Multi-arch repos live under a 'packages-multi-arch/' path segment that:
-#   - PREFIXES the deb/rpm dir for nightlies (single-family has no such prefix)
-#   - REPLACES the 'packages/' segment for prereleases and stable
 # ---------------------------------------------------------------------------
 build_repo_url() {
     local release_type="$1"
@@ -187,8 +191,8 @@ build_repo_url() {
 
     case "$release_type" in
         nightlies)
-            local nightly_root="https://rocm.nightlies.amd.com"
-            [ "$multi_arch" = "1" ] && nightly_root="${nightly_root}/${pkg_segment}"
+            local nightly_root="${NIGHTLY_PER_FAMILY_BASE_URL}"
+            [ "$multi_arch" = "1" ] && nightly_root="${NIGHTLY_MULTI_ARCH_BASE_URL}"
             if [ "$pkg_type" = "deb" ]; then
                 echo "${nightly_root}/deb/${nightly_build_dir}"
             else

--- a/dockerfiles/install_rocm_tarball.sh
+++ b/dockerfiles/install_rocm_tarball.sh
@@ -15,7 +15,8 @@
 #   AMDGPU_FAMILY    - AMD GPU family (e.g., gfx110X-all, gfx94X-dcgpu).
 #                      Special value: 'multi-arch' downloads AMD's bundled
 #                      tarball that contains kpack files for all GPU families
-#                      (from the tarball-multi-arch/ path).
+#                      (from the tarball-multi-arch/ path, except on the nightly
+#                      host where every tarball shares one tarball/ directory).
 #   RELEASE_TYPE     - Release type: nightlies (default), prereleases, devreleases, stable
 #
 # Examples:
@@ -35,10 +36,10 @@ RELEASE_TYPE="${3:-nightlies}"
 # URL-encode '+' as '%2B' in VERSION (required for devreleases)
 VERSION_ENCODED="${VERSION//+/%2B}"
 
-# AMDGPU_FAMILY=multi-arch selects AMD's bundled all-GPU tarball at the
-# tarball-multi-arch/ path. AMD's URL path uses "multi-arch" (with hyphen)
-# but the tarball filename slot uses "multiarch" (no hyphen) — handle both
-# conventions explicitly here.
+# AMDGPU_FAMILY=multi-arch selects AMD's bundled all-GPU tarball. The tarball
+# filename slot uses "multiarch" (no hyphen) while the directory name that
+# carries it uses "multi-arch" (with hyphen) — handle both conventions
+# explicitly here.
 if [ "$AMDGPU_FAMILY" = "multi-arch" ]; then
     TARBALL_DIR="tarball-multi-arch"
     FAMILY_SLOT="multiarch"
@@ -47,14 +48,22 @@ else
     FAMILY_SLOT="$AMDGPU_FAMILY"
 fi
 
-# Build tarball URL based on release type
+# Directory holding the tarballs, by release type:
+# - nightlies use: https://nightly.repo.amd.com/rocm/core/tarball/
 # - stable releases use: https://repo.amd.com/rocm/${TARBALL_DIR}/
 # - other releases use: https://rocm.{RELEASE_TYPE}.amd.com/${TARBALL_DIR}/
-if [ "$RELEASE_TYPE" = "stable" ]; then
-    TARBALL_URL="https://repo.amd.com/rocm/${TARBALL_DIR}/therock-dist-linux-${FAMILY_SLOT}-${VERSION_ENCODED}.tar.gz"
-else
-    TARBALL_URL="https://rocm.${RELEASE_TYPE}.amd.com/${TARBALL_DIR}/therock-dist-linux-${FAMILY_SLOT}-${VERSION_ENCODED}.tar.gz"
-fi
+case "$RELEASE_TYPE" in
+    nightlies)
+        LISTING_URL="https://nightly.repo.amd.com/rocm/core/tarball/"
+        ;;
+    stable)
+        LISTING_URL="https://repo.amd.com/rocm/${TARBALL_DIR}/"
+        ;;
+    *)
+        LISTING_URL="https://rocm.${RELEASE_TYPE}.amd.com/${TARBALL_DIR}/"
+        ;;
+esac
+TARBALL_URL="${LISTING_URL}therock-dist-linux-${FAMILY_SLOT}-${VERSION_ENCODED}.tar.gz"
 
 echo "=============================================="
 echo "ROCm Tarball Installation"
@@ -73,11 +82,6 @@ echo "Downloading tarball..."
 # If direct URL fails, try fuzzy match (supports simplified AMDGPU_FAMILY like gfx110x)
 if ! curl -fsSL -o "$TARBALL_FILE" "$TARBALL_URL" 2>/dev/null; then
     echo "Direct URL not found, searching for matching tarball..."
-    if [ "$RELEASE_TYPE" = "stable" ]; then
-        LISTING_URL="https://repo.amd.com/rocm/${TARBALL_DIR}/"
-    else
-        LISTING_URL="https://rocm.${RELEASE_TYPE}.amd.com/${TARBALL_DIR}/"
-    fi
     # Case-insensitive search for tarball matching FAMILY_SLOT and VERSION.
     # The HTML listing contains literal '+' (not URL-encoded), so use VERSION
     # with '+' escaped as '\+' for PCRE rather than VERSION_ENCODED.
@@ -126,7 +130,7 @@ echo "Created symlink: /opt/rocm -> $ROCM_INSTALL_DIR"
 
 # Verify bin and lib folder exists after extraction
 echo "Verifying installation..."
-for dir in bin clients include lib libexec share; do
+for dir in bin include lib libexec share; do
     if [ ! -d "$ROCM_INSTALL_DIR/$dir" ]; then
         echo "Error: ROCm $dir directory not found"
         exit 1


### PR DESCRIPTION
## Motivation

Nightly package installs broke for any build dated 2026-08-23 or later. The old host
(`rocm.nightlies.amd.com`) still answers but stopped publishing multi-arch nightlies at
`20260822`, so a current date could not resolve a run directory.

JIRA ID : ROCM-29976

## Technical Details
* **`dockerfiles/install_rocm_packages.sh`**:
  * Add `NIGHTLY_MULTI_ARCH_BASE_URL` and `NIGHTLY_PER_FAMILY_BASE_URL` constants, consumed
    by both `resolve_nightly_build_dir()` and `build_repo_url()` so the listing searched and
    the repo configured cannot drift apart.
  * Nightly URLs become `${base}/deb/${build_dir}` and `${base}/rpm/${build_dir}/x86_64`,
    matching `get_repo_url()` in `build_tools/packaging/linux/get_url_repo_params.py` (the
    unit-tested spec).
  * Per-family nightlies stay on the retired host — that layout was never migrated, and the
    spec above still points there.
* **`dockerfiles/install_rocm_tarball.sh`**:
  * Nightlies use `https://nightly.repo.amd.com/rocm/core/tarball/`.
  * Resolve the directory once via `case` and reuse it for the direct download and the
    fuzzy-search fallback; previously it was computed twice, so the fallback could retry a
    different host.
  * Drop `clients` from the verification loop (now `bin include lib libexec share`).
* Prereleases and stable are untouched: `rc.repo.amd.com` and `stable.repo.amd.com` are not
  serving yet.

## Test Plan

Real `docker build` runs with `dockerfiles/rocm_runtime.Dockerfile` on an x86_64 host
(Docker 28.1.1). No GPU on the host, so verification is CPU-tier — which fully covers this
change, since it only affects URL resolution and installation. Nightly `10.1.0a20260825`,
stable baseline `7.13.0`.
| # | Method | Family | Base image | Channel | Expectation |
|---|---|---|---|---|---|
| 1 | packages | multi-arch | ubuntu:24.04 | nightlies | succeeds (deb) |
| 2 | packages | multi-arch | ubuntu:22.04 | nightlies | succeeds (deb) |
| 3 | packages | multi-arch | almalinux:8 | nightlies | succeeds (rpm) |
| 4 | tarball | multi-arch | ubuntu:24.04 | nightlies | succeeds |
| 5 | tarball | gfx110X-all | ubuntu:24.04 | nightlies | succeeds |
| 6 | packages | gfx110x | ubuntu:24.04 | nightlies | clean failure (legacy host frozen) |
| 7 | packages | multi-arch | ubuntu:24.04 | stable | unaffected |


Each image is checked by compiling **and linking** a HIP program with a `__global__` kernel
via `hipcc --offload-arch=gfx1100` and running it, rather than only checking that directories exist.

## Test Result

All seven behave as expected.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.


[ROCM-29976]: https://amd-hub.atlassian.net/browse/ROCM-29976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ