### PR TITLE
feat(ci): add baseline_repository input for external repo stage reuse

### DIFF
--- a/.github/workflows/setup_multi_arch.yml
+++ b/.github/workflows/setup_multi_arch.yml
@@ -44,6 +44,13 @@ on:
         description: "Workflow run ID to copy prebuilt stage artifacts from."
         type: string
         default: ""
+      baseline_repository:
+        description: >-
+          Repository to query for baseline_run_id. External repos should set
+          this to github.repository when using their own baseline_run_id.
+          Defaults to THEROCK_REPOSITORY (the 'repository' input).
+        type: string
+        default: ""
       stage_reuse_mode:
         description: >-
           Artifact-reuse mode: "off" disables all reuse, ignores prebuilt_stages
@@ -211,6 +218,8 @@ jobs:
           WINDOWS_TEST_LABELS: ${{ inputs.windows_test_labels }}
           PREBUILT_STAGES: ${{ inputs.prebuilt_stages }}
           BASELINE_RUN_ID: ${{ inputs.baseline_run_id }}
+          # Which repo to query for baseline_run_id. Defaults to THEROCK_REPOSITORY.
+          BASELINE_REPOSITORY: ${{ inputs.baseline_repository }}
           STAGE_REUSE_MODE: ${{ inputs.stage_reuse_mode }}
           # The checkout commit is used for commit-compatibility checking.
           STAGE_REUSE_CURRENT_SHA: ${{ steps.checkout.outputs.commit }}

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -274,7 +274,9 @@ class CIInputs:
             windows_test_labels=windows_test_labels,
             prebuilt_stages=os.environ.get("PREBUILT_STAGES", ""),
             baseline_run_id=os.environ.get("BASELINE_RUN_ID", ""),
-            baseline_repository=os.environ.get("THEROCK_REPOSITORY", ""),
+            # Which repo to query for baseline_run_id. Defaults to THEROCK_REPOSITORY.
+            baseline_repository=os.environ.get("BASELINE_REPOSITORY")
+            or os.environ.get("THEROCK_REPOSITORY", ""),
             external_repo=os.environ.get("EXTERNAL_REPO", ""),
         )
 


### PR DESCRIPTION
When doing testing in rocm-libraries for ASAN, i noticed [prebuilt_stages failed](https://github.com/ROCm/rocm-libraries/actions/runs/33137569576/job/98741505996) due to [baseline_repository](https://github.com/ROCm/TheRock/blob/55c642acf0fc232c5e1c2130590cbdfb41e3e358/.github/workflows/multi_arch_ci_linux.yml#L87) sourced from `THEROCK_REPOSITORY` pointing to TheRock

In general, this works for using TheRock's prebuilt artifacts in external repo PRs, pushes, etc. however, this is not helpful for workflow_dispatch when needing to use prebuilt artifacts

I added a new input that will pass in baseline_repository if specified in external repos. I tested in [rocm-libraries change](https://github.com/ROCm/rocm-libraries/pull/11497/changes) with [workflow_dispatch fixed](https://github.com/ROCm/rocm-libraries/actions/runs/33418978461/job/99576422189) with [regular PR checks using TheRock properly](https://github.com/ROCm/rocm-libraries/actions/runs/33421314550/job/99584614500?pr=11497)

I also made a [workflow_dispatch test](https://github.com/ROCm/rockrel/actions/runs/33418671668/job/99575744166) in [rockrel to make sure no breaks](https://github.com/ROCm/rockrel/compare/users/geomin12/test-baseline-repository-fix?expand=1) and all is good! 

Next after this PR lands:
- adding input in external repos to pick up this change