### PR TITLE
[ci] Add test:multi-gpu label to run all multi-GPU jobs

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -988,6 +988,19 @@ def run():
     # This string -> array conversion ensures no partial strings are detected during test selection (ex: "hipblas" in ["hipblaslt", "rocblas"] = false)
     project_array = [item.strip() for item in projects_to_test.split(",")]
 
+    # Resolve the test-label groups for this run. TEST_LABEL_GROUPS provides the
+    # static, explicitly-curated groups. "multi-gpu" is a *dynamic* group: it
+    # expands to every component that declares a multi_gpu runner requirement
+    # (e.g. rccl, rocshmem, and the *-multi-gpu split jobs), so a dev can request
+    # all multi-GPU tests with a single `test:multi-gpu` label. Computing it from
+    # the matrix means new multi-GPU components are picked up automatically. An
+    # explicit TEST_LABEL_GROUPS["multi-gpu"] entry, if ever added, wins.
+    label_groups = dict(TEST_LABEL_GROUPS)
+    label_groups.setdefault(
+        "multi-gpu",
+        [key for key, cfg in selected_matrix.items() if "multi_gpu" in cfg],
+    )
+
     all_components = []
     for key in selected_matrix:
         job_name = selected_matrix[key]["job_name"]
@@ -1033,7 +1046,7 @@ def run():
         expanded_test_labels = [
             member
             for label in parsed_test_labels
-            for member in TEST_LABEL_GROUPS.get(label, [label])
+            for member in label_groups.get(label, [label])
         ]
         if key != "sanity" and expanded_test_labels and key not in expanded_test_labels:
             logging.info(f"Excluding job {job_name} since it's not in the test labels")

--- a/build_tools/github_actions/tests/fetch_test_configurations_test.py
+++ b/build_tools/github_actions/tests/fetch_test_configurations_test.py
@@ -738,6 +738,41 @@ class FetchTestConfigurationsTest(unittest.TestCase):
         self.assertIn("rocdecode", names)
         self.assertIn("rocjpeg", names)
 
+    def test_multi_gpu_label_selects_all_multi_gpu_jobs(self):
+        """test:multi-gpu is a dynamic group selecting every component that needs a
+        multi-GPU runner (rccl, rocshmem, ...) and nothing else."""
+        with patch.dict(os.environ, {"TEST_LABELS": json.dumps(["test:multi-gpu"])}):
+            fetch_test_configurations.run()
+            components = self._get_components()
+
+        names = {job["job_name"] for job in components}
+        self.assertIn("rccl", names)
+        self.assertIn("rocshmem", names)
+        # Only multi-GPU jobs get selected: a plain single-GPU job is excluded.
+        self.assertNotIn("rocblas", names)
+        # Every selected component is flagged for a multi-GPU runner.
+        for job in components:
+            self.assertIn(
+                "multi_gpu_runner",
+                job,
+                f"{job['job_name']} was selected by test:multi-gpu but is not a "
+                "multi-GPU job",
+            )
+
+    def test_multi_gpu_label_composes_with_component_label(self):
+        """test:multi-gpu can be combined with a specific component label."""
+        with patch.dict(
+            os.environ,
+            {"TEST_LABELS": json.dumps(["test:multi-gpu", "test:rocblas"])},
+        ):
+            fetch_test_configurations.run()
+            components = self._get_components()
+
+        names = {job["job_name"] for job in components}
+        self.assertIn("rccl", names)
+        self.assertIn("rocshmem", names)
+        self.assertIn("rocblas", names)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/build_tools/github_actions/tests/unit_test_runner.py
+++ b/build_tools/github_actions/tests/unit_test_runner.py
@@ -247,6 +247,8 @@ class ValidTestCategoriesTest(unittest.TestCase):
                 "ffm-standard",
                 "ffm-comprehensive",
                 "ffm-full",
+                "emu-fast",
+                "emu-full",
             },
         )
 

--- a/docs/development/ci_behavior_manipulation.md
+++ b/docs/development/ci_behavior_manipulation.md
@@ -27,6 +27,7 @@ The following labels may be added to a pull request to modify CI behavior:
 | `ci:host-asan`     | Alias for `ci:asan`. Enable ASAN CI builds and tests.                                                                                                                                             |
 | `gfx...`           | Opt-in to building and testing the specified gfx family (e.g. `gfx120X`, `gfx950`)                                                                                                                |
 | `test:...`         | Run tests only for the specified projects (e.g. `test:rocthrust`, `test:hipblaslt`). Sets test level to `full` unless overridden by `test_filter:`. Multiple `test:` labels can be combined.      |
+| `test:multi-gpu`   | Run all multi-GPU test jobs (e.g. `rccl`, `rocshmem`, and any `*-multi-gpu` split jobs). Group label that expands to every component requiring a multi-GPU runner. Combinable with other `test:`. |
 | `test_runner:...`  | Run tests on only custom test machines (e.g. `test_runner:oem`). Single-arch CI only.                                                                                                             |
 | `test_filter:...`  | Override the test level (e.g. `test_filter:comprehensive`, `test_filter:quick`). Takes priority over all other test level logic. See [test_filtering.md](./test_filtering.md) for allowed values. |
 


### PR DESCRIPTION
## Summary

Adds a `test:multi-gpu` label so a dev can trigger **all** multi-GPU test jobs with a single label, instead of enumerating each component (as requested in review on #5792 — e.g. "rccl update, we want to run all multi-gpu tests").

- New **dynamic** label group in `fetch_test_configurations.py`: `test:multi-gpu` expands to every component that declares a `multi_gpu` runner requirement. Today that's `rccl` and `rocshmem`; it automatically picks up future multi-GPU components (such as the `*-multi-gpu` split jobs from #5792) with no further changes.
- Uses the existing `test:`-label mechanism, so it composes with other `test:` labels and sets test level to `full` (via existing `_has_test_labels` logic in `configure_multi_arch_ci.py`). An explicit `TEST_LABEL_GROUPS["multi-gpu"]` entry, if ever added, takes priority over the dynamic computation.
- Documents the label in `docs/development/ci_behavior_manipulation.md`.
- Aligns a stale `VALID_TEST_CATEGORIES` unit test with the `emu-*` categories already present on `main` (pre-existing failure, unrelated to this change).

## Test plan

- [x] `python3 -m unittest fetch_test_configurations_test unit_test_runner` (80 tests pass)
- [x] New tests: `test:multi-gpu` selects only multi-GPU jobs (rccl/rocshmem, not rocblas); composes with `test:rocblas`
- [ ] CI: add `test:multi-gpu` to a PR and confirm only multi-GPU jobs run on 8-GPU runners

## Notes

- Complements #5792 (which adds the `hipfft-multi-gpu` / `rocfft-multi-gpu` split jobs). Because the group is computed from the matrix, once #5792 merges those jobs are selected by `test:multi-gpu` automatically. The two PRs touch the same label-filter block, so a trivial merge reconciliation may be needed depending on merge order.

Made with [Cursor](https://cursor.com)