### PR TITLE
Re-land (7486) fix: external repo pin SHA in TheRock manifest

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
@@ -99,6 +99,7 @@ jobs:
       TEATIME_FORCE_INTERACTIVE: 0
       RELEASE_TYPE: ${{ inputs.release_type }}
       EXTERNAL_FETCH_SOURCES_ARGS: ${{ inputs.external_repo_config != '' && fromJSON(inputs.external_repo_config).fetch_sources_args || '' }}
+      EXTERNAL_REPO_CONFIG: ${{ inputs.external_repo_config }}
 
     steps:
       - name: "Quartz - started ${{ env.QUARTZ_WORKFLOW_POSTFIX }}"

--- a/.github/workflows/multi_arch_build_windows_artifacts.yml
+++ b/.github/workflows/multi_arch_build_windows_artifacts.yml
@@ -97,6 +97,7 @@ jobs:
       TEATIME_FORCE_INTERACTIVE: 0
       RELEASE_TYPE: ${{ inputs.release_type }}
       EXTERNAL_FETCH_SOURCES_ARGS: ${{ inputs.external_repo_config != '' && fromJSON(inputs.external_repo_config).fetch_sources_args || '' }}
+      EXTERNAL_REPO_CONFIG: ${{ inputs.external_repo_config }}
 
     steps:
       - name: "Quartz - started ${{ env.QUARTZ_WORKFLOW_POSTFIX }}"

--- a/build_tools/generate_therock_manifest.py
+++ b/build_tools/generate_therock_manifest.py
@@ -179,6 +179,27 @@ def rocm_version_from_package_version(rocm_package_version: str) -> str | None:
     return match.group(1)
 
 
