### PR TITLE
[ci] forward quartz_tracking_id to Windows media-libs stage

### DIFF
--- a/.github/workflows/multi_arch_build_windows.yml
+++ b/.github/workflows/multi_arch_build_windows.yml
@@ -218,6 +218,7 @@ jobs:
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
       external_repo_config: ${{ inputs.external_repo_config }}
+      quartz_tracking_id: ${{ inputs.quartz_tracking_id }}
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary

The `media-libs` stage in `multi_arch_build_windows.yml` calls
`multi_arch_build_windows_artifacts.yml` without forwarding
`quartz_tracking_id`, so that stage cannot report release lineage to Quartz.
Every other Windows stage (compiler-runtime, runtime-tests, math-libs,
debug-tools) already forwards it.

The gap was introduced when the media-libs stage was added (#7279), after the
quartz wiring landed (#7443). 