### PR TITLE
feat(ci): add `off` mode for artifact reuse

### DIFF
--- a/.github/workflows/multi_arch_ci.yml
+++ b/.github/workflows/multi_arch_ci.yml
@@ -46,13 +46,13 @@ on:
         type: choice
         default: "dry-run"
         options:
+          - "off"
           - "dry-run"
           - "reuse-stage"
-        # This drives the AUTOMATIC stage-reuse detection layer, which is
-        # separate from the manual `prebuilt_stages` input above. dry-run only
-        # reports which unaffected stages could be reused; reuse-stage actually
-        # reuses them (skips the build and copies artifacts from a baseline run).
-        description: "dry-run (report only) | reuse-stage (auto-reuse unaffected stages)"
+        # off disables all artifact reuse and ignores explicit prebuilt stages and
+        # baseline inputs. dry-run reports automatic reuse opportunities without
+        # applying them. reuse-stage applies automatic reuse.
+        description: "off (disable reuse) | dry-run (report only) | reuse-stage (auto-reuse unaffected stages)"
       stage_reuse_max_age_hours:
         type: string
         default: "72"

--- a/.github/workflows/setup_multi_arch.yml
+++ b/.github/workflows/setup_multi_arch.yml
@@ -46,9 +46,11 @@ on:
         default: ""
       stage_reuse_mode:
         description: >-
