### PR TITLE
feat(ci): run gfx90a tests on all post-submit builds

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -317,8 +317,6 @@ amdgpu_family_info_matrix_postsubmit = {
             "family": "gfx90a",
             "fetch-gfx-targets": ["gfx90a"],
             "build_variants": ["release"],
-            # Only run tests on submodule bumps (builds always run)
-            "submodule_bump_tests_only": True,
         },
         "windows": {
             "test-runs-on": "",


### PR DESCRIPTION
Remove submodule_bump_tests_only flag so gfx90a tests run on postsubmit. we are getting bad signal from https://github.com/ROCm/TheRock/issues/7226