### PR TITLE
Revert "ci(rocgdb): mark rocgdb-gpu and rocgdb-corefile as expected failures

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -398,7 +398,6 @@ test_matrix = {
     "rocgdb-gpu": {
         **_rocgdb_common,
         "job_name": "rocgdb-gpu",
-        "expect_failure": True,
         "test_script": "python ./build/tests/rocgdb/test_rocgdb.py --parallel -f 0.25 --toolchain llvm --tests gdb.rocm",
     },
     # Corefile tests require specific hardware support (GPU core dump capable runners).
@@ -408,7 +407,6 @@ test_matrix = {
     "rocgdb-corefile": {
         **_rocgdb_common,
         "job_name": "rocgdb-corefile",
-        "expect_failure": True,
         "test_script": (
             "python ./build/tests/rocgdb/test_rocgdb.py --parallel -f 0.25 --toolchain llvm --tests"
             " gdb.rocm/corefile.exp"


### PR DESCRIPTION
Reverts ROCm/TheRock#7627

This was a temporary situation that should be fixed by recent rocm-systems bump and a compiler bump:

- compiler: https://github.com/ROCm/TheRock/pull/7673
- rocm-systems: https://github.com/ROCm/TheRock/pull/7688

@skip-pr-bot