### PR TITLE
Optimize "build tarballs" script and workflow jobs

### DIFF
--- a/build_tools/artifact_manager.py
+++ b/build_tools/artifact_manager.py
@@ -10,14 +10,14 @@ for performance.
 
 Usage:
     # Fetch inbound artifacts for a stage (downloads and extracts in parallel)
-    python stage_artifact_manager.py fetch \
+    python artifact_manager.py fetch \
         --stage math-libs \
         --amdgpu-families gfx94X-dcgpu \
         --run-id 12345 \
         --output-dir build/
 
     # Fetch and flatten artifacts into single directory structure
-    python stage_artifact_manager.py fetch \
+    python artifact_manager.py fetch \
         --stage math-libs \
         --amdgpu-families gfx94X-dcgpu \
         --run-id 12345 \
@@ -25,14 +25,14 @@ Usage:
         --flatten
 
     # Push produced artifacts after building (compresses and uploads in parallel)
-    python stage_artifact_manager.py push \
+    python artifact_manager.py push \
         --stage math-libs \
         --amdgpu-families gfx94X-dcgpu \
         --run-id 12345 \
         --build-dir build/
 
     # List what artifacts a stage needs/produces
-    python stage_artifact_manager.py info \
+    python artifact_manager.py info \
         --stage math-libs \
         --amdgpu-families gfx94X-dcgpu
 
@@ -274,6 +274,7 @@ class ExtractRequest:
     output_dir: Path
     delete_archive: bool
     flatten: bool
+    extraction_cache_dir: Optional[Path] = None
     bootstrap: bool = False
     # Shared state for parallel bootstrap extraction
     cleaned_paths: Optional[set] = None
@@ -360,6 +361,36 @@ class BootstrappingPopulator(ArtifactPopulator):
             self.created_markers.append(prebuilt_path)
 
 
+def _populate_extraction_cache(archive_path: Path, cache_dir: Path) -> Path:
+    """Extract an artifact once so later flatten operations can hardlink it.
+
+    Callers must treat flattened output files as read-only while the cache is
+    in use because they share inodes with the cached files.
+    """
+    cached_artifact_dir = cache_dir / archive_path.name
+    manifest_path = cached_artifact_dir / "artifact_manifest.txt"
+    if manifest_path.exists():
+        log(f"  == Reusing extracted {archive_path.name}")
+        return cached_artifact_dir
+
+    if cached_artifact_dir.exists():
+        rmtree_with_retry(cached_artifact_dir)
+    cached_artifact_dir.mkdir(parents=True)
+
+    log(f"  ++ Caching extracted {archive_path.name}")
+    populator = ArtifactPopulator(
+        output_path=cached_artifact_dir, verbose=False, flatten=False
+    )
+    populator(archive_path)
+
+    # ArtifactPopulator expects this manifest when its input is an exploded
+    # artifact directory. Write it last so its presence also marks a complete
+    # cache entry.
+    relpaths = sorted(populator.relpaths)
+    manifest_path.write_text("\n".join(relpaths) + "\n")
+    return cached_artifact_dir
+
+
 def extract_artifact(request: ExtractRequest) -> Optional[Path]:
     """Extract a single artifact archive."""
     try:
@@ -379,11 +410,16 @@ def extract_artifact(request: ExtractRequest) -> Optional[Path]:
             populator(archive_path)
         elif request.flatten:
             output_dir = request.output_dir
-            log(f"  ++ Flattening {archive_path.name} to {output_dir}")
+            artifact_path = archive_path
+            if request.extraction_cache_dir is not None:
+                artifact_path = _populate_extraction_cache(
+                    archive_path, request.extraction_cache_dir
+                )
+            log(f"  ++ Flattening {artifact_path.name} to {output_dir}")
             flattener = ArtifactPopulator(
                 output_path=output_dir, verbose=False, flatten=True
             )
-            flattener(archive_path)
+            flattener(artifact_path)
         else:
             output_dir = request.output_dir / artifact_name
             if output_dir.exists():
@@ -453,6 +489,8 @@ def do_fetch(args: argparse.Namespace):
 
     # Build download requests
     output_dir = Path(args.output_dir)
+    if args.extraction_cache_dir is not None:
+        args.extraction_cache_dir.mkdir(parents=True, exist_ok=True)
     shared_cache = args.download_cache_dir is not None
     download_dir = (
         args.download_cache_dir if shared_cache else output_dir / ".download_cache"
@@ -536,6 +574,7 @@ def do_fetch(args: argparse.Namespace):
                                 # happens after all extractions complete
                                 delete_archive=False,
                                 flatten=args.flatten,
+                                extraction_cache_dir=args.extraction_cache_dir,
                                 bootstrap=args.bootstrap,
                                 cleaned_paths=(
                                     bootstrap_cleaned_paths if args.bootstrap else None
@@ -1258,6 +1297,15 @@ def main(argv: Optional[List[str]] = None):
         "Defaults to OUTPUT_DIR/.download_cache (cleaned up after extraction).",
     )
     fetch_parser.add_argument(
+        "--extraction-cache-dir",
+        type=Path,
+        default=None,
+        help="Shared cache for extracted artifacts used with --flatten. "
+        "Files in flattened output directories are hardlinked from this cache, "
+        "avoiding repeated decompression and data copies. Flattened outputs "
+        "must remain read-only while the cache is in use.",
+    )
+    fetch_parser.add_argument(
         "--download-concurrency",
         type=int,
         default=10,
@@ -1385,6 +1433,14 @@ def main(argv: Optional[List[str]] = None):
     list_parser.set_defaults(func=do_list_stages)
 
     args = parser.parse_args(argv)
+    if (
+        args.command == "fetch"
+        and args.extraction_cache_dir is not None
+        and (not args.flatten or args.no_extract)
+    ):
+        fetch_parser.error(
+            "--extraction-cache-dir requires --flatten with extraction enabled"
+        )
 
     # Set environment variable if --local-staging-dir provided (only on fetch/push)
     local_staging_dir = getattr(args, "local_staging_dir", None)

--- a/build_tools/artifact_manager.py
+++ b/build_tools/artifact_manager.py
@@ -518,8 +518,10 @@ def do_fetch(args: argparse.Namespace):
     ]
 
     if not download_requests:
-        log("No matching artifacts found to download")
-        return
+        raise RuntimeError(
+            f"ERROR: No matching artifacts found in {backend.base_uri} for "
+            f"target families: {', '.join(target_families)}"
+        )
 
     log(f"\nDownloading {len(download_requests)} artifacts...")
 

--- a/build_tools/build_tarballs.py
+++ b/build_tools/build_tarballs.py
@@ -62,12 +62,32 @@ import sys
 import time
 from pathlib import Path
 
+from zlib_ng import gzip_ng_threaded
+
 DEFAULT_EXCLUDED_ARTIFACTS: list[str] = ["fftw3"]
 DEFAULT_EXCLUDED_COMPONENTS: list[str] = ["test"]
+DEFAULT_COMPRESSION_BACKEND = "zlib-ng"
+DEFAULT_COMPRESSION_LEVEL = 6
+DEFAULT_COMPRESSION_THREADS = 8
 
 
 def log(msg: str) -> None:
     print(msg, flush=True)
+
+
+def log_command_duration(*, start_time: float, start_cpu: os.times_result) -> None:
+    elapsed = time.monotonic() - start_time
+    end_cpu = os.times()
+    cpu_user = (end_cpu.user - start_cpu.user) + (
+        end_cpu.children_user - start_cpu.children_user
+    )
+    cpu_system = (end_cpu.system - start_cpu.system) + (
+        end_cpu.children_system - start_cpu.children_system
+    )
+    log(
+        f"++ Completed in {elapsed:.1f}s "
+        f"(CPU: {cpu_user:.1f}s user, {cpu_system:.1f}s system)"
+    )
 
 
 def run_command(args: list[str | Path], cwd: Path | None = None) -> None:
@@ -80,14 +100,7 @@ def run_command(args: list[str | Path], cwd: Path | None = None) -> None:
             args, cwd=str(cwd) if cwd else None, stdin=subprocess.DEVNULL
         )
     finally:
