### PR TITLE
feat(ci): enable host-asan tests for external repo presubmit builds

### DIFF
--- a/.github/workflows/setup_multi_arch.yml
+++ b/.github/workflows/setup_multi_arch.yml
@@ -94,10 +94,10 @@ on:
         description: "Build native Linux packages (deb/rpm) and run their install tests."
         type: boolean
         default: true
-      presubmit:
+      asan_presubmit:
         description: >-
-          Declare this caller an automatic presubmit gate: a run scoped cheaply
-          enough to start on every pull request. Currently this lets host-asan
+          Declare this caller an automatic ASAN presubmit gate: a run scoped
+          cheaply enough to start on every pull request. Lets host-asan
           allocate a sandbox test runner outside of nightly.
         type: boolean
         default: false
@@ -226,7 +226,7 @@ jobs:
           BUILD_PYTORCH: ${{ inputs.build_pytorch }}
           BUILD_JAX: ${{ inputs.build_jax }}
           BUILD_NATIVE_LINUX: ${{ inputs.build_native_linux }}
-          PRESUBMIT: ${{ inputs.presubmit }}
+          ASAN_PRESUBMIT: ${{ inputs.asan_presubmit }}
           PYTHON_VERSION: ${{ inputs.python_version }}
           LINUX_AMDGPU_FAMILIES: ${{ inputs.linux_amdgpu_families }}
           WINDOWS_AMDGPU_FAMILIES: ${{ inputs.windows_amdgpu_families }}

--- a/.github/workflows/setup_multi_arch.yml
+++ b/.github/workflows/setup_multi_arch.yml
@@ -94,6 +94,13 @@ on:
         description: "Build native Linux packages (deb/rpm) and run their install tests."
         type: boolean
         default: true
+      presubmit:
+        description: >-
+          Declare this caller an automatic presubmit gate: a run scoped cheaply
+          enough to start on every pull request. Currently this lets host-asan
+          allocate a sandbox test runner outside of nightly.
+        type: boolean
+        default: false
       python_version:
         description: "Single Python version for wheel builds; empty uses the default matrix."
         type: string
@@ -219,6 +226,7 @@ jobs:
           BUILD_PYTORCH: ${{ inputs.build_pytorch }}
           BUILD_JAX: ${{ inputs.build_jax }}
           BUILD_NATIVE_LINUX: ${{ inputs.build_native_linux }}
+          PRESUBMIT: ${{ inputs.presubmit }}
           PYTHON_VERSION: ${{ inputs.python_version }}
           LINUX_AMDGPU_FAMILIES: ${{ inputs.linux_amdgpu_families }}
           WINDOWS_AMDGPU_FAMILIES: ${{ inputs.windows_amdgpu_families }}

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -1261,9 +1261,16 @@ def _expand_build_config_for_platform(
                     f"disabling tests"
                 )
         elif build_variant == "host-asan":
