### PR TITLE
ci: splitting native package repo build and upload

### DIFF
--- a/.github/workflows/multi_arch_build_native_linux_packages.yml
+++ b/.github/workflows/multi_arch_build_native_linux_packages.yml
@@ -153,6 +153,12 @@ jobs:
             --packages-dir "${{ env.PACKAGE_DIST_DIR }}" \
             --pkg-type ${{ inputs.native_package_type }}
 
+      - name: Build Package repository
+        run: |
+          python ./build_tools/packaging/linux/build_package_repo.py \
+            --pkg-type "${{ inputs.native_package_type }}" \
+            --package-dir "${{ env.PACKAGE_DIST_DIR }}"
+
       - name: Configure AWS credentials for artifact uploads
         uses: ./.github/actions/configure_aws_artifacts_credentials
         with:

--- a/.github/workflows/multi_arch_build_native_linux_packages.yml
+++ b/.github/workflows/multi_arch_build_native_linux_packages.yml
@@ -157,7 +157,8 @@ jobs:
         run: |
           python ./build_tools/packaging/linux/build_package_repo.py \
             --pkg-type "${{ inputs.native_package_type }}" \
-            --package-dir "${{ env.PACKAGE_DIST_DIR }}"
+            --package-dir "${{ env.PACKAGE_DIST_DIR }}" \
+            --release-type "${{ env.RELEASE_TYPE }}"
 
       - name: Configure AWS credentials for artifact uploads
         uses: ./.github/actions/configure_aws_artifacts_credentials

--- a/build_tools/packaging/linux/build_package_repo.py
+++ b/build_tools/packaging/linux/build_package_repo.py
@@ -14,19 +14,28 @@ layout (``pool/main/`` or ``x86_64/``) before indexing.
 Output is consumed unchanged by ``upload_package_repo.py`` (Issue #6540: local
 metadata is authoritative; no S3 merge/regen after upload).
 
+Public API:
+
+  - :func:`generate_release_file_with_checksums` — write DEB ``Release`` with checksums
+  - :func:`create_deb_repo` — ``pool/``, ``dists/``, and ``Release`` for DEB
+  - :func:`create_rpm_repo` — ``x86_64/`` layout and ``createrepo_c`` for RPM
+  - :func:`parse_release_type` — normalize ``--release-type`` CLI value
+  - :func:`run_command` — subprocess helper for packaging tools
+  - :func:`main` — CLI entry point
+
 Usage:
   python ./build_tools/packaging/linux/build_package_repo.py \\
     --pkg-type deb \\
-    --package-dir /path/to/packages
+    --package-dir /path/to/packages \\
+    --release-type nightly
 
-``RELEASE_TYPE`` (default ``ci``) labels DEB ``Release`` metadata for nightly,
-dev, or release builds.
+``--release-type`` (default ``ci``) labels DEB ``Release`` metadata for nightly,
+dev, or release builds. Ignored for ``rpm``.
 """
 
 import argparse
 import datetime
 import hashlib
-import os
 import shutil
 import subprocess
 import sys
@@ -35,15 +44,37 @@ from pathlib import Path
 # Bytes read per iteration when hashing Packages files for Release checksums.
 _HASH_READ_CHUNK_BYTES = 65536
 
-_THIS_DIR = Path(__file__).resolve().parent
 
-if os.fspath(_THIS_DIR) not in sys.path:
-    sys.path.insert(0, os.fspath(_THIS_DIR))
+def parse_release_type(
+    parser: argparse.ArgumentParser,
+    release_type: str,
+) -> str:
+    """Normalize ``--release-type`` for DEB ``Release`` file labeling.
+
+    Strips surrounding whitespace and lowercases the value so workflow inputs
+    such as ``NIGHTLY`` produce a consistent ``Label: ROCm … Packages`` field.
+
+    Args:
+        parser: Argument parser used to report validation errors via
+            :meth:`argparse.ArgumentParser.error`.
+        release_type: Raw value from the ``--release-type`` CLI flag.
+
+    Returns:
+        Normalized release type string passed to :func:`create_deb_repo`.
+
+    Raises:
+        SystemExit: If ``release_type`` is empty after normalization
+            (via ``parser.error``).
+    """
+    normalized = release_type.strip().lower()
+    if not normalized:
+        parser.error("--release-type cannot be empty")
+    return normalized
 
 
 def generate_release_file_with_checksums(
     release_file: Path | str,
-    job_type: str,
+    release_type: str,
     dists_dir: Path,
 ) -> None:
     """Generate a Debian ``Release`` file with MD5Sum, SHA1, and SHA256 sections.