-          Automatic stage-reuse mode (separate from the manual prebuilt_stages
-          input): "dry-run" (default) only reports which unaffected stages could
-          be reused; "reuse-stage" actually reuses them.
+          Artifact-reuse mode: "off" disables all reuse, ignores prebuilt_stages
+          and baseline_run_id, and performs no reuse analysis or baseline lookup;
+          "dry-run" (default) reports what automatic reuse could do while still
+          honoring explicit prebuilt_stages; "reuse-stage" applies automatic
+          reuse and also honors explicit prebuilt_stages.
         type: string
         default: "dry-run"
       stage_reuse_max_age_hours:

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -915,38 +915,52 @@ def decide_jobs(
     """
 
     # Build ROCm.
-    # Parse explicit prebuilt stages from workflow_dispatch input. These are
-    # the MANUAL inputs and are always honored, unchanged, in every mode.
+    stage_reuse_mode = StageReuseMode.from_environ()
 
-    stage_decisions: dict[str, JobAction] = {}
-    if ci_inputs.prebuilt_stages:
-        for stage in _parse_prebuilt_stages(ci_inputs.prebuilt_stages):
-            stage_decisions[stage] = JobAction.PREBUILT
+    if stage_reuse_mode is StageReuseMode.OFF:
+        # Strong off is authoritative: do not parse or honor explicit
+        # prebuilt_stages, do not retain a baseline, and do not invoke automatic
+        # stage-reuse analysis.
+        if ci_inputs.prebuilt_stages or ci_inputs.baseline_run_id:
+            logging.info(
+                "[STAGE-REUSE] mode=off: ignoring prebuilt_stages and "
+                "baseline_run_id; all in-scope stages will rebuild"
+            )
+        else:
+            logging.info(
+                "[STAGE-REUSE] mode=off: artifact reuse disabled; "
+                "all in-scope stages will rebuild"
+            )
 
-    # Automatic stage reuse, behind STAGE_REUSE_MODE: in dry-run we only report
-    # which stages WOULD be reused and apply nothing; in "reuse-stage" the
-    # eligible stages are merged into stage_decisions so the orchestrator skips
-    # their builds and copies artifacts instead. The platforms and families to
-    # verify come straight from the resolved target selection.
+        stage_decisions: dict[str, JobAction] = {}
+        baseline_run_id = ""
+        baseline_repository = ""
+        auto_stage_reuse = None
 
-    auto_stage_reuse = compute_auto_stage_reuse(
-        changed_files=git_context.changed_files,
-        mode=StageReuseMode.from_environ(),
-        linux_amdgpu_families=targets.linux_families,
-        windows_amdgpu_families=targets.windows_families,
-    )
+    else:
+        # Explicit prebuilt stages are honored in dry-run and reuse-stage modes.
+        stage_decisions = {}
+        if ci_inputs.prebuilt_stages:
+            for stage in _parse_prebuilt_stages(ci_inputs.prebuilt_stages):
+                stage_decisions[stage] = JobAction.PREBUILT
 
-    baseline_repository = ci_inputs.baseline_repository
-    baseline_run_id = ci_inputs.baseline_run_id
+        # In dry-run, automatic reuse is analyzed but not applied. In
+        # reuse-stage, eligible stages are added to stage_decisions.
+        auto_stage_reuse = compute_auto_stage_reuse(
+            changed_files=git_context.changed_files,
+            mode=stage_reuse_mode,
+            linux_amdgpu_families=targets.linux_families,
+            windows_amdgpu_families=targets.windows_families,
+        )
 
-    # Apply automatic stage reuse. For external repos (rocm-libraries, rocm-systems),
-    # we reuse stages from TheRock baselines. For same-repo runs, baseline_repository
-    # is empty or matches the current repo.
-    # reuse-stage mode returns non-empty applied_reuse_stages.
-    for stage in auto_stage_reuse.applied_reuse_stages:
-        stage_decisions.setdefault(stage, JobAction.PREBUILT)
-    if auto_stage_reuse.applied_reuse_stages and auto_stage_reuse.baseline_run_id:
-        baseline_run_id = auto_stage_reuse.baseline_run_id
+        baseline_repository = ci_inputs.baseline_repository
+        baseline_run_id = ci_inputs.baseline_run_id
+
+        for stage in auto_stage_reuse.applied_reuse_stages:
+            stage_decisions.setdefault(stage, JobAction.PREBUILT)
+
+        if auto_stage_reuse.applied_reuse_stages and auto_stage_reuse.baseline_run_id:
+            baseline_run_id = auto_stage_reuse.baseline_run_id
 
     build_rocm = BuildRocmDecision(
         action=JobAction.RUN,
@@ -954,7 +968,6 @@ def decide_jobs(
         baseline_run_id=baseline_run_id,
         baseline_repository=baseline_repository,
     )
-
     # Test ROCm.
     test_type, test_type_reason = _determine_test_type(
         ci_inputs=ci_inputs,

--- a/build_tools/github_actions/stage_reuse_decision.py
+++ b/build_tools/github_actions/stage_reuse_decision.py
@@ -17,27 +17,31 @@ is reported reusable:
 
 Mode switch
 -----------
-The module is wired into CI behind a two-way ``STAGE_REUSE_MODE`` switch so it
-can be observed before it changes anything:
+The module is wired into CI behind a three-way ``STAGE_REUSE_MODE`` switch:
 
+* ``off``        - Disable artifact reuse completely. Do not run impact
+                   analysis, search for baseline runs, query GitHub, or inspect
+                   artifact storage.
 * ``dry-run``    - DEFAULT. Compute the analysis and LOG, for each stage that
                    *would* be reused, a line to the console + step summary, but
-                   return NO auto stages, so ``prebuilt_stages`` is unchanged
-                   and every stage still builds exactly.
+                   return NO automatically reused stages.
 * ``reuse-stage`` - Compute the analysis and actually return the reuse stages so
                      the orchestrator copies their artifacts and skips the build.
 
-Note: this ``STAGE_REUSE_MODE`` switch drives the *automatic* detection layer.
-It is orthogonal to the ``prebuilt_stages`` workflow input, which is the
-explicit, manual list of stages to reuse and is always honored regardless of
-mode.
+``off`` is authoritative. ``configure_multi_arch_ci.py`` also ignores explicit
+``prebuilt_stages`` and ``baseline_run_id`` inputs in this mode, ensuring that
+all in-scope stages are rebuilt.
+
+In ``dry-run`` and ``reuse-stage`` modes, the explicit ``prebuilt_stages``
+workflow input remains separate from automatic stage-reuse analysis.
 
 Environment Variables
 --------------------
 ``_default_baseline_selector`` reads the following environment variables. These
 are set by ``setup_multi_arch.yml`` and form the stage-reuse interface:
 
-* ``STAGE_REUSE_MODE``           - ``dry-run`` (default) or ``reuse-stage``.
+* ``STAGE_REUSE_MODE``           - ``off``, ``dry-run`` (default), or
+                                    ``reuse-stage``.
 * ``GITHUB_REPOSITORY``          - ``owner/repo`` (default ``ROCm/TheRock``).
 * ``STAGE_REUSE_BASELINE_BRANCH``  - baseline branch to search (default ``main``).
 * ``STAGE_REUSE_BASELINE_WORKFLOW`` - baseline workflow file
@@ -79,6 +83,7 @@ GENERIC_FAMILY = "generic"
 
 
 class StageReuseMode(enum.Enum):
+    OFF = "off"
     DRY_RUN = "dry-run"
     REUSE_STAGE = "reuse-stage"
 
@@ -266,6 +271,7 @@ def compute_auto_stage_reuse(
     baseline_selector_factory: Callable[[str], BaselineSelector] | None = None,
 ) -> AutoStageReuse:
     """Compute auto stage-reuse decisions, verified against a baseline run.
+
     A stage is only reusable when it is unaffected by the change AND its
     artifacts are present in a healthy baseline run for *every* platform being
     built. The platforms are derived from which family lists are non-empty:
@@ -274,6 +280,20 @@ def compute_auto_stage_reuse(
     case where a stage available only in the Linux baseline is skipped on
     Windows. The report lines are logged before returning.
     """
+    if mode is StageReuseMode.OFF:
+        return _log_and_return(
+            _empty_result(
+                mode,
+                full_rebuild_required=True,
+                reasons=("artifact reuse disabled by STAGE_REUSE_MODE=off",),
+                report_lines=(
+                    f"{LOG_PREFIX} mode=off; artifact reuse disabled; "
+                    "skipping impact analysis and baseline lookup; "
+                    "all in-scope stages will rebuild.",
+                ),
+            )
+        )
+
     platforms = _build_platforms(linux_amdgpu_families, windows_amdgpu_families)
 
     logger.info(

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -567,6 +567,43 @@ class TestDecideJobs(unittest.TestCase):
         )
         self.assertEqual(result.build_rocm.rebuild_stages, [])
 
+    def test_off_ignores_manual_reuse_and_skips_auto_analysis(self):
+        with (
+            patch.dict(
+                os.environ,
+                {"STAGE_REUSE_MODE": "off"},
+                clear=False,
+            ),
+            patch.object(
+                cm,
+                "compute_auto_stage_reuse",
+            ) as compute_auto_stage_reuse,
+            patch.object(
+                cm,
+                "_get_all_build_stages",
+            ) as get_all_build_stages,
+        ):
+            result = cm.decide_jobs(
+                self._inputs(
+                    event_name="workflow_dispatch",
+                    prebuilt_stages="all",
+                    baseline_run_id="12345",
+                    baseline_repository="ROCm/TheRock",
+                ),
+                git_context=cm.GitContext(),
+                targets=cm.TargetSelection(),
+            )
+
+        # Strong off must skip both automatic analysis and manual "all" parsing.
+        compute_auto_stage_reuse.assert_not_called()
+        get_all_build_stages.assert_not_called()
+
+        self.assertEqual(result.build_rocm.stage_decisions, {})
+        self.assertEqual(result.build_rocm.prebuilt_stages, [])
+        self.assertEqual(result.build_rocm.baseline_run_id, "")
+        self.assertEqual(result.build_rocm.baseline_repository, "")
+        self.assertIsNone(result.auto_stage_reuse)
+
     def test_reuse_scoped_to_selected_targets(self):
         """decide_jobs threads the resolved targets into automatic reuse.
         With no families selected there are no build platforms, so automatic
@@ -1703,6 +1740,44 @@ class TestConfigurePipeline(unittest.TestCase):
         linux_payload = outputs.builds.linux.to_dict()
         self.assertEqual(linux_payload["baseline_run_id"], "123")
         self.assertEqual(linux_payload["prebuilt_stages"], "compiler-runtime")
+
+    def test_off_clears_reuse_from_platform_build_configs(self):
+        inputs = cm.CIInputs(
+            run_id="12345",
+            event_name="push",
+            commit_ref="main",
+            base_ref="HEAD^1",
+            build_variant="release",
+            prebuilt_stages="compiler-runtime,runtime-tests",
+            baseline_run_id="12345",
+            baseline_repository="ROCm/TheRock",
+        )
+
+        with patch.dict(
+            os.environ,
+            {"STAGE_REUSE_MODE": "off"},
+            clear=False,
+        ):
+            outputs = cm.configure(
+                inputs,
+                cm.GitContext.empty(),
+            )
+
+        self.assertIsNotNone(outputs.builds.linux)
+        self.assertIsNotNone(outputs.builds.windows)
+
+        for build_config in (
+            outputs.builds.linux,
+            outputs.builds.windows,
+        ):
+            self.assertEqual(build_config.prebuilt_stages, [])
+            self.assertEqual(build_config.baseline_run_id, "")
+            self.assertEqual(build_config.baseline_repository, "")
+
+            payload = build_config.to_dict()
+            self.assertEqual(payload["prebuilt_stages"], "")
+            self.assertEqual(payload["baseline_run_id"], "")
+            self.assertEqual(payload["baseline_repository"], "")
 
 
 # ---------------------------------------------------------------------------

--- a/build_tools/github_actions/tests/stage_reuse_decision_test.py
+++ b/build_tools/github_actions/tests/stage_reuse_decision_test.py
@@ -7,7 +7,7 @@ import os
 import sys
 import unittest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
@@ -111,12 +111,40 @@ class ModeParsingTest(unittest.TestCase):
 
     def test_explicit_modes(self):
         for value, expected in [
+            ("off", StageReuseMode.OFF),
             ("dry-run", StageReuseMode.DRY_RUN),
             ("reuse-stage", StageReuseMode.REUSE_STAGE),
             ("garbage", StageReuseMode.DRY_RUN),
         ]:
             with patch.dict(os.environ, {"STAGE_REUSE_MODE": value}):
                 self.assertEqual(StageReuseMode.from_environ(), expected)
+
+    def test_off_short_circuits_all_analysis_and_lookup(self):
+        baseline_selector = Mock()
+
+        with (
+            patch.object(srd, "_build_platforms") as build_platforms,
+            patch.object(srd, "get_topology") as get_topology,
+            patch.object(srd, "plan_stage_reuse") as plan_stage_reuse,
+        ):
+            result = compute_auto_stage_reuse(
+                changed_files=["rocm-libraries/projects/rocBLAS/x.cpp"],
+                mode=StageReuseMode.OFF,
+                linux_amdgpu_families=["gfx94X-dcgpu"],
+                baseline_selector=baseline_selector,
+            )
+
+        build_platforms.assert_not_called()
+        get_topology.assert_not_called()
+        plan_stage_reuse.assert_not_called()
+        baseline_selector.assert_not_called()
+
+        self.assertTrue(result.full_rebuild_required)
+        self.assertIsNone(result.baseline_run_id)
+        self.assertEqual(result.candidate_stages, ())
+        self.assertEqual(result.available_stages, ())
+        self.assertEqual(result.applied_reuse_stages, ())
+        self.assertIn("mode=off", "\n".join(result.report_lines))
 
 
 class AvailabilityGateTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

Issue: https://github.com/ROCm/TheRock/issues/3343

Add an explicit `off` mode for multi-arch artifact reuse.

`STAGE_REUSE_MODE` now supports:

- `off` - disable artifact reuse completely
- `dry-run` - analyze and report potential reuse without applying automatic reuse
- `reuse-stage` - analyze and apply automatic stage reuse

When `stage_reuse_mode=off`, artifact reuse is fully short-circuited:

- Skip stage-impact analysis for reuse.
- Skip baseline discovery and lookup.
- Skip artifact availability checks.
- Ignore explicit `prebuilt_stages`.
- Ignore `baseline_run_id`.
- Do not select any prebuilt stages.
- Rebuild all in-scope stages.

This provides a strong opt-out that callers can use for release-branch validation where builds should not depend on artifacts produced by another workflow run or branch.

## Motivation

Release branches may not want to use `main` as the artifact-reuse baseline search path, particularly while validating cherry-picks.

Previously, the available modes were:

- `dry-run`, which still performs reuse analysis and baseline lookup.
- `reuse-stage`, which performs and applies artifact reuse.

There was no way to completely disable the artifact-reuse path.

The new `off` mode provides that behavior and can be selected by release-branch workflows to ensure that all in-scope build stages are rebuilt from source.

Release-branch policy itself is intentionally left to callers; this PR only adds the strong `off` behavior to TheRock.

## Testing

```bash
python build_tools/github_actions/tests/stage_reuse_decision_test.py

Ran 33 tests in 0.004s

OK

python build_tools/github_actions/tests/configure_multi_arch_ci_test.py

Ran 103 tests in 0.025s

OK (skipped=1)
```

## Follow-up

A follow-up change in `rocm-libraries` will select `stage_reuse_mode: off` when CI is running against `release/*` branches.

The intended policy is:

- PRs targeting `release/*` → `off`
- Manual runs on `release/*` → `off`
- Non-release branches → keep using `reuse-stage`

This keeps the branch-selection policy in the caller while TheRock owns the semantics of the `off` mode.

Additional follow-up: 
Make these options
``` 
- "off"
- "dry-run"
- "reuse-stage"
```
available on https://github.com/ROCm/TheRock/blob/main/.github/workflows/multi_arch_ci_asan.yml too