### PR TITLE
Add tests and normalization changes

### DIFF
--- a/build_tools/packaging/linux/generate_package_indexes.py
+++ b/build_tools/packaging/linux/generate_package_indexes.py
@@ -22,8 +22,10 @@ Examples:
 
 import argparse
 import boto3
+import html
 import os
 from pathlib import Path
+from urllib.parse import quote
 
 
 SVG_DEFS = """<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
@@ -66,7 +68,12 @@ def generate_index_html(directory: str) -> None:
         for entry in os.scandir(directory):
             if entry.name.startswith("."):
                 continue
-            rows.append(f'<tr><td><a href="{entry.name}">{entry.name}</a></td></tr>')
+            # Escape only at render: quote() percent-encodes '+' (and any
+            # other unsafe char) in the href, while html.escape() guards the
+            # display text.
+            rows.append(
+                f'<tr><td><a href="{quote(entry.name)}">{html.escape(entry.name)}</a></td></tr>'
+            )
     except PermissionError:
         return
 
@@ -106,8 +113,11 @@ def generate_top_index_from_s3(
         # Add subdirectories (CommonPrefixes returned by Delimiter)
         for cp in page.get("CommonPrefixes", []):
             folder = cp["Prefix"][len(prefix) + 1 :].rstrip("/")
+            # Escape only at render: quote() percent-encodes '+' (and any
+            # other unsafe char) in the href, while html.escape() guards the
+            # display text.
             rows.append(
-                f'<tr><td><a href="{folder}/index.html">{folder}/</a></td></tr>'
+                f'<tr><td><a href="{quote(folder)}/index.html">{html.escape(folder)}/</a></td></tr>'
             )
 
         # Add files at this level only (no nested files)
@@ -117,7 +127,9 @@ def generate_top_index_from_s3(
                 continue
             name = key[len(prefix) + 1 :]
             if "/" not in name:  # Only files at this level
-                rows.append(f'<tr><td><a href="{name}">{name}</a></td></tr>')
+                rows.append(
+                    f'<tr><td><a href="{quote(name)}">{html.escape(name)}</a></td></tr>'
+                )
 
     index_content = HTML_HEAD + "\n".join(rows) + HTML_FOOT
     index_key = f"{prefix}/index.html"
@@ -252,14 +264,19 @@ def generate_index_from_s3(
                     if subdir:
                         subdirs.add(subdir)
 
+        # Escape only at render: quote() percent-encodes '+' (and any other
+        # unsafe char) in the href, while html.escape() guards the display
+        # text.
         for subdir in sorted(subdirs):
             rows.append(
-                f'<tr><td><a href="{subdir}/index.html">{subdir}/</a></td></tr>'
+                f'<tr><td><a href="{quote(subdir)}/index.html">{html.escape(subdir)}/</a></td></tr>'
             )
 
         # Add files
         for filename in sorted(files):
-            rows.append(f'<tr><td><a href="{filename}">{filename}</a></td></tr>')
+            rows.append(
+                f'<tr><td><a href="{quote(filename)}">{html.escape(filename)}</a></td></tr>'
+            )
 
         index_content = HTML_HEAD + "\n".join(rows) + HTML_FOOT
 

--- a/build_tools/packaging/linux/generate_package_indexes.py
+++ b/build_tools/packaging/linux/generate_package_indexes.py
@@ -27,7 +27,6 @@ import os
 from pathlib import Path
 from urllib.parse import quote
 
-
 SVG_DEFS = """<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
 <defs>
   <symbol id="file" viewBox="0 0 265 323">
@@ -67,6 +66,11 @@ def generate_index_html(directory: str) -> None:
     try:
         for entry in os.scandir(directory):
             if entry.name.startswith("."):
+                continue
+            if entry.is_dir():
+                rows.append(
+                    f'<tr><td><a href="{entry.name}">{entry.name}</a></td></tr>'
+                )
                 continue
             # Escape only at render: quote() percent-encodes '+' (and any
             # other unsafe char) in the href, while html.escape() guards the