+def parse_and_validate_external_repo_config(raw: str | None) -> dict | None:
+    """Parse and validate external repo configuration used by super-repo CI."""
+    if not raw:
+        return None
+
+    config = json.loads(raw)
+
+    if not isinstance(config, dict):
+        raise ValueError("EXTERNAL_REPO_CONFIG must be a JSON object")
+
+    submodule_path = config.get("submodule_path")
+    ref = config.get("ref")
+
+    if not submodule_path or not ref:
+        raise ValueError(
+            "EXTERNAL_REPO_CONFIG must contain both 'submodule_path' and 'ref'"
+        )
+
+    return config
+
+
 def build_manifest_schema(
     repo_root: Path,
     the_rock_commit: str,
@@ -186,14 +207,31 @@ def build_manifest_schema(
     github_run_id: str | None = None,
     rocm_package_version: str | None = None,
     rocm_version: str | None = None,
+    external_repo_config: dict | None = None,
 ) -> dict:
     # Enumerate submodules from .gitmodules at the specified commit.
     entries = list_submodules_from_gitmodules_at_commit(repo_root, the_rock_commit)
 
     # Build rows with pins (from tree) and patch lists
     rows = []
+
+    external_repo_submodule_path = None
+    external_repo_ref = None
+    external_repo_matched = False
+
+    if external_repo_config:
+        external_repo_submodule_path = external_repo_config["submodule_path"]
+        external_repo_ref = external_repo_config["ref"]
+
     for e in sorted(entries, key=lambda x: x["path"] or ""):
+        # Normal TheRock build: use the submodule gitlink from the TheRock tree.
         pin = submodule_pin(repo_root, the_rock_commit, e["path"])
+
+        # External-repo CI may build a different commit than the gitlink pinned
+        # in TheRock. Record the commit actually built in the manifest.
+        if external_repo_submodule_path and e["path"] == external_repo_submodule_path:
+            pin = external_repo_ref
+            external_repo_matched = True
         rows.append(
             {
                 "submodule_name": e["name"],
@@ -203,7 +241,11 @@ def build_manifest_schema(
                 "patches": patches_for_submodule_by_name(repo_root, e["name"]),
             }
         )
-
+    if external_repo_config and not external_repo_matched:
+        raise ValueError(
+            f"External repo submodule path {external_repo_submodule_path!r} "
+            "does not match a TheRock submodule path"
+        )
     manifest = {
         "the_rock_commit": the_rock_commit,
     }
@@ -230,6 +272,7 @@ def build_partial_manifest_schema(
     github_run_id: str | None = None,
     rocm_package_version: str | None = None,
     rocm_version: str | None = None,
+    external_repo_config: dict | None = None,
 ) -> dict:
     # Enumerate submodules from the filesystem .gitmodules file when git metadata
     # is unavailable (for example, source trees with .git removed).
@@ -237,17 +280,35 @@ def build_partial_manifest_schema(
 
     # Build rows without pins, since gitlink SHAs are not available without git metadata.
     rows = []
+
+    external_repo_submodule_path = None
+    external_repo_ref = None
+    external_repo_matched = False
+
+    if external_repo_config:
+        external_repo_submodule_path = external_repo_config["submodule_path"]
+        external_repo_ref = external_repo_config["ref"]
+
     for e in sorted(entries, key=lambda x: x["path"] or ""):
+        pin = None
+
+        if external_repo_submodule_path and e["path"] == external_repo_submodule_path:
+            pin = external_repo_ref
+            external_repo_matched = True
         rows.append(
             {
                 "submodule_name": e["name"],
                 "submodule_path": e["path"],
                 "submodule_url": e["url"],
-                "pin_sha": None,
+                "pin_sha": pin,
                 "patches": patches_for_submodule_by_name(repo_root, e["name"]),
             }
         )
-
+    if external_repo_config and not external_repo_matched:
+        raise ValueError(
+            f"External repo submodule path {external_repo_submodule_path!r} "
+            "does not match a TheRock submodule path"
+        )
     manifest = {
         "the_rock_commit": None,
     }
@@ -298,8 +359,12 @@ def main():
         help="ROCm package version to include in the manifest",
         default=None,
     )
+
     args = ap.parse_args()
 
+    external_repo_config = parse_and_validate_external_repo_config(
+        os.getenv("EXTERNAL_REPO_CONFIG")
+    )
     repo_root = source_root()
     github_job = os.getenv("GITHUB_JOB")
     github_run_id = os.getenv("GITHUB_RUN_ID")
@@ -320,6 +385,7 @@ def main():
             github_run_id,
             args.rocm_package_version,
             rocm_version,
+            external_repo_config,
         )
     else:
         manifest = build_partial_manifest_schema(
@@ -328,6 +394,7 @@ def main():
             github_run_id,
             args.rocm_package_version,
             rocm_version,
+            external_repo_config,
         )
 
     # Merge flag settings into the manifest if provided.

--- a/build_tools/github_actions/detect_external_repo_config.py
+++ b/build_tools/github_actions/detect_external_repo_config.py
@@ -465,6 +465,7 @@ def main(argv=None):
             "ref": source_ref,
             "checkout_path": checkout_path,
             "source_package": source_package,
+            "submodule_path": config["submodule_path"],
             "fetch_sources_args": config.get("fetch_sources_args", ""),
             "extra_cmake_options": extra_cmake_options,
             "projects": projects,


### PR DESCRIPTION
Relands #7486.

Fixes #7487.

Fix `therock_manifest.json` so external/super-repo CI records the commit that was actually built for the externally supplied repository.

Previously, manifest generation always derived submodule `pin_sha` values from the TheRock tree using:

`git ls-tree <the_rock_commit> -- <submodule_path>`

This is correct for normal TheRock builds, but incorrect for super-repo CI when `rocm-systems`, `rocm-libraries`, or another supported external repository is checked out at a different SHA than the submodule SHA currently pinned by TheRock.

For example, super-repo CI could build:

- `rocm-systems`: `c1dba564...`

while TheRock still pins:

- `rocm-systems`: `ef3b147...`

The build used `c1dba564...`, but the generated manifest incorrectly recorded `ef3b147...`.

## Changes

- Add `submodule_path` to the serialized `external_repo_config`.
- Pass the existing `external_repo_config` to Linux and Windows artifact-build jobs through `EXTERNAL_REPO_CONFIG`.
- Update `generate_therock_manifest.py` to:
  - continue using the TheRock gitlink SHA for normal builds;
  - use `external_repo.ref` for the matching externally supplied submodule;
  - match the external repository to its manifest entry using `submodule_path`;
  - reject unmatched external submodule paths;
  - require `submodule_path` and `ref` to be nonempty strings.
- Add focused unit tests for external-repository configuration parsing and field-type validation.

No CMake changes are required because the job-level environment is inherited by the manifest-generation custom command.

## Behavior

Normal TheRock build:

`pin_sha = SHA pinned by the TheRock submodule gitlink`

External/super-repo build:

`matching external submodule pin_sha = external_repo.ref`

`all other submodules = TheRock gitlink SHA`

## Validation

Added unit-test coverage for:

- missing or empty external-repository configuration;
- valid external-repository configuration;
- non-object external-repository JSON;
- empty, whitespace-only, and non-string `submodule_path` values;
- empty, whitespace-only, and non-string `ref` values.

Verified by inspection that `EXTERNAL_REPO_CONFIG` is passed to both the Linux and Windows artifact-build jobs.

Relevant unit-test coverage:

- `build_tools/tests/generate_therock_manifest_test.py`

### End-to-end super-repo validation

Validated using [ROCm/rocm-libraries PR #11386](https://github.com/ROCm/rocm-libraries/pull/11386) and [workflow run 35025968613](https://github.com/ROCm/rocm-libraries/actions/runs/35025968613), with TheRock commit `192afa84ecad9cc1dd04adf6e7cd37273e45c88f`.

The relevant SHAs were:

| Source | SHA |
|---|---|
| TheRock-pinned `rocm-libraries` gitlink | `a218bddb1ba5e81a11173eebc07f2dfd5798af09` |
| `rocm-libraries` PR head | `1d1e9d9eb33e3bdc3f722b03914d0935b6230a47` |
| PR merge commit supplied through `${{ github.sha }}` | `122520321f087cae4100a6892875f72789650b90` |
| Generated manifest `rocm-libraries.pin_sha` | `122520321f087cae4100a6892875f72789650b90` |

The generated manifest recorded the external PR merge commit that CI built instead of the older `rocm-libraries` gitlink pinned by TheRock, confirming the fix end to end.