### PR TITLE
fix(dockerfiles): follow the prerelease and stable repo moves

### DIFF
--- a/dockerfiles/install_rocm_packages.sh
+++ b/dockerfiles/install_rocm_packages.sh
@@ -48,6 +48,18 @@ NIGHTLY_MULTI_ARCH_BASE_URL="https://nightly.repo.amd.com/rocm/core/packages"
 # retired host, which stopped publishing in 2026.
 NIGHTLY_PER_FAMILY_BASE_URL="https://rocm.nightlies.amd.com"
 
+# Roots of the prerelease and stable package repositories. Releases predating a
+# channel's switchover were never copied across, so both hosts stay in use.
+PRERELEASE_PRODUCT_BASE_URL="https://rc.repo.amd.com/rocm/core/packages"
+PRERELEASE_PRODUCT_MIN_VERSION="10.1"
+PRERELEASE_LEGACY_BASE_URL="https://rocm.prereleases.amd.com"
+STABLE_PRODUCT_BASE_URL="https://stable.repo.amd.com/rocm/core/packages"
+STABLE_PRODUCT_MIN_VERSION="10.0"
+STABLE_LEGACY_BASE_URL="https://repo.amd.com/rocm"
+
+# One key signs every prerelease and stable stream, old hosts included.
+PRODUCT_GPG_KEY_URL="https://stable.repo.amd.com/rocm/gpg/packages.gpg"
+
 # ---------------------------------------------------------------------------
 # Helper: extract MAJOR.MINOR from VERSION (e.g., 7.13.0a20260322 → 7.13)
 # ---------------------------------------------------------------------------
@@ -177,7 +189,32 @@ resolve_nightly_build_dir() {
 }
 
 # ---------------------------------------------------------------------------
+# Helper: report whether this release uses the ROCm Core product layout
+#
+# sort -VC exits 0 only when its input is already in version order, so this
+# reads as threshold <= release. Version order puts 7.14 below 10.0; a string
+# compare would get that backwards.
+# ---------------------------------------------------------------------------
+uses_product_layout() {
+    local release_type="$1"
+    local major_minor="$2"
+    local threshold
+
+    case "$release_type" in
+        prereleases) threshold="$PRERELEASE_PRODUCT_MIN_VERSION" ;;
+        stable)      threshold="$STABLE_PRODUCT_MIN_VERSION" ;;
+        *)           return 1 ;;
+    esac
+
+    printf '%s\n%s\n' "$threshold" "$major_minor" | sort -VC
+}
+
+# ---------------------------------------------------------------------------
 # Helper: build the repo base URL
+#
+# The product layout is flat — <base>/<distro> — one repo serving both install
+# modes, so pkg_segment applies only to the legacy hosts, which give each mode
+# its own tree.
 # ---------------------------------------------------------------------------
 build_repo_url() {
     local release_type="$1"
@@ -185,6 +222,7 @@ build_repo_url() {
     local repo_distro="$3"
     local nightly_build_dir="$4"
     local multi_arch="${5:-0}"
+    local major_minor="${6:-}"
 
     local pkg_segment="packages"
     [ "$multi_arch" = "1" ] && pkg_segment="packages-multi-arch"
@@ -200,17 +238,25 @@ build_repo_url() {
             fi
             ;;
         prereleases)
+            local prerelease_root="${PRERELEASE_LEGACY_BASE_URL}/${pkg_segment}"
+            if uses_product_layout prereleases "$major_minor"; then
+                prerelease_root="${PRERELEASE_PRODUCT_BASE_URL}"
+            fi
             if [ "$pkg_type" = "deb" ]; then
-                echo "https://rocm.prereleases.amd.com/${pkg_segment}/${repo_distro}"
+                echo "${prerelease_root}/${repo_distro}"
             else
-                echo "https://rocm.prereleases.amd.com/${pkg_segment}/${repo_distro}/x86_64"
+                echo "${prerelease_root}/${repo_distro}/x86_64"
             fi
             ;;
         stable)
+            local stable_root="${STABLE_LEGACY_BASE_URL}/${pkg_segment}"
+            if uses_product_layout stable "$major_minor"; then
+                stable_root="${STABLE_PRODUCT_BASE_URL}"
+            fi
             if [ "$pkg_type" = "deb" ]; then
-                echo "https://repo.amd.com/rocm/${pkg_segment}/${repo_distro}"
+                echo "${stable_root}/${repo_distro}"
             else
-                echo "https://repo.amd.com/rocm/${pkg_segment}/${repo_distro}/x86_64"
+                echo "${stable_root}/${repo_distro}/x86_64"
             fi
             ;;
         *)
