### PR TITLE
Add rocprofiler-sensitive logging tests to PR JAX small selection

### DIFF
--- a/build_tools/github_actions/tests/configure_jax_test_matrix_test.py
+++ b/build_tools/github_actions/tests/configure_jax_test_matrix_test.py
@@ -232,5 +232,14 @@ class OutputsTest(unittest.TestCase):
                 self.outputs(argv)
 
 
+class SmallTestSelectionTest(unittest.TestCase):
+    def test_pr_small_selection_includes_rocprofiler_smoke(self):
+        repo_root = Path(__file__).resolve().parents[3]
+        listed = (repo_root / matrix_script.SMALL_TEST_LIST).read_text().splitlines()
+        paths = {line.partition("#")[0].strip() for line in listed if line.strip()}
+        self.assertIn("tests/logging_test.py", paths)
+        self.assertIn("tests/profiler_test.py", paths)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/external-builds/jax/test_selection/README.md
+++ b/external-builds/jax/test_selection/README.md
@@ -44,7 +44,8 @@ warns and runs nothing until `ROCm/jax-lab` is public.
 
 The smallest set of JAX tests that covers 100% of the LLM-weighted module
 graph on ROCm GPU: greedy weighted max-coverage over the 110-test ROCm
-candidate pool saturates at these 42.
+candidate pool saturates at 42 files, plus `logging_test.py` for subprocess
+stderr checks that catch stray rocprofiler-sdk output on XLA shutdown.
 
 Regenerate it whenever JAX is bumped to a new major version, with the
 `jax-test-selector` tool in its recommended `w+p` configuration:

--- a/external-builds/jax/test_selection/small_tests.txt
+++ b/external-builds/jax/test_selection/small_tests.txt
@@ -22,6 +22,7 @@ tests/lax_scipy_test.py
 tests/lax_test.py
 tests/layout_test.py
 tests/linalg_test.py
+tests/logging_test.py
 tests/memories_test.py
 tests/nn_test.py
 tests/ode_test.py


### PR DESCRIPTION
## Summary
- Add `tests/logging_test.py` to `external-builds/jax/test_selection/small_tests.txt` so PR blocking JAX CI runs subprocess stderr checks that load the ROCm XLA backend.
- Document in the test-selection README that this file is outside the LLM coverage set but guards against stray rocprofiler-sdk output on process exit (see ROCm/TheRock#7682).

## Why these tests
XLA registers an `XLA-with-rocprofiler-sdk` client at plugin load. Subprocess tests in `logging_test.py` (especially `test_subprocess_toggling_logging_level`) assert stderr stays empty after `jax_logging_level` is cleared, which catches rocprofiler-sdk lifecycle WARNING logs at shutdown that bypass JAX logging controls. `profiler_test.py` was already in the small list; it exercises the profiler API but not this stderr path.

## Test plan
- [x] PR JAX CI (`test_size: small`) collects and runs `tests/logging_test.py`
- [x] Confirm failure reproduces on ROCm builds with rocprofiler-sdk registration.cpp lifecycle WARNING logs (TheRock#7682)
- [x] Confirm pass once rocm-systems demotes those logs or CI sets `ROCPROFILER_LOG_LEVEL=error`


ISSUE ID: related to https://github.com/ROCm/TheRock/issues/7682 to catch regressions like this in PR blocking CI