### PR TITLE
fix: Add COMPILER_RT_BUILD_PROFILE_ROCM forwarding to LLVM build

### DIFF
--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -75,6 +75,14 @@ if(THEROCK_ENABLE_COMPILER)
      message(WARNING "LLVM parallel link jobs is unlimited. Memory usage may be much higher. Set -DLLVM_PARALLEL_LINK_JOBS to reduce memory use.")
   endif()
 
+  # Coverage instrumented builds need the ROCm profiling runtime
+  # (libclang_rt.profile_rocm) so that instrumented device code can write
+  # profraw files. The flag is only meaningful to compiler-rt, so forward it.
+  if(COMPILER_RT_BUILD_PROFILE_ROCM)
+    message(STATUS "COMPILER_RT_BUILD_PROFILE_ROCM enabled - building the ROCm profiling runtime")
+    list(APPEND _extra_llvm_cmake_args "-DCOMPILER_RT_BUILD_PROFILE_ROCM=ON")
+  endif()
+
   # If the compiler is not pristine (i.e. has patches), then there will be a
   # ".amd-llvm.smrev" file present which must be used instead of the auto
   # computed git revision. If present, this will have a stable hash of


### PR DESCRIPTION
## Motivation

Coverage instrumented builds need the ROCm profiling runtime (libclang_rt.profile_rocm) so that instrumented device code can write profraw files.

## Technical Details

Added a simple pass through from the super build to amd-llvm, which tells it to build the llvm-profile runtime that can be linked to by device code.

## Test Plan

We needed this option to be able to build jobs for code coverage.  We have tested it thoroughly during the code coverage PoC and offline.  We also have a test run in our legacy system that consumes TheRock superbuild with below passed results.

## Test Result

Passed run in legacy CI system:
https://math-ci.amd.com/job/rocm-libraries/job/codecov/job/rocfft/job/PR-11263/1/stages/

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.


https://github.com/ROCm/TheRock/issues/6572
