### PR TITLE
[rocjitsu] Move rocjitsu tests out of compiler-runtime

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux.yml
+++ b/.github/workflows/multi_arch_build_portable_linux.yml
@@ -5,16 +5,17 @@
 #
 # This workflow builds TheRock in stages:
 # 1. compiler-runtime (generic) - sysdeps, base, compiler, runtimes, profiler-core
-# 2. runtime-tests (generic) - hip-tests, rocrtst (parallel to math-libs)
-# 3. wsl-rocdxg (generic) - WSL-only ROCDXG bridge library (after compiler-runtime)
-# 4. math-libs (per-arch) - BLAS, FFT, etc.
-# 5. comm-libs (per-arch) - RCCL, rocshmem (parallel to math-libs)
-# 6. storage-libs (generic) - hipfile (parallel to math-libs)
-# 7. debug-tools (generic) - amd-dbgapi, rocr-debug-agent, rocgdb (parallel to math-libs)
-# 8. dctools-core (generic) - RDC (parallel to math-libs)
-# 9. profiler-apps (generic) - rocprofiler-systems (parallel to math-libs)
-# 10. cv-libs (generic) - rpp
-# 11. media-libs (generic) - sysdeps-amd-mesa, rocdecode, rocjpeg
+# 2. emulation (generic) - rocjitsu, rocjitsu-hotswap, mirage
+# 3. runtime-tests (generic) - hip-tests, rocrtst (parallel to math-libs)
+# 4. wsl-rocdxg (generic) - WSL-only ROCDXG bridge library (after compiler-runtime)
+# 5. math-libs (per-arch) - BLAS, FFT, etc.
+# 6. comm-libs (per-arch) - RCCL, rocshmem (after emulation)
+# 7. storage-libs (generic) - hipfile (parallel to math-libs)
+# 8. debug-tools (generic) - amd-dbgapi, rocr-debug-agent, rocgdb (parallel to math-libs)
+# 9. dctools-core (generic) - RDC (parallel to math-libs)
+# 10. profiler-apps (generic) - rocprofiler-systems (parallel to math-libs)
+# 11. cv-libs (generic) - rpp
+# 12. media-libs (generic) - sysdeps-amd-mesa, rocdecode, rocjpeg
 
 name: Multi-Arch Build (Linux)
 
@@ -103,6 +104,31 @@ jobs:
       stage_name: compiler-runtime
       stage_display_name: "Stage - Compiler Runtime"
       timeout_minutes: 480  # 8 hours (compiler is big)
+      dist_amdgpu_families: ${{ inputs.dist_amdgpu_families }}
+      rocm_package_version: ${{ inputs.rocm_package_version }}
+      build_variant_cmake_preset: ${{ inputs.build_variant_cmake_preset }}
+      build_runs_on: ${{ inputs.build_runs_on }}
+      release_type: ${{ inputs.release_type }}
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref }}
+      external_repo_config: ${{ inputs.external_repo_config }}
+      quartz_tracking_id: ${{ inputs.quartz_tracking_id }}
+    permissions:
+      contents: read
+      id-token: write
+
+  # ==========================================================================
+  # STAGE: emulation (generic)
+  # ==========================================================================
+  emulation:
+    needs: compiler-runtime
+    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'emulation') && !contains(inputs.skip_stages, 'emulation') }}
+    uses: ./.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+    secrets: inherit
+    with:
+      stage_name: emulation
+      stage_display_name: "Stage - Emulation"
+      timeout_minutes: 240  # 4 hours
       dist_amdgpu_families: ${{ inputs.dist_amdgpu_families }}
       rocm_package_version: ${{ inputs.rocm_package_version }}
       build_variant_cmake_preset: ${{ inputs.build_variant_cmake_preset }}
@@ -207,7 +233,7 @@ jobs:
   # Running as a single generic job avoids redundant per-arch builds.
   # ==========================================================================
   comm-libs:
-    needs: compiler-runtime
+    needs: [compiler-runtime, emulation]
     if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'comm-libs') && !contains(inputs.skip_stages, 'comm-libs') }}
     uses: ./.github/workflows/multi_arch_build_portable_linux_artifacts.yml
     secrets: inherit
@@ -383,7 +409,7 @@ jobs:
 
   notify_quartz_completed:
     if: ${{ always() && vars.NOTIFY_QUARTZ_ENABLED == 'true' }}
-    needs: [compiler-runtime, runtime-tests, wsl-rocdxg, math-libs, comm-libs, storage-libs, debug-tools, dctools-core, profiler-apps, media-libs]
+    needs: [compiler-runtime, emulation, runtime-tests, wsl-rocdxg, math-libs, comm-libs, storage-libs, debug-tools, dctools-core, profiler-apps, media-libs]
     name: "Quartz - completed - build ROCm"
     runs-on: ubuntu-24.04
     timeout-minutes: 10

