### PR TITLE
[docs] Add syntax hints to a few code blocks

### DIFF
--- a/docs/development/adding_tests.md
+++ b/docs/development/adding_tests.md
@@ -47,7 +47,7 @@ Add an entry in [`test_matrix`](../../build_tools/github_actions/fetch_test_conf
 
 In [`fetch_test_configurations.py`](../../build_tools/github_actions/fetch_test_configurations.py), a test option (in this example rocBLAS) in `test_matrix` is setup as:
 
-```
+```python
 "rocblas": {
     "job_name": "rocblas",
     "fetch_artifact_args": "--blas --tests",

--- a/docs/development/artifacts.md
+++ b/docs/development/artifacts.md
@@ -13,7 +13,7 @@ Generally, each artifact is an extract of the top level build tree, containing a
 
 After each sub-project build stage, corresponding artifact sub-directories will be populated in the `build/artifacts` directory. As a visual-aid, consider the directory listing of the `base`, `sysdeps`, and `rand` artifacts:
 
-```
+```bash
 $ ls -1d artifacts/{base_*,sysdeps_*,rand_*}
 artifacts/base_dbg_generic
 artifacts/base_dev_generic
@@ -119,7 +119,7 @@ These commands always ensure that the `artifact_manifest.txt` is written to the 
 
 Artifacts are constructed by adding a `therock_provide_artifact()` command to a CMake file. Working forward on our sysdeps example, here is the directive to create its artifact:
 
-```
+```cmake
 therock_provide_artifact(sysdeps
   TARGET_NEUTRAL
   DESCRIPTOR artifact.toml
@@ -152,7 +152,7 @@ The artifact descriptor uses a pattern based language to define what files are i
 
 Abbreviated example:
 
-```
+```toml
 # bzip2
 [components.lib."third-party/sysdeps/linux/bzip2/build/stage"]
 [components.dev."third-party/sysdeps/linux/bzip2/build/stage"]

--- a/docs/development/development_guide.md
+++ b/docs/development/development_guide.md
@@ -91,7 +91,7 @@ First, build TheRock as usual but requesting only a certain component. This is d
 
 The `hipify` sources are in the `compiler/hipify` directory and the outer build target and CMake flags are contained in the `compiler/CMakeLists.txt` file. Once the initial configure is done, you will see a corresponding directory in your build directory. At the time of writing, this directory looks something like this:
 
-```
+```bash
 $ ls -lh
 total 8.0K
 drwxrwxr-x 1 stella stella  272 Mar 11 19:38 build
@@ -133,7 +133,7 @@ If not doing deep development on the component, it is often effective to just us
 
 This can be done (using `hipify` as the example component name) with commands like this:
 
-```
+```bash
 ninja hipify+expunge && ninja hipify
 ```
 

--- a/docs/development/sanitizers.md
+++ b/docs/development/sanitizers.md
@@ -43,7 +43,7 @@ When a project is configured for sanitizers, it will have certain variables inje
 
 You are recommended to code defensively with patterns like:
 
-```
+```cmake
 if(NOT DEFINED THEROCK_SANITIZER)
   set(THEROCK_SANITIZER)
 endif()
@@ -56,7 +56,7 @@ Note that you may need to add additional environment variable special casing to 
 
 Example:
 
-```
+```cmake
 if(NOT DEFINED THEROCK_SANITIZER_LAUNCHER)
   set(THEROCK_SANITIZER_LAUNCHER)
 endif()
@@ -75,7 +75,7 @@ We may add more built-in helpers if we see a lot of common usages like this. How
 
 If needing to activate specific codepaths in ROCm libraries specifically for ASAN, CMake plumbing can be done to set ad-hoc defines, but it is highly recommended to instead use built-in compile definitions for this. For example:
 
-```
+```c
 #if defined(__has_feature)
 # if __has_feature(address_sanitizer)
     // Code that builds only when AddressSanitizer is enabled


### PR DESCRIPTION
## Motivation

A few code blocks were missing syntax highlighting (https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#syntax-highlighting). I just fixed a few that I saw, there are probably others.

## Technical Details

We could enforce this via https://github.com/DavidAnson/markdownlint with the "MD040 - Fenced code blocks should have a language specified" rule: https://github.com/DavidAnson/markdownlint/blob/main/doc/md040.md, or another similar tool.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.

@skip-pr-bot