@@ -55,9 +86,13 @@ def generate_release_file_with_checksums(
     Args:
         release_file: Path to the ``Release`` file to create (typically
             ``dists/stable/Release`` under the package tree).
-        job_type: Release label suffix (from ``RELEASE_TYPE``, e.g. ``nightly``).
+        release_type: Release channel label (e.g. ``nightly``, ``ci``) for the
+            ``Label`` field in ``Release``.
         dists_dir: Directory containing ``Packages`` / ``Packages.gz``
             (``dists/stable/main/binary-amd64/``).
+
+    Returns:
+        None. Writes ``release_file`` on disk.
     """
     files_to_hash = [
         (dists_dir / "Packages", "main/binary-amd64/Packages"),
@@ -94,7 +129,7 @@ def generate_release_file_with_checksums(
     with open(release_file, "w", encoding="utf-8") as f:
         f.write(
             f"""Origin: AMD ROCm
-Label: ROCm {job_type} Packages
+Label: ROCm {release_type} Packages
 Suite: stable
 Codename: stable
 Architectures: amd64
@@ -134,6 +169,9 @@ def run_command(
         cwd: Working directory for the child process.
         stdout: When set, redirect child stdout to this file path.
 
+    Returns:
+        None.
+
     Raises:
         subprocess.CalledProcessError: If the command exits with a non-zero status.
         OSError: If ``stdout`` cannot be opened for writing.
@@ -146,7 +184,7 @@ def run_command(
         subprocess.run(cmd, check=True, cwd=cwd)
 
 
-def create_deb_repo(package_dir: Path | str, job_type: str) -> None:
+def create_deb_repo(package_dir: Path | str, release_type: str) -> None:
     """Build Debian repository metadata from the complete local ``.deb`` tree.
 
     Moves top-level ``.deb`` files into ``pool/main/``, runs ``dpkg-scanpackages``
@@ -156,7 +194,11 @@ def create_deb_repo(package_dir: Path | str, job_type: str) -> None:
     Args:
         package_dir: Root of the native packaging output tree (``PACKAGE_DIST_DIR``
             in CI). Modified in place.
-        job_type: ``RELEASE_TYPE`` value for ``Release`` file labeling.
+        release_type: Release channel label for the ``Release`` file (from
+            ``--release-type``).
+
+    Returns:
+        None. Creates ``pool/``, ``dists/``, and ``Release`` under ``package_dir``.
 
     Raises:
         subprocess.CalledProcessError: If ``dpkg-scanpackages`` or ``gzip`` fails.
@@ -187,7 +229,7 @@ def create_deb_repo(package_dir: Path | str, job_type: str) -> None:
     )
 
     release = package_path / "dists" / "stable" / "Release"
-    generate_release_file_with_checksums(release, job_type, dists)
+    generate_release_file_with_checksums(release, release_type, dists)
 
 
 def create_rpm_repo(package_dir: Path | str) -> None:
@@ -199,6 +241,9 @@ def create_rpm_repo(package_dir: Path | str) -> None:
 
     Args:
         package_dir: Root of the native packaging output tree. Modified in place.
+
+    Returns:
+        None. Creates ``x86_64/repodata/`` under ``package_dir``.
 
     Raises:
         subprocess.CalledProcessError: If ``createrepo_c`` fails.
@@ -220,8 +265,31 @@ def create_rpm_repo(package_dir: Path | str) -> None:
     )
 
 
-def main() -> None:
-    """Parse CLI args and build repository metadata for ``deb`` or ``rpm``."""
+def main(argv: list[str] | None = None) -> int:
+    """Parse CLI arguments and build repository metadata for ``deb`` or ``rpm``.
+
+    Reads ``--pkg-type``, ``--package-dir``, and ``--release-type`` from the
+    command line. For ``deb``, calls :func:`create_deb_repo` with the normalized
+    release type. For ``rpm``, calls :func:`create_rpm_repo` (release type is
+    ignored).
+
+    Args:
+        argv: Command-line arguments (defaults to ``sys.argv[1:]`` when ``None``).
+
+    CLI arguments:
+
+        --pkg-type:
+            Required. ``deb`` or ``rpm``.
+        --package-dir:
+            Required. Directory containing built ``.deb`` or ``.rpm`` files from
+            ``build_package.py``. Modified in place.
+        --release-type:
+            Optional. Release channel label for DEB ``Release`` metadata
+            (default: ``ci``). Lowercased before use. Ignored for ``rpm``.
+
+    Returns:
+        Process exit code (``0`` on success).
+    """
     parser = argparse.ArgumentParser(
         description="Build Debian or RPM repository metadata from a local package tree.",
     )
@@ -233,19 +301,33 @@ def main() -> None:
     )
     parser.add_argument(
         "--package-dir",
+        type=Path,
         required=True,
         help="Path to the directory containing built packages (modified in place).",
     )
-    args = parser.parse_args()
+    parser.add_argument(
+        "--release-type",
+        default="ci",
+        help=(
+            "Release channel label for DEB Release metadata "
+            "(ci, dev, nightly, prerelease, release). Ignored for rpm."
+        ),
+    )
+    args = parser.parse_args(argv)
 
-    package_dir = Path(args.package_dir).resolve()
-    job_type = os.environ.get("RELEASE_TYPE", "ci")
+    package_dir = args.package_dir.resolve()
+    if not package_dir.is_dir():
+        parser.error(f"--package-dir is not a directory: {package_dir}")
+
+    release_type = parse_release_type(parser, args.release_type)
 
     if args.pkg_type == "deb":
-        create_deb_repo(package_dir, job_type)
+        create_deb_repo(package_dir, release_type)
     else:
         create_rpm_repo(package_dir)
 
+    return 0
+
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main(sys.argv[1:]))

--- a/build_tools/packaging/linux/build_package_repo.py
+++ b/build_tools/packaging/linux/build_package_repo.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+Build Debian or RPM repository metadata from a local native packaging tree.
+
+Called from ``multi_arch_build_native_linux_packages.yml`` **after** the simulate
+install test and **before** ``upload_package_repo.py``. Simulate must run first
+because this script moves loose ``.deb`` / ``.rpm`` files into standard repo
+layout (``pool/main/`` or ``x86_64/``) before indexing.
+
+Output is consumed unchanged by ``upload_package_repo.py`` (Issue #6540: local
+metadata is authoritative; no S3 merge/regen after upload).
+
+Usage:
+  python ./build_tools/packaging/linux/build_package_repo.py \\
+    --pkg-type deb \\
+    --package-dir /path/to/packages
+
+``RELEASE_TYPE`` (default ``ci``) labels DEB ``Release`` metadata for nightly,
+dev, or release builds.
+"""
+
+import argparse
+import datetime
+import hashlib
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+# Bytes read per iteration when hashing Packages files for Release checksums.
+_HASH_READ_CHUNK_BYTES = 65536
+
+_THIS_DIR = Path(__file__).resolve().parent
+
+if os.fspath(_THIS_DIR) not in sys.path:
+    sys.path.insert(0, os.fspath(_THIS_DIR))
+
+
+def generate_release_file_with_checksums(
+    release_file: Path | str,
+    job_type: str,
+    dists_dir: Path,
+) -> None:
+    """Generate a Debian ``Release`` file with MD5Sum, SHA1, and SHA256 sections.
+
+    Reads ``Packages`` and ``Packages.gz`` from ``dists_dir`` and writes a
+    upload-ready ``Release`` file. ``apt update`` requires checksum sections; a
+    header-only ``Release`` is not sufficient for clients.
+
+    Args:
+        release_file: Path to the ``Release`` file to create (typically
+            ``dists/stable/Release`` under the package tree).
+        job_type: Release label suffix (from ``RELEASE_TYPE``, e.g. ``nightly``).
+        dists_dir: Directory containing ``Packages`` / ``Packages.gz``
+            (``dists/stable/main/binary-amd64/``).
+    """
+    files_to_hash = [
+        (dists_dir / "Packages", "main/binary-amd64/Packages"),
+        (dists_dir / "Packages.gz", "main/binary-amd64/Packages.gz"),
+    ]
+
+    md5_entries: list[str] = []
+    sha1_entries: list[str] = []
+    sha256_entries: list[str] = []
+
+    for file_path, rel_path in files_to_hash:
+        if not file_path.exists():
+            continue
+
+        file_size = file_path.stat().st_size
+
+        md5_hash = hashlib.md5()
+        sha1_hash = hashlib.sha1()
+        sha256_hash = hashlib.sha256()
+
+        with open(file_path, "rb") as f:
+            while True:
+                data = f.read(_HASH_READ_CHUNK_BYTES)
+                if not data:
+                    break
+                md5_hash.update(data)
+                sha1_hash.update(data)
+                sha256_hash.update(data)
+
+        md5_entries.append(f" {md5_hash.hexdigest()} {file_size:16d} {rel_path}")
+        sha1_entries.append(f" {sha1_hash.hexdigest()} {file_size:16d} {rel_path}")
+        sha256_entries.append(f" {sha256_hash.hexdigest()} {file_size:16d} {rel_path}")
+
+    with open(release_file, "w", encoding="utf-8") as f:
+        f.write(
+            f"""Origin: AMD ROCm
+Label: ROCm {job_type} Packages
+Suite: stable
+Codename: stable
+Architectures: amd64
+Components: main
+Description: ROCm APT Repository
+Date: {datetime.datetime.now(datetime.timezone.utc):%a, %d %b %Y %H:%M:%S UTC}
+"""
+        )
+
+        if md5_entries:
+            f.write("MD5Sum:\n")
+            f.write("\n".join(md5_entries))
+            f.write("\n")
+
+        if sha1_entries:
+            f.write("SHA1:\n")
+            f.write("\n".join(sha1_entries))
+            f.write("\n")
+
+        if sha256_entries:
+            f.write("SHA256:\n")
+            f.write("\n".join(sha256_entries))
+            f.write("\n")
+
+    print("✅ Release file generated with checksums: MD5, SHA1, SHA256")
+
+
+def run_command(
+    cmd: list[str],
+    cwd: str | Path | None = None,
+    stdout: Path | str | None = None,
+) -> None:
+    """Run a subprocess without shell interpolation.
+
+    Args:
+        cmd: Executable and arguments as a list of strings.
+        cwd: Working directory for the child process.
+        stdout: When set, redirect child stdout to this file path.
+
+    Raises:
+        subprocess.CalledProcessError: If the command exits with a non-zero status.
+        OSError: If ``stdout`` cannot be opened for writing.
+    """
+    print(f"Running: {' '.join(cmd)}")
+    if stdout is not None:
+        with open(stdout, "wb") as f:
+            subprocess.run(cmd, check=True, cwd=cwd, stdout=f)
+    else:
+        subprocess.run(cmd, check=True, cwd=cwd)
+
+
+def create_deb_repo(package_dir: Path | str, job_type: str) -> None:
+    """Build Debian repository metadata from the complete local ``.deb`` tree.
+
+    Moves top-level ``.deb`` files into ``pool/main/``, runs ``dpkg-scanpackages``
+    and ``gzip`` to produce ``Packages`` / ``Packages.gz``, then writes
+    ``dists/stable/Release`` with checksums.
+
+    Args:
+        package_dir: Root of the native packaging output tree (``PACKAGE_DIST_DIR``
+            in CI). Modified in place.
+        job_type: ``RELEASE_TYPE`` value for ``Release`` file labeling.
+
+    Raises:
+        subprocess.CalledProcessError: If ``dpkg-scanpackages`` or ``gzip`` fails.
+    """
+    print("Creating APT repository...")
+
+    package_path = Path(package_dir)
+    dists = package_path / "dists" / "stable" / "main" / "binary-amd64"
+    pool = package_path / "pool" / "main"
+
+    dists.mkdir(parents=True, exist_ok=True)
+    pool.mkdir(parents=True, exist_ok=True)
+
+    # Flat .deb files from build_package.py → pool layout before scan.
+    for f in package_path.iterdir():
+        if f.suffix == ".deb":
+            shutil.move(f, pool / f.name)
+
+    run_command(
+        ["dpkg-scanpackages", "-m", "pool/main", "/dev/null"],
+        cwd=str(package_path),
+        stdout=dists / "Packages",
+    )
+    run_command(
+        ["gzip", "-9c", "Packages"],
+        cwd=str(dists),
+        stdout=dists / "Packages.gz",
+    )
+
+    release = package_path / "dists" / "stable" / "Release"
+    generate_release_file_with_checksums(release, job_type, dists)
+
+
+def create_rpm_repo(package_dir: Path | str) -> None:
+    """Create RPM ``repodata/`` from the complete local build tree.
+
+    Moves top-level ``.rpm`` files into ``x86_64/`` and runs ``createrepo_c`` so
+    ``repodata/`` indexes every package present locally (Fixes #6540 on CI re-runs
+    when ``upload_package_repo.py`` dedupes package uploads).
+
+    Args:
+        package_dir: Root of the native packaging output tree. Modified in place.
+
+    Raises:
+        subprocess.CalledProcessError: If ``createrepo_c`` fails.
+    """
+    print("Creating RPM repository...")
+
+    package_path = Path(package_dir)
+    arch_dir = package_path / "x86_64"
+    arch_dir.mkdir(parents=True, exist_ok=True)
+
+    # Flat .rpm files from build_package.py → x86_64/ before createrepo_c.
+    for f in package_path.iterdir():
+        if f.suffix == ".rpm":
+            shutil.move(f, arch_dir / f.name)
+
+    run_command(
+        ["createrepo_c", "--no-database", "--simple-md-filenames", "."],
+        cwd=str(arch_dir),
+    )
+
+
+def main() -> None:
+    """Parse CLI args and build repository metadata for ``deb`` or ``rpm``."""
+    parser = argparse.ArgumentParser(
+        description="Build Debian or RPM repository metadata from a local package tree.",
+    )
+    parser.add_argument(
+        "--pkg-type",
+        required=True,
+        choices=["deb", "rpm"],
+        help="Package format to index (deb or rpm).",
+    )
+    parser.add_argument(
+        "--package-dir",
+        required=True,
+        help="Path to the directory containing built packages (modified in place).",
+    )
+    args = parser.parse_args()
+
+    package_dir = Path(args.package_dir).resolve()
+    job_type = os.environ.get("RELEASE_TYPE", "ci")
+
+    if args.pkg_type == "deb":
+        create_deb_repo(package_dir, job_type)
+    else:
+        create_rpm_repo(package_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/build_tools/packaging/linux/tests/build_package_repo_test.py
+++ b/build_tools/packaging/linux/tests/build_package_repo_test.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for ``build_package_repo.py``.
+
+Regression guards for local repo metadata creation (Phase 2 split from upload).
+
+Coverage:
+
+  - ``generate_release_file_with_checksums`` — DEB ``Release`` has checksum sections
+
+Prerequisites:
+
+  - Python 3.10 or newer
+  - Run from TheROCK repository root (modules resolved via ``__file__``)
+  - Stdlib only (no boto3 / live ``createrepo_c`` in these tests)
+
+Run::
+
+    python3.12 build_tools/packaging/linux/tests/build_package_repo_test.py -v
+
+    python3.12 -m unittest discover -s build_tools/packaging/linux/tests \\
+        -p 'build_package_repo_test.py' -v
+"""
+
+import gzip
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+THIS_SCRIPT_DIR = Path(__file__).resolve().parent
+LINUX_DIR = THIS_SCRIPT_DIR.parent
+
+if os.fspath(LINUX_DIR) not in sys.path:
+    sys.path.insert(0, os.fspath(LINUX_DIR))
+
+import build_package_repo as repo_builder  # noqa: E402
+
+TEST_JOB_TYPE = "nightly"
+
+
+class GenerateReleaseFileTest(unittest.TestCase):
+    """Tests for ``generate_release_file_with_checksums()`` (DEB upload-ready Release)."""
+
+    def test_release_includes_checksum_sections(self) -> None:
+        """Release must include MD5/SHA256 sections before S3 upload."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            dists_dir = Path(temp_dir) / "main" / "binary-amd64"
+            dists_dir.mkdir(parents=True)
+            (dists_dir / "Packages").write_text("Package: demo\n", encoding="utf-8")
+            with gzip.open(dists_dir / "Packages.gz", "wb") as handle:
+                handle.write(b"Package: demo\n")
+
+            release_file = Path(temp_dir) / "Release"
+            repo_builder.generate_release_file_with_checksums(
+                release_file, TEST_JOB_TYPE, dists_dir
+            )
+            release_text = release_file.read_text(encoding="utf-8")
+
+        self.assertIn("MD5Sum:", release_text)
+        self.assertIn("SHA256:", release_text)
+        self.assertIn("main/binary-amd64/Packages", release_text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/build_tools/packaging/linux/tests/build_package_repo_test.py
+++ b/build_tools/packaging/linux/tests/build_package_repo_test.py
@@ -9,6 +9,8 @@ Regression guards for local repo metadata creation (Phase 2 split from upload).
 Coverage:
 
   - ``generate_release_file_with_checksums`` — DEB ``Release`` has checksum sections
+  - ``parse_release_type`` — ``--release-type`` normalization and empty rejection
+  - ``main`` — ``--package-dir`` must be an existing directory
 
 Prerequisites:
 
@@ -24,6 +26,7 @@ Run::
         -p 'build_package_repo_test.py' -v
 """
 
+import argparse
 import gzip
 import os
 import sys
@@ -39,14 +42,19 @@ if os.fspath(LINUX_DIR) not in sys.path:
 
 import build_package_repo as repo_builder  # noqa: E402
 
-TEST_JOB_TYPE = "nightly"
+TEST_RELEASE_TYPE = "nightly"
 
 
 class GenerateReleaseFileTest(unittest.TestCase):
-    """Tests for ``generate_release_file_with_checksums()`` (DEB upload-ready Release)."""
+    """Tests for :func:`build_package_repo.generate_release_file_with_checksums`."""
 
     def test_release_includes_checksum_sections(self) -> None:
-        """Release must include MD5/SHA256 sections before S3 upload."""
+        """DEB Release must include checksum sections and a release-type label.
+
+        Builds a minimal ``Packages`` / ``Packages.gz`` tree, writes a
+        ``Release`` file, and asserts MD5/SHA256 sections, indexed paths, and
+        the ``Label: ROCm … Packages`` line are present.
+        """
         with tempfile.TemporaryDirectory() as temp_dir:
             dists_dir = Path(temp_dir) / "main" / "binary-amd64"
             dists_dir.mkdir(parents=True)
@@ -56,13 +64,48 @@ class GenerateReleaseFileTest(unittest.TestCase):
 
             release_file = Path(temp_dir) / "Release"
             repo_builder.generate_release_file_with_checksums(
-                release_file, TEST_JOB_TYPE, dists_dir
+                release_file, TEST_RELEASE_TYPE, dists_dir
             )
             release_text = release_file.read_text(encoding="utf-8")
 
         self.assertIn("MD5Sum:", release_text)
         self.assertIn("SHA256:", release_text)
         self.assertIn("main/binary-amd64/Packages", release_text)
+        self.assertIn(f"Label: ROCm {TEST_RELEASE_TYPE} Packages", release_text)
+
+
+class ParseReleaseTypeTest(unittest.TestCase):
+    """Tests for :func:`build_package_repo.parse_release_type`."""
+
+    def test_parse_release_type_strips_and_lowercases(self) -> None:
+        """Whitespace is trimmed and the value is lowercased."""
+        parser = argparse.ArgumentParser()
+        self.assertEqual(
+            repo_builder.parse_release_type(parser, "  NIGHTLY  "),
+            "nightly",
+        )
+
+    def test_parse_release_type_rejects_empty(self) -> None:
+        """Empty or whitespace-only values exit via ``parser.error``."""
+        parser = argparse.ArgumentParser()
+        with self.assertRaises(SystemExit):
+            repo_builder.parse_release_type(parser, "   ")
+
+
+class MainTest(unittest.TestCase):
+    """Tests for :func:`build_package_repo.main`."""
+
+    def test_main_rejects_nonexistent_package_dir(self) -> None:
+        """``--package-dir`` must refer to an existing directory."""
+        with self.assertRaises(SystemExit):
+            repo_builder.main(
+                [
+                    "--pkg-type",
+                    "deb",
+                    "--package-dir",
+                    "/nonexistent/package/dir",
+                ],
+            )
 
 
 if __name__ == "__main__":

--- a/build_tools/packaging/linux/tests/upload_package_repo_test.py
+++ b/build_tools/packaging/linux/tests/upload_package_repo_test.py
@@ -4,12 +4,11 @@
 
 """Unit tests for ``upload_package_repo.py``.
 
-Regression guards for Issue #6540 and the simplified upload path: local repo
-metadata is built once and uploaded by ``upload_to_s3`` (no S3 merge/regen).
+Regression guards for Issue #6540 upload path: metadata is always uploaded;
+package dedupe skips only ``.deb`` / ``.rpm`` files.
 
 Coverage:
 
-  - ``generate_release_file_with_checksums`` — DEB ``Release`` has checksum sections
   - ``upload_to_s3`` — uploads ``repodata/``; dedupes ``.rpm`` only (not metadata)
   - ``s3_object_exists`` — ``head_object`` success and 404 handling (dedupe helper)
   - ``_package_install_url`` — RPM baseurl includes ``x86_64/``
@@ -28,7 +27,6 @@ Run::
         -p 'upload_package_repo_test.py' -v
 """
 
-import gzip
 import os
 import sys
 import tempfile
@@ -74,30 +72,6 @@ upload_repo = _import_upload_package_repo()
 
 TEST_BUCKET = "therock-test-bucket"
 TEST_PREFIX = "12345-linux/packages/rpm/20250825-12345"
-TEST_JOB_TYPE = "nightly"
-
-
-class GenerateReleaseFileTest(unittest.TestCase):
-    """Tests for ``generate_release_file_with_checksums()`` (DEB upload-ready Release)."""
-
-    def test_release_includes_checksum_sections(self) -> None:
-        """Release must include MD5/SHA256 sections before ``upload_to_s3`` uploads it."""
-        with tempfile.TemporaryDirectory() as temp_dir:
-            dists_dir = Path(temp_dir) / "main" / "binary-amd64"
-            dists_dir.mkdir(parents=True)
-            (dists_dir / "Packages").write_text("Package: demo\n", encoding="utf-8")
-            with gzip.open(dists_dir / "Packages.gz", "wb") as handle:
-                handle.write(b"Package: demo\n")
-
-            release_file = Path(temp_dir) / "Release"
-            upload_repo.generate_release_file_with_checksums(
-                release_file, TEST_JOB_TYPE, dists_dir
-            )
-            release_text = release_file.read_text(encoding="utf-8")
-
-        self.assertIn("MD5Sum:", release_text)
-        self.assertIn("SHA256:", release_text)
-        self.assertIn("main/binary-amd64/Packages", release_text)
 
 
 class UploadToS3Test(unittest.TestCase):

--- a/build_tools/packaging/linux/upload_package_repo.py
+++ b/build_tools/packaging/linux/upload_package_repo.py
@@ -4,41 +4,35 @@
 # SPDX-License-Identifier: MIT
 
 """
-Packaging + repository upload tool.
+Upload native Linux package repositories to S3.
 
-Upload flow (Issue #6540 — local metadata is authoritative):
+Expects ``--package-dir`` to already contain repo metadata from
+``build_package_repo.py`` (``dists/`` or ``repodata/``). Uploads packages
+with optional dedupe and always re-uploads metadata (Issue #6540).
 
-  1. ``create_deb_repo`` / ``create_rpm_repo`` — index the **complete local build tree**
-     (``dpkg-scanpackages`` or ``createrepo_c``).
-  2. ``upload_to_s3`` — upload ``.deb`` / ``.rpm`` files (optional dedupe when already on S3).
-  3. ``upload_to_s3`` — upload repository metadata (``repodata/`` or ``dists/``) in the
-     same walk; metadata is **never** deduped and **never** regenerated from S3.
+CI flow (``multi_arch_build_native_linux_packages.yml``)::
 
-Previously, metadata was skipped during upload and merged from S3 using only newly
-uploaded packages. On CI re-runs where all packages dedupe, repodata stayed stale.
+  build_package.py → simulate test → build_package_repo.py → this script
 
 Usage:
-  python ./build_tools/packaging/linux/upload_package_repo.py \
-    --pkg-type deb \
-    --run-id 16418185899 \
+  python ./build_tools/packaging/linux/upload_package_repo.py \\
+    --pkg-type deb \\
+    --run-id 16418185899 \\
     --package-dir /path/to/packages
 
-Bucket + prefix are resolved automatically via WorkflowOutputRoot using
-the GITHUB_REPOSITORY and RELEASE_TYPE environment variables:
-  - CI builds    → therock-ci-artifacts / <run_id>-linux/packages/deb
-  - dev builds   → therock-dev-artifacts / <run_id>-linux/packages/deb
-  - nightly      → therock-nightly-artifacts / <run_id>-linux/packages/deb
-  - prerelease   → therock-prerelease-artifacts / <run_id>-linux/packages/deb
+Bucket + prefix are resolved via ``WorkflowOutputRoot`` from
+``GITHUB_REPOSITORY``, ``RELEASE_TYPE``, and fork detection:
+
+  - CI builds    → therock-ci-artifacts / ``<run_id>-linux/packages/{deb|rpm}``
+  - dev builds   → therock-dev-artifacts / ...
+  - nightly      → therock-nightly-artifacts / ...
+  - prerelease   → therock-prerelease-artifacts / ...
 """
 
 import argparse
 import boto3
 import botocore.client
-import datetime
-import hashlib
 import os
-import shutil
-import subprocess
 import sys
 from pathlib import Path
 
@@ -46,12 +40,10 @@ _THIS_DIR = Path(__file__).resolve().parent
 _BUILD_TOOLS_DIR = _THIS_DIR.parent.parent
 _GITHUB_ACTIONS_DIR = _BUILD_TOOLS_DIR / "github_actions"
 
-if str(_THIS_DIR) not in sys.path:
-    sys.path.insert(0, str(_THIS_DIR))
-if str(_BUILD_TOOLS_DIR) not in sys.path:
-    sys.path.insert(0, str(_BUILD_TOOLS_DIR))
-if str(_GITHUB_ACTIONS_DIR) not in sys.path:
-    sys.path.insert(0, str(_GITHUB_ACTIONS_DIR))
+for path in (_THIS_DIR, _BUILD_TOOLS_DIR, _GITHUB_ACTIONS_DIR):
+    path_str = os.fspath(path)
+    if path_str not in sys.path:
+        sys.path.insert(0, path_str)
 
 from _therock_utils.storage_backend import StorageBackend, create_storage_backend
 from _therock_utils.storage_location import StorageLocation
@@ -59,127 +51,22 @@ from _therock_utils.workflow_outputs import WorkflowOutputRoot
 from github_actions_api import gha_append_step_summary
 
 
-def generate_release_file_with_checksums(
-    release_file: Path | str,
-    job_type: str,
-    dists_dir: Path,
-) -> None:
-    """Generate a Debian Release file with MD5Sum, SHA1, and SHA256 checksums.
+def s3_object_exists(
+    s3: botocore.client.BaseClient, bucket: str, key: str
+) -> bool:
+    """Return whether an S3 object exists at ``bucket``/``key``.
 
-    Called from ``create_deb_repo`` so ``Release`` is ready before S3 upload.
-    ``apt update`` requires checksum sections; a header-only Release is not enough.
+    Used by package dedupe in :func:`upload_to_s3`. A 404 response means the
+    object is absent; other ``ClientError`` codes propagate to the caller.
 
     Args:
-        release_file: Path to the Release file to create
-        job_type: Job type for metadata (nightly/dev/release)
-        dists_dir: Directory containing Packages files (main/binary-amd64/)
+        s3: boto3 S3 client (or compatible mock).
+        bucket: S3 bucket name.
+        key: Object key within the bucket.
+
+    Returns:
+        ``True`` if ``head_object`` succeeds, ``False`` on 404.
     """
-    # Files to hash (relative paths from dists/stable/)
-    files_to_hash = [
-        (dists_dir / "Packages", "main/binary-amd64/Packages"),
-        (dists_dir / "Packages.gz", "main/binary-amd64/Packages.gz"),
-    ]
-
-    # Calculate all hashes
-    md5_entries = []
-    sha1_entries = []
-    sha256_entries = []
-
-    for file_path, rel_path in files_to_hash:
-        if not file_path.exists():
-            continue
-
-        # Get file size
-        file_size = file_path.stat().st_size
-
-        # Calculate hashes
-        md5_hash = hashlib.md5()
-        sha1_hash = hashlib.sha1()
-        sha256_hash = hashlib.sha256()
-
-        with open(file_path, "rb") as f:
-            while True:
-                data = f.read(65536)  # Read in 64KB chunks
-                if not data:
-                    break
-                md5_hash.update(data)
-                sha1_hash.update(data)
-                sha256_hash.update(data)
-
-        # Store entries (space-aligned format)
-        md5_entries.append(f" {md5_hash.hexdigest()} {file_size:16d} {rel_path}")
-        sha1_entries.append(f" {sha1_hash.hexdigest()} {file_size:16d} {rel_path}")
-        sha256_entries.append(f" {sha256_hash.hexdigest()} {file_size:16d} {rel_path}")
-
-    # Write Release file
-    with open(release_file, "w", encoding="utf-8") as f:
-        # Header fields
-        f.write(
-            f"""Origin: AMD ROCm
-Label: ROCm {job_type} Packages
-Suite: stable
-Codename: stable
-Architectures: amd64
-Components: main
-Description: ROCm APT Repository
-Date: {datetime.datetime.now(datetime.timezone.utc):%a, %d %b %Y %H:%M:%S UTC}
-"""
-        )
-
-        # MD5Sum section
-        if md5_entries:
-            f.write("MD5Sum:\n")
-            f.write("\n".join(md5_entries))
-            f.write("\n")
-
-        # SHA1 section
-        if sha1_entries:
-            f.write("SHA1:\n")
-            f.write("\n".join(sha1_entries))
-            f.write("\n")
-
-        # SHA256 section
-        if sha256_entries:
-            f.write("SHA256:\n")
-            f.write("\n".join(sha256_entries))
-            f.write("\n")
-
-    print(f"✅ Release file generated with checksums: MD5, SHA1, SHA256")
-
-
-def run_command(
-    cmd: list[str],
-    cwd: str | Path | None = None,
-    stdout: Path | str | None = None,
-) -> None:
-    """Run a command safely without shell interpolation.
-
-    Args:
-        cmd: Command and arguments as a list of strings
-        cwd: Working directory for the command
-        stdout: Optional path to redirect stdout to a file
-
-    Raises:
-        subprocess.CalledProcessError: If the command exits with non-zero status
-    """
-    print(f"Running: {' '.join(cmd)}")
-    if stdout is not None:
-        with open(stdout, "wb") as f:
-            subprocess.run(cmd, check=True, cwd=cwd, stdout=f)
-    else:
-        subprocess.run(cmd, check=True, cwd=cwd)
-
-
-def find_package_dir() -> Path:
-    """Return the default local package output directory for manual runs."""
-    base = Path.cwd() / "output" / "packages"
-    if not base.exists():
-        raise RuntimeError(f"Package directory not found: {base}")
-    return base
-
-
-def s3_object_exists(s3: botocore.client.BaseClient, bucket: str, key: str) -> bool:
-    """Return True when ``key`` exists in ``bucket`` (404 → False, other errors propagate)."""
     try:
         s3.head_object(Bucket=bucket, Key=key)
         return True
@@ -187,69 +74,6 @@ def s3_object_exists(s3: botocore.client.BaseClient, bucket: str, key: str) -> b
         if e.response["Error"]["Code"] == "404":
             return False
         raise
-
-
-def create_deb_repo(package_dir: Path | str, job_type: str) -> None:
-    """Build Debian repo metadata from the complete local ``.deb`` tree.
-
-    Scans every ``.deb`` under ``package_dir`` (after moving into ``pool/main/``),
-    writes ``Packages`` / ``Packages.gz``, then a ``Release`` file with checksums.
-    All of these files are uploaded by ``upload_to_s3`` — no post-upload S3 merge.
-    """
-    print("Creating APT repository...")
-
-    package_path = Path(package_dir)
-    dists = package_path / "dists" / "stable" / "main" / "binary-amd64"
-    pool = package_path / "pool" / "main"
-
-    dists.mkdir(parents=True, exist_ok=True)
-    pool.mkdir(parents=True, exist_ok=True)
-
-    # Flat .deb files from the build step → standard pool layout before scan.
-    for f in package_path.iterdir():
-        if f.suffix == ".deb":
-            shutil.move(f, pool / f.name)
-
-    # Index every package in pool/ (full tree), not just newly built artifacts.
-    run_command(
-        ["dpkg-scanpackages", "-m", "pool/main", "/dev/null"],
-        cwd=str(package_path),
-        stdout=dists / "Packages",
-    )
-    run_command(
-        ["gzip", "-9c", "Packages"],
-        cwd=str(dists),
-        stdout=dists / "Packages.gz",
-    )
-
-    # Release with checksums is upload-ready; no S3-side merge after upload.
-    release = package_path / "dists" / "stable" / "Release"
-    generate_release_file_with_checksums(release, job_type, dists)
-
-
-def create_rpm_repo(package_dir: Path | str) -> None:
-    """Create RPM ``repodata/`` from the complete local build tree.
-
-    Runs ``createrepo_c`` over every ``.rpm`` in the tree so ``repodata/`` indexes
-    the full multi-arch fetch/build output, not just packages uploaded in this run.
-    ``upload_to_s3`` uploads ``repodata/`` as-is (Fixes #6540 on CI re-runs).
-    """
-    print("Creating RPM repository...")
-
-    package_path = Path(package_dir)
-    arch_dir = package_path / "x86_64"
-    arch_dir.mkdir(parents=True, exist_ok=True)
-
-    # Flat .rpm files from the build step → x86_64/ before createrepo_c.
-    for f in package_path.iterdir():
-        if f.suffix == ".rpm":
-            shutil.move(f, arch_dir / f.name)
-
-    # repodata/ indexes all RPMs present locally; upload_to_s3 copies it verbatim.
-    run_command(
-        ["createrepo_c", "--no-database", "--simple-md-filenames", "."],
-        cwd=str(arch_dir),
-    )
 
 
 def upload_to_s3(
@@ -260,7 +84,7 @@ def upload_to_s3(
 ) -> botocore.client.BaseClient:
     """Upload packages and repository metadata under ``source_dir`` to S3.
 
-    Walks the full tree produced by ``create_*_repo``. Repository metadata
+    Walks the full tree produced by ``build_package_repo.py``. Repository metadata
     (``repodata/`` for RPM, ``dists/`` for DEB) is uploaded like any other file —
     it is **not** skipped and **not** deduped.
 
@@ -270,7 +94,7 @@ def upload_to_s3(
     local tree (Issue #6540).
 
     Args:
-        source_dir: Local package tree (``output/packages`` in CI).
+        source_dir: Local package tree (``PACKAGE_DIST_DIR`` in CI).
         bucket: S3 bucket name.
         prefix: S3 key prefix for this repo (no trailing slash).
         dedupe: When True, skip uploading package files that already exist on S3.
@@ -287,11 +111,9 @@ def upload_to_s3(
 
     for root, _, files in os.walk(source_dir):
         for fname in files:
-            # Always skip local index.html files, those are generated server-side.
             if fname == "index.html":
                 continue
 
-            # Skip build manifest files - these are for local tracking only
             if fname.lower().endswith(".txt"):
                 print(f"Skipping build manifest file (local only): {fname}")
                 continue
@@ -301,9 +123,6 @@ def upload_to_s3(
             key = f"{prefix}/{rel.as_posix()}"
 
             # Issue #6540: dedupe packages only — repodata/ and dists/ always upload.
-            # Previously repodata/ was skipped here and rebuilt from S3; on re-runs
-            # where every .rpm deduped, repodata never refreshed and clients saw stale
-            # or incomplete indexes.
             if dedupe and (fname.endswith(".deb") or fname.endswith(".rpm")):
                 if s3_object_exists(s3, bucket, key):
                     print(f"Skipping existing package: {fname}")
@@ -362,7 +181,7 @@ def upload_packaging_logs(
 
 
 def _emit_github_output(key: str, value: str) -> None:
-    """Write a key=value pair to $GITHUB_OUTPUT if running in GitHub Actions."""
+    """Append ``key=value`` to ``$GITHUB_OUTPUT`` when running in GitHub Actions."""
     github_output = os.environ.get("GITHUB_OUTPUT")
     if github_output:
         with open(github_output, "a", encoding="utf-8") as f:
@@ -370,11 +189,18 @@ def _emit_github_output(key: str, value: str) -> None:
 
 
 def _package_install_url(bucket: str, prefix: str, pkg_type: str) -> str:
-    """Compute the package manager install URL for a given repo location.
+    """Compute the package-manager install URL for a repository location.
 
-    For RPM repos, dnf/yum baseurl must point to the x86_64/ subdirectory
-    (the directory containing repodata/). For DEB repos, apt points to the
-    repo root (it resolves dists/ itself).
+    RPM ``baseurl`` must point at ``x86_64/`` (where ``repodata/`` lives).
+    DEB clients use the repo root; apt resolves ``dists/`` itself.
+
+    Args:
+        bucket: S3 artifact bucket name.
+        prefix: S3 key prefix for this native package repo.
+        pkg_type: ``deb`` or ``rpm``.
+
+    Returns:
+        HTTPS URL suitable for ``sources.list`` or ``.repo`` ``baseurl``.
     """
     base = StorageLocation(bucket, prefix).https_url
     if pkg_type == "rpm":
@@ -385,66 +211,59 @@ def _package_install_url(bucket: str, prefix: str, pkg_type: str) -> str:
 def _resolve_upload_target(
     args: argparse.Namespace,
     pkg_type: str,
-) -> tuple[str, str, str, bool, str]:
-    """Resolve S3 bucket, prefix, install URL, dedupe flag, and job type.
+) -> tuple[str, str, str, bool]:
+    """Resolve S3 destination and install URL for a native package upload.
 
     Dedupe is always enabled for CI uploads: re-runs share the same S3 prefix
     under ``WorkflowOutputRoot``. Only ``.deb`` / ``.rpm`` objects are skipped
     when already present; metadata is rebuilt locally and re-uploaded each run.
 
+    Args:
+        args: Parsed CLI namespace (must include ``run_id``).
+        pkg_type: ``deb`` or ``rpm``.
+
     Returns:
-        Tuple of (bucket, prefix, install_url, dedupe, job_type)
+        ``(bucket, prefix, install_url, dedupe)`` where ``dedupe`` is always
+        ``True`` for workflow-driven uploads.
     """
-    # Derive bucket + prefix from WorkflowOutputRoot.
-    # This is the single source of truth for CI path layout.
     root = WorkflowOutputRoot.from_workflow_run(run_id=args.run_id, platform="linux")
     loc = root.native_linux_packages(pkg_type)
-    job_type = os.environ.get("RELEASE_TYPE", "ci")
     install_url = _package_install_url(loc.bucket, loc.relative_path, pkg_type)
-    # CI re-runs share the same S3 prefix; dedupe skips existing .deb/.rpm only.
-    return loc.bucket, loc.relative_path, install_url, True, job_type
+    return loc.bucket, loc.relative_path, install_url, True
 
 
 def main() -> None:
-    """Build local repo metadata, upload packages + metadata to S3, emit CI outputs."""
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--pkg-type", required=True, choices=["deb", "rpm"])
-
-    # Use WorkflowOutputRoot for bucket/prefix resolution.
-    # Bucket and prefix are derived automatically from CI context
-    # (GITHUB_REPOSITORY, RELEASE_TYPE, fork detection).
+    """Upload repo tree to S3, emit workflow outputs, and write the step summary."""
+    parser = argparse.ArgumentParser(
+        description="Upload native Linux package repository artifacts to S3.",
+    )
+    parser.add_argument(
+        "--pkg-type",
+        required=True,
+        choices=["deb", "rpm"],
+        help="Package format (deb or rpm).",
+    )
     parser.add_argument(
         "--run-id",
         required=True,
-        help="GitHub Actions workflow run ID (required for WorkflowOutputRoot path resolution)",
+        help="GitHub Actions workflow run ID (WorkflowOutputRoot path resolution).",
     )
-
     parser.add_argument(
         "--package-dir",
         required=True,
-        help="Path to the directory containing built packages.",
+        help="Path to the directory containing packages and repo metadata.",
     )
 
     args = parser.parse_args()
     package_dir = Path(args.package_dir).resolve()
 
-    bucket, prefix, install_url, dedupe, job_type = _resolve_upload_target(
-        args, args.pkg_type
-    )
+    bucket, prefix, install_url, dedupe = _resolve_upload_target(args, args.pkg_type)
 
-    # Step 1: index full local tree (createrepo_c / dpkg-scanpackages + Release).
-    if args.pkg_type == "deb":
-        create_deb_repo(package_dir, job_type)
-    else:
-        create_rpm_repo(package_dir)
-
-    # Step 2+3: upload packages (dedupe OK) and local metadata (always upload).
     upload_to_s3(package_dir, bucket, prefix, dedupe=dedupe)
 
     print(f"Package repository URL: {install_url}")
     _emit_github_output("package_repository_url", install_url)
 
-    # Upload packaging logs and write step summary
     output_root = WorkflowOutputRoot.from_workflow_run(
         run_id=args.run_id, platform="linux"
     )
@@ -454,7 +273,6 @@ def main() -> None:
     if log_index_url:
         _emit_github_output("packaging_logs_url", log_index_url)
 
-    # Write GitHub Actions step summary
     pkg_type_upper = args.pkg_type.upper()
     if args.pkg_type == "deb":
         install_instructions = f"""### {pkg_type_upper} Package Build Results

--- a/build_tools/packaging/linux/upload_package_repo.py
+++ b/build_tools/packaging/linux/upload_package_repo.py
@@ -12,7 +12,7 @@ with optional dedupe and always re-uploads metadata (Issue #6540).
 
 CI flow (``multi_arch_build_native_linux_packages.yml``)::
 
-  build_package.py → simulate test → build_package_repo.py → this script
+  build_package.py → simulate test → build_package_repo.py (--release-type) → this script
 
 Usage:
   python ./build_tools/packaging/linux/upload_package_repo.py \\

--- a/build_tools/packaging/linux/upload_package_repo.py
+++ b/build_tools/packaging/linux/upload_package_repo.py
@@ -51,9 +51,7 @@ from _therock_utils.workflow_outputs import WorkflowOutputRoot
 from github_actions_api import gha_append_step_summary
 
 
-def s3_object_exists(
-    s3: botocore.client.BaseClient, bucket: str, key: str
-) -> bool:
+def s3_object_exists(s3: botocore.client.BaseClient, bucket: str, key: str) -> bool:
     """Return whether an S3 object exists at ``bucket``/``key``.
 
     Used by package dedupe in :func:`upload_to_s3`. A 404 response means the

--- a/docs/packaging/native_packaging.md
+++ b/docs/packaging/native_packaging.md
@@ -91,7 +91,7 @@ Optional Fields
 
 ## S3 Configuration and Package Repository URLs
 
-The following table shows the S3 bucket configuration and public repository URLs for each release type. This configuration is used by `build_tools/packaging/linux/get_s3_config.py` and `build_tools/packaging/linux/upload_package_repo.py`.
+The following table shows the S3 bucket configuration and public repository URLs for each release type. This configuration is used by `build_tools/packaging/linux/get_s3_config.py`. CI workflows build repository metadata locally with `build_tools/packaging/linux/build_package_repo.py` (after the simulate install test), then upload with `build_tools/packaging/linux/upload_package_repo.py`.
 
 ### Current Multi-Arch Release Packages
 


### PR DESCRIPTION
## Motivation

Extract repo creation into build_package_repo.py, add a CI step after simulate (before upload), and make upload_package_repo.py upload-only
build_package.py → simulate test → build_package_repo.py → upload_package_repo.py                                  

## Technical Details

	• Create build_package_repo.py with moved functions + CLI
	• Strip repo build from upload_package_repo.py
	• Add workflow step after simulate, before upload
	• Split/update unit tests
	• Push → CI green on unit tests + native package workflow

ISSUE ID: 6540
Part of https://github.com/ROCm/TheRock/issues/6540
Dependent PR: https://github.com/ROCm/TheRock/pull/6761

## Test Plan

Verify on CI
	1. Unit tests: build_package_repo_test.py + upload_package_repo_test.py
	2. multi_arch_build_native_linux_packages deb + rpm legs
	3. Simulate still passes (runs before repo build)
	4. Re-run behavior unchanged (#6540 fix intact)

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