--- a/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
@@ -207,11 +207,9 @@ jobs:
         run: |
           cmake --build "${BUILD_DIR}" --target build-test-amd-comgr -- -k 0
 
-      # Remaining build tests (e.g. rocjitsu, mirage) still run and report, but
-      # are not yet gating. Comgr is split out above so its failures block CI.
-      # TODO(#6112): rocjitsu tests are being moved out; drop this step once done.
-      - name: Run build tests (other, non-blocking)
-        if: ${{ !cancelled() && inputs.stage_name == 'compiler-runtime' }}
+      # Rocjitsu and mirage build tests report failures without gating CI.
+      - name: Run build tests (emulation, non-blocking)
+        if: ${{ !cancelled() && inputs.stage_name == 'emulation' }}
         continue-on-error: true
         env:
           TEATIME_FORCE_INTERACTIVE: 1

--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -153,9 +153,12 @@ artifact_groups = [
     "hip-runtime",
     "kfdtest",
     "opencl-runtime",
-    "profiler-core",
-    "rocjitsu"
+    "profiler-core"
 ]
+
+[build_stages.emulation]
+description = "ROCm emulation, virtualization, and instrumentation tools"
+artifact_groups = ["rocjitsu"]
 
 [build_stages.wsl-rocdxg]
 description = "WSL-only ROCDXG bridge library"

--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -352,7 +352,7 @@ source_sets = ["amd-mesa", "rocm-systems"]
 [artifact_groups.rocjitsu]
 description = "ROCm emulation, virtualization, and instrumentation tools"
 type = "generic"
-artifact_group_deps = ["third-party-sysdeps"]
+artifact_group_deps = ["base", "third-party-sysdeps"]
 source_sets = ["rocm-systems"]
 disable_platforms = ["windows"]
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -534,9 +534,12 @@ cmake --build "${BUILD_DIR}" --target therock-build-tests -- -k 0
 > [Super-project CMake build - Design for testing](#super-project-cmake-build---design-for-testing) section above.
 
 > [!WARNING]
-> Build tests currently run _after_ other build steps rather than in parallel
-> with them. This can introduce bottlenecks and could be revisited once all
-> build tests pass and can be marked blocking, see notes in
+> Each stage currently runs its build tests after producing that stage's
+> artifacts rather than requesting both targets together. Non-blocking
+> emulation build tests run in a dedicated stage so they do not delay the
+> compiler-runtime fan-out, except for consumers of emulation artifacts.
+> The remaining per-stage sequencing could be revisited once all build tests
+> pass and can be marked blocking. See notes in
 > [`.github/workflows/multi_arch_build_portable_linux_artifacts.yml`](/.github/workflows/multi_arch_build_portable_linux_artifacts.yml)
 > and
 > [`.github/workflows/multi_arch_build_windows_artifacts.yml`](/.github/workflows/multi_arch_build_windows_artifacts.yml)

--- a/build_tools/tests/build_topology_test.py
+++ b/build_tools/tests/build_topology_test.py
@@ -1139,7 +1139,9 @@ class RealTopologyTest(unittest.TestCase):
             emulation_artifacts,
             {"rocjitsu", "rocjitsu-hotswap", "mirage"},
         )
-        self.assertIn("sysdeps", topology.get_inbound_artifacts("emulation"))
+        emulation_inbound = topology.get_inbound_artifacts("emulation")
+        self.assertIn("base", emulation_inbound)
+        self.assertIn("sysdeps", emulation_inbound)
 
         comm_libs_inbound = topology.get_inbound_artifacts("comm-libs")
         self.assertIn("rocjitsu", comm_libs_inbound)

--- a/build_tools/tests/build_topology_test.py
+++ b/build_tools/tests/build_topology_test.py
@@ -1126,6 +1126,25 @@ class BuildTopologyTest(unittest.TestCase):
 class RealTopologyTest(unittest.TestCase):
     """Assertions against the repo's actual BUILD_TOPOLOGY.toml."""
 
