### PR TITLE
ci: map external subtrees for test dependency selection

### DIFF
--- a/test_tools/determine_rocm_test_dependencies.py
+++ b/test_tools/determine_rocm_test_dependencies.py
@@ -71,10 +71,20 @@ _TEST_POLICIES_NAME = "test_policies.toml"
 _TEST_TOOLS_DIR = Path(__file__).resolve().parent
 
 _EXTERNAL_SUBTREE_ALIASES = {
+    "emulation/mirage": "mirage",
+    "emulation/rocjitsu": "rocjitsu",
     "shared/rocroller": "rocroller",
+    "shared/amdgpu-windows-interop": "hip-clr",
     "dnn-providers/hipblaslt-provider": "hipblasltprovider",
     "dnn-providers/hip-kernel-provider": "hipkernelprovider",
     "dnn-providers/miopen-provider": "miopenprovider",
+    "projects/clr": "hip-clr",
+    "projects/cuid": "rdc",
+    "projects/hip": "hip-clr",
+    "projects/hipother": "hip-clr",
+    "projects/rocdbgapi": "amd-dbgapi",
+    "projects/rocm-smi-lib": "rocm_smi_lib",
+    "projects/rocprofiler": "rocprofiler-sdk",
 }
 
 

--- a/test_tools/determine_rocm_test_dependencies.py
+++ b/test_tools/determine_rocm_test_dependencies.py
@@ -70,6 +70,13 @@ _TEST_POLICIES_NAME = "test_policies.toml"
 # them script-relative lets selection work from a clean checkout with no build/.
 _TEST_TOOLS_DIR = Path(__file__).resolve().parent
 
+_EXTERNAL_SUBTREE_ALIASES = {
+    "shared/rocroller": "rocroller",
+    "dnn-providers/hipblaslt-provider": "hipblasltprovider",
+    "dnn-providers/hip-kernel-provider": "hipkernelprovider",
+    "dnn-providers/miopen-provider": "miopenprovider",
+}
+
 
 def _test_tools_file(name: str, therock_dir: Path | None) -> Path:
     """Resolve a committed file under test_tools/.
@@ -214,12 +221,13 @@ def get_subprojects_to_test(
     selection works from a clean checkout with no build/ directory.
 
     Inputs and outputs are consumer-graph keys (the lowercased subproject names in
-    therock_consumer_graph.json). This function only lowercases; the CLI also
-    strips a leading `projects/`. Callers holding other identifiers must map them
-    to graph keys first — notably, subtree paths like `projects/clr` (-> `hip-clr`)
-    or `shared/rocroller`, and the hyphenated CI test-matrix keys
-    (`hipdnn-integration-tests` vs the graph's `hipdnn_integration_tests`). That
-    mapping is tracked separately.
+    therock_consumer_graph.json). This function only lowercases; the CLI handles
+    the external-repo subtree identifiers it receives from GitHub Actions by
+    stripping a leading `projects/` and mapping known non-project subtree paths
+    to graph keys. Callers holding other identifiers must map them to graph keys
+    first — notably, subtree paths like `projects/clr` (-> `hip-clr`) and the
+    hyphenated CI test-matrix keys (`hipdnn-integration-tests` vs the graph's
+    `hipdnn_integration_tests`). That mapping is tracked separately.
     """
     graph = _load_consumer_graph(therock_dir)
     policies = _load_policies(therock_dir)
@@ -378,6 +386,14 @@ def list_subprojects(therock_dir: Path | None = None, show_deps: bool = False):
     return sorted(graph.keys())
 
 
+def _normalize_changed_project(project: str) -> str:
+    """Normalize CI subtree identifiers to consumer-graph keys for the CLI."""
+    project_lower = project.lower()
+    if project_lower in _EXTERNAL_SUBTREE_ALIASES:
+        return _EXTERNAL_SUBTREE_ALIASES[project_lower]
+    return project_lower.removeprefix("projects/")
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Compute subproject test dependencies from the consumer graph"
@@ -396,7 +412,8 @@ def main():
         nargs="*",
         metavar="PROJECT",
         help="Project(s) that changed. Accepts space- or comma-separated list. "