@@ -224,24 +270,13 @@ build_repo_url() {
 # ---------------------------------------------------------------------------
 # Helper: get GPG key URL for signed repos
 #
-# The same AMD signing key is used for both `packages/` and
-# `packages-multi-arch/` repositories, so the key URL is always sourced from
-# `packages/gpg/` regardless of install mode. (The mirror file under
-# `packages-multi-arch/gpg/` currently returns 403 on direct GET.)
+# One AMD key signs every prerelease and stable stream, legacy hosts included,
+# so they all read it from the stable host. Nightlies are unsigned.
 # ---------------------------------------------------------------------------
 get_gpg_key_url() {
-    local release_type="$1"
-
-    case "$release_type" in
-        prereleases)
-            echo "https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg"
-            ;;
-        stable)
-            echo "https://repo.amd.com/rocm/packages/gpg/rocm.gpg"
-            ;;
-        *)
-            echo ""
-            ;;
+    case "$1" in
+        prereleases|stable) echo "$PRODUCT_GPG_KEY_URL" ;;
+        *)                  echo "" ;;
     esac
 }
 
@@ -415,7 +450,7 @@ if [ "$RELEASE_TYPE" = "nightlies" ]; then
 fi
 
 # Build repo URL
-REPO_URL=$(build_repo_url "$RELEASE_TYPE" "$PKG_TYPE" "$REPO_DISTRO" "$NIGHTLY_BUILD_DIR" "$MULTI_ARCH")
+REPO_URL=$(build_repo_url "$RELEASE_TYPE" "$PKG_TYPE" "$REPO_DISTRO" "$NIGHTLY_BUILD_DIR" "$MULTI_ARCH" "$MAJOR_MINOR")
 GPG_KEY_URL=$(get_gpg_key_url "$RELEASE_TYPE")
 
 echo "Repo URL:        ${REPO_URL}"

--- a/dockerfiles/install_rocm_tarball.sh
+++ b/dockerfiles/install_rocm_tarball.sh
@@ -14,9 +14,8 @@
 #   VERSION          - Full version string (e.g., 7.11.0a20251211, 7.10.0)
 #   AMDGPU_FAMILY    - AMD GPU family (e.g., gfx110X-all, gfx94X-dcgpu).
 #                      Special value: 'multi-arch' downloads AMD's bundled
-#                      tarball that contains kpack files for all GPU families
-#                      (from the tarball-multi-arch/ path, except on the nightly
-#                      host where every tarball shares one tarball/ directory).
+#                      tarball, whose .kpack/ covers every supported target
+#                      rather than a single family.
 #   RELEASE_TYPE     - Release type: nightlies (default), prereleases, devreleases, stable
 #
 # Examples:
@@ -36,10 +35,9 @@ RELEASE_TYPE="${3:-nightlies}"
 # URL-encode '+' as '%2B' in VERSION (required for devreleases)
 VERSION_ENCODED="${VERSION//+/%2B}"
 
