### PR TITLE
[ci] Split test requirements by subproject

### DIFF
--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -231,8 +231,9 @@ jobs:
             --shard-index "${{ matrix.shard }}" \
             --total-shards "${{ fromJSON(inputs.component).total_shards }}" \
             --test-type "${{ fromJSON(inputs.component).test_type }}" \
-            --print-cmd \
-            ${{ fromJSON(inputs.component).fetch_artifact_args && format('--fetch-artifact-args="{0}"', fromJSON(inputs.component).fetch_artifact_args) || '' }}
+            --fetch-artifact-args="${{ fromJSON(inputs.component).fetch_artifact_args }}" \
+            --additional-requirements-files="${{ join(fromJSON(inputs.component).additional_requirements_files, ',') }}" \
+            --print-cmd
 
       - name: Post-job cleanup GPU processes on Linux
         if: ${{ always() && runner.os == 'Linux' }}

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -165,10 +165,9 @@ jobs:
           python ./build_tools/print_driver_gpu_info.py
 
       - name: Setup Additional Requirements
-        if: ${{ fromJSON(inputs.component).additional_requirements_files != '' }}
         run: |
           python ./build_tools/install_additional_requirements.py \
-            --requirements-files ${{ join(fromJSON(inputs.component).additional_requirements_files, ',') }}
+            --requirements-files "${{ join(fromJSON(inputs.component).additional_requirements_files, ',') }}"
 
         # TODO(#3755): Clean this up after final sanitizer environment variable flags are determined
       - name: Enable sanitizer-specific test flags

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -826,6 +826,9 @@ test_matrix = {
         "job_name": "hipthreads",
         "fetch_artifact_args": "--hipthreads --tests",
         "timeout_minutes": 30,
+        "additional_requirements_files": [
+            "hipthreads/test/requirements-test.txt",
+        ],
         "test_script": f"python {_get_script_path('test_hipthreads.py')}",
         "platform": ["linux", "windows"],
         "total_shards_dict": {

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -142,7 +142,9 @@ def _family_matches(
 
 
 # Common settings applied to all jobs
-_common_settings = {}
+_common_settings = {
+    "additional_requirements_files": [],
+}
 
 # Common settings for rocgdb jobs
 _rocgdb_common = {
@@ -287,6 +289,9 @@ test_matrix = {
         "job_name": "tensilelite",
         "fetch_artifact_args": "--blas --tests",
         "timeout_minutes": 15,
+        "additional_requirements_files": [
+            "share/hipblaslt/tensilelite/requirements-test.txt",
+        ],
         "test_script": f"python {_get_script_path('pytest_runner.py')}",
         "platform": ["linux"],
         "total_shards_dict": {
@@ -791,6 +796,9 @@ test_matrix = {
         "job_name": "libhipcxx_amdclang",
         "fetch_artifact_args": "--libhipcxx --tests",
         "timeout_minutes": 30,
+        "additional_requirements_files": [
+            "libhipcxx/requirements-test.txt",
+        ],
         "test_script": f"python {_get_script_path('test_libhipcxx_amdclang.py')}",
         "platform": ["linux", "windows"],
         "total_shards_dict": {
@@ -803,6 +811,9 @@ test_matrix = {
         "job_name": "libhipcxx_hiprtc",
         "fetch_artifact_args": "--libhipcxx --tests",
         "timeout_minutes": 20,
+        "additional_requirements_files": [
+            "libhipcxx/requirements-test.txt",
+        ],
         "test_script": f"python {_get_script_path('test_libhipcxx_hiprtc.py')}",
         "platform": ["linux"],
         "total_shards_dict": {

--- a/build_tools/github_actions/reproduce_test_failure.py
+++ b/build_tools/github_actions/reproduce_test_failure.py
@@ -75,7 +75,7 @@ def build_reproduction_command(args: argparse.Namespace) -> str:
         f"--run-id {args.run_id} "
         f"--repository {args.repository} "
         f"--amdgpu-family {args.amdgpu_family} "
-        f'--test-script "{args.test_script}" '
+        f'--test-script "{args.test_script}"'
     )
     if args.amdgpu_targets:
         cmd += f" --amdgpu-targets {args.amdgpu_targets}"
@@ -87,7 +87,26 @@ def build_reproduction_command(args: argparse.Namespace) -> str:
         cmd += f" --test-type {args.test_type}"
     if args.fetch_artifact_args:
         cmd += f' --fetch-artifact-args="{args.fetch_artifact_args}"'
+    if args.additional_requirements_files:
+        cmd += (
+            " --additional-requirements-files="
+            f'"{args.additional_requirements_files}"'
+        )
     return cmd
+
+
+def append_additional_requirements_step(
+    steps: list[tuple[str, str]], requirements_files: str
+) -> None:
+    """Add a step that installs requirements shipped in fetched artifacts."""
+    if requirements_files:
+        steps.append(
+            (
+                "Installing component test dependencies",
+                "python build_tools/install_additional_requirements.py "
+                f'--requirements-files "{requirements_files}"',
+            )
+        )
 
 
 def run_linux(args: argparse.Namespace) -> int:
@@ -132,6 +151,8 @@ def run_linux(args: argparse.Namespace) -> int:
             ),
         ),
     ]
+
+    append_additional_requirements_step(steps, args.additional_requirements_files)
 
     if args.setup_only:
         steps.append(("Setup complete", f"echo 'Run: {args.test_script}'"))
@@ -300,6 +321,8 @@ def run_windows(args: argparse.Namespace) -> int:
         ]
     )
 
+    append_additional_requirements_step(steps, args.additional_requirements_files)
+
     if args.setup_only:
         steps.append(("Setup complete", f"Write-Host 'Run: {args.test_script}'"))
     else:
@@ -364,8 +387,11 @@ def main() -> int:
         default=DEFAULT_CONTAINER_IMAGE,
         help="Docker image (Linux only)",
     )
+    parser.add_argument("--fetch-artifact-args", default="", help="Extra artifact args")
     parser.add_argument(
-        "--fetch-artifact-args", nargs="?", default="", help="Extra artifact args"
+        "--additional-requirements-files",
+        default="",
+        help="Comma-separated requirements files relative to the artifact root",
     )
     parser.add_argument(
         "--setup-only", action="store_true", help="Setup only, don't run test"

--- a/build_tools/github_actions/tests/fetch_test_configurations_test.py
+++ b/build_tools/github_actions/tests/fetch_test_configurations_test.py
@@ -442,6 +442,24 @@ class FetchTestConfigurationsTest(unittest.TestCase):
     # Output contract
     # -----------------------
 
+    def test_additional_requirements_files_are_preserved_in_output(self):
+        requirements_files = [
+            "share/example/requirements.txt",
+            "share/example/requirements-test.txt",
+        ]
+        self._inject_job(
+            "custom-requirements",
+            additional_requirements_files=requirements_files,
+        )
+
+        fetch_test_configurations.run()
+        components = self._get_components()
+
+        self.assertEqual(len(components), 1)
+        self.assertEqual(
+            components[0]["additional_requirements_files"], requirements_files
+        )
+
     def test_windows_hip_tests_emits_pal_and_rocr_entries(self):
         """On Windows, hip-tests runs with both PAL and ROCR backends."""
         sys.argv = ["fetch_test_configurations.py", "--platform=windows"]

--- a/build_tools/github_actions/tests/reproduce_test_failure_test.py
+++ b/build_tools/github_actions/tests/reproduce_test_failure_test.py
@@ -1,0 +1,153 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+import argparse
+import os
+from pathlib import Path
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
+
+import reproduce_test_failure
+
+
+class ReproduceTestFailureTest(unittest.TestCase):
+    def _make_args(
+        self,
+        *,
+        amdgpu_targets: str = "gfx942",
+        shard_index: str = "2",
+        total_shards: str = "4",
+        test_type: str = "quick",
+        fetch_artifact_args: str = "--blas --tests",
+        additional_requirements_files: str = (
+            "share/hipblaslt/tensilelite/requirements-test.txt"
+        ),
+    ) -> argparse.Namespace:
+        return argparse.Namespace(
+            run_id="1234",
+            repository="ROCm/TheRock",
+            amdgpu_family="gfx94X-dcgpu",
+            amdgpu_targets=amdgpu_targets,
+            test_script="python test.py",
+            shard_index=shard_index,
+            total_shards=total_shards,
+            test_type=test_type,
+            container_image="test-image",
+            fetch_artifact_args=fetch_artifact_args,
+            additional_requirements_files=additional_requirements_files,
+            setup_only=False,
+            print_cmd=False,
+        )
+
+    def test_build_reproduction_command_includes_non_default_arguments(self):
+        command = reproduce_test_failure.build_reproduction_command(self._make_args())
+
+        self.assertEqual(
+            command,
+            "python build_tools/github_actions/reproduce_test_failure.py "
+            "--run-id 1234 --repository ROCm/TheRock "
+            '--amdgpu-family gfx94X-dcgpu --test-script "python test.py" '
+            "--amdgpu-targets gfx942 --shard-index 2 --total-shards 4 "
+            '--test-type quick --fetch-artifact-args="--blas --tests" '
+            '--additional-requirements-files="share/hipblaslt/'
+            'tensilelite/requirements-test.txt"',
+        )
+
+    def test_build_reproduction_command_omits_default_arguments(self):
+        command = reproduce_test_failure.build_reproduction_command(
+            self._make_args(
+                amdgpu_targets="",
+                shard_index="1",
+                total_shards="1",
+                test_type="full",
+                fetch_artifact_args="",
+                additional_requirements_files="",
+            )
+        )
+
+        self.assertEqual(
+            command,
+            "python build_tools/github_actions/reproduce_test_failure.py "
+            "--run-id 1234 --repository ROCm/TheRock "
+            '--amdgpu-family gfx94X-dcgpu --test-script "python test.py"',
+        )
+
+    def test_run_linux_runs_ordered_setup_and_test_steps(self):
+        with (
+            mock.patch.object(
+                reproduce_test_failure, "check_docker", return_value=True
+            ),
+            mock.patch.object(
+                reproduce_test_failure.subprocess,
+                "run",
+                return_value=mock.Mock(returncode=0),
+            ) as run,
+        ):
+            result = reproduce_test_failure.run_linux(self._make_args())
+
+        self.assertEqual(result, 0)
+        run.assert_called_once()
+        docker_command = run.call_args.args[0]
+        self.assertEqual(docker_command[:2], ["docker", "run"])
+        self.assertEqual(
+            docker_command[-4:-1],
+            [
+                "test-image",
+                "/bin/bash",
+                "-c",
+            ],
+        )
+
+        script = docker_command[-1]
+        script_lines = script.splitlines()
+        progress_lines = [line for line in script_lines if line.startswith("echo '[")]
+        step_descriptions = [
+            line.partition("] ")[2].removesuffix("'") for line in progress_lines
+        ]
+        self.assertEqual(
+            step_descriptions,
+            [
+                "Installing uv",
+                "Cloning TheRock",
+                "Creating virtual environment",
+                "Installing dependencies",
+                "Downloading artifacts",
+                "Setting environment variables",
+                "Installing component test dependencies",
+                "Running test",
+            ],
+        )
+
+        artifact_command = next(
+            line for line in script_lines if "install_rocm_from_artifacts.py" in line
+        )
+        self.assertIn("GITHUB_REPOSITORY=ROCm/TheRock", artifact_command)
+        self.assertIn("--run-id 1234", artifact_command)
+        self.assertIn("--amdgpu-family gfx94X-dcgpu", artifact_command)
+        self.assertIn("--amdgpu-targets gfx942", artifact_command)
+        self.assertIn("--blas --tests", artifact_command)
+
+        requirements_command = next(
+            line
+            for line in script_lines
+            if "install_additional_requirements.py" in line
+        )
+        self.assertIn(
+            "share/hipblaslt/tensilelite/requirements-test.txt",
+            requirements_command,
+        )
+
+        environment_command = next(
+            line for line in script_lines if "export THEROCK_BIN_DIR" in line
+        )
+        self.assertIn("export SHARD_INDEX=2", environment_command)
+        self.assertIn("export TOTAL_SHARDS=4", environment_command)
+        self.assertIn("export TEST_TYPE=quick", environment_command)
+        self.assertTrue(any(line.startswith("python test.py") for line in script_lines))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/build_tools/install_additional_requirements.py
+++ b/build_tools/install_additional_requirements.py
@@ -6,7 +6,7 @@
 """Script to install additional requirements.txt files for projects that require additional files for testing.
 
 Requires a requirements-file input parameter that is a list of comma separated paths to requirements.txt files.
-This path will always be relative to the absolute path of the OUTPUT_ARTIFACTS_DIR.
+An empty value is a no-op. Each path is relative to the absolute path of the OUTPUT_ARTIFACTS_DIR.
 
 Usage:
 python install_additional_requirements.py
@@ -44,11 +44,15 @@ THEROCK_OUTPUT_DIR = str(
 
 
 def install_requirements(req_files_list: str):
+    if not req_files_list:
+        logging.info("No additional requirements files to install")
+        return
+
+    requirements_files = req_files_list.split(",")
+
     environ_vars = os.environ.copy()
     environ_vars["CC"] = "clang"
     environ_vars["CXX"] = "clang++"
-
-    requirements_files = req_files_list.split(",")
 
     for file in requirements_files:
         cmd = [

--- a/docs/development/adding_tests.md
+++ b/docs/development/adding_tests.md
@@ -2,7 +2,7 @@
 
 ## Test Flow
 
-After TheRock builds its artifacts, we test those artifacts through [`test_artifacts.yml`](../../.github/workflows/test_artifacts.yml). The testing flow works as:
+After TheRock builds its artifacts, we test those artifacts through [`test_artifacts.yml`](/.github/workflows/test_artifacts.yml). The testing flow works as:
 
 ```mermaid
 graph LR
@@ -12,12 +12,12 @@ graph LR
 where we:
 
 1. Check that the artifacts pass sanity tests.
-1. The `configure_test_matrix` step runs [`fetch_test_configurations.py`](../../build_tools/github_actions/fetch_test_configurations.py), where we generate a test matrix for which tests to run.
+1. The `configure_test_matrix` step runs [`fetch_test_configurations.py`](/build_tools/github_actions/fetch_test_configurations.py), where we generate a test matrix for which tests to run.
 1. After we generate the matrix, `test_components` executes those tests in parallel.
 
 ### How these tests are executed
 
-These tests are retrieved from [`fetch_test_configurations.py`](../../build_tools/github_actions/fetch_test_configurations.py), where we generate a matrix of tests to run for various AMD GPU families from [`amdgpu_family_matrix.py`](../../build_tools/github_actions/amdgpu_family_matrix.py) on both Linux and Windows test machines.
+These tests are retrieved from [`fetch_test_configurations.py`](/build_tools/github_actions/fetch_test_configurations.py), where we generate a matrix of tests to run for various AMD GPU families from [`amdgpu_family_matrix.py`](/build_tools/github_actions/amdgpu_family_matrix.py) on both Linux and Windows test machines.
 
 These tests are run per pull request, main branch commit, `workflow_dispatch` and nightly runs.
 
@@ -27,7 +27,29 @@ Since TheRock is the open source build system for HIP and ROCm, we are intereste
 
 ## Adding tests
 
-To add tests, add your executable logic to `github_actions/test_executable_scripts` with a Python file (in order to be compatible with Linux and Windows). Below is an example for [`hipblaslt.py`](../../build_tools/github_actions/test_executable_scripts/test_hipblaslt.py):
+Adding a component test has two steps:
+
+1. Teach
+   [`install_rocm_from_artifacts.py`](/build_tools/install_rocm_from_artifacts.py)
+   how to install the component's test artifacts and their dependencies.
+1. Add a test executable script and an entry in
+   [`fetch_test_configurations.py`](/build_tools/github_actions/fetch_test_configurations.py).
+
+### 1. Configure artifact installation
+
+When adding a new component to TheRock (typically a new `.toml` file), update
+[`install_rocm_from_artifacts.py`](/build_tools/install_rocm_from_artifacts.py)
+so CI workflows and users can selectively install its test artifacts and their
+dependencies. Adding libraries to an existing component requires no script
+changes. See [Adding Support for New Components](./installing_artifacts.md#adding-support-for-new-components)
+for step-by-step instructions.
+
+### 2. Add the test executable and configuration
+
+Add your executable logic to
+[`github_actions/test_executable_scripts/`](/build_tools/github_actions/test_executable_scripts/)
+with a Python file (in order to be compatible with Linux and Windows). Below is
+an example from [`test_hipblaslt.py`](/build_tools/github_actions/test_executable_scripts/test_hipblaslt.py):
 
 ```python
 cmd = [f"{THEROCK_BIN_DIR}/hipblaslt-test", "--gtest_filter=*pre_checkin*"]
@@ -39,13 +61,13 @@ subprocess.run(
 )
 ```
 
-After creating your script, please refer below to create your test entry in [`fetch_test_configurations.py`](../../build_tools/github_actions/fetch_test_configurations.py)
+After creating your script, please refer below to create your test entry in [`fetch_test_configurations.py`](/build_tools/github_actions/fetch_test_configurations.py)
 
-## Fields for the test matrix
+#### 2a. Fields for the test matrix
 
-Add an entry in [`test_matrix`](../../build_tools/github_actions/fetch_test_configurations.py), then your test will be enabled in the test workflow
+Add an entry in [`test_matrix`](/build_tools/github_actions/fetch_test_configurations.py), then your test will be enabled in the test workflow
 
-In [`fetch_test_configurations.py`](../../build_tools/github_actions/fetch_test_configurations.py), a test option (in this example rocBLAS) in `test_matrix` is setup as:
+In [`fetch_test_configurations.py`](/build_tools/github_actions/fetch_test_configurations.py), a test option (in this example rocBLAS) in `test_matrix` is setup as:
 
 ```
 "rocblas": {
@@ -57,17 +79,49 @@ In [`fetch_test_configurations.py`](../../build_tools/github_actions/fetch_test_
 }
 ```
 
-| Field Name          | Type   | Platform | Description                                                                                                                        |
-| ------------------- | ------ | -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| job_name            | string | Any      | Name of the job                                                                                                                    |
-| fetch_artifact_args | string | Any      | Arguments for which artifacts for [`install_rocm_from_artifacts.py`](../../build_tools/install_rocm_from_artifacts.py) to retrieve |
-| timeout_minutes     | int    | Any      | The timeout (in minutes) for the test step                                                                                         |
-| test_script         | string | Any      | The path to the test script                                                                                                        |
-| platform            | array  | Any      | An array of platforms that the test can execute on, options are `linux` and `windows`                                              |
-| container_image     | string | Linux    | The name of a container image to use for this component                                                                            |
-| container_options   | string | Linux    | Additional options to be passed when launching the container                                                                       |
+| Field Name                    | Type   | Platform | Description                                                                                                                   |
+| ----------------------------- | ------ | -------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| job_name                      | string | Any      | Name of the job                                                                                                               |
+| fetch_artifact_args           | string | Any      | Arguments for which artifacts for [`install_rocm_from_artifacts.py`](/build_tools/install_rocm_from_artifacts.py) to retrieve |
+| additional_requirements_files | array  | Any      | Paths within the fetched artifacts to Python requirements files needed by this test                                           |
+| timeout_minutes               | int    | Any      | The timeout (in minutes) for the test step                                                                                    |
+| test_script                   | string | Any      | The path to the test script                                                                                                   |
+| platform                      | array  | Any      | An array of platforms that the test can execute on, options are `linux` and `windows`                                         |
+| container_image               | string | Linux    | The name of a container image to use for this component                                                                       |
+| container_options             | string | Linux    | Additional options to be passed when launching the container                                                                  |
 
-> [!NOTE]
-> When adding a new component to TheRock (typically a new .toml file), you may need to update `install_rocm_from_artifacts.py` to allow CI workflows and users to selectively install it.<br>
-> Adding libraries to existing components requires no script changes.<br>
-> See the [Adding Support for New Components](./installing_artifacts.md#adding-support-for-new-components) guide for step-by-step instructions.
+#### 2b. Python requirements for component tests
+
+Every component test job installs the root
+[`requirements-test.txt`](/requirements-test.txt). This file is for common
+requirements used by TheRock's test infrastructure or by all subproject tests.
+Keep its package download size minimal: adding a dependency used by only one
+subproject makes every component test environment download and install it.
+
+Keep requirements used by an individual subproject with that subproject's
+source, typically in a `requirements-test.txt` file. The requirements file must
+be copied or installed into a source, build, or stage tree included by the
+subproject's test artifact. Add an include pattern to the artifact TOML file if
+the test artifact does not already capture the requirements file.
+
+Register each artifact path in the test's `additional_requirements_files` entry
+in
+[`fetch_test_configurations.py`](/build_tools/github_actions/fetch_test_configurations.py):
+
+```python
+"example": {
+    "job_name": "example",
+    "fetch_artifact_args": "--example --tests",
+    "additional_requirements_files": [
+        "share/example/tests/requirements-test.txt",
+    ],
+    "timeout_minutes": 10,
+    "test_script": f"python {_get_script_path('test_example.py')}",
+    "platform": ["linux"],
+}
+```
+
+The paths are relative to the extracted test artifact directory, not the source
+checkout. The test workflow installs these files into the common test virtual
+environment after fetching the component's artifacts. A test can register more
+than one requirements file when necessary.

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -15,10 +15,11 @@ python-debian==1.1.1
 setuptools>=80.9.0,<82.0.0
 python-magic==0.4.27; sys_platform != "win32"
 
-#test_artifacts_covered_by_packages requirement
+# build_tools/memory_monitor.py requirement
+psutil==7.1.3
+
+# test_artifacts_covered_by_packages requirement
 toml>=0.10.2
 
-# build_tools/packaging/linux/tests/build_package_test.py imports build_package.py,
-# which pulls this in via deb_package.py and rpm_package.py.
-# Keep the specifier in sync with requirements.txt.
+# build_tools/packaging/linux/tests/build_package_test.py requirement
 jinja2>=3.0.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -15,21 +15,6 @@ python-debian==1.1.1
 setuptools>=80.9.0,<82.0.0
 python-magic==0.4.27; sys_platform != "win32"
 
-# tensilelite/rocisa test requirements
-# TODO: Keep in sync with rocm-libraries/projects/hipblaslt/tensilelite/requirements.txt
-msgpack>=1.0.0
-joblib>=1.4.0
-numpy>=1.26.0
-filelock>=3.0.0
-syrupy==5.3.2
-hip-python; sys_platform != "win32"
-pytest-xdist>=1.32.0
-
-# libhipcxx test requirement
-lit==18.1.8
-psutil==7.1.3
-sccache==0.10.0
-
 #test_artifacts_covered_by_packages requirement
 toml>=0.10.2
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,9 @@
+# Common Python requirements for TheRock's test infrastructure and all
+# subproject test jobs. Keep this list minimal because every component test
+# environment downloads these packages. Put requirements used by an individual
+# subproject in a file distributed with its test artifact and register that file
+# with additional_requirements_files. See docs/development/adding_tests.md.
+
 boto3==1.39.15
 pytest==9.0.3 # This versions has subtests built-in.
 pytest-check==2.5.3


### PR DESCRIPTION
> [!IMPORTANT]
> This relates to the following PRs:
> * https://github.com/ROCm/libhipcxx/pull/29
> * https://github.com/ROCm/rocm-libraries/pull/11396
> * https://github.com/ROCm/rocm-libraries/pull/11438 

## Motivation

* Fixes https://github.com/ROCm/TheRock/issues/7491

We've been using a common https://github.com/ROCm/TheRock/blob/main/requirements-test.txt file across all ROCm subproject tests that seemed convenient to extend at the time, but it has a few drawbacks:

* https://github.com/ROCm/TheRock/pull/5529 added 50MB+ of dependencies only used for tensilelite tests but downloaded for all subprojects, sometimes contributing up to 50 minutes of job time _per CI run_ just downloading packages on runners with slow network and no pip cache
* https://github.com/ROCm/TheRock/pull/6106 required sending a pull request to TheRock in order to run "TensileLite characterization (snapshot) tests", when such changes could be made purely here in rocm-libraries if we keep the responsibility for maintaining requirements lists next to the test code itself

## Technical Details

> [!IMPORTANT]
> Now each project that installs additional requirements should provide its own `requirements.txt` as part of its test artifact and register that with the CI test system via the `additional_requirements_files` field in `build_tools/github_actions/fetch_test_configurations.py`.

Comparing https://github.com/ROCm/TheRock/actions/runs/33191445520 (this branch) vs a baseline https://github.com/ROCm/TheRock/actions/runs/33159247177, in aggregate across up to 50 subproject test jobs, this results in:
* Most test jobs now download ~15MB instead of 110MB of python packages --> save ~4.5GB of download bandwidth per full CI run
* Installing requirements median time dropped from 39s to 2.5s --> save ~24 runner-minutes per full CI run

## Test Plan

* Tested via `workflow_dispatch`: https://github.com/ROCm/TheRock/actions/runs/33191445520 and checked that jobs complete successfully after installing the expected set of packages
* Note the 'quick' test levels, while projects run additional tests that other test levels that _may_ have additional requirements

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
