### PR TITLE
Replace rocm-smi with amd-smi in GPU CI helpers

### DIFF
--- a/build_tools/github_actions/cleanup_processes.sh
+++ b/build_tools/github_actions/cleanup_processes.sh
@@ -342,9 +342,9 @@ if [[ ${#KILLABLE_PIDS[@]} -gt 0 ]]; then
 fi
 
 if [[ "$CLEANUP_GPU_RESET" == "true" && ${#STUCK_PIDS[@]} -gt 0 ]]; then
-    echo "[*] Attempting GPU reset via rocm-smi..."
-    if command -v rocm-smi &>/dev/null; then
-        if rocm-smi --gpureset 2>&1; then
+    echo "[*] Attempting GPU reset via amd-smi..."
+    if command -v amd-smi &>/dev/null; then
+        if amd-smi reset -G 2>&1; then
             echo "[+] GPU reset completed"
             sleep 2
             for pid in "${STUCK_PIDS[@]}"; do
@@ -356,7 +356,7 @@ if [[ "$CLEANUP_GPU_RESET" == "true" && ${#STUCK_PIDS[@]} -gt 0 ]]; then
             echo "[-] GPU reset failed (may require elevated permissions)"
         fi
     else
-        echo "[-] rocm-smi not found, cannot perform GPU reset"
+        echo "[-] amd-smi not found, cannot perform GPU reset"
     fi
 fi
 

--- a/build_tools/memory_monitor.py
+++ b/build_tools/memory_monitor.py
@@ -53,30 +53,32 @@ CRIT_PERCENT = 90
 
 
 def get_gpu_memory() -> list[dict]:
-    """Get AMD GPU memory using rocm-smi."""
+    """Get AMD GPU memory using amd-smi."""
     gpus = []
     try:
         result = subprocess.run(
-            ["rocm-smi", "--showmeminfo", "vram", "--json"],
+            ["amd-smi", "metric", "-m", "--json"],
             capture_output=True,
             text=True,
             timeout=5,
         )
         if result.returncode == 0:
             data = json.loads(result.stdout)
-            for card_id, card_data in data.items():
-                if card_id.startswith("card"):
-                    used = int(card_data.get("VRAM Total Used Memory (B)", 0))
-                    total = int(card_data.get("VRAM Total Memory (B)", 0))
-                    if total > 0:
-                        gpus.append(
-                            {
-                                "id": card_id,
-                                "used_gb": used / GB,
-                                "total_gb": total / GB,
-                                "percent": (used / total) * 100,
-                            }
-                        )
+            for entry in data.get("gpu_data", []):
+                mem = entry.get("mem_usage", {})
+                total_mb = mem.get("total_vram", {}).get("value", 0)
+                used_mb = mem.get("used_vram", {}).get("value", 0)
+                if total_mb > 0:
+                    total = int(total_mb * 1024 * 1024)
+                    used = int(used_mb * 1024 * 1024)
+                    gpus.append(
+                        {
+                            "id": f"gpu{entry.get('gpu', 0)}",
+                            "used_gb": used / GB,
+                            "total_gb": total / GB,
+                            "percent": (used / total) * 100,
+                        }
+                    )
     except (subprocess.TimeoutExpired, FileNotFoundError, json.JSONDecodeError):
         pass
     return gpus

--- a/build_tools/tests/memory_monitor_test.py
+++ b/build_tools/tests/memory_monitor_test.py
@@ -1,15 +1,23 @@
 #!/usr/bin/env python3
 """Tests for memory_monitor.py"""
 
+import json
 import sys
 import time
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from memory_monitor import ResourceMonitor, get_storage_info, get_thread_info
+from memory_monitor import (
+    GB,
+    ResourceMonitor,
+    get_gpu_memory,
+    get_storage_info,
+    get_thread_info,
+)
 
 
 def test_collect_stats():
@@ -48,6 +56,31 @@ def test_monitor_start_stop():
 
     assert len(monitor.samples) >= 1
     assert monitor.stop_event.is_set()
+
+
+def test_get_gpu_memory_from_amd_smi_json():
+    """Parse VRAM from amd-smi metric JSON output."""
+    payload = {
+        "gpu_data": [
+            {
+                "gpu": 0,
+                "mem_usage": {
+                    "total_vram": {"value": 131072},
+                    "used_vram": {"value": 65536},
+                },
+            }
+        ]
+    }
+    completed = mock.Mock(returncode=0, stdout=json.dumps(payload))
+
+    with mock.patch("memory_monitor.subprocess.run", return_value=completed):
+        gpus = get_gpu_memory()
+
+    assert len(gpus) == 1
+    assert gpus[0]["id"] == "gpu0"
+    assert gpus[0]["total_gb"] == pytest.approx(131072 * 1024 * 1024 / GB)
+    assert gpus[0]["used_gb"] == pytest.approx(65536 * 1024 * 1024 / GB)
+    assert gpus[0]["percent"] == pytest.approx(50.0)
 
 
 def test_responsive_shutdown():


### PR DESCRIPTION
## Summary

- `cleanup_processes.sh`: `rocm-smi --gpureset` → `amd-smi reset -G`
- `memory_monitor.py`: VRAM query via `amd-smi metric -m --json`
- `memory_monitor_test.py`: unit test for amd-smi JSON parsing

## Context

Reopened per review: these helpers are worth migrating independent of JAX workflows. `cleanup_processes.sh` runs from TheRock `test_component.yml`; `memory_monitor.py` is used by `therock-test-component.yml` in rocm-libraries. rocm-smi is deprecated in favor of AMD SMI ([TheRock#6852](https://github.com/ROCm/TheRock/pull/6852)).

## Issue Tracking

JIRA ID: ROCM-966

## Test plan

- [x] `pytest build_tools/tests/memory_monitor_test.py::test_get_gpu_memory_from_amd_smi_json`
- [x] `bash -n build_tools/github_actions/cleanup_processes.sh`
- [x] `amd-smi metric -m --json` returns VRAM on ROCm 7.14
- [x] `amd-smi reset -G` available (same sudo requirement as before)