-        elapsed = time.monotonic() - start_time
-        end_cpu = os.times()
-        child_user = end_cpu.children_user - start_cpu.children_user
-        child_system = end_cpu.children_system - start_cpu.children_system
-        log(
-            f"++ Completed in {elapsed:.1f}s "
-            f"(child CPU: {child_user:.1f}s user, {child_system:.1f}s system)"
-        )
+        log_command_duration(start_time=start_time, start_cpu=start_cpu)
 
 
 def fetch_and_flatten(
@@ -150,22 +163,111 @@ def is_kpack_split(flatten_dir: Path) -> bool:
     return manifest.get("flags", {}).get("KPACK_SPLIT_ARTIFACTS", False)
 
 
-def compress_tarball(*, source_dir: Path, tarball_path: Path) -> None:
+def compress_with_zlib_ng(
+    *,
+    source_dir: Path,
+    tarball_path: Path,
+    compression_level: int,
+    compression_threads: int,
+) -> None:
+    """Stream a tar archive through zlib-ng's threaded gzip writer."""
+    command = ["tar", "cf", "-", "."]
+    log(
+        f"++ Exec [{source_dir}]$ {shlex.join(command)} | "
+        "zlib_ng.gzip_ng_threaded.open"
+        f"(level={compression_level}, threads={compression_threads}) > {tarball_path}"
+    )
+    start_time = time.monotonic()
+    start_cpu = os.times()
+    tar_process = subprocess.Popen(
+        command,
+        cwd=source_dir,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+    )
+    assert tar_process.stdout is not None
+    try:
+        with tar_process.stdout:
+            with gzip_ng_threaded.open(
+                tarball_path,
+                "wb",
+                compresslevel=compression_level,
+                threads=compression_threads,
+            ) as gzip_output:
+                shutil.copyfileobj(
+                    tar_process.stdout,
+                    gzip_output,
+                    length=1024 * 1024,
+                )
+        return_code = tar_process.wait()
+        if return_code != 0:
+            raise subprocess.CalledProcessError(return_code, command)
+    except BaseException:
+        if tar_process.poll() is None:
+            tar_process.terminate()
+        tar_process.wait()
+        raise
+    finally:
+        log_command_duration(start_time=start_time, start_cpu=start_cpu)
+
+
+def compress_tarball(
+    *,
+    source_dir: Path,
+    tarball_path: Path,
+    compression_backend: str = DEFAULT_COMPRESSION_BACKEND,
+    compression_level: int = DEFAULT_COMPRESSION_LEVEL,
+    compression_threads: int = DEFAULT_COMPRESSION_THREADS,
+) -> None:
     """Compress a directory into a .tar.gz tarball.
 
-    Uses subprocess ``tar cfz`` rather than Python's ``tarfile`` module
-    (tarfile was significantly slower and produced larger output with default
-    settings — its ``compresslevel`` parameter may help but was not tuned).
-
-    Uses gzip to match the existing release tarball format. Switching to
-    zstd (``tar cf - . | zstd``) would be faster with better compression,
-    but requires downstream consumers to support ``.tar.zst``.
+    The system ``tar`` builds the archive. By default its output is streamed
+    through zlib-ng so gzip compression can use multiple threads. The system
+    gzip backend is retained for direct performance comparisons.
     """
     log(f"\nCompressing {source_dir} -> {tarball_path}")
     tarball_path.parent.mkdir(parents=True, exist_ok=True)
-    run_command(["tar", "cfz", str(tarball_path), "."], cwd=source_dir)
+    try:
+        if compression_backend == "zlib-ng":
+            compress_with_zlib_ng(
+                source_dir=source_dir,
+                tarball_path=tarball_path,
+                compression_level=compression_level,
+                compression_threads=compression_threads,
+            )
+        elif compression_backend == "system-gzip":
+            run_command(["tar", "cfz", str(tarball_path), "."], cwd=source_dir)
+        else:
+            raise ValueError(f"Unknown compression backend: {compression_backend}")
+    except BaseException:
+        tarball_path.unlink(missing_ok=True)
+        raise
     size_mb = tarball_path.stat().st_size / (1024 * 1024)
     log(f"  Created {tarball_path.name} ({size_mb:.1f} MB)")
+
+
+def available_cpu_count() -> int:
+    """Return the CPUs available to this process, respecting Linux affinity."""
+    try:
+        return len(os.sched_getaffinity(0))
+    except (AttributeError, OSError):
+        return os.cpu_count() or 1
+
+
+def determine_compress_workers(
+    *,
+    task_count: int,
+    requested_workers: int | None,
+    compression_backend: str,
+    compression_threads: int,
+) -> int:
+    """Select archive concurrency without oversubscribing compression CPUs."""
+    if requested_workers is not None:
+        return min(task_count, requested_workers)
+    cpus_per_archive = (
+        compression_threads + 1 if compression_backend == "zlib-ng" else 1
+    )
+    return min(task_count, max(1, available_cpu_count() // cpus_per_archive))
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -207,7 +309,36 @@ def main(argv: list[str] | None = None) -> None:
         action="store_true",
         help="Also produce -tests tarballs that include test artifacts",
     )
+    parser.add_argument(
+        "--compression-backend",
+        choices=["zlib-ng", "system-gzip"],
+        default=DEFAULT_COMPRESSION_BACKEND,
+        help="Gzip implementation to use (default: zlib-ng)",
+    )
+    parser.add_argument(
+        "--compression-level",
+        type=int,
+        choices=range(10),
+        default=DEFAULT_COMPRESSION_LEVEL,
+        help="Gzip compression level for zlib-ng (default: 6)",
+    )
+    parser.add_argument(
+        "--compression-threads",
+        type=int,
+        default=DEFAULT_COMPRESSION_THREADS,
+        help="Compression threads per zlib-ng tarball (default: 8)",
+    )
+    parser.add_argument(
+        "--compress-workers",
+        type=int,
+        default=None,
+        help="Concurrent tarballs to compress (default: auto based on CPU count)",
+    )
     args = parser.parse_args(argv)
+    if args.compression_threads < 1:
+        parser.error("--compression-threads must be at least 1")
+    if args.compress_workers is not None and args.compress_workers < 1:
+        parser.error("--compress-workers must be at least 1")
     # Normalize empty string to None (workflow inputs default to "")
     args.run_github_repo = args.run_github_repo or None
 
@@ -225,6 +356,9 @@ def main(argv: list[str] | None = None) -> None:
     log(f"  Version: {args.package_version}")
     log(f"  Output: {args.output_dir}")
     log(f"  Include test tarballs: {args.include_test_tarballs}")
+    log(f"  Compression backend: {args.compression_backend}")
+    log(f"  Compression level: {args.compression_level}")
+    log(f"  Compression threads per tarball: {args.compression_threads}")
 
     # Phase 1: Fetch and flatten sequentially.
     # Sequential so the shared download cache avoids re-downloading generic
@@ -308,14 +442,35 @@ def main(argv: list[str] | None = None) -> None:
                 (tests_multiarch_dir, args.output_dir / tests_tarball_name)
             )
 
-    # Phase 2: Compress all tarballs in parallel.
-    # Each tar cfz is single-threaded, so running N families concurrently
-    # on a multi-core runner scales well with minimal per-job slowdown.
-    # TODO: Add --compress-workers flag to cap concurrency on smaller runners.
-    log(f"\nCompressing {len(compress_tasks)} tarballs in parallel...")
-    with ProcessPoolExecutor(max_workers=len(compress_tasks)) as executor:
+    # Phase 2: Compress tarballs in parallel, with optional intra-archive
+    # parallelism from zlib-ng.
+    compress_workers = determine_compress_workers(
+        task_count=len(compress_tasks),
+        requested_workers=args.compress_workers,
+        compression_backend=args.compression_backend,
+        compression_threads=args.compression_threads,
+    )
+    if args.compression_backend == "zlib-ng":
+        compression_description = (
+            f"zlib-ng level {args.compression_level}, "
+            f"{args.compression_threads} threads per tarball"
+        )
+    else:
+        compression_description = "system gzip"
+    log(
+        f"\nCompressing {len(compress_tasks)} tarballs with {compress_workers} "
+        f"workers using {compression_description}..."
+    )
+    with ProcessPoolExecutor(max_workers=compress_workers) as executor:
         futures = {
-            executor.submit(compress_tarball, source_dir=src, tarball_path=dst): dst
+            executor.submit(
+                compress_tarball,
+                source_dir=src,
+                tarball_path=dst,
+                compression_backend=args.compression_backend,
+                compression_level=args.compression_level,
+                compression_threads=args.compression_threads,
+            ): dst
             for src, dst in compress_tasks
         }
         for future in as_completed(futures):

--- a/build_tools/build_tarballs.py
+++ b/build_tools/build_tarballs.py
@@ -68,7 +68,11 @@ from zlib_ng import gzip_ng_threaded
 DEFAULT_EXCLUDED_ARTIFACTS: list[str] = ["fftw3"]
 DEFAULT_EXCLUDED_COMPONENTS: list[str] = ["test"]
 DEFAULT_COMPRESSION_BACKEND = "zlib-ng"
+# Level 9 recovers system-gzip's archive size while still keeping tarball
+# construction well below the other release packaging jobs.
 DEFAULT_COMPRESSION_LEVEL = 9
+# Eight threads balances single-archive throughput with enough archive-level
+# concurrency to start the largest tarballs together on high-core-count runners.
 DEFAULT_COMPRESSION_THREADS = 8
 
 # Higher priorities represent tarballs expected to take longer to compress.
@@ -280,6 +284,8 @@ def determine_compress_workers(
     """Select archive concurrency without oversubscribing compression CPUs."""
     if requested_workers is not None:
         return min(task_count, requested_workers)
+    # Each zlib-ng archive also runs a tar producer alongside its compression
+    # threads, so reserve one additional CPU for that subprocess.
     cpus_per_archive = (
         compression_threads + 1 if compression_backend == "zlib-ng" else 1
     )
@@ -376,9 +382,9 @@ def main(argv: list[str] | None = None) -> None:
     log(f"  Compression level: {args.compression_level}")
     log(f"  Compression threads per tarball: {args.compression_threads}")
 
-    # Phase 1: Fetch and flatten sequentially.
-    # Sequential so the shared download cache avoids re-downloading generic
-    # (host) artifacts for each family.
+    # Phase 1: Fetch and flatten sequentially so generic (host) artifacts can
+    # reuse both their downloaded archives and extracted contents across the
+    # family and multiarch staging trees.
     family_dirs = []
     compress_tasks: list[CompressionTask] = []
     for family in families:

--- a/build_tools/build_tarballs.py
+++ b/build_tools/build_tarballs.py
@@ -54,9 +54,12 @@ files (e.g. ``lib/hipblaslt/library/*.co``) only for the target family.
 import argparse
 from concurrent.futures import ProcessPoolExecutor, as_completed
 import json
+import os
 import shlex
+import shutil
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 DEFAULT_EXCLUDED_ARTIFACTS: list[str] = ["fftw3"]
@@ -70,7 +73,21 @@ def log(msg: str) -> None:
 def run_command(args: list[str | Path], cwd: Path | None = None) -> None:
     args = [str(arg) for arg in args]
     log(f"++ Exec{f' [{cwd}]' if cwd else ''}$ {shlex.join(args)}")
-    subprocess.check_call(args, cwd=str(cwd) if cwd else None, stdin=subprocess.DEVNULL)
+    start_time = time.monotonic()
+    start_cpu = os.times()
+    try:
+        subprocess.check_call(
+            args, cwd=str(cwd) if cwd else None, stdin=subprocess.DEVNULL
+        )
+    finally:
+        elapsed = time.monotonic() - start_time
+        end_cpu = os.times()
+        child_user = end_cpu.children_user - start_cpu.children_user
+        child_system = end_cpu.children_system - start_cpu.children_system
+        log(
+            f"++ Completed in {elapsed:.1f}s "
+            f"(child CPU: {child_user:.1f}s user, {child_system:.1f}s system)"
+        )
 
 
 def fetch_and_flatten(
@@ -80,6 +97,7 @@ def fetch_and_flatten(
     platform: str,
     output_dir: Path,
     download_cache_dir: Path,
+    extraction_cache_dir: Path,
     run_github_repo: str | None = None,
     exclude_components: list[str] | None = None,
     exclude_artifacts: list[str] | None = None,
@@ -106,6 +124,7 @@ def fetch_and_flatten(
         f"--output-dir={output_dir}",
         "--flatten",
         f"--download-cache-dir={download_cache_dir}",
+        f"--extraction-cache-dir={extraction_cache_dir}",
     ]
     if exclude_components:
         cmd.append(f"--exclude-components={','.join(exclude_components)}")
@@ -114,6 +133,12 @@ def fetch_and_flatten(
     if run_github_repo:
         cmd.append(f"--run-github-repo={run_github_repo}")
     run_command(cmd)
+    disk_usage = shutil.disk_usage(output_dir)
+    log(
+        "  Disk after staging: "
+        f"{disk_usage.used / (1024**3):.1f} GiB used, "
+        f"{disk_usage.free / (1024**3):.1f} GiB free"
+    )
 
 
 def is_kpack_split(flatten_dir: Path) -> bool:
@@ -192,6 +217,7 @@ def main(argv: list[str] | None = None) -> None:
 
     work_dir = args.output_dir / ".work"
     download_cache_dir = work_dir / "download-cache"
+    extraction_cache_dir = work_dir / "extraction-cache"
     download_cache_dir.mkdir(parents=True, exist_ok=True)
 
     log(f"Building tarballs for {len(families)} families: {', '.join(families)}")
@@ -213,6 +239,7 @@ def main(argv: list[str] | None = None) -> None:
             platform=args.platform,
             output_dir=flatten_dir,
             download_cache_dir=download_cache_dir,
+            extraction_cache_dir=extraction_cache_dir,
             run_github_repo=args.run_github_repo,
             exclude_components=DEFAULT_EXCLUDED_COMPONENTS,
             exclude_artifacts=DEFAULT_EXCLUDED_ARTIFACTS,
@@ -230,6 +257,7 @@ def main(argv: list[str] | None = None) -> None:
                 platform=args.platform,
                 output_dir=tests_dir,
                 download_cache_dir=download_cache_dir,
+                extraction_cache_dir=extraction_cache_dir,
                 run_github_repo=args.run_github_repo,
             )
             tests_tarball_name = (
@@ -252,6 +280,7 @@ def main(argv: list[str] | None = None) -> None:
             platform=args.platform,
             output_dir=multiarch_dir,
             download_cache_dir=download_cache_dir,
+            extraction_cache_dir=extraction_cache_dir,
             run_github_repo=args.run_github_repo,
             exclude_components=DEFAULT_EXCLUDED_COMPONENTS,
             exclude_artifacts=DEFAULT_EXCLUDED_ARTIFACTS,
@@ -268,6 +297,7 @@ def main(argv: list[str] | None = None) -> None:
                 platform=args.platform,
                 output_dir=tests_multiarch_dir,
                 download_cache_dir=download_cache_dir,
+                extraction_cache_dir=extraction_cache_dir,
                 run_github_repo=args.run_github_repo,
             )
             tests_tarball_name = (

--- a/build_tools/build_tarballs.py
+++ b/build_tools/build_tarballs.py
@@ -68,7 +68,7 @@ from zlib_ng import gzip_ng_threaded
 DEFAULT_EXCLUDED_ARTIFACTS: list[str] = ["fftw3"]
 DEFAULT_EXCLUDED_COMPONENTS: list[str] = ["test"]
 DEFAULT_COMPRESSION_BACKEND = "zlib-ng"
-DEFAULT_COMPRESSION_LEVEL = 6
+DEFAULT_COMPRESSION_LEVEL = 9
 DEFAULT_COMPRESSION_THREADS = 8
 
 # Higher priorities represent tarballs expected to take longer to compress.
@@ -336,7 +336,7 @@ def main(argv: list[str] | None = None) -> None:
         type=int,
         choices=range(10),
         default=DEFAULT_COMPRESSION_LEVEL,
-        help="Gzip compression level for zlib-ng (default: 6)",
+        help="Gzip compression level for zlib-ng (default: 9)",
     )
     parser.add_argument(
         "--compression-threads",

--- a/build_tools/build_tarballs.py
+++ b/build_tools/build_tarballs.py
@@ -53,6 +53,7 @@ files (e.g. ``lib/hipblaslt/library/*.co``) only for the target family.
 
 import argparse
 from concurrent.futures import ProcessPoolExecutor, as_completed
+from dataclasses import dataclass
 import json
 import os
 import shlex
@@ -69,6 +70,21 @@ DEFAULT_EXCLUDED_COMPONENTS: list[str] = ["test"]
 DEFAULT_COMPRESSION_BACKEND = "zlib-ng"
 DEFAULT_COMPRESSION_LEVEL = 6
 DEFAULT_COMPRESSION_THREADS = 8
+
+# Higher priorities represent tarballs expected to take longer to compress.
+# Starting the slowest tasks first lets faster tasks run concurrently and
+# reduces the chance that one large archive extends the end of the job.
+FAMILY_TARBALL_PRIORITY = 0
+FAMILY_TESTS_TARBALL_PRIORITY = 1
+MULTIARCH_TARBALL_PRIORITY = 2
+MULTIARCH_TESTS_TARBALL_PRIORITY = 3
+
+
+@dataclass(frozen=True)
+class CompressionTask:
+    source_dir: Path
+    tarball_path: Path
+    priority: int
 
 
 def log(msg: str) -> None:
@@ -364,7 +380,7 @@ def main(argv: list[str] | None = None) -> None:
     # Sequential so the shared download cache avoids re-downloading generic
     # (host) artifacts for each family.
     family_dirs = []
-    compress_tasks = []
+    compress_tasks: list[CompressionTask] = []
     for family in families:
         flatten_dir = work_dir / family
         fetch_and_flatten(
@@ -382,7 +398,13 @@ def main(argv: list[str] | None = None) -> None:
         tarball_name = (
             f"therock-dist-{args.platform}-{family}-{args.package_version}.tar.gz"
         )
-        compress_tasks.append((flatten_dir, args.output_dir / tarball_name))
+        compress_tasks.append(
+            CompressionTask(
+                source_dir=flatten_dir,
+                tarball_path=args.output_dir / tarball_name,
+                priority=FAMILY_TARBALL_PRIORITY,
+            )
+        )
         if args.include_test_tarballs:
             tests_dir = work_dir / "tests" / family
             fetch_and_flatten(
@@ -398,7 +420,13 @@ def main(argv: list[str] | None = None) -> None:
                 f"therock-dist-{args.platform}-{family}-tests-"
                 f"{args.package_version}.tar.gz"
             )
-            compress_tasks.append((tests_dir, args.output_dir / tests_tarball_name))
+            compress_tasks.append(
+                CompressionTask(
+                    source_dir=tests_dir,
+                    tarball_path=args.output_dir / tests_tarball_name,
+                    priority=FAMILY_TESTS_TARBALL_PRIORITY,
+                )
+            )
 
     # Phase 1.5: If KPACK_SPLIT_ARTIFACTS is enabled, fetch all families
     # into a single combined directory. With KPACK split, device-specific
@@ -422,7 +450,13 @@ def main(argv: list[str] | None = None) -> None:
         tarball_name = (
             f"therock-dist-{args.platform}-multiarch-{args.package_version}.tar.gz"
         )
-        compress_tasks.append((multiarch_dir, args.output_dir / tarball_name))
+        compress_tasks.append(
+            CompressionTask(
+                source_dir=multiarch_dir,
+                tarball_path=args.output_dir / tarball_name,
+                priority=MULTIARCH_TARBALL_PRIORITY,
+            )
+        )
         if args.include_test_tarballs:
             tests_multiarch_dir = work_dir / "tests" / "multiarch"
             fetch_and_flatten(
@@ -439,11 +473,17 @@ def main(argv: list[str] | None = None) -> None:
                 f"{args.package_version}.tar.gz"
             )
             compress_tasks.append(
-                (tests_multiarch_dir, args.output_dir / tests_tarball_name)
+                CompressionTask(
+                    source_dir=tests_multiarch_dir,
+                    tarball_path=args.output_dir / tests_tarball_name,
+                    priority=MULTIARCH_TESTS_TARBALL_PRIORITY,
+                )
             )
 
     # Phase 2: Compress tarballs in parallel, with optional intra-archive
-    # parallelism from zlib-ng.
+    # parallelism from zlib-ng. Start the expected largest archives first to
+    # reduce the tail when there are more archives than compression workers.
+    compress_tasks.sort(key=lambda task: task.priority, reverse=True)
     compress_workers = determine_compress_workers(
         task_count=len(compress_tasks),
         requested_workers=args.compress_workers,
@@ -465,13 +505,13 @@ def main(argv: list[str] | None = None) -> None:
         futures = {
             executor.submit(
                 compress_tarball,
-                source_dir=src,
-                tarball_path=dst,
+                source_dir=task.source_dir,
+                tarball_path=task.tarball_path,
                 compression_backend=args.compression_backend,
                 compression_level=args.compression_level,
                 compression_threads=args.compression_threads,
-            ): dst
-            for src, dst in compress_tasks
+            ): task.tarball_path
+            for task in compress_tasks
         }
         for future in as_completed(futures):
             future.result()  # Raises on failure

--- a/build_tools/tests/artifact_manager_tool_test.py
+++ b/build_tools/tests/artifact_manager_tool_test.py
@@ -491,6 +491,30 @@ class TestPushStageAll(ArtifactManagerTestBase):
 class TestFetchFailureExitCode(ArtifactManagerTestBase):
     """Tests that fetch command exits with non-zero code on download failures."""
 
+    @mock.patch("artifact_manager.create_backend_from_env")
+    def test_fetch_fails_when_no_artifacts_match(self, mock_backend_factory):
+        """Test that fetch raises when the backend has no matches."""
+        import artifact_manager
+
+        mock_backend_factory.return_value = FailingBackend()
+        argv = [
+            "fetch",
+            "--stage",
+            "downstream-stage",
+            "--output-dir",
+            str(self.output_dir),
+            "--topology",
+            str(self.topology_path),
+            "--platform",
+            TEST_PLATFORM,
+        ]
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "No matching artifacts found in failing://test-local-linux",
+        ):
+            artifact_manager.main(argv)
+
     @mock.patch("artifact_manager._delay_for_retry")
     @mock.patch("artifact_manager.create_backend_from_env")
     def test_fetch_fails_when_download_fails(self, mock_backend_factory, mock_delay):

--- a/build_tools/tests/artifact_manager_tool_test.py
+++ b/build_tools/tests/artifact_manager_tool_test.py
@@ -488,8 +488,8 @@ class TestPushStageAll(ArtifactManagerTestBase):
             )
 
 
-class TestFetchFailureExitCode(ArtifactManagerTestBase):
-    """Tests that fetch command exits with non-zero code on download failures."""
+class TestFetchFailures(ArtifactManagerTestBase):
+    """Tests that fetch fails when required artifacts cannot be retrieved."""
 
     @mock.patch("artifact_manager.create_backend_from_env")
     def test_fetch_fails_when_no_artifacts_match(self, mock_backend_factory):
@@ -1200,6 +1200,42 @@ class TestFetchExtractionCache(ArtifactManagerTestBase):
                 self.assertEqual(
                     os.readlink(output_dir / "regular-symlink.txt"), "regular.txt"
                 )
+
+    def test_incomplete_cache_entry_is_rebuilt(self):
+        """A cache entry without its completion manifest is replaced."""
+        import artifact_manager
+
+        archive_path = self._create_real_artifact()
+        extraction_cache_dir = Path(self.temp_dir) / "extraction-cache"
+        cached_artifact_dir = extraction_cache_dir / archive_path.name
+        cached_artifact_dir.mkdir(parents=True)
+        stale_file = cached_artifact_dir / "stale.txt"
+        stale_file.write_text("incomplete extraction")
+        output_dir = Path(self.temp_dir) / "output"
+
+        result = artifact_manager.extract_artifact(
+            artifact_manager.ExtractRequest(
+                archive_path=archive_path,
+                output_dir=output_dir,
+                delete_archive=False,
+                flatten=True,
+                extraction_cache_dir=extraction_cache_dir,
+            )
+        )
+
+        self.assertEqual(result, output_dir)
+        self.assertFalse(stale_file.exists())
+        self.assertEqual(
+            (cached_artifact_dir / "artifact_manifest.txt").read_text(),
+            "component/stage\n",
+        )
+        cached_regular_file = (
+            cached_artifact_dir / "component" / "stage" / "regular.txt"
+        )
+        self.assertEqual(cached_regular_file.read_text(), "artifact contents")
+        self.assertTrue(
+            os.path.samefile(output_dir / "regular.txt", cached_regular_file)
+        )
 
 
 class TestFetchDownloadCache(ArtifactManagerTestBase):

--- a/build_tools/tests/artifact_manager_tool_test.py
+++ b/build_tools/tests/artifact_manager_tool_test.py
@@ -12,6 +12,7 @@ import hashlib
 import os
 import platform
 import shutil
+import stat
 import sys
 import tempfile
 import unittest
@@ -27,6 +28,7 @@ def is_windows():
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 
 from _therock_utils.artifact_backend import ArtifactBackend, LocalDirectoryBackend
+from _therock_utils.archive_util import open_archive_for_write
 from _therock_utils.workflow_outputs import WorkflowOutputRoot
 
 # Minimal topology TOML for testing push/fetch behavior.
@@ -1070,6 +1072,110 @@ class TestFetchFlatten(ArtifactManagerTestBase):
 
         # Exit code 2 is used by argparse for command-line syntax errors
         self.assertEqual(ctx.exception.code, 2)
+
+
+class TestFetchExtractionCache(ArtifactManagerTestBase):
+    """Tests for reusing extracted artifacts in flattened output trees."""
+
+    def _create_real_artifact(self) -> Path:
+        artifact_dir = Path(self.temp_dir) / "artifact"
+        stage_dir = artifact_dir / "component" / "stage"
+        stage_dir.mkdir(parents=True)
+        manifest_path = artifact_dir / "artifact_manifest.txt"
+        manifest_path.write_text("component/stage\n")
+
+        regular_file = stage_dir / "regular.txt"
+        regular_file.write_text("artifact contents")
+        executable_file = stage_dir / "executable"
+        executable_file.write_text("#!/bin/sh\n")
+        executable_file.chmod(0o755)
+        os.link(regular_file, stage_dir / "regular-hardlink.txt")
+        if not is_windows():
+            os.symlink("regular.txt", stage_dir / "regular-symlink.txt")
+
+        archive_path = Path(self.temp_dir) / "test-artifact_lib_generic.tar.zst"
+        with open_archive_for_write(archive_path, "zstd") as archive:
+            # ArtifactPopulator requires the manifest to be the first member.
+            archive.add(manifest_path, arcname="artifact_manifest.txt")
+            for filename in (
+                "regular.txt",
+                "regular-hardlink.txt",
+                "executable",
+                "regular-symlink.txt",
+            ):
+                path = stage_dir / filename
+                if path.exists() or path.is_symlink():
+                    archive.add(path, arcname=f"component/stage/{filename}")
+        return archive_path
+
+    def test_second_flatten_reuses_extracted_files(self):
+        import artifact_manager
+
+        archive_path = self._create_real_artifact()
+        extraction_cache_dir = Path(self.temp_dir) / "extraction-cache"
+        direct_output = Path(self.temp_dir) / "direct-output"
+        first_output = Path(self.temp_dir) / "first-output"
+        second_output = Path(self.temp_dir) / "second-output"
+
+        direct_result = artifact_manager.extract_artifact(
+            artifact_manager.ExtractRequest(
+                archive_path=archive_path,
+                output_dir=direct_output,
+                delete_archive=False,
+                flatten=True,
+            )
+        )
+        self.assertEqual(direct_result, direct_output)
+
+        first_result = artifact_manager.extract_artifact(
+            artifact_manager.ExtractRequest(
+                archive_path=archive_path,
+                output_dir=first_output,
+                delete_archive=False,
+                flatten=True,
+                extraction_cache_dir=extraction_cache_dir,
+            )
+        )
+        self.assertEqual(first_result, first_output)
+
+        # Prove the second flatten no longer needs the compressed archive.
+        archive_path.unlink()
+        second_result = artifact_manager.extract_artifact(
+            artifact_manager.ExtractRequest(
+                archive_path=archive_path,
+                output_dir=second_output,
+                delete_archive=False,
+                flatten=True,
+                extraction_cache_dir=extraction_cache_dir,
+            )
+        )
+        self.assertEqual(second_result, second_output)
+
+        cached_stage = extraction_cache_dir / archive_path.name / "component" / "stage"
+        for output_dir in (direct_output, first_output, second_output):
+            self.assertEqual(
+                (output_dir / "regular.txt").read_text(), "artifact contents"
+            )
+            if not is_windows():
+                self.assertEqual(
+                    stat.S_IMODE((output_dir / "executable").stat().st_mode), 0o755
+                )
+            self.assertTrue(
+                os.path.samefile(
+                    output_dir / "regular.txt",
+                    output_dir / "regular-hardlink.txt",
+                )
+            )
+            if output_dir != direct_output:
+                self.assertTrue(
+                    os.path.samefile(
+                        output_dir / "regular.txt", cached_stage / "regular.txt"
+                    )
+                )
+            if not is_windows():
+                self.assertEqual(
+                    os.readlink(output_dir / "regular-symlink.txt"), "regular.txt"
+                )
 
 
 class TestFetchDownloadCache(ArtifactManagerTestBase):

--- a/build_tools/tests/build_tarballs_test.py
+++ b/build_tools/tests/build_tarballs_test.py
@@ -193,7 +193,7 @@ class TestMain(unittest.TestCase):
         self.assertEqual(
             compress_mock.call_args.kwargs["compression_backend"], "zlib-ng"
         )
-        self.assertEqual(compress_mock.call_args.kwargs["compression_level"], 6)
+        self.assertEqual(compress_mock.call_args.kwargs["compression_level"], 9)
         self.assertEqual(compress_mock.call_args.kwargs["compression_threads"], 8)
 
     def test_kpack_builds_common_tarball_with_one_family(self) -> None:

--- a/build_tools/tests/build_tarballs_test.py
+++ b/build_tools/tests/build_tarballs_test.py
@@ -216,10 +216,10 @@ class TestMain(unittest.TestCase):
             call.kwargs["tarball_path"].name for call in compress_mock.call_args_list
         ]
         self.assertEqual(
-            sorted(compressed_names),
+            compressed_names,
             [
-                "therock-dist-linux-gfx94X-dcgpu-7.13.0.tar.gz",
                 "therock-dist-linux-multiarch-7.13.0.tar.gz",
+                "therock-dist-linux-gfx94X-dcgpu-7.13.0.tar.gz",
             ],
         )
 
@@ -251,10 +251,10 @@ class TestMain(unittest.TestCase):
             call.kwargs["tarball_path"].name for call in compress_mock.call_args_list
         ]
         self.assertEqual(
-            sorted(compressed_names),
+            compressed_names,
             [
-                "therock-dist-linux-gfx94X-dcgpu-7.13.0.tar.gz",
                 "therock-dist-linux-gfx94X-dcgpu-tests-7.13.0.tar.gz",
+                "therock-dist-linux-gfx94X-dcgpu-7.13.0.tar.gz",
             ],
         )
 
@@ -287,14 +287,14 @@ class TestMain(unittest.TestCase):
             call.kwargs["tarball_path"].name for call in compress_mock.call_args_list
         ]
         self.assertEqual(
-            sorted(compressed_names),
+            compressed_names,
             [
-                "therock-dist-linux-gfx110X-all-7.13.0.tar.gz",
+                "therock-dist-linux-multiarch-tests-7.13.0.tar.gz",
+                "therock-dist-linux-multiarch-7.13.0.tar.gz",
+                "therock-dist-linux-gfx94X-dcgpu-tests-7.13.0.tar.gz",
                 "therock-dist-linux-gfx110X-all-tests-7.13.0.tar.gz",
                 "therock-dist-linux-gfx94X-dcgpu-7.13.0.tar.gz",
-                "therock-dist-linux-gfx94X-dcgpu-tests-7.13.0.tar.gz",
-                "therock-dist-linux-multiarch-7.13.0.tar.gz",
-                "therock-dist-linux-multiarch-tests-7.13.0.tar.gz",
+                "therock-dist-linux-gfx110X-all-7.13.0.tar.gz",
             ],
         )
 

--- a/build_tools/tests/build_tarballs_test.py
+++ b/build_tools/tests/build_tarballs_test.py
@@ -16,7 +16,12 @@ from unittest import mock
 
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 
-from build_tarballs import compress_tarball, is_kpack_split, main
+from build_tarballs import (
+    compress_tarball,
+    determine_compress_workers,
+    is_kpack_split,
+    main,
+)
 
 
 class MainMocks(NamedTuple):
@@ -97,6 +102,49 @@ class TestCompressTarball(unittest.TestCase):
                 self.assertIn("./bin/hello", names)
                 self.assertIn("./lib/libfoo.so", names)
 
+    def test_creates_tarball_with_system_gzip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            src = tmpdir / "src"
+            src.mkdir()
+            (src / "hello").write_text("hello world")
+
+            tarball_path = tmpdir / "test.tar.gz"
+            compress_tarball(
+                source_dir=src,
+                tarball_path=tarball_path,
+                compression_backend="system-gzip",
+            )
+
+            with tarfile.open(tarball_path, "r:gz") as tf:
+                self.assertIn("./hello", tf.getnames())
+
+
+class TestDetermineCompressWorkers(unittest.TestCase):
+    @mock.patch("build_tarballs.available_cpu_count", return_value=32)
+    def test_zlib_ng_reserves_cpus_per_archive(self, _: mock.Mock) -> None:
+        self.assertEqual(
+            determine_compress_workers(
+                task_count=10,
+                requested_workers=None,
+                compression_backend="zlib-ng",
+                compression_threads=8,
+            ),
+            3,
+        )
+
+    @mock.patch("build_tarballs.available_cpu_count", return_value=32)
+    def test_requested_workers_are_capped_by_task_count(self, _: mock.Mock) -> None:
+        self.assertEqual(
+            determine_compress_workers(
+                task_count=4,
+                requested_workers=8,
+                compression_backend="zlib-ng",
+                compression_threads=8,
+            ),
+            4,
+        )
+
 
 class TestMain(unittest.TestCase):
     def _run_main_with_mocks(
@@ -142,6 +190,11 @@ class TestMain(unittest.TestCase):
             compressed_names,
             ["therock-dist-linux-gfx94X-dcgpu-7.13.0.tar.gz"],
         )
+        self.assertEqual(
+            compress_mock.call_args.kwargs["compression_backend"], "zlib-ng"
+        )
+        self.assertEqual(compress_mock.call_args.kwargs["compression_level"], 6)
+        self.assertEqual(compress_mock.call_args.kwargs["compression_threads"], 8)
 
     def test_kpack_builds_common_tarball_with_one_family(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/build_tools/tests/build_tarballs_test.py
+++ b/build_tools/tests/build_tarballs_test.py
@@ -101,6 +101,9 @@ class TestCompressTarball(unittest.TestCase):
                 names = tf.getnames()
                 self.assertIn("./bin/hello", names)
                 self.assertIn("./lib/libfoo.so", names)
+                hello_file = tf.extractfile("./bin/hello")
+                self.assertIsNotNone(hello_file)
+                self.assertEqual(hello_file.read(), b"hello world")
 
     def test_creates_tarball_with_system_gzip(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,6 +6,7 @@ pytest-timeout==2.4.0
 perfetto==0.7.0 # Newer versions of perfetto remove support for required GLIBC version.
 PyYAML==6.0.2
 pyzstd>=0.16.0
+zlib-ng>=1.0.0
 prettytable==3.12.0
 requests==2.33.0
 jsonschema==4.23.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ pre-commit>=4.3.0
 python-magic>=0.4.27; platform_system != "Windows"
 PyYAML==6.0.2
 pyzstd>=0.16.0
+zlib-ng>=1.0.0
 # `pkg_resources` has been removed from Setuptools in version 82.0.0
 # but it still a dependency in some environments (issue#3311)
 setuptools>=80.9.0,<82.0.0


### PR DESCRIPTION
## Motivation

The "build tarballs" job is currently a bottleneck for our release workflow runs, contributing to issues like https://github.com/ROCm/TheRock/issues/7584:

* Non-ASan example: https://github.com/ROCm/TheRock/actions/runs/32843555429
    | Packaging job | Duration |
    |---|---:|
    | Python packages | 13m28s |
    | Tarballs | 1h21m24s |
    | Native DEB packages | 49m51s |
    | Native RPM packages | 17m47s |   
* ASan example: https://github.com/ROCm/TheRock/actions/runs/31754588494
    | Packaging job | Duration |
    |---|---:|
    | Python packages | 1h38m56s |
    | Tarballs | 4h03m24s |
    | Native DEB packages | 1h39m36s |
    | Native RPM packages | 1h15m48s |

This optimizes tarball building so that it is no longer a bottleneck while also decreasing tarball binary size through higher compression:

Job type | Logs link | Job duration | multiarch-tests binary size 
-- | -- |  -- | --
Non-ASan baseline | [logs here](https://github.com/ROCm/TheRock/actions/runs/32843555429/job/97898286590) | 1h20m42s | 14433.4 MB
Non-ASan optimized | [logs here](https://github.com/ROCm/TheRock/actions/runs/32989643966/job/98243934972) | 8m53s | 14367.6 MB
ASan baseline | [logs here](https://github.com/ROCm/TheRock/actions/runs/31754588494/job/94677418023) |  2h14m36s | 42047.2 MB
ASan optimized | [logs here](https://github.com/ROCm/TheRock/actions/runs/32989724543/job/98244187888) | 34m35s | 41627.5 MB

## Background

"Build tarballs" is the script/job that turns ROCm [artifacts](https://github.com/ROCm/TheRock/blob/main/docs/development/artifacts.md) into ROCm [tarballs](https://github.com/ROCm/TheRock/blob/main/RELEASES.md#installing-multi-arch-tarballs). It involves downloading artifacts, extracting them into merged folders, compressing those folders into `tar.gz` files (future plans include switching to `.zip` on Windows), then uploading them. For example, here are some log snippets from each stage:
```
Downloading 220 artifacts...
  ++ Downloading amd-dbgapi_dbg_generic.tar.zst
  ++ Flattening blas_run_generic.tar.zst to /home/runner/_work/TheRock/TheRock/tarballs/.work/gfx94X-dcgpu
Compressing /home/runner/_work/TheRock/TheRock/tarballs/.work/multiarch -> /home/runner/_work/TheRock/TheRock/tarballs/therock-dist-linux-multiarch-10.1.0.dev0+564fcb5db47af14ade7a41d7aab43248561d90c1.tar.gz
  Created therock-dist-linux-multiarch-10.1.0.dev0+564fcb5db47af14ade7a41d7aab43248561d90c1.tar.gz (9980.6 MB)
```

Each run handles on the order of 30 tarball outputs totaling 100GB with significant overlap between files across tarballs.

## Technical Details

This includes three optimizations:
1. Decompress each artifact once and hardlink it into each staging tree, rather than decompress into staging trees directly
2. Parallelize tarball compression using the [zlib-ng](https://github.com/zlib-ng/zlib-ng) python package instead of the system `tar`
3. Reorder compression tasks so slower tasks (unified multiarch tarballs, tarballs including tests) start before faster tasks

More details for this work are available here: https://github.com/ScottTodd/rocm-workspace/blob/main/tasks/completed/tarball-packaging-optimization-experiments.md.

## Test Plan

Tarball builds are **not tested on CI**, so CI on this PR will only test the changes to `build_tools/artifact_manager.py`. The workflow runs of [`multi_arch_build_tarballs.yml`](https://github.com/ROCm/TheRock/actions/workflows/multi_arch_build_tarballs.yml) I linked above should suffice for e2e testing.

### Correctness testing

* New and existing unit tests
* Switching to zlib-ng and changing compression levels affects the generated tarball archives, so I compared tarball contents before and after, checking for metadata differences or file inclusion differences using these scripts: https://gist.github.com/ScottTodd/c85e9728a34a449442431409006c6e44. Each archive had the same uncompressed files, only differing in `mtime` metadata. See https://github.com/ScottTodd/rocm-workspace/blob/main/tasks/completed/tarball-packaging-optimization-experiments.md#correctness-results for the detailed report.

### Performance testing

Testing was performed locallly on Windows (AMD Ryzen Threadripper PRO 7975WX 32-Cores) as well as on our self-hosted `aws-linux-scale-rocm-prod` runners (96 cores).

* Extraction cache test results: [see detailed results here](https://github.com/ScottTodd/rocm-workspace/blob/main/tasks/completed/tarball-packaging-optimization-experiments.md#extraction-cache-isolation-four-family-experiment)
  | Phase | Baseline | Extraction cache | Change |
  |---|---:|---:|---:|
  | Staging | 5m52s | 1m03s | 82.2% reduction, 5.61x faster |
  | Compression | 8m11s | 7m35s | 7.3% (N/A, unchanged code, run variance) |
  | Script total | 14m02s | 8m38s | 38.5% reduction, 1.63x faster |
* Compression level microbenchmarks: [see detailed results here](https://github.com/ScottTodd/rocm-workspace/blob/main/tasks/completed/tarball-packaging-optimization-experiments.md#compression-level-microbenchmark)
  | Backend/level | Time | Size | Size versus warmed system gzip |
  |---|---:|---:|---:|
  | System gzip, warmed | 22.890s | 219,154,772 | baseline |
  | zlib-ng level 6 | 2.026s | 223,470,427 | +1.97% |
  | zlib-ng level 7 | 2.460s | 221,742,724 | +1.18% |
  | zlib-ng level 8 | 5.841s | 220,501,646 | +0.61% |
  | zlib-ng level 9 | 5.413s | 217,343,726 | -0.83% |

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
