### PR TITLE
fix(ci): skip rocminfo on gfx125X-dcgpu due to kernel bug

### DIFF
--- a/build_tools/print_driver_gpu_info.py
+++ b/build_tools/print_driver_gpu_info.py
@@ -112,12 +112,18 @@ def run_sanity(os_name: str) -> None:
             args=["static"],
             extra_command_search_paths=[bin_dir],
         )
-        run_command_with_search(
-            label="rocminfo",
-            command="rocminfo",
-            args=[],
-            extra_command_search_paths=[bin_dir],
-        )
+        # TODO(#7659): re-enable MI455 rocminfo test once kernel bug is fixed
+        amdgpu_families = os.getenv("AMDGPU_FAMILIES", "")
+        if "gfx125X-dcgpu" in amdgpu_families:
+            log("\n=== rocminfo ===")
+            log("Skipping rocminfo: gfx125X-dcgpu has a kernel bug, see #7659")
+        else:
+            run_command_with_search(
+                label="rocminfo",
+                command="rocminfo",
+                args=[],
+                extra_command_search_paths=[bin_dir],
+            )
         run_command_with_search(
             label="Kernel version",
             command="uname",

--- a/tests/test_rocm_sanity.py
+++ b/tests/test_rocm_sanity.py
@@ -61,6 +61,11 @@ class TestROCmSanity:
     @pytest.mark.skipif(
         is_asan(), reason="rocminfo test fails with ASAN build, see TheRock#3312"
     )
+    # TODO(#7659): re-enable MI455 rocminfo test once kernel bug is fixed
+    @pytest.mark.skipif(
+        AMDGPU_FAMILIES and "gfx125X-dcgpu" in AMDGPU_FAMILIES,
+        reason="rocminfo fails on gfx125X-dcgpu due to kernel bug, see #7659",
+    )
     @pytest.mark.parametrize(
         "to_search",
         [


### PR DESCRIPTION
Skip rocminfo usage in GPU sanity check and test_rocm_sanity.py when AMDGPU_FAMILIES contains gfx125X-dcgpu to work around a kernel bug affecting MI455.

ISSUE ID: #7659
