### PR TITLE
ci: skip uploading log files

### DIFF
--- a/build_tools/packaging/linux/build_package.py
+++ b/build_tools/packaging/linux/build_package.py
@@ -672,7 +672,7 @@ def run(args: argparse.Namespace):
         logger.error("No packages found to build. Package list is empty.")
         sys.exit(1)
 
-    logs_dir = Path(config.dest_dir) / "logs"
+    logs_dir = Path(config.dest_dir).parent / "logs"
     logs_dir.mkdir(parents=True, exist_ok=True)
 
     built_pkglist = []

--- a/build_tools/packaging/linux/upload_package_repo.py
+++ b/build_tools/packaging/linux/upload_package_repo.py
@@ -285,7 +285,12 @@ def upload_to_s3(
     skipped = 0
     uploaded = 0
 
-    for root, _, files in os.walk(source_dir):
+    for root, dirs, files in os.walk(source_dir):
+        # Exclude the logs/ subtree — packaging logs are uploaded separately
+        # by upload_packaging_logs() to logs/packaging/<pkg_type>, not here.
+        if "logs" in dirs:
+            dirs.remove("logs")
+
         for fname in files:
             # Always skip local index.html files, those are generated server-side.
             if fname == "index.html":
@@ -437,9 +442,13 @@ def main() -> None:
     else:
         create_rpm_repo(package_dir)
 
-    # Step 2: upload packaging logs to logs/packaging/, then remove the local
-    # logs/ directory entirely so upload_to_s3() can never pick it up when
-    # walking package_dir for packages/<pkg_type>.
+    # Step 2+3: upload packages (dedupe OK) and local metadata (always upload).
+    upload_to_s3(package_dir, bucket, prefix, dedupe=dedupe)
+
+    print(f"Package repository URL: {install_url}")
+    _emit_github_output("package_repository_url", install_url)
+
+    # Upload packaging logs and write step summary
     output_root = WorkflowOutputRoot.from_workflow_run(
         run_id=args.run_id, platform="linux"
     )
@@ -447,18 +456,6 @@ def main() -> None:
     log_index_url = upload_packaging_logs(
         package_dir, args.pkg_type, output_root, backend
     )
-
-    log_dir = package_dir / "logs"
-    if log_dir.is_dir():
-        shutil.rmtree(log_dir)
-        print(f"Removed local log directory: {log_dir}")
-
-    # Step 3: upload packages (dedupe OK) and local metadata (always upload).
-    upload_to_s3(package_dir, bucket, prefix, dedupe=dedupe)
-
-    print(f"Package repository URL: {install_url}")
-    _emit_github_output("package_repository_url", install_url)
-
     if log_index_url:
         _emit_github_output("packaging_logs_url", log_index_url)
 

--- a/build_tools/packaging/linux/upload_package_repo.py
+++ b/build_tools/packaging/linux/upload_package_repo.py
@@ -450,9 +450,7 @@ def main() -> None:
     )
     backend = create_storage_backend()
     logs_dir = package_dir.parent / "logs"
-    log_index_url = upload_packaging_logs(
-        logs_dir, args.pkg_type, output_root, backend
-    )
+    log_index_url = upload_packaging_logs(logs_dir, args.pkg_type, output_root, backend)
     if log_index_url:
         _emit_github_output("packaging_logs_url", log_index_url)
 

