### PR TITLE
feat(ci): Adding postinst and prerm for developer tools

### DIFF
--- a/build_tools/packaging/linux/deb_package.py
+++ b/build_tools/packaging/linux/deb_package.py
@@ -402,7 +402,7 @@ def generate_debian_postscripts(pkg_info, deb_dir, config: PackageConfig):
         pattern = f"{pkg_name}-{script}.j2"
         for file in templates_root.glob(pattern):
             script_file = Path(deb_dir) / script
-            template = env.get_template(str(file.relative_to(SCRIPT_DIR)))
+            template = env.get_template(file.relative_to(SCRIPT_DIR).as_posix())
             with script_file.open("w", encoding="utf-8") as f:
                 f.write(template.render(context))
             os.chmod(script_file, 0o755)

--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -3822,6 +3822,7 @@
     "Vendor": "Advanced Micro Devices, Inc",
     "Homepage": "https://github.com/ROCm/rocm-libraries",
     "Metapackage": "True",
+    "Postinstall": "True",
     "Gfxarch": "False"
   },
   {

--- a/build_tools/packaging/linux/template/scripts/amdrocm-core-postinst.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-core-postinst.j2
@@ -44,7 +44,7 @@ do_update_alternatives(){
     # previous patch level is small.
     altscore=$((altscore*1000000+(now-1600000000)/60))
 
-    binaries=( hipcc hipconfig hipify-clang rocminfo amdclang amdclang++ amdclang-cl amdclang-cpp amdflang amdlld )
+    binaries=( hipcc hipconfig hipify-clang rocminfo amd-smi rocm_agent_enumerator amdclang amdclang++ amdclang-cl amdclang-cpp amdflang amdlld )
 
     {% if target == "deb" %}
        PKG_INSTALL_PREFIX={{ install_prefix }}

--- a/build_tools/packaging/linux/template/scripts/amdrocm-core-postinst.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-core-postinst.j2
@@ -44,7 +44,7 @@ do_update_alternatives(){
     # previous patch level is small.
     altscore=$((altscore*1000000+(now-1600000000)/60))
 
-    binaries=( hipcc hipconfig hipify-clang rocminfo amd-smi rocm_agent_enumerator rocm-smi rocprofv3 rocprofv3-avail rocgdb rocpd amdclang amdclang++ amdclang-cl amdclang-cpp amdflang amdlld )
+    binaries=( hipcc hipconfig hipify-clang rocminfo amdclang amdclang++ amdclang-cl amdclang-cpp amdflang amdlld )
 
     {% if target == "deb" %}
        PKG_INSTALL_PREFIX={{ install_prefix }}

--- a/build_tools/packaging/linux/template/scripts/amdrocm-core-prerm.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-core-prerm.j2
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-binaries=( hipcc hipconfig hipify-clang rocminfo amd-smi rocm_agent_enumerator rocm-smi rocprofv3 rocprofv3-avail rocgdb rocpd amdclang amdclang++ amdclang-cl amdclang-cpp amdflang amdlld )
+binaries=( hipcc hipconfig hipify-clang rocminfo amdclang amdclang++ amdclang-cl amdclang-cpp amdflang amdlld )
 
 is_debian_like() {
     local id_like="$1"

--- a/build_tools/packaging/linux/template/scripts/amdrocm-core-prerm.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-core-prerm.j2
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-binaries=( hipcc hipconfig hipify-clang rocminfo amdclang amdclang++ amdclang-cl amdclang-cpp amdflang amdlld )
+binaries=( hipcc hipconfig hipify-clang rocminfo amd-smi rocm_agent_enumerator amdclang amdclang++ amdclang-cl amdclang-cpp amdflang amdlld )
 
 is_debian_like() {
     local id_like="$1"

--- a/build_tools/packaging/linux/template/scripts/amdrocm-developer-tools-postinst.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-developer-tools-postinst.j2
@@ -44,7 +44,7 @@ do_update_alternatives(){
     # previous patch level is small.
     altscore=$((altscore*1000000+(now-1600000000)/60))
 
-    binaries=( rocgdb rocprofv3 rocprofv3-avail rocpd amd-smi rocm_agent_enumerator rocm-smi )
+    binaries=( rocgdb rocprofv3 rocprofv3-avail rocpd rocminfo amd-smi rocm_agent_enumerator )
 
     {% if target == "deb" %}
        PKG_INSTALL_PREFIX={{ install_prefix }}

--- a/build_tools/packaging/linux/template/scripts/amdrocm-developer-tools-postinst.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-developer-tools-postinst.j2
@@ -83,4 +83,3 @@ then
 else
     do_update_alternatives
 fi
-

--- a/build_tools/packaging/linux/template/scripts/amdrocm-developer-tools-postinst.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-developer-tools-postinst.j2
@@ -52,6 +52,21 @@ do_update_alternatives(){
        PKG_INSTALL_PREFIX="$RPM_INSTALL_PREFIX0"
     {% endif %}
 
+    # Install /opt/rocm/core soft link
+    update-alternatives --install "/opt/rocm/core" "core" "$PKG_INSTALL_PREFIX" "$altscore"
+    update-alternatives --install "/opt/rocm/core-{{ version_major }}" "core-{{ version_major }}" "$PKG_INSTALL_PREFIX" "$altscore"
+
+    # Install /opt/rocm/bin, /opt/rocm/lib, and /opt/rocm/include soft links
+    update-alternatives --install "/opt/rocm/bin" "rocm-bin" "$PKG_INSTALL_PREFIX/bin" "$altscore"
+    update-alternatives --install "/opt/rocm/lib" "rocm-lib" "$PKG_INSTALL_PREFIX/lib" "$altscore"
+    update-alternatives --install "/opt/rocm/include" "rocm-include" "$PKG_INSTALL_PREFIX/include" "$altscore"
+
+    # Install /opt/rocm/llvm, /opt/rocm/amdgcn, /opt/rocm/libexec, and /opt/rocm/share soft links
+    update-alternatives --install "/opt/rocm/llvm" "rocm-llvm" "$PKG_INSTALL_PREFIX/llvm" "$altscore"
+    update-alternatives --install "/opt/rocm/amdgcn" "rocm-amdgcn" "$PKG_INSTALL_PREFIX/amdgcn" "$altscore"
+    update-alternatives --install "/opt/rocm/libexec" "rocm-libexec" "$PKG_INSTALL_PREFIX/libexec" "$altscore"
+    update-alternatives --install "/opt/rocm/share" "rocm-share" "$PKG_INSTALL_PREFIX/share" "$altscore"
+
     for i in "${binaries[@]}"
     do
         # No obvious recover strategy if things fail

--- a/build_tools/packaging/linux/template/scripts/amdrocm-developer-tools-postinst.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-developer-tools-postinst.j2
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+is_debian_like() {
+    local id_like="$1"
+    case " $id_like " in
+        (*" debian "*|*" ubuntu "*)
+            return 0
+            ;;
+        (*)
+            return 1
+            ;;
+    esac
+}
+
+do_update_alternatives(){
+    # skip update if program doesn't exist
+    command -v update-alternatives >/dev/null || return 0
+    local binaries altscore now
+    now=$(date -u +%s)          # Number of seconds since 1 Jan 1970
+
+
+    # The reason for this approach rather than using the build number
+    # is to allow for jobs from different builds. In one build job the
+    # job number might be at 1200, whilst in a release job the number
+    # may be only 1. This approach assums that if you install a build
+    # with a different semantic version then the highest is the
+    # desired one, but if you install two with the same semver then
+    # the newest is the desired version.
+
+    # Build up a score. It needs to fit in 32 bits
+    altscore=$(({{ version_major }} - 3))
+    altscore=$((altscore * 14 + {{ version_minor }})) # Allow up to 14 minor
+    altscore=$((altscore * 14 + {{ version_patch }})) # Allow up to 14 patch
+
+    # So far if the version is less than 9 we have a number (altscore)
+    # that is less than 1175.  2**31/1175 is about 1.8 million. So
+    # multiply altscore by 1,000,000 and add in a factor of how many
+    # minutes have passed from an arbitary point in time (1,600,000,000
+    # seconds after 1 Jan 1970 or Sep 13 12:26:40 2020) on the
+    # basis that no one is going to be installing a new version more
+    # often than every minute. This does get things wrong if a million
+    # minutes pass and you are downgrading, but the chances of someone
+    # waiting almost 2 years between installing a version and the
+    # previous patch level is small.
+    altscore=$((altscore*1000000+(now-1600000000)/60))
+
+    binaries=( rocgdb rocprofv3 rocprofv3-avail rocpd amd-smi rocm_agent_enumerator rocm-smi )
+
+    {% if target == "deb" %}
+       PKG_INSTALL_PREFIX={{ install_prefix }}
+    {% else %}
+       PKG_INSTALL_PREFIX="$RPM_INSTALL_PREFIX0"
+    {% endif %}
+
+    for i in "${binaries[@]}"
+    do
+        # No obvious recover strategy if things fail
+        # No manual or other slave pages to install
+        if [ -e $PKG_INSTALL_PREFIX/bin/"$i" ]
+        then
+            update-alternatives --install /usr/bin/"$i" "$i" \
+                                $PKG_INSTALL_PREFIX/bin/"$i" "$altscore"
+        else
+            echo "$PKG_INSTALL_PREFIX/bin/$i not found, but that is OK" >&2
+        fi
+    done
+    true
+}
+
+if [ -e /etc/os-release ] && source /etc/os-release && is_debian_like "${ID_LIKE:-$ID}"
+then
+    case "$1" in
+       (configure)
+       do_update_alternatives
+       ;;
+       (abort-upgrade|abort-remove|abort-deconfigure)
+           echo "$1"
+       ;;
+       (*)
+          exit 0
+       ;;
+    esac
+else
+    do_update_alternatives
+fi
+

--- a/build_tools/packaging/linux/template/scripts/amdrocm-developer-tools-prerm.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-developer-tools-prerm.j2
@@ -47,4 +47,3 @@ then
 else
     do_update_alternatives
 fi
-

--- a/build_tools/packaging/linux/template/scripts/amdrocm-developer-tools-prerm.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-developer-tools-prerm.j2
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+binaries=( rocgdb rocprofv3 rocprofv3-avail rocpd amd-smi rocm_agent_enumerator rocm-smi )
+
+is_debian_like() {
+    local id_like="$1"
+    case " $id_like " in
+        (*" debian "*|*" ubuntu "*)
+            return 0
+            ;;
+        (*)
+            return 1
+            ;;
+    esac
+}
+
+do_update_alternatives(){
+    # skip update if program doesn't exist
+    command -v update-alternatives >/dev/null || return 0
+
+    {% if target == "deb" %}
+        PKG_INSTALL_PREFIX={{ install_prefix }}
+    {% else %}
+        PKG_INSTALL_PREFIX="$RPM_INSTALL_PREFIX0"
+    {% endif %}
+
+    for i in "${binaries[@]}"
+    do
+        update-alternatives --remove "$i" \
+            "$PKG_INSTALL_PREFIX/bin/$i" || true
+    done
+}
+
+if [ -e /etc/os-release ] && source /etc/os-release && is_debian_like "${ID_LIKE:-$ID}"
+then
+   case "$1" in
+       (remove|upgrade)
+           do_update_alternatives
+       ;;
+       (purge)
+           # nothing to do
+       ;;
+       (*)
+           exit 0
+       ;;
+   esac
+else
+    do_update_alternatives
+fi
+

--- a/build_tools/packaging/linux/template/scripts/amdrocm-developer-tools-prerm.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-developer-tools-prerm.j2
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-binaries=( rocgdb rocprofv3 rocprofv3-avail rocpd amd-smi rocm_agent_enumerator rocm-smi )
+binaries=( rocgdb rocprofv3 rocprofv3-avail rocpd rocminfo amd-smi rocm_agent_enumerator )
 
 is_debian_like() {
     local id_like="$1"

--- a/build_tools/packaging/linux/template/scripts/amdrocm-developer-tools-prerm.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-developer-tools-prerm.j2
@@ -29,6 +29,21 @@ do_update_alternatives(){
         update-alternatives --remove "$i" \
             "$PKG_INSTALL_PREFIX/bin/$i" || true
     done
+
+    # Remove /opt/rocm/core soft link
+    update-alternatives --remove "core" "$PKG_INSTALL_PREFIX" || true
+    update-alternatives --remove "core-{{ version_major }}" "$PKG_INSTALL_PREFIX" || true
+
+    # Remove /opt/rocm/bin, /opt/rocm/lib, and /opt/rocm/include soft links
+    update-alternatives --remove "rocm-bin" "$PKG_INSTALL_PREFIX/bin" || true
+    update-alternatives --remove "rocm-lib" "$PKG_INSTALL_PREFIX/lib" || true
+    update-alternatives --remove "rocm-include" "$PKG_INSTALL_PREFIX/include" || true
+
+    # Remove /opt/rocm/llvm, /opt/rocm/amdgcn, /opt/rocm/libexec, and /opt/rocm/share  soft links
+    update-alternatives --remove "rocm-llvm" "$PKG_INSTALL_PREFIX/llvm" || true
+    update-alternatives --remove "rocm-amdgcn" "$PKG_INSTALL_PREFIX/amdgcn" || true
+    update-alternatives --remove "rocm-libexec" "$PKG_INSTALL_PREFIX/libexec" || true
+    update-alternatives --remove "rocm-share" "$PKG_INSTALL_PREFIX/share" || true
 }
 
 if [ -e /etc/os-release ] && source /etc/os-release && is_debian_like "${ID_LIKE:-$ID}"


### PR DESCRIPTION
## Motivation

No postinst or prerm script for dev tools 

## Technical Details

added amdrocm-developer-tools-postinst.j2 and amdrocm-developer-tools-prerm.j2

Feature: https://github.com/ROCm/TheRock/issues/7814

## Test Plan

cd /dockerx/2026_8_25_rocm_devtools/TheRock/output/packages
dpkg -i --force-depends ./*.deb > /tmp/2026_9_2_log.txt 2>&1


grep -i "error" /tmp/2026_9_2_log.txt
grep -iE -A2 "dependency problems" /tmp/2026_9_2_log.txt
grep -i "Setting up" /tmp/2026_9_2_log.txt   # confirms which packages' postinst actually ran

update-alternatives --display core
update-alternatives --display rocm-bin
update-alternatives --display rocm-lib
update-alternatives --display rocm-include
update-alternatives --display rocm-llvm
update-alternatives --display rocm-amdgcn
update-alternatives --display rocm-libexec
update-alternatives --display rocm-share

update-alternatives --display rocgdb
update-alternatives --display amd-smi
update-alternatives --display rocm-smi
update-alternatives --display rocprofv3
update-alternatives --display rocprofv3-avail
update-alternatives --display rocpd
update-alternatives --display rocm_agent_enumerator

ls -l /opt/rocm/bin | head -10
ls -l /opt/rocm/core
which rocgdb amd-smi rocm-smi rocprofv3

## Test Result

No errors found in logs and logs confirmed postinstall is running: 
Setting up amdrocm-core10.1-gfx1200 (10.1.0~dev20260825-32826218207) ...
Setting up amdrocm-core10.1-gfx1201 (10.1.0~dev20260825-32826218207) ...
Setting up amdrocm-core10.1 (10.1.0~dev20260825-32826218207) ...
Setting up amdrocm-developer-tools10.1 (10.1.0~dev20260825-32826218207) ...
Setting up amdrocm-developer-tools (10.1.0~dev20260825-32826218207) ...

Binaries and symlinks are present 
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