+    def test_emulation_has_a_dedicated_build_stage(self):
+        topology = get_topology()
+
+        compiler_artifacts = topology.get_produced_artifacts("compiler-runtime")
+        self.assertNotIn("rocjitsu", compiler_artifacts)
+        self.assertNotIn("rocjitsu-hotswap", compiler_artifacts)
+        self.assertNotIn("mirage", compiler_artifacts)
+
+        emulation_artifacts = topology.get_produced_artifacts("emulation")
+        self.assertEqual(
+            emulation_artifacts,
+            {"rocjitsu", "rocjitsu-hotswap", "mirage"},
+        )
+        self.assertIn("sysdeps", topology.get_inbound_artifacts("emulation"))
+
+        comm_libs_inbound = topology.get_inbound_artifacts("comm-libs")
+        self.assertIn("rocjitsu", comm_libs_inbound)
+        self.assertIn("rocjitsu-hotswap", comm_libs_inbound)
+
     def test_hipkernelprovider_is_split_per_arch(self):
         # rocKE ships per-arch AOT bundles under engines/arch_content/rocke/<arch>,
         # so hipkernelprovider must stay target-specific and kpack-split; reverting

--- a/docs/development/ci_overview.md
+++ b/docs/development/ci_overview.md
@@ -14,19 +14,26 @@ Instead of Jenkins and Groovy pipelines, TheRock uses **GitHub Actions** workflo
 
 ## CI Architecture
 
-TheRock uses a multi-stage CI pipeline that splits the build into stages (compiler-runtime → runtime-tests/math-libs, etc.) with dependency chaining. Below is a general diagram of the CI flow
+TheRock uses a multi-stage CI pipeline that splits the build into stages with
+dependency chaining. The Linux pipeline builds emulation separately from the
+compiler and runtime, while communication libraries wait for emulation because
+RCCL consumes rocjitsu-generated artifacts.
 
 ```mermaid
 graph TD
-    A[generic build] --> B1[arch build - gfx94X-dcgpu]
-    A[generic build] --> B2[arch build - gfx110X-dgpu]
-    B1 --> C[test - gfx94X-dcgpu]
-    B2 --> D[test - gfx110X-dgpu]
+    compilerRuntime[Compiler and runtime] --> emulation[Emulation]
+    compilerRuntime --> mathGfx94X[Math libraries - gfx94X]
+    compilerRuntime --> mathGfx110X[Math libraries - gfx110X]
+    compilerRuntime --> runtimeTests[Runtime tests]
+    emulation --> commLibraries[Communication libraries]
+    mathGfx94X --> testGfx94X[Tests - gfx94X]
+    mathGfx110X --> testGfx110X[Tests - gfx110X]
 ```
 
 Each stage runs as a separate job, uploads its artifacts and logs to S3, then downstream stages download and build on top of them. This allows for:
 
-- **Parallelization:** Multiple GPU families can build math-libs simultaneously once compiler-runtime completes
+- **Parallelization:** Emulation, runtime tests, and multiple GPU-family math
+  library builds can run as separate jobs once compiler-runtime completes
 - **Incremental builds:** Test-only runs can skip build stages by downloading pre-built artifacts
 - **Flexibility:** Different stages can run on different runner types (e.g., CPU-only for build, GPU for tests)
 


### PR DESCRIPTION
## Motivation

The compiler-runtime stage currently runs rocjitsu and Mirage build tests after producing its artifacts. These non-blocking tests add several minutes before most downstream build stages can begin.

This PR moves emulation artifacts and tests into a dedicated stage, removing them from the compiler-runtime critical path while preserving their current non-blocking status.

<!-- Most pull requests should be associated with at least one GitHub issue -->

https://github.com/ROCm/TheRock/issues/6112
https://github.com/ROCm/TheRock/issues/4789

## Technical Details

* Adds a generic Linux emulation build stage containing rocjitsu, rocjitsu-hotswap, and Mirage.
* Removes the rocjitsu artifact group from compiler-runtime.
* Runs the existing rocjitsu and Mirage build-tree CTests in the emulation stage with continue-on-error: true.
* Leaves the blocking Comgr tests in compiler-runtime.
* Makes comm-libs wait for emulation because RCCL consumes rocjitsu-hotswap artifacts.
* Leaves Windows behavior unchanged because the emulation artifacts are disabled on Windows.
* Adds topology regression coverage and updates the testing and CI documentation.

The existing therock_cmake_subproject_build_test() registrations are unchanged.

## Test Plan

* Validate BUILD_TOPOLOGY.toml.
* Run topology, stage configuration, stage impact, stage reuse, and multi-arch configuration tests.
* Run pre-commit checks, including actionlint.
* Generate compiler-runtime and emulation Ninja graphs and inspect their therock-build-tests dependencies.

## Test Result

* Topology validation passed.
* 195 targeted tests passed; 1 unrelated test was skipped.
* Pre-commit and actionlint passed.
* Generated Ninja graphs confirmed:
  * compiler-runtime: only build-test-amd-comgr
  * emulation: build-test-rocjitsu and build-test-mirage

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