-        "Supports 'rocblas' or 'projects/rocblas' format.",
+        "Supports graph keys, 'projects/<name>', and known external subtree "
+        "paths such as 'shared/rocroller'.",
     )
     parser.add_argument(
         "--level",
@@ -469,7 +486,7 @@ def main():
         changed = flattened
 
     if changed:
-        changed = [p.removeprefix("projects/") for p in changed]
+        changed = [_normalize_changed_project(p) for p in changed]
 
     # No projects specified → all tests
     if not changed:

--- a/test_tools/tests/determine_rocm_test_dependencies_test.py
+++ b/test_tools/tests/determine_rocm_test_dependencies_test.py
@@ -300,9 +300,7 @@ class TestCliInputParsing(_FixtureTestCase):
         self.assertIn("rdc", projects)
 
     def test_shared_rocroller_prefix_mapped(self) -> None:
-        proc = self._run(
-            "--changed-projects", "shared/rocroller", "--level", "4"
-        )
+        proc = self._run("--changed-projects", "shared/rocroller", "--level", "4")
         self.assertEqual(proc.returncode, 0, proc.stderr)
         projects = json.loads(proc.stdout.strip())
         self.assertIn("rocroller", projects)

--- a/test_tools/tests/determine_rocm_test_dependencies_test.py
+++ b/test_tools/tests/determine_rocm_test_dependencies_test.py
@@ -299,6 +299,49 @@ class TestCliInputParsing(_FixtureTestCase):
         self.assertIn("amdsmi", projects)
         self.assertIn("rdc", projects)
 
+    def test_shared_rocroller_prefix_mapped(self) -> None:
+        proc = self._run(
+            "--changed-projects", "shared/rocroller", "--level", "4"
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        projects = json.loads(proc.stdout.strip())
+        self.assertIn("rocroller", projects)
+        self.assertIn("hipblaslt", projects)
+
+    def test_dnn_provider_prefixes_mapped(self) -> None:
+        graph = {
+            "hipblasltprovider": {"consumers": []},
+            "hipkernelprovider": {"consumers": []},
+            "miopenprovider": {"consumers": []},
+        }
+        root = _make_fixture(graph=graph, policies="")
+        try:
+            cases = {
+                "dnn-providers/hipblaslt-provider": "hipblasltprovider",
+                "dnn-providers/hip-kernel-provider": "hipkernelprovider",
+                "dnn-providers/miopen-provider": "miopenprovider",
+            }
+            for changed_project, expected in cases.items():
+                with self.subTest(changed_project=changed_project):
+                    proc = subprocess.run(
+                        [
+                            sys.executable,
+                            str(SCRIPT),
+                            "--therock-dir",
+                            str(root),
+                            "--changed-projects",
+                            changed_project,
+                            "--level",
+                            "4",
+                        ],
+                        capture_output=True,
+                        text=True,
+                    )
+                    self.assertEqual(proc.returncode, 0, proc.stderr)
+                    self.assertEqual(json.loads(proc.stdout.strip()), [expected])
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
     def test_comma_separated_input(self) -> None:
         proc = self._run("--changed-projects", "amdsmi,rocroller", "--level", "4")
         self.assertEqual(proc.returncode, 0, proc.stderr)
@@ -506,9 +549,9 @@ class TestRealCommittedPolicies(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# Identifier-space contract: inputs must be consumer-graph keys. The function only
-# lowercases; the CLI also strips a leading `projects/`. Subtree paths and
-# hyphenated matrix keys are NOT graph keys and must be mapped by the caller.
+# Identifier-space contract: function inputs must be consumer-graph keys. The
+# CLI accepts external-repo subtree identifiers and normalizes known forms before
+# calling into the graph selection logic.
 # ---------------------------------------------------------------------------
 class TestIdentifierSpaceContract(_FixtureTestCase):
     def test_graph_key_input_resolves(self) -> None:
@@ -539,8 +582,8 @@ class TestIdentifierSpaceContract(_FixtureTestCase):
         self.assertIn("unrecognized", proc.stderr.lower())
 
     def test_shared_prefix_not_stripped(self) -> None:
-        # Only `projects/` is stripped, not `shared/`. `shared/rocroller` is not a
-        # graph key, so it does not resolve to `rocroller`.
+        # Direct function callers pass graph keys. CLI-only aliases such as
+        # `shared/rocroller` are not normalized here.
         buf = io.StringIO()
         with redirect_stderr(buf):
             selected = get_subprojects_to_test(["shared/rocroller"], self.root, level=4)

--- a/test_tools/tests/determine_rocm_test_dependencies_test.py
+++ b/test_tools/tests/determine_rocm_test_dependencies_test.py
@@ -342,6 +342,51 @@ class TestCliInputParsing(_FixtureTestCase):
         finally:
             shutil.rmtree(root, ignore_errors=True)
 
+    def test_rocm_systems_prefixes_mapped(self) -> None:
+        graph = {
+            "amd-dbgapi": {"consumers": []},
+            "hip-clr": {"consumers": []},
+            "mirage": {"consumers": []},
+            "rdc": {"consumers": []},
+            "rocjitsu": {"consumers": []},
+            "rocm_smi_lib": {"consumers": []},
+            "rocprofiler-sdk": {"consumers": []},
+        }
+        root = _make_fixture(graph=graph, policies="")
+        try:
+            cases = {
+                "emulation/mirage": "mirage",
+                "emulation/rocjitsu": "rocjitsu",
+                "projects/clr": "hip-clr",
+                "projects/cuid": "rdc",
+                "projects/hip": "hip-clr",
+                "projects/hipother": "hip-clr",
+                "projects/rocdbgapi": "amd-dbgapi",
+                "projects/rocm-smi-lib": "rocm_smi_lib",
+                "projects/rocprofiler": "rocprofiler-sdk",
+                "shared/amdgpu-windows-interop": "hip-clr",
+            }
+            for changed_project, expected in cases.items():
+                with self.subTest(changed_project=changed_project):
+                    proc = subprocess.run(
+                        [
+                            sys.executable,
+                            str(SCRIPT),
+                            "--therock-dir",
+                            str(root),
+                            "--changed-projects",
+                            changed_project,
+                            "--level",
+                            "4",
+                        ],
+                        capture_output=True,
+                        text=True,
+                    )
+                    self.assertEqual(proc.returncode, 0, proc.stderr)
+                    self.assertEqual(json.loads(proc.stdout.strip()), [expected])
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
     def test_comma_separated_input(self) -> None:
         proc = self._run("--changed-projects", "amdsmi,rocroller", "--level", "4")
         self.assertEqual(proc.returncode, 0, proc.stderr)
@@ -559,9 +604,9 @@ class TestIdentifierSpaceContract(_FixtureTestCase):
         self.assertIn("amdsmi", selected)
         self.assertIn("rdc", selected)
 
-    def test_subtree_path_is_not_a_graph_key(self) -> None:
-        # The CLI strips `projects/` -> `clr`, still not the graph key `hip-clr`,
-        # so it selects only itself with a warning.
+    def test_unmapped_project_prefix_strips_to_name(self) -> None:
+        # Unknown `projects/` paths still fall back to stripping the prefix; if
+        # the result is not a graph key, selection warns and returns that name.
         proc = subprocess.run(
             [
                 sys.executable,
@@ -569,7 +614,7 @@ class TestIdentifierSpaceContract(_FixtureTestCase):
                 "--therock-dir",
                 str(self.root),
                 "--changed-projects",
-                "projects/clr",
+                "projects/not-a-graph-key",
                 "--level",
                 "4",
             ],
@@ -578,7 +623,7 @@ class TestIdentifierSpaceContract(_FixtureTestCase):
         )
         self.assertEqual(proc.returncode, 0, proc.stderr)
         selected = set(json.loads(proc.stdout.strip()))
-        self.assertEqual(selected, {"clr"})
+        self.assertEqual(selected, {"not-a-graph-key"})
         self.assertIn("unrecognized", proc.stderr.lower())
 
     def test_shared_prefix_not_stripped(self) -> None:


### PR DESCRIPTION
Summary:
- Normalize known external super-repo subtree paths before running TheRock test dependency selection.
- Map rocm-libraries subtree paths for rocRoller and DNN providers to their TheRock consumer-graph test keys.
- Map rocm-systems subtree paths whose external names do not match TheRock test graph keys, including HIP runtime paths, rocdbgapi, rocm-smi-lib, rocprofiler, emulation projects, CUID, and Windows interop.
- Keep the core dependency resolver operating on TheRock graph keys; the external path mapping is limited to the CI input boundary.

Validation context:
- This is a follow-up to the previous TheRock CI plumbing work that added multi-arch build/test toggles.
- rocm-libraries validation PR ROCm/rocm-libraries#11468 showed `shared/rocroller` rebuilt the expected component but did not select rocRoller tests.
- rocm-libraries validation PR ROCm/rocm-libraries#11469 showed `dnn-providers/miopen-provider` rebuilt the expected component but did not select MIOpen provider tests.
- rocm-systems mappings were checked against the current super-repo `repos-config.json` entries, the known JSON-gap entries, TheRock project mappings, and TheRock consumer test graph keys.

Testing:
- Ran `python -m unittest test_tools.tests.determine_rocm_test_dependencies_test`.
- Ran `git diff --check`.
- Spot-checked CLI test selection for `shared/rocroller`, `dnn-providers/miopen-provider`, `projects/clr`, `projects/rocm-smi-lib`, and `shared/amdgpu-windows-interop`.

ISSUE ID: https://github.com/ROCm/TheRock/issues/3343