--- a/build_tools/packaging/linux/upload_package_repo.py
+++ b/build_tools/packaging/linux/upload_package_repo.py
@@ -296,11 +296,6 @@ def upload_to_s3(
                 print(f"Skipping build manifest file (local only): {fname}")
                 continue
 
-            # Skip log files - these are uploaded separately to logs/packaging/
-            if fname.lower().endswith(".log"):
-                print(f"Skipping log file (uploaded separately): {fname}")
-                continue
-
             local = Path(root) / fname
             rel = local.relative_to(source_dir)
             key = f"{prefix}/{rel.as_posix()}"

--- a/build_tools/packaging/linux/upload_package_repo.py
+++ b/build_tools/packaging/linux/upload_package_repo.py
@@ -285,12 +285,7 @@ def upload_to_s3(
     skipped = 0
     uploaded = 0
 
-    for root, dirs, files in os.walk(source_dir):
-        # Exclude the logs/ subtree — packaging logs are uploaded separately
-        # by upload_packaging_logs() to logs/packaging/<pkg_type>, not here.
-        if "logs" in dirs:
-            dirs.remove("logs")
-
+    for root, _, files in os.walk(source_dir):
         for fname in files:
             # Always skip local index.html files, those are generated server-side.
             if fname == "index.html":
@@ -327,7 +322,7 @@ def upload_to_s3(
 
 
 def upload_packaging_logs(
-    package_dir: Path,
+    log_dir: Path,
     pkg_type: str,
     output_root: WorkflowOutputRoot,
     backend: StorageBackend,
@@ -338,7 +333,9 @@ def upload_packaging_logs(
     specified by WorkflowOutputRoot.native_linux_packages_log_dir().
 
     Args:
-        package_dir: Directory containing built packages (logs are in logs/ subdir)
+        log_dir: Directory containing packaging log files. Kept outside of
+        package_dir so upload_to_s3() never walks/uploads these files
+        to the packages/<pkg_type> S3 prefix.
         pkg_type: Package type ('deb' or 'rpm')
         output_root: WorkflowOutputRoot for computing S3 paths
         backend: Storage backend for uploads
@@ -346,7 +343,6 @@ def upload_packaging_logs(
     Returns:
         URL to the log index page, or None if no logs were uploaded
     """
-    log_dir = package_dir / "logs"
     if not log_dir.is_dir():
         print(f"[INFO] Log directory {log_dir} not found. Skipping log upload.")
         return None
@@ -453,8 +449,9 @@ def main() -> None:
         run_id=args.run_id, platform="linux"
     )
     backend = create_storage_backend()
+    logs_dir = package_dir.parent / "logs"
     log_index_url = upload_packaging_logs(
-        package_dir, args.pkg_type, output_root, backend
+        logs_dir, args.pkg_type, output_root, backend
     )
     if log_index_url:
         _emit_github_output("packaging_logs_url", log_index_url)

--- a/build_tools/packaging/linux/upload_package_repo.py
+++ b/build_tools/packaging/linux/upload_package_repo.py
@@ -296,6 +296,11 @@ def upload_to_s3(
                 print(f"Skipping build manifest file (local only): {fname}")
                 continue
 
+            # Skip log files - these are uploaded separately to logs/packaging/
+            if fname.lower().endswith(".log"):
+                print(f"Skipping log file (uploaded separately): {fname}")
+                continue
+
             local = Path(root) / fname
             rel = local.relative_to(source_dir)
             key = f"{prefix}/{rel.as_posix()}"

--- a/build_tools/packaging/linux/upload_package_repo.py
+++ b/build_tools/packaging/linux/upload_package_repo.py
@@ -296,11 +296,6 @@ def upload_to_s3(
                 print(f"Skipping build manifest file (local only): {fname}")
                 continue
 
-            # Skip log files - these are uploaded separately to logs/packaging/
-            if fname.lower().endswith(".log"):
-                print(f"Skipping log file (uploaded separately): {fname}")
-                continue
-
             local = Path(root) / fname
             rel = local.relative_to(source_dir)
             key = f"{prefix}/{rel.as_posix()}"
@@ -442,13 +437,9 @@ def main() -> None:
     else:
         create_rpm_repo(package_dir)
 
-    # Step 2+3: upload packages (dedupe OK) and local metadata (always upload).
-    upload_to_s3(package_dir, bucket, prefix, dedupe=dedupe)
-
-    print(f"Package repository URL: {install_url}")
-    _emit_github_output("package_repository_url", install_url)
-
-    # Upload packaging logs and write step summary
+    # Step 2: upload packaging logs to logs/packaging/, then remove the local
+    # logs/ directory entirely so upload_to_s3() can never pick it up when
+    # walking package_dir for packages/<pkg_type>.
     output_root = WorkflowOutputRoot.from_workflow_run(
         run_id=args.run_id, platform="linux"
     )
@@ -456,6 +447,18 @@ def main() -> None:
     log_index_url = upload_packaging_logs(
         package_dir, args.pkg_type, output_root, backend
     )
+
+    log_dir = package_dir / "logs"
+    if log_dir.is_dir():
+        shutil.rmtree(log_dir)
+        print(f"Removed local log directory: {log_dir}")
+
+    # Step 3: upload packages (dedupe OK) and local metadata (always upload).
+    upload_to_s3(package_dir, bucket, prefix, dedupe=dedupe)
+
+    print(f"Package repository URL: {install_url}")
+    _emit_github_output("package_repository_url", install_url)
+
     if log_index_url:
         _emit_github_output("packaging_logs_url", log_index_url)
 


### PR DESCRIPTION
## Motivation

Packages location has logs being uploaded to it. Logs should be blocked from being uploaded there like how txt files are currently being blocked
 
[therock-ci-artifacts.s3.amazonaws.com/33013518162-linux/packages/deb/index.html](https://therock-ci-artifacts.s3.amazonaws.com/33013518162-linux/packages/deb/index.html) wrong because logs are being uploaded where packages should be 
 
[therock-ci-artifacts.s3.amazonaws.com/33013518162-linux/logs/packaging/index.html](https://therock-ci-artifacts.s3.amazonaws.com/33013518162-linux/logs/packaging/index.html) correct location for logs

Fixes: https://github.com/ROCm/TheRock/issues/7729

## Technical Details

skip log files when uploading. Change upload_to_s3 function

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
