### PR TITLE
feat(amd-mesa): Use dladdr to auto-locate VA driver when ROCM_PATH is unset

### DIFF
--- a/third-party/sysdeps/linux/amd-mesa/patch_source.sh
+++ b/third-party/sysdeps/linux/amd-mesa/patch_source.sh
@@ -59,7 +59,17 @@ sed -i "/^[[:space:]]*if[[:space:]]*(![[:space:]]*search_path)[[:space:]]*$/{
                 search_path = temp_path;\
             }\
         } else {\
-            search_path = VA_DRIVERS_PATH;\
+            Dl_info dl_info;\
+            if (dladdr((void *)va_openDriver, &dl_info) && dl_info.dli_fname) {\
+                const char *last_slash = strrchr(dl_info.dli_fname, '/');\
+                if (last_slash) {\
+                    temp_path = strndup(dl_info.dli_fname, last_slash - dl_info.dli_fname);\
+                    if (temp_path)\
+                        search_path = temp_path;\
+                }\
+            }\
+            if (!search_path)\
+                search_path = VA_DRIVERS_PATH;\
         }\
     }
     }


### PR DESCRIPTION
## Motivation

When neither LIBVA_DRIVERS_PATH nor ROCM_PATH environment variables are set, libva falls back to the compile-time VA_DRIVERS_PATH default, which causes dlopen of radeonsi_drv_video.so to fail with a vague "libva init failed" error. 
JIRA ID : AICV-287

## Technical Details

Since librocm_sysdeps_va.so and radeonsi_drv_video.so are co-located in the same directory, use dladdr() to resolve the directory of the loaded libva shared library itself and use that as the driver search path. This makes the driver discoverable without requiring any environment variables.


## Test Plan

rocdecode/rocjpeg ctests.

## Test Result

rocdecode/rocjpeg ctests should pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
