### PR TITLE
[SWSPLAT-24296] Backport ELFIO hash table bounds validation

### DIFF
--- a/patches/third-party/elfio/0002-Validate-symbol-hash-table-bounds.patch
+++ b/patches/third-party/elfio/0002-Validate-symbol-hash-table-bounds.patch
@@ -1,0 +1,271 @@
+From 18763ab8805f0ba3c949434739e90fa98ea637ec Mon Sep 17 00:00:00 2001
+From: sstamenk <strahinja.stamenkovic@amd.com>
+Date: Mon, 31 Aug 2026 14:56:57 +0200
+Subject: [PATCH] Validate symbol hash table bounds
+
+ELFIO 3.12 trusts file-controlled SysV and GNU hash metadata before checking that headers, bloom filters, buckets, and chains fit inside the hash section. Zero bucket counts cause division by zero, truncated tables cause out-of-bounds reads, and cyclic or unterminated chains can traverse indefinitely.
+
+Use bounded, endian-aware reads; validate table extents and symbol counts; and cap traversal by the available chain data. Preserve linear symbol lookup as the safe fallback.
+
+This is a temporary TheRock backport while the fix is reviewed upstream.
+
+Upstream tracking: https://github.com/serge1/ELFIO/pull/174
+
+Reproduction: use a SysV hash header with nbucket=0 for SIGFPE, an eight-byte table with nbucket=1 for an ASan OOB read, or a self-referential chain for an infinite loop.
+---
+ elfio/elfio_symbols.hpp | 200 +++++++++++++++++++++++++++-------------
+ 1 file changed, 137 insertions(+), 63 deletions(-)
+
+diff --git a/elfio/elfio_symbols.hpp b/elfio/elfio_symbols.hpp
+index d868500..13b900d 100644
+--- a/elfio/elfio_symbols.hpp
++++ b/elfio/elfio_symbols.hpp
+@@ -23,6 +23,8 @@ THE SOFTWARE.
+ #ifndef ELFIO_SYMBOLS_HPP
+ #define ELFIO_SYMBOLS_HPP
+ 
++#include <cstring>
++
+ namespace ELFIO {
+ 
+ //------------------------------------------------------------------------------
+@@ -286,6 +288,25 @@ template <class S> class symbol_section_accessor_template
+     //------------------------------------------------------------------------------
+     Elf_Half get_hash_table_index() const { return hash_section_index; }
+ 
++    //------------------------------------------------------------------------------
++    template <class T>
++    bool read_hash_value( Elf_Xword byte_offset, T& value ) const
++    {
++        const char* data =
++            hash_section == nullptr ? nullptr : hash_section->get_data();
++        Elf_Xword data_size =
++            hash_section == nullptr ? 0 : hash_section->get_size();
++        if ( data == nullptr || byte_offset > data_size ||
++             sizeof( T ) > data_size - byte_offset ) {
++            return false;
++        }
++
++        T raw_value;
++        std::memcpy( &raw_value, data + byte_offset, sizeof( raw_value ) );
++        value = elf_file.get_convertor()( raw_value );
++        return true;
++    }
++
+     //------------------------------------------------------------------------------
+     bool hash_lookup( const std::string& name,
+                       Elf64_Addr&        value,
+@@ -295,33 +316,52 @@ template <class S> class symbol_section_accessor_template
+                       Elf_Half&          section_index,
+                       unsigned char&     other ) const
+     {
+-        bool                       ret       = false;
+-        const endianess_convertor& convertor = elf_file.get_convertor();
++        Elf_Word nbucket = 0;
++        Elf_Word nchain  = 0;
++        if ( !read_hash_value( 0, nbucket ) ||
++             !read_hash_value( sizeof( Elf_Word ), nchain ) || nbucket == 0 ) {
++            return false;
++        }
+ 
+-        Elf_Word nbucket = *(const Elf_Word*)hash_section->get_data();
+-        nbucket          = convertor( nbucket );
+-        Elf_Word nchain =
+-            *(const Elf_Word*)( hash_section->get_data() + sizeof( Elf_Word ) );
+-        nchain       = convertor( nchain );
+-        Elf_Word val = elf_hash( (const unsigned char*)name.c_str() );
+-        Elf_Word y =
+-            *(const Elf_Word*)( hash_section->get_data() +
+-                                ( 2 + val % nbucket ) * sizeof( Elf_Word ) );
+-        y = convertor( y );
+-        std::string str;
+-        get_symbol( y, str, value, size, bind, type, section_index, other );
+-        while ( str != name && STN_UNDEF != y && y < nchain ) {
+-            y = *(const Elf_Word*)( hash_section->get_data() +
+-                                    ( 2 + nbucket + y ) * sizeof( Elf_Word ) );
+-            y = convertor( y );
+-            get_symbol( y, str, value, size, bind, type, section_index, other );
++        Elf_Xword word_count = hash_section->get_size() / sizeof( Elf_Word );
++        if ( word_count < 2 || nbucket > word_count - 2 ||
++             nchain > word_count - 2 - nbucket || nchain > get_symbols_num() ) {
++            return false;
+         }
+ 
+-        if ( str == name ) {
+-            ret = true;
++        Elf_Word hash = elf_hash( (const unsigned char*)name.c_str() );
++        Elf_Word symbol;
++        if ( !read_hash_value(
++                 ( 2 + static_cast<Elf_Xword>( hash % nbucket ) ) *
++                     sizeof( Elf_Word ),
++                 symbol ) ) {
++            return false;
+         }
+ 
+-        return ret;
++        for ( Elf_Word steps = 0; symbol != STN_UNDEF && steps < nchain;
++              ++steps ) {
++            if ( symbol >= nchain ) {
++                return false;
++            }
++
++            std::string symbol_name;
++            if ( !get_symbol( symbol, symbol_name, value, size, bind, type,
++                              section_index, other ) ) {
++                return false;
++            }
++            if ( symbol_name == name ) {
++                return true;
++            }
++
++            if ( !read_hash_value(
++                     ( 2 + static_cast<Elf_Xword>( nbucket ) + symbol ) *
++                         sizeof( Elf_Word ),
++                     symbol ) ) {
++                return false;
++            }
++        }
++
++        return false;
+     }
+ 
+     //------------------------------------------------------------------------------
+@@ -334,61 +374,95 @@ template <class S> class symbol_section_accessor_template
+                           Elf_Half&          section_index,
+                           unsigned char&     other ) const
+     {
+-        bool                       ret       = false;
+-        const endianess_convertor& convertor = elf_file.get_convertor();
++        uint32_t nbuckets    = 0;
++        uint32_t symoffset   = 0;
++        uint32_t bloom_size  = 0;
++        uint32_t bloom_shift = 0;
++        if ( !read_hash_value( 0, nbuckets ) ||
++             !read_hash_value( sizeof( uint32_t ), symoffset ) ||
++             !read_hash_value( 2 * sizeof( uint32_t ), bloom_size ) ||
++             !read_hash_value( 3 * sizeof( uint32_t ), bloom_shift ) ||
++             nbuckets == 0 || bloom_size == 0 ||
++             bloom_shift >= 8 * sizeof( uint32_t ) ) {
++            return false;
++        }
++
++        Elf_Xword hash_size   = hash_section->get_size();
++        Elf_Xword header_size = 4 * sizeof( uint32_t );
++        if ( hash_size < header_size ||
++             bloom_size > ( hash_size - header_size ) / sizeof( T ) ) {
++            return false;
++        }
+ 
+-        uint32_t nbuckets    = *( (uint32_t*)hash_section->get_data() + 0 );
+-        uint32_t symoffset   = *( (uint32_t*)hash_section->get_data() + 1 );
+-        uint32_t bloom_size  = *( (uint32_t*)hash_section->get_data() + 2 );
+-        uint32_t bloom_shift = *( (uint32_t*)hash_section->get_data() + 3 );
+-        nbuckets             = convertor( nbuckets );
+-        symoffset            = convertor( symoffset );
+-        bloom_size           = convertor( bloom_size );
+-        bloom_shift          = convertor( bloom_shift );
++        Elf_Xword buckets_offset =
++            header_size + static_cast<Elf_Xword>( bloom_size ) * sizeof( T );
++        if ( nbuckets > ( hash_size - buckets_offset ) / sizeof( uint32_t ) ) {
++            return false;
++        }
+ 
+-        T* bloom_filter =
+-            (T*)( hash_section->get_data() + 4 * sizeof( uint32_t ) );
++        Elf_Xword chains_offset =
++            buckets_offset +
++            static_cast<Elf_Xword>( nbuckets ) * sizeof( uint32_t );
++        Elf_Xword chain_count =
++            ( hash_size - chains_offset ) / sizeof( uint32_t );
++        Elf_Xword symbol_count = get_symbols_num();
++        if ( symoffset > symbol_count ) {
++            return false;
++        }
+ 
+         uint32_t hash = elf_gnu_hash( (const unsigned char*)name.c_str() );
+         uint32_t bloom_index = ( hash / ( 8 * sizeof( T ) ) ) % bloom_size;
+         T        bloom_bits =
+             ( (T)1 << ( hash % ( 8 * sizeof( T ) ) ) ) |
+             ( (T)1 << ( ( hash >> bloom_shift ) % ( 8 * sizeof( T ) ) ) );
+-
+-        if ( ( convertor( bloom_filter[bloom_index] ) & bloom_bits ) !=
+-             bloom_bits )
+-            return ret;
++        T bloom_value = 0;
++        if ( !read_hash_value( header_size +
++                                   static_cast<Elf_Xword>( bloom_index ) *
++                                       sizeof( T ),
++                               bloom_value ) ||
++             ( bloom_value & bloom_bits ) != bloom_bits ) {
++            return false;
++        }
+ 
+         uint32_t bucket = hash % nbuckets;
+-        auto*    buckets =
+-            (uint32_t*)( hash_section->get_data() + 4 * sizeof( uint32_t ) +
+-                         bloom_size * sizeof( T ) );
+-        auto* chains =
+-            (uint32_t*)( hash_section->get_data() + 4 * sizeof( uint32_t ) +
+-                         bloom_size * sizeof( T ) +
+-                         nbuckets * sizeof( uint32_t ) );
+-
+-        if ( convertor( buckets[bucket] ) >= symoffset ) {
+-            uint32_t    chain_index = convertor( buckets[bucket] ) - symoffset;
+-            uint32_t    chain_hash  = convertor( chains[chain_index] );
+-            std::string symname;
+-
+-            while ( true ) {
+-                if ( ( chain_hash >> 1 ) == ( hash >> 1 ) &&
+-                     get_symbol( chain_index + symoffset, symname, value, size,
+-                                 bind, type, section_index, other ) &&
+-                     name == symname ) {
+-                    ret = true;
+-                    break;
+-                }
++        uint32_t symbol = 0;
++        if ( !read_hash_value( buckets_offset +
++                                   static_cast<Elf_Xword>( bucket ) *
++                                       sizeof( uint32_t ),
++                               symbol ) ||
++             symbol < symoffset ) {
++            return false;
++        }
+ 
+-                if ( chain_hash & 1 )
+-                    break;
+-                chain_hash = convertor( chains[++chain_index] );
++        Elf_Xword chain_index = symbol - symoffset;
++        while ( chain_index < chain_count ) {
++            if ( chain_index >= symbol_count - symoffset ) {
++                return false;
++            }
++
++            uint32_t chain_hash = 0;
++            if ( !read_hash_value( chains_offset +
++                                       chain_index * sizeof( uint32_t ),
++                                   chain_hash ) ) {
++                return false;
++            }
++
++            std::string symbol_name;
++            if ( ( chain_hash >> 1 ) == ( hash >> 1 ) &&
++                 get_symbol( static_cast<Elf_Xword>( symoffset ) + chain_index,
++                             symbol_name, value, size, bind, type,
++                             section_index, other ) &&
++                 name == symbol_name ) {
++                return true;
++            }
++
++            if ( chain_hash & 1 ) {
++                return false;
+             }
++            ++chain_index;
+         }
+ 
+-        return ret;
++        return false;
+     }
+ 
+     //------------------------------------------------------------------------------
+-- 
+2.43.0


### PR DESCRIPTION
## Motivation

Backport [ELFIO #174](https://github.com/serge1/ELFIO/pull/174) to TheRock's pinned ELFIO 3.12.

JIRA ID: SWSPLAT-24296

## Technical Details

Update SysV and GNU hash-table validation and traversal, using endian-aware, alignment-safe reads. Retain the public API and linear lookup fallback.

Remove the patch when upgrading to an ELFIO release containing the upstream change.

## Test Plan

Apply the patch with TheRock's patch script. Run the ELFIO suite and local lookup checks across ELF32/ELF64 and both byte orders.

## Test Result

- Patch application passed; the resulting source matched the tested source.
- ELFIO suite and local lookup checks passed with MSVC ASan; focused lookup checks passed with GCC ASan/UBSan.

## Submission Checklist

- [x] Reviewed the [contributing guidelines](https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md).

Prepared with AI assistance.
