### PR TITLE
ci(jax): drop hardcoded Google DNS from wheel test containers

### DIFF
--- a/.github/workflows/test_linux_jax_wheels.yml
+++ b/.github/workflows/test_linux_jax_wheels.yml
@@ -145,9 +145,6 @@ jobs:
     runs-on: ${{ inputs.test_runs_on }}
     container:
       image: ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:405945a40deaff9db90b9839c0f41d4cba4a383c1a7459b28627047bf6302a26
-      # DNS workaround: These --dns entries are added to resolve CloudFront/runner DNS issues
-      # They should NOT be required for testing JAX and can be removed once DNS issues are resolved
-      # TODO: Remove these lines when issue is fixed - https://github.com/ROCm/TheRock/issues/3014
       options:  >-
           --device /dev/kfd
           --device /dev/dri
@@ -155,8 +152,6 @@ jobs:
           --group-add video
           --user root
           --env-file /etc/podinfo/gha-gpu-isolation-settings
-          --dns 8.8.8.8
-          --dns 8.8.4.4
     defaults:
       run:
         shell: bash

--- a/.github/workflows/test_multi_arch_linux_jax_wheels.yml
+++ b/.github/workflows/test_multi_arch_linux_jax_wheels.yml
@@ -227,8 +227,6 @@ jobs:
         --env-file /etc/podinfo/gha-gpu-isolation-settings
         -e KUBE_CPU_REQUEST
         -e KUBE_MEMORY_REQUEST
-        --dns 8.8.8.8
-        --dns 8.8.4.4
 
     defaults:
       run:


### PR DESCRIPTION
## Summary
- Remove `--dns 8.8.8.8` and `--dns 8.8.4.4` from the Linux JAX wheel test container options.
- Drop the related DNS workaround comments / https://github.com/ROCm/TheRock/issues/3014 TODO now that the flags are gone.

These were a CloudFront/runner DNS workaround and should no longer be required.

## Test plan
- [ ] Confirm JAX wheel test workflows still start containers without the Google DNS flags
- [ ] Confirm package/index fetches in those jobs resolve normally (no CloudFront/DNS regressions)

Made with [Cursor](https://cursor.com)