-# AMDGPU_FAMILY=multi-arch selects AMD's bundled all-GPU tarball. The tarball
-# filename slot uses "multiarch" (no hyphen) while the directory name that
-# carries it uses "multi-arch" (with hyphen) — handle both conventions
-# explicitly here.
+# AMDGPU_FAMILY=multi-arch selects AMD's bundled all-GPU tarball, whose filename
+# spells the slot "multiarch" while the legacy directory carrying it spells it
+# "multi-arch". TARBALL_DIR is consulted only for the legacy hosts.
 if [ "$AMDGPU_FAMILY" = "multi-arch" ]; then
     TARBALL_DIR="tarball-multi-arch"
     FAMILY_SLOT="multiarch"
@@ -48,16 +46,54 @@ else
     FAMILY_SLOT="$AMDGPU_FAMILY"
 fi
 
-# Directory holding the tarballs, by release type:
-# - nightlies use: https://nightly.repo.amd.com/rocm/core/tarball/
-# - stable releases use: https://repo.amd.com/rocm/${TARBALL_DIR}/
-# - other releases use: https://rocm.{RELEASE_TYPE}.amd.com/${TARBALL_DIR}/
+# Releases from which each channel serves the ROCm Core product layout. Anything
+# older stayed behind on the original host and was never copied across.
+PRERELEASE_PRODUCT_MIN_VERSION="10.1"
+STABLE_PRODUCT_MIN_VERSION="10.0"
+
+# MAJOR.MINOR drives the host choice below. A version string without one leaves
+# this empty, which sorts below every threshold and so lands on the legacy host.
+MAJOR_MINOR=$(echo "$VERSION" | grep -oE '^[0-9]+\.[0-9]+' || true)
+
+# ---------------------------------------------------------------------------
+# Helper: report whether MAJOR.MINOR is at least the given threshold
+#
+# sort -VC exits 0 only when its input is already in version order, so this
+# reads as want <= have. Version order puts 7.14 below 10.0; a string compare
+# would get that backwards.
+# ---------------------------------------------------------------------------
+version_at_least() {
+    local have="$1"
+    local want="$2"
+    printf '%s\n%s\n' "$want" "$have" | sort -VC
+}
+
+# Tarball directory by release type. The product layout is flat — a single
+# tarball/ directory holding every family — so TARBALL_DIR applies only to the
+# legacy hosts, which give each install mode its own tree:
+# - nightlies use:   https://nightly.repo.amd.com/rocm/core/tarball/
+# - prereleases use: https://rc.repo.amd.com/rocm/core/tarball/       (>= 10.1)
+#                    https://rocm.prereleases.amd.com/${TARBALL_DIR}/ (older)
+# - stable uses:     https://stable.repo.amd.com/rocm/core/tarball/   (>= 10.0)
+#                    https://repo.amd.com/rocm/${TARBALL_DIR}/        (older)
+# - other releases:  https://rocm.{RELEASE_TYPE}.amd.com/${TARBALL_DIR}/
 case "$RELEASE_TYPE" in
     nightlies)
         LISTING_URL="https://nightly.repo.amd.com/rocm/core/tarball/"
         ;;
+    prereleases)
+        if version_at_least "$MAJOR_MINOR" "$PRERELEASE_PRODUCT_MIN_VERSION"; then
+            LISTING_URL="https://rc.repo.amd.com/rocm/core/tarball/"
+        else
+            LISTING_URL="https://rocm.prereleases.amd.com/${TARBALL_DIR}/"
+        fi
+        ;;
     stable)
-        LISTING_URL="https://repo.amd.com/rocm/${TARBALL_DIR}/"
+        if version_at_least "$MAJOR_MINOR" "$STABLE_PRODUCT_MIN_VERSION"; then
+            LISTING_URL="https://stable.repo.amd.com/rocm/core/tarball/"
+        else
+            LISTING_URL="https://repo.amd.com/rocm/${TARBALL_DIR}/"
+        fi
         ;;
     *)
         LISTING_URL="https://rocm.${RELEASE_TYPE}.amd.com/${TARBALL_DIR}/"


