### PR TITLE
Fixed the rocWMMA gemm benchmark missing binaries

### DIFF
--- a/math-libs/artifact-rocwmma.toml
+++ b/math-libs/artifact-rocwmma.toml
@@ -17,6 +17,7 @@ include = [
   # Tests
   "bin/*_test*",
   "bin/*-validate*",
+  "bin/*-bench*",
   "bin/rocwmma/CTestTestfile.cmake",
   "bin/rocwmma/*/CTestTestfile.cmake",
 ]


### PR DESCRIPTION
## Motivation

Binaries of benchmarks for primitives libraries are missing from the Linux build. This PR fixes the issue.

ISSUE ID : https://amd.atlassian.net/browse/PAVSDEV-6229

## Technical Details
Failures seeing due to gemm benchmark missing binaries. They were built, but TheRock's artifact descriptor selects test files by filename glob and only lists bin/*_test* and bin/*-validate*. 

## Test Plan

CI on linux with THEROCK_BUILD_TESTING=ON should now build the binaries and include them in the tarball.

## Test Result

Check the CI and confirm the issue is fixed.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