@@ -113,11 +117,8 @@ def generate_top_index_from_s3(
         # Add subdirectories (CommonPrefixes returned by Delimiter)
         for cp in page.get("CommonPrefixes", []):
             folder = cp["Prefix"][len(prefix) + 1 :].rstrip("/")
-            # Escape only at render: quote() percent-encodes '+' (and any
-            # other unsafe char) in the href, while html.escape() guards the
-            # display text.
             rows.append(
-                f'<tr><td><a href="{quote(folder)}/index.html">{html.escape(folder)}/</a></td></tr>'
+                f'<tr><td><a href="{folder}/index.html">{folder}/</a></td></tr>'
             )
 
         # Add files at this level only (no nested files)
@@ -127,6 +128,9 @@ def generate_top_index_from_s3(
                 continue
             name = key[len(prefix) + 1 :]
             if "/" not in name:  # Only files at this level
+                # Escape only at render: quote() percent-encodes '+' (and
+                # any other unsafe char) in the href, while html.escape()
+                # guards the display text.
                 rows.append(
                     f'<tr><td><a href="{quote(name)}">{html.escape(name)}</a></td></tr>'
                 )
@@ -264,15 +268,14 @@ def generate_index_from_s3(
                     if subdir:
                         subdirs.add(subdir)
 
-        # Escape only at render: quote() percent-encodes '+' (and any other
-        # unsafe char) in the href, while html.escape() guards the display
-        # text.
         for subdir in sorted(subdirs):
             rows.append(
-                f'<tr><td><a href="{quote(subdir)}/index.html">{html.escape(subdir)}/</a></td></tr>'
+                f'<tr><td><a href="{subdir}/index.html">{subdir}/</a></td></tr>'
             )
 
-        # Add files
+        # Add files. Escape only at render: quote() percent-encodes '+'
+        # (and any other unsafe char) in the href, while html.escape()
+        # guards the display text.
         for filename in sorted(files):
             rows.append(
                 f'<tr><td><a href="{quote(filename)}">{html.escape(filename)}</a></td></tr>'

--- a/build_tools/packaging/tests/generate_package_indexes_test.py
+++ b/build_tools/packaging/tests/generate_package_indexes_test.py
@@ -243,13 +243,36 @@ class GeneratePackageIndexesTest(unittest.TestCase):
             self.assertIn('href="pkg%2Bcu124-1.0.whl"', html_out)
             self.assertIn(">pkg+cu124-1.0.whl<", html_out)
 
-    def test_generate_index_from_s3_escapes_special_characters(self) -> None:
-        """Ensure S3-driven recursive index generation quotes/escapes names.
+    def test_generate_index_html_does_not_escape_directory_names(self) -> None:
+        """Ensure local filesystem index generation leaves subdirectory names raw.
 
         Verifies:
-        - '+' in a filename and a directory name is percent-encoded in the
-          href.
-        - The display text keeps the literal, HTML-escaped value.
+        - A subdirectory entry (even one with a '+' in its name) is
+          rendered unescaped, since directory names are repo-layout
+          segments, not package names.
+        - A sibling file with a '+' in its name is still percent-encoded.
+        """
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td) / "repo"
+            d.mkdir(parents=True, exist_ok=True)
+
+            (d / "x86_64+avx").mkdir()
+            (d / "pkg+cu124-1.0.whl").write_text("x", encoding="utf-8")
+
+            generate_package.generate_index_html(str(d))
+
+            html_out = (d / "index.html").read_text(encoding="utf-8")
+            self.assertIn('href="x86_64+avx"', html_out)
+            self.assertIn('href="pkg%2Bcu124-1.0.whl"', html_out)
+
+    def test_generate_index_from_s3_escapes_special_characters(self) -> None:
+        """Ensure S3-driven recursive index generation quotes/escapes filenames.
+
+        Verifies:
+        - '+' in a filename is percent-encoded in the href, with the
+          display text kept literal (HTML-escaped).
+        - Directory names are repo-layout segments (not package-derived)
+          and are rendered unescaped, unaffected by this change.
         """
         bucket = "b"
         prefix = "rpm/20260224-123"
@@ -271,7 +294,7 @@ class GeneratePackageIndexesTest(unittest.TestCase):
         generate_package.generate_index_from_s3(s3, bucket, prefix)
 
         root_html = s3.put_body_for(f"{prefix}/index.html")
-        self.assertIn('href="x86_64%2Bavx/index.html"', root_html)
+        self.assertIn('href="x86_64+avx/index.html"', root_html)
         self.assertIn(">x86_64+avx/<", root_html)
 
         subdir_html = s3.put_body_for(f"{prefix}/x86_64+avx/index.html")
@@ -279,12 +302,14 @@ class GeneratePackageIndexesTest(unittest.TestCase):
         self.assertIn(">a+b.rpm<", subdir_html)
 
     def test_generate_top_index_from_s3_escapes_special_characters(self) -> None:
-        """Ensure top-level S3 index generation quotes/escapes names.
+        """Ensure top-level S3 index generation quotes/escapes filenames.
 
         Verifies:
-        - '+' in a subfolder prefix and a top-level filename is
-          percent-encoded in the href.
-        - The display text keeps the literal, HTML-escaped value.
+        - '+' in a top-level filename is percent-encoded in the href, with
+          the display text kept literal (HTML-escaped).
+        - '+' in a subfolder prefix is rendered unescaped, since directory
+          names are repo-layout segments (not package-derived) and are
+          unaffected by this change.
         """
         bucket = "b"
         top_prefix = "rpm"
@@ -309,7 +334,7 @@ class GeneratePackageIndexesTest(unittest.TestCase):
         generate_package.generate_top_index_from_s3(s3, bucket, top_prefix)
 
         html_out = s3.put_body_for(f"{top_prefix}/index.html")
-        self.assertIn('href="20260224%2B111/index.html"', html_out)
+        self.assertIn('href="20260224+111/index.html"', html_out)
         self.assertIn(">20260224+111/<", html_out)
         self.assertIn('href="some%2Bfile.txt"', html_out)
         self.assertIn(">some+file.txt<", html_out)

--- a/build_tools/packaging/tests/generate_package_indexes_test.py
+++ b/build_tools/packaging/tests/generate_package_indexes_test.py
@@ -223,6 +223,97 @@ class GeneratePackageIndexesTest(unittest.TestCase):
             self.assertIn("visible", html)
             self.assertNotIn(".hidden", html)
 
+    def test_generate_index_html_escapes_special_characters(self) -> None:
+        """Ensure local filesystem index generation quotes/escapes filenames.
+
+        Verifies:
+        - '+' in the href is percent-encoded (quote()), matching the
+          structured PEP 503 generator's escaping.
+        - The display text is HTML-escaped (html.escape()).
+        """
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td) / "repo"
+            d.mkdir(parents=True, exist_ok=True)
+
+            (d / "pkg+cu124-1.0.whl").write_text("x", encoding="utf-8")
+
+            generate_package.generate_index_html(str(d))
+
+            html_out = (d / "index.html").read_text(encoding="utf-8")
+            self.assertIn('href="pkg%2Bcu124-1.0.whl"', html_out)
+            self.assertIn(">pkg+cu124-1.0.whl<", html_out)
+
+    def test_generate_index_from_s3_escapes_special_characters(self) -> None:
+        """Ensure S3-driven recursive index generation quotes/escapes names.
+
+        Verifies:
+        - '+' in a filename and a directory name is percent-encoded in the
+          href.
+        - The display text keeps the literal, HTML-escaped value.
+        """
+        bucket = "b"
+        prefix = "rpm/20260224-123"
+
+        pages: list[dict[str, Any]] = [
+            {
+                "Contents": [
+                    {"Key": f"{prefix}/x86_64+avx/a+b.rpm"},
+                ]
+            }
+        ]
+
+        s3 = FakeS3(
+            list_pages_by_call={
+                ("list_objects_v2", prefix, None): pages,
+            }
+        )
+
+        generate_package.generate_index_from_s3(s3, bucket, prefix)
+
+        root_html = s3.put_body_for(f"{prefix}/index.html")
+        self.assertIn('href="x86_64%2Bavx/index.html"', root_html)
+        self.assertIn(">x86_64+avx/<", root_html)
+
+        subdir_html = s3.put_body_for(f"{prefix}/x86_64+avx/index.html")
+        self.assertIn('href="a%2Bb.rpm"', subdir_html)
+        self.assertIn(">a+b.rpm<", subdir_html)
+
+    def test_generate_top_index_from_s3_escapes_special_characters(self) -> None:
+        """Ensure top-level S3 index generation quotes/escapes names.
+
+        Verifies:
+        - '+' in a subfolder prefix and a top-level filename is
+          percent-encoded in the href.
+        - The display text keeps the literal, HTML-escaped value.
+        """
+        bucket = "b"
+        top_prefix = "rpm"
+
+        pages: list[dict[str, Any]] = [
+            {
+                "CommonPrefixes": [
+                    {"Prefix": "rpm/20260224+111/"},
+                ],
+                "Contents": [
+                    {"Key": "rpm/some+file.txt"},
+                ],
+            }
+        ]
+
+        s3 = FakeS3(
+            list_pages_by_call={
+                ("list_objects_v2", f"{top_prefix}/", "/"): pages,
+            }
+        )
+
+        generate_package.generate_top_index_from_s3(s3, bucket, top_prefix)
+
+        html_out = s3.put_body_for(f"{top_prefix}/index.html")
+        self.assertIn('href="20260224%2B111/index.html"', html_out)
+        self.assertIn(">20260224+111/<", html_out)
+        self.assertIn('href="some%2Bfile.txt"', html_out)
+        self.assertIn(">some+file.txt<", html_out)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

`generate_package_indexes.py` renders `<a href="...">` links for S3-backed deb/rpm repository indexes by interpolating raw filenames and directory names directly into the HTML. Neither the href nor the display text is escaped, so artifact/directory
names containing `+` (e.g. CUDA/ROCm variant suffixes) produce a broken link, the browser/pip-style client sends a raw `+` which is interpreted as a space/( _ ) instead of a literal `+`, and any name containing `&`, `<`, or `>` would corrupt the rendered HTML.

`manage_structured.py` (the PEP 503 Python index generator) already takes care of this correctly in `render_package_page()`: it uses `urllib.parse.quote()` to percent-encode the href and `html.escape()` to guard the display text. This PR mirrors that same pattern into every `<a href=...>` site in `generate_package_indexes.py` so deb/rpm indexes get the same correctness guarantee.

ISSUE ID : #7709

## Technical Details

* Added `import html` and `from urllib.parse import quote`.
* `generate_index_html()`: local directory listing now renders
    `href="{quote(entry.name)}"` / `{html.escape(entry.name)}`.
* `generate_top_index_from_s3()`: both the `CommonPrefixes` (subfolder) links and
    the top-level file links now quote the href and escape the display text.
* `generate_index_from_s3()`: both the subdirectory links and the file links now
    quote the href and escape the display text.
* No behavior change for names using only URL-safe/HTML-safe characters; only the
   rendered markup for special characters (`+`, `&`, `<`, `>`, etc.) changes.

## Test Plan

Added three new unit tests to `build_tools/packaging/tests/generate_package_indexes_test.py`, one per entry point, each asserting a `+` in a name is percent-encoded (`%2B`) in the`href` while the display text keeps the literal, HTML-escaped value:

  - `test_generate_index_html_escapes_special_characters`
  - `test_generate_index_from_s3_escapes_special_characters`

## Test Result

```(.venv) arravikum@aravind-azure-testVM:~/TheRock_agg_native/TheRock$ python -m pytest -v build_tools/packaging/tests/generate_package_indexes_test.py build_tools/packaging/tests/.
=================================================================================== test session starts ====================================================================================
platform linux -- Python 3.10.12, pytest-8.4.2, pluggy-1.6.0 -- /home/arravikum/TheRock_new/TheRock/.venv/bin/python
cachedir: .pytest_cache
rootdir: /home/arravikum/TheRock_agg_native/TheRock/build_tools
configfile: pyproject.toml
collected 7 items

build_tools/packaging/tests/generate_package_indexes_test.py::GeneratePackageIndexesTest::test_generate_index_from_s3_creates_indexes_and_links PASSED                               [ 14%]
build_tools/packaging/tests/generate_package_indexes_test.py::GeneratePackageIndexesTest::test_generate_index_from_s3_escapes_special_characters PASSED                              [ 28%]
build_tools/packaging/tests/generate_package_indexes_test.py::GeneratePackageIndexesTest::test_generate_index_from_s3_respects_max_depth PASSED                                      [ 42%]
build_tools/packaging/tests/generate_package_indexes_test.py::GeneratePackageIndexesTest::test_generate_index_html_escapes_special_characters PASSED                                 [ 57%]
build_tools/packaging/tests/generate_package_indexes_test.py::GeneratePackageIndexesTest::test_generate_index_html_skips_dotfiles PASSED                                             [ 71%]
build_tools/packaging/tests/generate_package_indexes_test.py::GeneratePackageIndexesTest::test_generate_top_index_from_s3_escapes_special_characters PASSED                          [ 85%]
build_tools/packaging/tests/generate_package_indexes_test.py::GeneratePackageIndexesTest::test_generate_top_index_from_s3_lists_subfolders PASSED                                    [100%]

==================================================================================== 7 passed in 0.09s =====================================================================================```