-            # Run host-asan tests only on nightly (schedule or workflow_dispatch)
-            # due to limited ASAN runner capacity and stability concerns.
-            if not (ci_inputs.is_schedule or ci_inputs.is_workflow_dispatch):
+            # Run host-asan tests on nightly (schedule or workflow_dispatch) or
+            # for external repo builds that have narrowed the build graph.
+            # External repos that set build_stages (e.g., rocm-systems presubmit)
+            # have already scoped the build enough to make sandbox runners
+            # affordable on every PR.
+            if not (
+                ci_inputs.is_schedule
+                or ci_inputs.is_workflow_dispatch
+                or (ci_inputs.external_repo and ci_inputs.build_stages)
+            ):
                 test_runs_on = ""
                 print(
                     f"  {family_name}: host-asan tests only run on nightly, "

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -245,6 +245,11 @@ class CIInputs:
     # Non-empty when an external repo calls TheRock workflows
     external_repo: str = ""
 
+    # Set by callers that are configured as an automatic presubmit gate: a
+    # scoped run cheap enough to start on every pull request. Currently this
+    # grants host-asan runs a sandbox test runner outside of nightly.
+    presubmit: bool = False
+
     def log(self) -> None:
         """Log parsed inputs for CI diagnostics."""
         print("CIInputs:")
@@ -312,6 +317,7 @@ class CIInputs:
         build_native_linux = (
             os.environ.get("BUILD_NATIVE_LINUX", "true").lower() != "false"
         )
+        presubmit = os.environ.get("PRESUBMIT", "false").lower() == "true"
         python_version = os.environ.get("PYTHON_VERSION", "").strip()
 
         pr_labels: list[str] = []
@@ -395,6 +401,7 @@ class CIInputs:
             build_pytorch=build_pytorch,
             build_jax=build_jax,
             build_native_linux=build_native_linux,
+            presubmit=presubmit,
             python_versions=[python_version] if python_version else [],
             pr_labels=pr_labels,
             linux_amdgpu_families=_parse_comma_list(
@@ -1261,20 +1268,22 @@ def _expand_build_config_for_platform(
                     f"disabling tests"
                 )
         elif build_variant == "host-asan":
-            # Run host-asan tests on nightly (schedule or workflow_dispatch) or
-            # for external repo builds that have narrowed the build graph.
-            # External repos that set build_stages (e.g., rocm-systems presubmit)
-            # have already scoped the build enough to make sandbox runners
-            # affordable on every PR.
+            # Run host-asan tests on nightly (schedule or workflow_dispatch), or
+            # for external repos that declare themselves an automatic presubmit
+            # gate. Presubmit is declared explicitly rather than inferred from
+            # build_stages: scoping the build graph and opting into sandbox test
+            # runners on every PR are separate decisions, and a caller that
+            # narrows its build for unrelated reasons should not silently start
+            # consuming ASAN runner capacity.
             if not (
                 ci_inputs.is_schedule
                 or ci_inputs.is_workflow_dispatch
-                or (ci_inputs.external_repo and ci_inputs.build_stages)
+                or (ci_inputs.external_repo and ci_inputs.presubmit)
             ):
                 test_runs_on = ""
                 print(
-                    f"  {family_name}: host-asan tests only run on nightly, "
-                    f"disabling tests"
+                    f"  {family_name}: host-asan tests run on nightly or for "
+                    f"external repo presubmits, disabling tests"
                 )
             elif "test-runs-on-sandbox" in platform_info:
                 test_runs_on = platform_info["test-runs-on-sandbox"]

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -245,10 +245,10 @@ class CIInputs:
     # Non-empty when an external repo calls TheRock workflows
     external_repo: str = ""
 
-    # Set by callers that are configured as an automatic presubmit gate: a
-    # scoped run cheap enough to start on every pull request. Currently this
-    # grants host-asan runs a sandbox test runner outside of nightly.
-    presubmit: bool = False
+    # Set by callers that are configured as an automatic ASAN presubmit gate: a
+    # scoped run cheap enough to start on every pull request. Grants host-asan
+    # runs a sandbox test runner outside of nightly.
+    asan_presubmit: bool = False
 
     def log(self) -> None:
         """Log parsed inputs for CI diagnostics."""
@@ -317,7 +317,7 @@ class CIInputs:
         build_native_linux = (
             os.environ.get("BUILD_NATIVE_LINUX", "true").lower() != "false"
         )
-        presubmit = os.environ.get("PRESUBMIT", "false").lower() == "true"
+        asan_presubmit = os.environ.get("ASAN_PRESUBMIT", "false").lower() == "true"
         python_version = os.environ.get("PYTHON_VERSION", "").strip()
 
         pr_labels: list[str] = []
@@ -401,7 +401,7 @@ class CIInputs:
             build_pytorch=build_pytorch,
             build_jax=build_jax,
             build_native_linux=build_native_linux,
-            presubmit=presubmit,
+            asan_presubmit=asan_presubmit,
             python_versions=[python_version] if python_version else [],
             pr_labels=pr_labels,
             linux_amdgpu_families=_parse_comma_list(
@@ -1278,7 +1278,7 @@ def _expand_build_config_for_platform(
             if not (
                 ci_inputs.is_schedule
                 or ci_inputs.is_workflow_dispatch
-                or (ci_inputs.external_repo and ci_inputs.presubmit)
+                or (ci_inputs.external_repo and ci_inputs.asan_presubmit)
             ):
                 test_runs_on = ""
                 print(


### PR DESCRIPTION
## Motivation

Host-asan CI currently only runs on `schedule` and `workflow_dispatch`. This enables it on `pull_request` events for callers that opt in, so that ASAN regressions are caught on the PR that introduces them rather than overnight.

GitHub issue: https://github.com/ROCm/TheRock/issues/7202

## Technical Details

Adds an `asan_presubmit` boolean input to `setup_multi_arch.yml`, plumbed through to `configure_multi_arch_ci.py` as `CIInputs.asan_presubmit`.

The host-asan gate now enables tests on these triggers:

| trigger | condition |
|---|---|
| `schedule` | always enabled |
| `workflow_dispatch` | always enabled |
| `push` | never enabled |
| `pull_request` | enabled for external repos that set the `asan_presubmit` opt-in |

The opt-in is declared explicitly by the caller rather than inferred from `build_stages`, so narrowing a build graph for unrelated reasons does not start consuming ASAN runner capacity.

Prerequisites, both already merged:
- https://github.com/ROCm/TheRock/pull/7600
- https://github.com/ROCm/TheRock/pull/7602

## Test Plan

Unit tests for the gate in `configure_multi_arch_ci_test.py`: the opt-in enables tests for an external repo, its absence leaves them unscheduled, and the opt-in alone does not enable them without an external repo.

End-to-end validation was run from rocm-systems against a TheRock branch carrying this change, driven incrementally so each failure could be attributed to a specific cause.

## Test Result

Unit tests: 953 passed, 2 skipped (950 before this change; the 3 added are the delta).

End-to-end, https://github.com/ROCm/rocm-systems/actions/runs/35140846158 confirms the pipeline reaches real ASAN results rather than failing on infrastructure:

- Host-asan tests are scheduled on the PR trigger and receive a sandbox runner.
- The sanity job runs `hip_check` to completion and reports a symbolized `AddressSanitizer: bad-free` in `libamdhip64.so.7` at `hsa_amd_memory_pool_free`, with both the allocation and free stacks resolved. This is a genuine finding, not an instrumentation artifact: ASAN's interceptors are installed and it tracked the 4 MB region across its lifetime.
- `hip-tests` discovers and runs roughly 4,900 tests, of which about 2,050 pass; the remaining failures are the same pre-existing `bad-free`.

Earlier runs in the sequence failed on infrastructure rather than test content, and each was fixed separately:
- ASAN runtime resolution after the layout change in #8077 — https://github.com/ROCm/TheRock/pull/8268
- The libraries baseline gate failing instead of skipping when `build_stages` narrows the graph — https://github.com/ROCm/TheRock/pull/8161
- Sanity-check preload — https://github.com/ROCm/TheRock/pull/8123

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.