### PR DESCRIPTION
## Motivation

Follow-up to #7644, which moved nightlies to `nightly.repo.amd.com` and left the note *"Prereleases and stable are untouched: rc./stable.repo.amd.com are not serving yet."* They are serving now.

The docs already describe the end state. `docs/packaging/native_packaging.md` scopes the ROCm Core product hierarchy to *"ROCm 10.1 nightlies and ROCm 10.0 stable releases"*; `docs/packaging/legacy_multi_arch_releases.md` lists what stays behind — nightlies through 7.14, **ROCm 10.0.0 release candidates**, and stable before 10.0. This PR catches the install scripts up to that policy rather than inventing one.

Older releases were never copied to the new hosts — `repo.amd.com` carries no `amdrocm10.*` at all — so this cannot be a flag-day swap. Both hosts stay reachable and the choice is made per release.

## Technical Details

| Channel | Switchover | At or above | Below |
|---|---|---|---|
| `stable` | 10.0 | `stable.repo.amd.com/rocm/core/` | `repo.amd.com/rocm/` |
| `prereleases` | 10.1 | `rc.repo.amd.com/rocm/core/` | `rocm.prereleases.amd.com/` |
| `nightlies` | — | unchanged | unchanged |

The two thresholds differ because 10.0.0 release candidates stay on the legacy prerelease host. Both scripts gate on `MAJOR.MINOR` and fall back to the legacy host when the version is missing or unparseable. The URLs produced match `get_repo_url()` in `build_tools/packaging/linux/get_url_repo_params.py`, whose docstring asks callers to keep these scripts in sync.

The product layout is flat — one repo and one `tarball/` directory serve both install modes — so the `packages/` vs `packages-multi-arch/` and `tarball` vs `tarball-multi-arch` split now applies only to the legacy hosts.

`get_gpg_key_url()` collapses to a single URL: one AMD key signs every prerelease and stable stream, legacy hosts included. Nightlies remain unsigned.

Behavior below each threshold, and on every other release type, is unchanged.

## Test Plan

Self-hosted Linux x86_64 builder (Ubuntu 24.04.4, GNU coreutils 9.4, Docker 28.1.1); containers `ubuntu:24.04`, `almalinux:9`, `almalinux:10`. The builder has no `/dev/kfd`, so this covers URL routing and installation only — which matches the blast radius of host-selection plumbing.

- **URL routing** — dry-run both URL builders across release type x version x install mode x distro, asserting the expected host. Versions span both thresholds (7.13.0 through 11.0.0) plus malformed inputs.
- **Differential vs. base** — the same harness against the pre-change scripts, diffing every generated URL, to confirm nothing beyond the intended migration moved.
- **Live reachability** — probe every generated URL (`Release`, `repomd.xml`, range GET, key GET).
- **GPG equivalence** — compare the key served by all three signed hosts, then verify each host's `InRelease` against the product key alone.
- **Real installs** — run both scripts unmodified, end to end, and let their own verification step decide. Covers multi-arch, an own-family arch, an exact arch inside a family group, and the family-group form as a negative case, on deb and rpm.

## Test Result

| Test | Cases | Result |
|---|---|---|
| URL routing assertions | 41 | 41 pass |
| Differential vs. base | 30 URLs | 14 unchanged, 16 changed — exactly the intended migration |
| GPG key equivalence | 3 hosts | identical key; all three `InRelease` verify against it |
| Package resolution, deb | 13 | 13 as expected |
| Package resolution, rpm | 8 | 8 as expected |
| Tarball install, real download | 11 | 11 as expected |
| End-to-end `install_rocm_packages.sh` | 6 | 6 pass |
| `shellcheck` | both scripts | no new findings |

The residual gap is that `prereleases` >= 10.1 cannot be verified end to end until `rc.repo.amd.com` publishes.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
