### PR TITLE
feat(ci): add path-based filtering for external repo builds

### DIFF
--- a/build_tools/github_actions/configure_ci_path_filters.py
+++ b/build_tools/github_actions/configure_ci_path_filters.py
@@ -8,12 +8,14 @@ This module provides utilities to:
 - Filter paths based on skippable patterns (docs, markdown, etc.)
 - Identify CI-related workflow files
 - Decide whether CI should run based on the modified paths
+- Check if external repo file changes require TheRock CI
 
 Public API:
     get_git_commit_hash() - Resolve a git ref to a commit hash
     get_git_modified_paths() - Get modified files from git diff compared to worktree
     get_git_submodule_paths() - Get list of git submodule paths in the repository
     is_ci_run_required() - Check if CI run is required based on modified paths
+    is_external_repo_ci_required() - Check if external repo changes require CI
 """
 
 import fnmatch
@@ -313,3 +315,115 @@ def _check_for_workflow_file_related_to_ci(paths: Optional[Iterable[str]]) -> bo
     if paths is None:
         return False
     return any(_is_path_workflow_file_related_to_ci(p) for p in paths)
+
+
+# ============================================================================
+# External Repo Path Filtering
+# ============================================================================
+
+# Skippable path patterns for external repos (rocm-libraries, rocm-systems).
+# These patterns are a superset of patterns from each external repo's
+# therock_configure_ci.py SKIPPABLE_PATH_PATTERNS. When all changed files
+# match these patterns, TheRock CI can be skipped for that external repo.
+#
+# This list combines common patterns across rocm-libraries and rocm-systems:
+# - rocm-libraries: https://github.com/ROCm/rocm-libraries/.github/scripts/therock_configure_ci.py
+# - rocm-systems: https://github.com/ROCm/rocm-systems/.github/scripts/therock_configure_ci.py
+_EXTERNAL_REPO_SKIPPABLE_PATH_PATTERNS = [
+    # Documentation files
+    "docs/*",
+    "*.md",
+    "*.rst",
+    "*.rtf",
+    # Git/GitHub metadata files
+    ".gitignore",
+    "*/.gitignore",
+    "*.pre-commit-config.*",
+    ".github/label*.yml",
+    "*CODEOWNERS",
+    "*LICENSE",
+    # Documentation tooling files
+    "*/.markdownlint-ci2.yaml",
+    "*/.readthedocs.yaml",
+    "*/.spellcheck.local.yaml",
+    "*/.wordlist.txt",
+    # Project-specific docs
+    "projects/*/docs/*",
+    "shared/*/docs/*",
+    "dnn-providers/*/docs/*",
+    # Experimental code (no impact on standard CI)
+    "experimental/*",
+    # AI/editor rules files
+    "*.clinerules",
+    "*.cursorrules",
+    "*.mdc",
+    # PR bot and standalone tools (no impact on builds)
+    "tools/libraries_pr_bot/*",
+    "tools/systems_pr_bot/*",
+    "projects/hipdnn/tools/*",
+    # WSL support files (rocm-systems)
+    "projects/rocr-runtime/libhsakmt/src/dxg/*",
+    # Composable Kernel standalone directories (not part of TheRock build)
+    "projects/composablekernel/Jenkinsfile",
+    "projects/composablekernel/Docker*",
+    "projects/composablekernel/client_example/*",
+    "projects/composablekernel/codegen/*",
+    "projects/composablekernel/dispatcher/*",
+    "projects/composablekernel/example/*",
+    "projects/composablekernel/experimental/*",
+    "projects/composablekernel/profiler/*",
+    "projects/composablekernel/python/*",
+    "projects/composablekernel/rocm_ck/*",
+    "projects/composablekernel/script/*",
+    "projects/composablekernel/test/*",
+    "projects/composablekernel/test_data/*",
+    "projects/composablekernel/tile_engine/*",
+    "projects/composablekernel/tutorial/*",
+    "projects/composablekernel/vars/*",
+    "projects/composablekernel/groovy/*",
+]
+
+
+def _is_external_repo_path_skippable(path: str) -> bool:
+    """Checks if a single external repo file path matches any skippable pattern."""
+    return any(
+        fnmatch.fnmatch(path, pattern)
+        for pattern in _EXTERNAL_REPO_SKIPPABLE_PATH_PATTERNS
+    )
+
+
+def is_external_repo_ci_required(
+    changed_files: Optional[Iterable[str]],
+    repo_name: str = "",
+) -> bool:
+    """Returns True if any changed file is non-skippable (requires CI)."""
+    repo_label = f"[{repo_name}] " if repo_name else ""
+
+    if changed_files is None:
+        print(f"{repo_label}No changed files provided, CI required (conservative)")
+        return True
+
+    changed_files_list = list(changed_files)
+    if not changed_files_list:
+        print(f"{repo_label}No files changed, skipping CI")
+        return False
+
+    non_skippable = [
+        f for f in changed_files_list if not _is_external_repo_path_skippable(f)
+    ]
+
+    print(f"{repo_label}Evaluating {len(changed_files_list)} changed file(s):")
+    for f in changed_files_list[:10]:
+        skippable = _is_external_repo_path_skippable(f)
+        print(f"  {'[skip]' if skippable else '[ci]  '} {f}")
+    if len(changed_files_list) > 10:
+        print(f"  ... and {len(changed_files_list) - 10} more")
+
+    if non_skippable:
+        print(
+            f"{repo_label}{len(non_skippable)} non-skippable file(s) found, CI required"
+        )
+        return True
+    else:
+        print(f"{repo_label}All files are skippable, CI can be skipped")
+        return False

--- a/build_tools/github_actions/configure_ci_path_filters.py
+++ b/build_tools/github_actions/configure_ci_path_filters.py
@@ -321,83 +321,34 @@ def _check_for_workflow_file_related_to_ci(paths: Optional[Iterable[str]]) -> bo
 # External Repo Path Filtering
 # ============================================================================
 
-# Skippable path patterns for external repos (rocm-libraries, rocm-systems).
-# These patterns are a superset of patterns from each external repo's
-# therock_configure_ci.py SKIPPABLE_PATH_PATTERNS. When all changed files
-# match these patterns, TheRock CI can be skipped for that external repo.
-#
-# This list combines common patterns across rocm-libraries and rocm-systems:
-# - rocm-libraries: https://github.com/ROCm/rocm-libraries/.github/scripts/therock_configure_ci.py
-# - rocm-systems: https://github.com/ROCm/rocm-systems/.github/scripts/therock_configure_ci.py
-_EXTERNAL_REPO_SKIPPABLE_PATH_PATTERNS = [
-    # Documentation files
-    "docs/*",
-    "*.md",
-    "*.rst",
-    "*.rtf",
-    # Git/GitHub metadata files
-    ".gitignore",
-    "*/.gitignore",
-    "*.pre-commit-config.*",
-    ".github/label*.yml",
-    "*CODEOWNERS",
-    "*LICENSE",
-    # Documentation tooling files
-    "*/.markdownlint-ci2.yaml",
-    "*/.readthedocs.yaml",
-    "*/.spellcheck.local.yaml",
-    "*/.wordlist.txt",
-    # Project-specific docs
-    "projects/*/docs/*",
-    "shared/*/docs/*",
-    "dnn-providers/*/docs/*",
-    # Experimental code (no impact on standard CI)
-    "experimental/*",
-    # AI/editor rules files
-    "*.clinerules",
-    "*.cursorrules",
-    "*.mdc",
-    # PR bot and standalone tools (no impact on builds)
-    "tools/libraries_pr_bot/*",
-    "tools/systems_pr_bot/*",
-    "projects/hipdnn/tools/*",
-    # WSL support files (rocm-systems)
-    "projects/rocr-runtime/libhsakmt/src/dxg/*",
-    # Composable Kernel standalone directories (not part of TheRock build)
-    "projects/composablekernel/Jenkinsfile",
-    "projects/composablekernel/Docker*",
-    "projects/composablekernel/client_example/*",
-    "projects/composablekernel/codegen/*",
-    "projects/composablekernel/dispatcher/*",
-    "projects/composablekernel/example/*",
-    "projects/composablekernel/experimental/*",
-    "projects/composablekernel/profiler/*",
-    "projects/composablekernel/python/*",
-    "projects/composablekernel/rocm_ck/*",
-    "projects/composablekernel/script/*",
-    "projects/composablekernel/test/*",
-    "projects/composablekernel/test_data/*",
-    "projects/composablekernel/tile_engine/*",
-    "projects/composablekernel/tutorial/*",
-    "projects/composablekernel/vars/*",
-    "projects/composablekernel/groovy/*",
-]
 
-
-def _is_external_repo_path_skippable(path: str) -> bool:
-    """Checks if a single external repo file path matches any skippable pattern."""
-    return any(
-        fnmatch.fnmatch(path, pattern)
-        for pattern in _EXTERNAL_REPO_SKIPPABLE_PATH_PATTERNS
-    )
+def _is_path_skippable_for_patterns(path: str, patterns: list[str]) -> bool:
+    """Checks if a file path matches any of the provided skippable patterns."""
+    return any(fnmatch.fnmatch(path, pattern) for pattern in patterns)
 
 
 def is_external_repo_ci_required(
     changed_files: Optional[Iterable[str]],
+    skip_ci_patterns: Optional[list[str]] = None,
     repo_name: str = "",
 ) -> bool:
-    """Returns True if any changed file is non-skippable (requires CI)."""
+    """Returns True if any changed file is non-skippable (requires CI).
+
+    Args:
+        changed_files: List of files changed in the external repo.
+        skip_ci_patterns: List of glob patterns for files that can skip CI.
+            These patterns are provided by the external repo, allowing each
+            repo to define its own skippable paths without updating TheRock.
+        repo_name: Name of the external repo for logging.
+
+    Returns:
+        True if CI is required, False if it can be skipped.
+    """
     repo_label = f"[{repo_name}] " if repo_name else ""
+
+    if skip_ci_patterns is None or not skip_ci_patterns:
+        print(f"{repo_label}No skip_ci_patterns provided, CI required")
+        return True
 
     if changed_files is None:
         print(f"{repo_label}No changed files provided, CI required (conservative)")
@@ -408,13 +359,14 @@ def is_external_repo_ci_required(
         print(f"{repo_label}No files changed, skipping CI")
         return False
 
-    non_skippable = [
-        f for f in changed_files_list if not _is_external_repo_path_skippable(f)
-    ]
+    def is_skippable(path: str) -> bool:
+        return _is_path_skippable_for_patterns(path, skip_ci_patterns)
+
+    non_skippable = [f for f in changed_files_list if not is_skippable(f)]
 
     print(f"{repo_label}Evaluating {len(changed_files_list)} changed file(s):")
     for f in changed_files_list[:10]:
-        skippable = _is_external_repo_path_skippable(f)
+        skippable = is_skippable(f)
         print(f"  {'[skip]' if skippable else '[ci]  '} {f}")
     if len(changed_files_list) > 10:
         print(f"  ... and {len(changed_files_list) - 10} more")

--- a/build_tools/github_actions/configure_external_repo_ci.py
+++ b/build_tools/github_actions/configure_external_repo_ci.py
@@ -4,7 +4,8 @@
 
 """Configure CI for external repos (rocm-systems, rocm-libraries).
 
-This script determines which projects changed and whether to run/skip tests.
+This script determines which projects changed and outputs changed_files for
+TheRock's configure_multi_arch_ci.py to evaluate path-based skip logic.
 
 Stage Reuse:
     TheRock's stage_reuse_decision.py handles stage impact analysis and
@@ -24,8 +25,8 @@ Usage:
 
 Outputs (to $GITHUB_OUTPUT):
     changed_projects: Comma-separated list of changed project paths
+    changed_files: JSON array of changed file paths (for TheRock path filtering)
     run_all_tests: "true" if CI files changed (run full test suite)
-    skip_tests: "true" if only docs/skippable files changed
 """
 
 import argparse
@@ -54,15 +55,6 @@ logger = logging.getLogger(__name__)
 
 F = TypeVar("F", bound=Callable[..., object])
 
-# Patterns for files that don't require tests (docs, etc.)
-SKIPPABLE_PATH_PATTERNS = [
-    "*.md",
-    "*.rst",
-    "docs/*",
-    "projects/*/docs/*",
-    "shared/*/docs/*",
-]
-
 # Patterns that trigger a full test run when changed (CI infrastructure)
 FULL_TEST_TRIGGER_PATTERNS = [
     ".github/workflows/therock*",
@@ -81,8 +73,8 @@ class ConfigureResult:
     """Result of CI configuration analysis."""
 
     changed_projects: str  # Comma-separated list
+    changed_files: List[str]  # List of changed file paths
     run_all_tests: bool
-    skip_tests: bool
 
 
 @dataclass
@@ -165,16 +157,6 @@ def matches_patterns(paths: Iterable[str], patterns: Iterable[str]) -> bool:
     return False
 
 
-def is_skippable(path: str) -> bool:
-    """Check if path is skippable (docs, etc.)."""
-    return any(fnmatch.fnmatch(path, p) for p in SKIPPABLE_PATH_PATTERNS)
-
-
-def has_non_skippable(paths: Iterable[str]) -> bool:
-    """Check if any path is non-skippable."""
-    return any(not is_skippable(p) for p in paths)
-
-
 def load_repo_config(config_path: str) -> List[RepoEntry]:
     """Load repository config from JSON."""
     try:
@@ -238,7 +220,7 @@ def configure(
     if event_name in ("schedule", "workflow_dispatch"):
         logger.info(f"{event_name} event - running all tests")
         return ConfigureResult(
-            changed_projects="", run_all_tests=True, skip_tests=False
+            changed_projects="", changed_files=[], run_all_tests=True
         )
 
     # Get modified paths via GitHub API
@@ -253,36 +235,31 @@ def configure(
     else:
         logger.warning("No SHAs provided - running all tests")
         return ConfigureResult(
-            changed_projects="", run_all_tests=True, skip_tests=False
+            changed_projects="", changed_files=[], run_all_tests=True
         )
 
     # If API returned None (truncated results), fall back to run-all
     if modified_paths is None:
         logger.info("Truncated API response - running all tests")
         return ConfigureResult(
-            changed_projects="", run_all_tests=True, skip_tests=False
+            changed_projects="", changed_files=[], run_all_tests=True
         )
 
-    if not modified_paths:
-        logger.info("No modified paths - skipping tests")
+    modified_paths_list = sorted(modified_paths)
+
+    if not modified_paths_list:
+        logger.info("No modified paths")
         return ConfigureResult(
-            changed_projects="", run_all_tests=False, skip_tests=True
+            changed_projects="", changed_files=[], run_all_tests=False
         )
 
-    logger.info(f"Modified paths: {len(modified_paths)} files")
+    logger.info(f"Modified paths: {len(modified_paths_list)} files")
 
     # Check if CI files changed (run all tests)
-    if matches_patterns(modified_paths, FULL_TEST_TRIGGER_PATTERNS):
+    if matches_patterns(modified_paths_list, FULL_TEST_TRIGGER_PATTERNS):
         logger.info("CI files changed - running all tests")
         return ConfigureResult(
-            changed_projects="", run_all_tests=True, skip_tests=False
-        )
-
-    # Check if only skippable files changed
-    if not has_non_skippable(modified_paths):
-        logger.info("Only skippable files changed - skipping tests")
-        return ConfigureResult(
-            changed_projects="", run_all_tests=False, skip_tests=True
+            changed_projects="", changed_files=modified_paths_list, run_all_tests=True
         )
 
     # Find changed projects from config
@@ -290,17 +267,17 @@ def configure(
     if not config:
         logger.warning("No config loaded - running all tests")
         return ConfigureResult(
-            changed_projects="", run_all_tests=True, skip_tests=False
+            changed_projects="", changed_files=modified_paths_list, run_all_tests=True
         )
 
     valid_prefixes = get_valid_prefixes(config)
-    matched = find_matched_subtrees(modified_paths, valid_prefixes)
+    matched = find_matched_subtrees(modified_paths_list, valid_prefixes)
     logger.info(f"Matched projects: {matched}")
 
     return ConfigureResult(
         changed_projects=",".join(matched),
+        changed_files=modified_paths_list,
         run_all_tests=False,
-        skip_tests=False,
     )
 
 
@@ -356,8 +333,8 @@ def main(argv: Optional[List[str]] = None) -> int:
     set_github_output(
         {
             "changed_projects": result.changed_projects,
+            "changed_files": json.dumps(result.changed_files),
             "run_all_tests": str(result.run_all_tests).lower(),
-            "skip_tests": str(result.skip_tests).lower(),
         }
     )
 

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -67,6 +67,7 @@ from configure_ci_path_filters import (
     get_git_modified_paths,
     get_git_submodule_paths,
     is_ci_run_required,
+    is_external_repo_ci_required,
 )
 from configure_jax_release_matrix import generate_jax_matrix_for_release_type
 from configure_pytorch_release_matrix import generate_pytorch_matrix_for_release_type
@@ -782,12 +783,29 @@ def should_skip_ci(
     if has_asan_label and ci_inputs.build_variant == "asan":
         print("  Running: ASAN CI triggered by PR label")
 
-    # External repo builds skip path filtering - they always run CI and use
-    # stage reuse to determine which stages to rebuild.
-    # TODO(#3343): Reuse skip path filters from external repos to short-circuit
-    # CI for docs-only changes, experimental projects, etc.
+    # External repo builds: evaluate changed_files from the external repo JSON.
+    # This allows external repos to skip TheRock CI when only docs/metadata
+    # files are changed.
     if ci_inputs.external_repo:
-        print("  External repo build: skipping path filter checks, using stage reuse")
+        try:
+            external_repo = json.loads(ci_inputs.external_repo)
+        except (json.JSONDecodeError, TypeError):
+            # Invalid JSON, run CI to be safe
+            print("  External repo build: invalid JSON, running CI")
+            return False
+
+        # Check changed_files from external repo if provided
+        changed_files = external_repo.get("changed_files")
+        if changed_files is not None:
+            repo_name = external_repo.get("repository", "").split("/")[-1]
+            if not is_external_repo_ci_required(changed_files, repo_name):
+                print("  External repo build: only skippable files changed")
+                return True
+            print("  External repo build: CI-relevant files changed, running CI")
+            return False
+
+        # No changed_files provided, run CI (stage reuse will optimize)
+        print("  External repo build: no path info, using stage reuse")
         return False
 
     # If we have a list of changed files (push/pull_request events), check if

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -755,18 +755,60 @@ def should_skip_ci(
     - 'ci:skip' PR label
     - Only skippable files changed (docs, .md, etc.)
     - No files changed
+    - ASAN builds on PRs without ci:asan or ci:host-asan labels
 
-    For external repo builds, path filtering is skipped since the external repo
-    name is used for stage reuse analysis, not for CI skip decisions.
+    For external repo builds, path filtering uses changed_files and
+    skip_ci_patterns from the external_repo JSON (both must be provided).
+    Schedule and workflow_dispatch runs always run CI.
     """
+    # 1. Common skip behavior
     if "ci:skip" in ci_inputs.pr_labels:
         print("  Skipping: 'ci:skip' PR label")
         return True
 
-    # Skip ASAN on PRs unless an enabling label is present.
-    # This avoids running expensive ASAN builds on every PR.
-    # Labels that enable ASAN CI:
-    #   - ci:asan / ci:host-asan: explicit opt-in for ASAN testing
+    # 2. Path filter skipping - check before ASAN label logic so we don't print
+    #    "Running: ASAN CI triggered by PR label" when CI will be skipped anyway.
+
+    # 2a. External repo builds: evaluate changed_files from the external repo JSON.
+    # This allows external repos to skip TheRock CI when only docs/metadata
+    # files are changed.
+    if ci_inputs.external_repo:
+        try:
+            external_repo = json.loads(ci_inputs.external_repo)
+        except (json.JSONDecodeError, TypeError) as e:
+            raise ValueError(
+                f"Invalid external_repo JSON: {ci_inputs.external_repo!r}"
+            ) from e
+
+        # Check changed_files and skip_ci_patterns from external repo if provided.
+        # External repos provide their own skip patterns, allowing them to define
+        # skippable paths without updating TheRock.
+        changed_files = external_repo.get("changed_files")
+        skip_ci_patterns = external_repo.get("skip_ci_patterns")
+        if changed_files is not None and skip_ci_patterns is not None:
+            repo_name = external_repo.get("repository", "").split("/")[-1]
+            if not is_external_repo_ci_required(
+                changed_files, skip_ci_patterns, repo_name
+            ):
+                print("  External repo build: only skippable files changed")
+                return True
+        # If we reach here, either:
+        # - changed_files/skip_ci_patterns not provided: continue to ASAN checks
+        # - CI is required: continue to ASAN checks
+        # Stage reuse will optimize builds regardless.
+
+    # 2b. Local repo: If we have a list of changed files (push/pull_request events),
+    # check if CI should run for that set of changed files.
+    if not ci_inputs.external_repo and git_context.changed_files is not None:
+        print(
+            f"  Checking {len(git_context.changed_files)} changed file(s) "
+            f"against path filters..."
+        )
+        if not is_ci_run_required(git_context.changed_files):
+            print("  Skipping: no CI-relevant files changed")
+            return True
+
+    # 3. ASAN skip - only evaluated if path filtering didn't skip CI
     has_asan_label = (
         "ci:asan" in ci_inputs.pr_labels or "ci:host-asan" in ci_inputs.pr_labels
     )
@@ -782,45 +824,6 @@ def should_skip_ci(
 
     if has_asan_label and ci_inputs.build_variant == "asan":
         print("  Running: ASAN CI triggered by PR label")
-
-    # External repo builds: evaluate changed_files from the external repo JSON.
-    # This allows external repos to skip TheRock CI when only docs/metadata
-    # files are changed.
-    if ci_inputs.external_repo:
-        try:
-            external_repo = json.loads(ci_inputs.external_repo)
-        except (json.JSONDecodeError, TypeError):
-            # Invalid JSON, run CI to be safe
-            print("  External repo build: invalid JSON, running CI")
-            return False
-
-        # Check changed_files from external repo if provided
-        changed_files = external_repo.get("changed_files")
-        if changed_files is not None:
-            repo_name = external_repo.get("repository", "").split("/")[-1]
-            if not is_external_repo_ci_required(changed_files, repo_name):
-                print("  External repo build: only skippable files changed")
-                return True
-            print("  External repo build: CI-relevant files changed, running CI")
-            return False
-
-        # No changed_files provided, run CI (stage reuse will optimize)
-        print("  External repo build: no path info, using stage reuse")
-        return False
-
-    # If we have a list of changed files (push/pull_request events), check if
-    # CI should run for that set of changed files. For example: if only .md
-    # files are changed, skip CI.
-    if git_context.changed_files is not None:
-        print(
-            f"  Checking {len(git_context.changed_files)} changed file(s) "
-            f"against path filters..."
-        )
-        if not is_ci_run_required(git_context.changed_files):
-            print("  Skipping: no CI-relevant files changed")
-            return True
-        else:
-            print("  CI-relevant files changed, running CI")
 
     return False
 

--- a/build_tools/github_actions/tests/configure_ci_path_filters_test.py
+++ b/build_tools/github_actions/tests/configure_ci_path_filters_test.py
@@ -15,6 +15,7 @@ from configure_ci_path_filters import (
     get_git_commit_hash,
     get_git_modified_paths,
     is_ci_run_required,
+    is_external_repo_ci_required,
 )
 from workflow_utils import get_transitive_workflow_uses
 
@@ -239,6 +240,100 @@ class ConfigureCIPathFiltersTest(unittest.TestCase):
             )
         if errors:
             self.fail("\n".join(errors))
+
+
+class ExternalRepoPathFiltersTest(unittest.TestCase):
+    """Tests for is_external_repo_ci_required function."""
+
+    def test_none_changed_files_requires_ci(self):
+        """None changed_files means unknown changes, run CI to be safe."""
+        self.assertTrue(is_external_repo_ci_required(None))
+
+    def test_empty_changed_files_skips_ci(self):
+        """Empty changed_files means no changes, skip CI."""
+        self.assertFalse(is_external_repo_ci_required([]))
+
+    def test_only_markdown_files_skips_ci(self):
+        """Only markdown files changed, skip CI."""
+        self.assertFalse(is_external_repo_ci_required(["README.md"]))
+        self.assertFalse(
+            is_external_repo_ci_required(["README.md", "docs/guide.md", "CHANGELOG.md"])
+        )
+
+    def test_only_rst_files_skips_ci(self):
+        """Only RST files changed, skip CI."""
+        self.assertFalse(is_external_repo_ci_required(["docs/index.rst"]))
+
+    def test_only_docs_directory_skips_ci(self):
+        """Only docs directory changes, skip CI."""
+        self.assertFalse(
+            is_external_repo_ci_required(["docs/guide.md", "docs/api/index.rst"])
+        )
+
+    def test_only_gitignore_skips_ci(self):
+        """Only .gitignore files changed, skip CI."""
+        self.assertFalse(is_external_repo_ci_required([".gitignore"]))
+        self.assertFalse(is_external_repo_ci_required(["projects/rocblas/.gitignore"]))
+
+    def test_only_project_docs_skips_ci(self):
+        """Only project-specific docs changed, skip CI."""
+        self.assertFalse(
+            is_external_repo_ci_required(
+                ["projects/rocblas/docs/README.md", "shared/utils/docs/guide.rst"]
+            )
+        )
+
+    def test_only_experimental_skips_ci(self):
+        """Only experimental files changed, skip CI."""
+        self.assertFalse(is_external_repo_ci_required(["experimental/new_feature.cpp"]))
+
+    def test_only_ai_rules_skips_ci(self):
+        """Only AI/editor rules files changed, skip CI."""
+        self.assertFalse(
+            is_external_repo_ci_required([".clinerules", ".cursorrules", "CLAUDE.mdc"])
+        )
+
+    def test_source_file_requires_ci(self):
+        """Source file change requires CI."""
+        self.assertTrue(is_external_repo_ci_required(["projects/rocblas/src/lib.cpp"]))
+
+    def test_cmake_file_requires_ci(self):
+        """CMake file change requires CI."""
+        self.assertTrue(is_external_repo_ci_required(["CMakeLists.txt"]))
+
+    def test_python_script_requires_ci(self):
+        """Python script change requires CI."""
+        self.assertTrue(is_external_repo_ci_required(["scripts/build.py"]))
+
+    def test_mixed_skippable_and_non_skippable_requires_ci(self):
+        """Mix of skippable and non-skippable requires CI."""
+        self.assertTrue(
+            is_external_repo_ci_required(["README.md", "projects/rocblas/src/lib.cpp"])
+        )
+
+    def test_github_workflow_requires_ci(self):
+        """GitHub workflow file requires CI (not in skippable patterns)."""
+        self.assertTrue(is_external_repo_ci_required([".github/workflows/ci.yml"]))
+
+    def test_codeowners_skips_ci(self):
+        """CODEOWNERS file is skippable."""
+        self.assertFalse(is_external_repo_ci_required(["CODEOWNERS"]))
+        self.assertFalse(is_external_repo_ci_required([".github/CODEOWNERS"]))
+
+    def test_license_skips_ci(self):
+        """LICENSE file is skippable."""
+        self.assertFalse(is_external_repo_ci_required(["LICENSE"]))
+        self.assertFalse(is_external_repo_ci_required(["LICENSE.md"]))
+
+    def test_repo_name_included_in_logging(self):
+        """Repo name is used in logging output."""
+        # This is a smoke test - just verify it doesn't crash
+        self.assertTrue(
+            is_external_repo_ci_required(["src/lib.cpp"], repo_name="rocm-libraries")
+        )
+        self.assertFalse(
+            is_external_repo_ci_required(["README.md"], repo_name="rocm-systems")
+        )
 
 
 if __name__ == "__main__":

--- a/build_tools/github_actions/tests/configure_ci_path_filters_test.py
+++ b/build_tools/github_actions/tests/configure_ci_path_filters_test.py
@@ -245,94 +245,200 @@ class ConfigureCIPathFiltersTest(unittest.TestCase):
 class ExternalRepoPathFiltersTest(unittest.TestCase):
     """Tests for is_external_repo_ci_required function."""
 
+    # Test patterns that simulate what external repos would provide
+    TEST_SKIP_PATTERNS = [
+        "docs/*",
+        "*.md",
+        "*.rst",
+        ".gitignore",
+        "*/.gitignore",
+        "*CODEOWNERS",
+        "*LICENSE",
+        "projects/*/docs/*",
+        "shared/*/docs/*",
+        "experimental/*",
+        "*.clinerules",
+        "*.cursorrules",
+        "*.mdc",
+    ]
+
     def test_none_changed_files_requires_ci(self):
         """None changed_files means unknown changes, run CI to be safe."""
-        self.assertTrue(is_external_repo_ci_required(None))
+        self.assertTrue(
+            is_external_repo_ci_required(None, skip_ci_patterns=self.TEST_SKIP_PATTERNS)
+        )
 
     def test_empty_changed_files_skips_ci(self):
         """Empty changed_files means no changes, skip CI."""
-        self.assertFalse(is_external_repo_ci_required([]))
+        self.assertFalse(
+            is_external_repo_ci_required([], skip_ci_patterns=self.TEST_SKIP_PATTERNS)
+        )
 
     def test_only_markdown_files_skips_ci(self):
         """Only markdown files changed, skip CI."""
-        self.assertFalse(is_external_repo_ci_required(["README.md"]))
         self.assertFalse(
-            is_external_repo_ci_required(["README.md", "docs/guide.md", "CHANGELOG.md"])
+            is_external_repo_ci_required(
+                ["README.md"], skip_ci_patterns=self.TEST_SKIP_PATTERNS
+            )
+        )
+        self.assertFalse(
+            is_external_repo_ci_required(
+                ["README.md", "docs/guide.md", "CHANGELOG.md"],
+                skip_ci_patterns=self.TEST_SKIP_PATTERNS,
+            )
         )
 
     def test_only_rst_files_skips_ci(self):
         """Only RST files changed, skip CI."""
-        self.assertFalse(is_external_repo_ci_required(["docs/index.rst"]))
+        self.assertFalse(
+            is_external_repo_ci_required(
+                ["docs/index.rst"], skip_ci_patterns=self.TEST_SKIP_PATTERNS
+            )
+        )
 
     def test_only_docs_directory_skips_ci(self):
         """Only docs directory changes, skip CI."""
         self.assertFalse(
-            is_external_repo_ci_required(["docs/guide.md", "docs/api/index.rst"])
+            is_external_repo_ci_required(
+                ["docs/guide.md", "docs/api/index.rst"],
+                skip_ci_patterns=self.TEST_SKIP_PATTERNS,
+            )
         )
 
     def test_only_gitignore_skips_ci(self):
         """Only .gitignore files changed, skip CI."""
-        self.assertFalse(is_external_repo_ci_required([".gitignore"]))
-        self.assertFalse(is_external_repo_ci_required(["projects/rocblas/.gitignore"]))
+        self.assertFalse(
+            is_external_repo_ci_required(
+                [".gitignore"], skip_ci_patterns=self.TEST_SKIP_PATTERNS
+            )
+        )
+        self.assertFalse(
+            is_external_repo_ci_required(
+                ["projects/rocblas/.gitignore"],
+                skip_ci_patterns=self.TEST_SKIP_PATTERNS,
+            )
+        )
 
     def test_only_project_docs_skips_ci(self):
         """Only project-specific docs changed, skip CI."""
         self.assertFalse(
             is_external_repo_ci_required(
-                ["projects/rocblas/docs/README.md", "shared/utils/docs/guide.rst"]
+                ["projects/rocblas/docs/README.md", "shared/utils/docs/guide.rst"],
+                skip_ci_patterns=self.TEST_SKIP_PATTERNS,
             )
         )
 
     def test_only_experimental_skips_ci(self):
         """Only experimental files changed, skip CI."""
-        self.assertFalse(is_external_repo_ci_required(["experimental/new_feature.cpp"]))
+        self.assertFalse(
+            is_external_repo_ci_required(
+                ["experimental/new_feature.cpp"],
+                skip_ci_patterns=self.TEST_SKIP_PATTERNS,
+            )
+        )
 
     def test_only_ai_rules_skips_ci(self):
         """Only AI/editor rules files changed, skip CI."""
         self.assertFalse(
-            is_external_repo_ci_required([".clinerules", ".cursorrules", "CLAUDE.mdc"])
+            is_external_repo_ci_required(
+                [".clinerules", ".cursorrules", "CLAUDE.mdc"],
+                skip_ci_patterns=self.TEST_SKIP_PATTERNS,
+            )
         )
 
     def test_source_file_requires_ci(self):
         """Source file change requires CI."""
-        self.assertTrue(is_external_repo_ci_required(["projects/rocblas/src/lib.cpp"]))
+        self.assertTrue(
+            is_external_repo_ci_required(
+                ["projects/rocblas/src/lib.cpp"],
+                skip_ci_patterns=self.TEST_SKIP_PATTERNS,
+            )
+        )
 
     def test_cmake_file_requires_ci(self):
         """CMake file change requires CI."""
-        self.assertTrue(is_external_repo_ci_required(["CMakeLists.txt"]))
+        self.assertTrue(
+            is_external_repo_ci_required(
+                ["CMakeLists.txt"], skip_ci_patterns=self.TEST_SKIP_PATTERNS
+            )
+        )
 
     def test_python_script_requires_ci(self):
         """Python script change requires CI."""
-        self.assertTrue(is_external_repo_ci_required(["scripts/build.py"]))
+        self.assertTrue(
+            is_external_repo_ci_required(
+                ["scripts/build.py"], skip_ci_patterns=self.TEST_SKIP_PATTERNS
+            )
+        )
 
     def test_mixed_skippable_and_non_skippable_requires_ci(self):
         """Mix of skippable and non-skippable requires CI."""
         self.assertTrue(
-            is_external_repo_ci_required(["README.md", "projects/rocblas/src/lib.cpp"])
+            is_external_repo_ci_required(
+                ["README.md", "projects/rocblas/src/lib.cpp"],
+                skip_ci_patterns=self.TEST_SKIP_PATTERNS,
+            )
         )
 
     def test_github_workflow_requires_ci(self):
         """GitHub workflow file requires CI (not in skippable patterns)."""
-        self.assertTrue(is_external_repo_ci_required([".github/workflows/ci.yml"]))
+        self.assertTrue(
+            is_external_repo_ci_required(
+                [".github/workflows/ci.yml"], skip_ci_patterns=self.TEST_SKIP_PATTERNS
+            )
+        )
 
     def test_codeowners_skips_ci(self):
         """CODEOWNERS file is skippable."""
-        self.assertFalse(is_external_repo_ci_required(["CODEOWNERS"]))
-        self.assertFalse(is_external_repo_ci_required([".github/CODEOWNERS"]))
+        self.assertFalse(
+            is_external_repo_ci_required(
+                ["CODEOWNERS"], skip_ci_patterns=self.TEST_SKIP_PATTERNS
+            )
+        )
+        self.assertFalse(
+            is_external_repo_ci_required(
+                [".github/CODEOWNERS"], skip_ci_patterns=self.TEST_SKIP_PATTERNS
+            )
+        )
 
     def test_license_skips_ci(self):
         """LICENSE file is skippable."""
-        self.assertFalse(is_external_repo_ci_required(["LICENSE"]))
-        self.assertFalse(is_external_repo_ci_required(["LICENSE.md"]))
+        self.assertFalse(
+            is_external_repo_ci_required(
+                ["LICENSE"], skip_ci_patterns=self.TEST_SKIP_PATTERNS
+            )
+        )
+        self.assertFalse(
+            is_external_repo_ci_required(
+                ["LICENSE.md"], skip_ci_patterns=self.TEST_SKIP_PATTERNS
+            )
+        )
 
     def test_repo_name_included_in_logging(self):
         """Repo name is used in logging output."""
         # This is a smoke test - just verify it doesn't crash
         self.assertTrue(
-            is_external_repo_ci_required(["src/lib.cpp"], repo_name="rocm-libraries")
+            is_external_repo_ci_required(
+                ["src/lib.cpp"],
+                skip_ci_patterns=self.TEST_SKIP_PATTERNS,
+                repo_name="rocm-libraries",
+            )
         )
         self.assertFalse(
-            is_external_repo_ci_required(["README.md"], repo_name="rocm-systems")
+            is_external_repo_ci_required(
+                ["README.md"],
+                skip_ci_patterns=self.TEST_SKIP_PATTERNS,
+                repo_name="rocm-systems",
+            )
+        )
+
+    def test_no_patterns_requires_ci(self):
+        """If no skip_ci_patterns provided, CI is required."""
+        self.assertTrue(
+            is_external_repo_ci_required(["README.md"], skip_ci_patterns=None)
+        )
+        self.assertTrue(
+            is_external_repo_ci_required(["README.md"], skip_ci_patterns=[])
         )
 
 

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -359,8 +359,8 @@ class TestShouldSkipCI(unittest.TestCase):
         self.assertFalse(cm.should_skip_ci(inputs, git))
 
     @patch("configure_multi_arch_ci.is_ci_run_required")
-    def test_external_repo_skips_path_filter(self, mock_filter):
-        """External repo builds skip path filtering and always run CI."""
+    def test_external_repo_no_path_info_runs_ci(self, mock_filter):
+        """External repo without path info runs CI (uses stage reuse)."""
         inputs = self._inputs(
             external_repo='{"repository":"ROCm/rocm-libraries","ref":"abc123"}'
         )
@@ -368,6 +368,34 @@ class TestShouldSkipCI(unittest.TestCase):
         self.assertFalse(cm.should_skip_ci(inputs, git))
         # Path filter should not be called for external repos
         mock_filter.assert_not_called()
+
+    @patch("configure_multi_arch_ci.is_external_repo_ci_required")
+    def test_external_repo_changed_files_skippable_skips(self, mock_external_ci):
+        """External repo with skippable changed_files skips CI."""
+        mock_external_ci.return_value = False
+        inputs = self._inputs(
+            external_repo='{"repository":"ROCm/rocm-libraries","ref":"abc123","changed_files":["README.md","docs/guide.md"]}'
+        )
+        git = cm.GitContext(changed_files=["rocm-libraries"])
+        self.assertTrue(cm.should_skip_ci(inputs, git))
+        mock_external_ci.assert_called_once()
+
+    @patch("configure_multi_arch_ci.is_external_repo_ci_required")
+    def test_external_repo_changed_files_non_skippable_runs(self, mock_external_ci):
+        """External repo with non-skippable changed_files runs CI."""
+        mock_external_ci.return_value = True
+        inputs = self._inputs(
+            external_repo='{"repository":"ROCm/rocm-libraries","ref":"abc123","changed_files":["projects/rocblas/src/lib.cpp"]}'
+        )
+        git = cm.GitContext(changed_files=["rocm-libraries"])
+        self.assertFalse(cm.should_skip_ci(inputs, git))
+        mock_external_ci.assert_called_once()
+
+    def test_external_repo_invalid_json_runs_ci(self):
+        """External repo with invalid JSON runs CI (conservative)."""
+        inputs = self._inputs(external_repo="not valid json")
+        git = cm.GitContext(changed_files=["rocm-libraries"])
+        self.assertFalse(cm.should_skip_ci(inputs, git))
 
 
 # ---------------------------------------------------------------------------

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -369,12 +369,23 @@ class TestShouldSkipCI(unittest.TestCase):
         # Path filter should not be called for external repos
         mock_filter.assert_not_called()
 
+    @patch("configure_multi_arch_ci.is_ci_run_required")
+    def test_external_repo_missing_skip_ci_patterns_runs_ci(self, mock_filter):
+        """External repo with changed_files but no skip_ci_patterns runs CI."""
+        inputs = self._inputs(
+            external_repo='{"repository":"ROCm/rocm-libraries","ref":"abc123","changed_files":["README.md"]}'
+        )
+        git = cm.GitContext(changed_files=["rocm-libraries"])
+        # Without skip_ci_patterns, we can't evaluate path filtering
+        self.assertFalse(cm.should_skip_ci(inputs, git))
+        mock_filter.assert_not_called()
+
     @patch("configure_multi_arch_ci.is_external_repo_ci_required")
     def test_external_repo_changed_files_skippable_skips(self, mock_external_ci):
         """External repo with skippable changed_files skips CI."""
         mock_external_ci.return_value = False
         inputs = self._inputs(
-            external_repo='{"repository":"ROCm/rocm-libraries","ref":"abc123","changed_files":["README.md","docs/guide.md"]}'
+            external_repo='{"repository":"ROCm/rocm-libraries","ref":"abc123","changed_files":["README.md","docs/guide.md"],"skip_ci_patterns":["*.md","docs/*"]}'
         )
         git = cm.GitContext(changed_files=["rocm-libraries"])
         self.assertTrue(cm.should_skip_ci(inputs, git))
@@ -385,17 +396,19 @@ class TestShouldSkipCI(unittest.TestCase):
         """External repo with non-skippable changed_files runs CI."""
         mock_external_ci.return_value = True
         inputs = self._inputs(
-            external_repo='{"repository":"ROCm/rocm-libraries","ref":"abc123","changed_files":["projects/rocblas/src/lib.cpp"]}'
+            external_repo='{"repository":"ROCm/rocm-libraries","ref":"abc123","changed_files":["projects/rocblas/src/lib.cpp"],"skip_ci_patterns":["*.md","docs/*"]}'
         )
         git = cm.GitContext(changed_files=["rocm-libraries"])
         self.assertFalse(cm.should_skip_ci(inputs, git))
         mock_external_ci.assert_called_once()
 
-    def test_external_repo_invalid_json_runs_ci(self):
-        """External repo with invalid JSON runs CI (conservative)."""
+    def test_external_repo_invalid_json_raises(self):
+        """External repo with invalid JSON raises ValueError."""
         inputs = self._inputs(external_repo="not valid json")
         git = cm.GitContext(changed_files=["rocm-libraries"])
-        self.assertFalse(cm.should_skip_ci(inputs, git))
+        with self.assertRaises(ValueError) as ctx:
+            cm.should_skip_ci(inputs, git)
+        self.assertIn("Invalid external_repo JSON", str(ctx.exception))
 
 
 # ---------------------------------------------------------------------------

--- a/build_tools/tests/configure_external_repo_ci_test.py
+++ b/build_tools/tests/configure_external_repo_ci_test.py
@@ -18,47 +18,9 @@ from configure_external_repo_ci import (
     configure,
     find_matched_subtrees,
     get_valid_prefixes,
-    has_non_skippable,
-    is_skippable,
     load_repo_config,
     matches_patterns,
 )
-
-
-class IsSkippableTest(unittest.TestCase):
-    """Tests for is_skippable()."""
-
-    def test_markdown_files_are_skippable(self):
-        self.assertTrue(is_skippable("README.md"))
-        self.assertTrue(is_skippable("docs/guide.md"))
-
-    def test_rst_files_are_skippable(self):
-        self.assertTrue(is_skippable("index.rst"))
-
-    def test_docs_directory_is_skippable(self):
-        self.assertTrue(is_skippable("docs/api.txt"))
-        self.assertTrue(is_skippable("projects/rocblas/docs/readme.md"))
-
-    def test_source_files_are_not_skippable(self):
-        self.assertFalse(is_skippable("src/main.cpp"))
-        self.assertFalse(is_skippable("projects/rocblas/src/blas.cpp"))
-        self.assertFalse(is_skippable("CMakeLists.txt"))
-
-
-class HasNonSkippableTest(unittest.TestCase):
-    """Tests for has_non_skippable()."""
-
-    def test_all_skippable_returns_false(self):
-        paths = ["README.md", "docs/guide.rst", "CHANGELOG.md"]
-        self.assertFalse(has_non_skippable(paths))
-
-    def test_mixed_returns_true(self):
-        paths = ["README.md", "src/main.cpp"]
-        self.assertTrue(has_non_skippable(paths))
-
-    def test_all_non_skippable_returns_true(self):
-        paths = ["src/a.cpp", "src/b.cpp"]
-        self.assertTrue(has_non_skippable(paths))
 
 
 class MatchesPatternsTest(unittest.TestCase):
@@ -159,7 +121,7 @@ class ConfigureTest(unittest.TestCase):
             config_path="",
         )
         self.assertEqual(result.run_all_tests, True)
-        self.assertEqual(result.skip_tests, False)
+        self.assertEqual(result.changed_files, [])
 
     def test_workflow_dispatch_runs_all_tests(self):
         result = configure(
@@ -170,19 +132,24 @@ class ConfigureTest(unittest.TestCase):
             config_path="",
         )
         self.assertEqual(result.run_all_tests, True)
-        self.assertEqual(result.skip_tests, False)
+        self.assertEqual(result.changed_files, [])
 
     @patch("configure_external_repo_ci.get_modified_paths_api")
-    def test_only_docs_changed_skips_tests(self, mock_api):
+    @patch("configure_external_repo_ci.load_repo_config")
+    def test_only_docs_changed_returns_changed_files(self, mock_config, mock_api):
         mock_api.return_value = {"README.md", "docs/guide.md"}
+        mock_config.return_value = [
+            RepoEntry(name="rocblas", url="", branch="", category="projects"),
+        ]
         result = configure(
             event_name="pull_request",
             github_repo="ROCm/rocm-libraries",
             base_sha="abc123",
             head_sha="def456",
-            config_path="",
+            config_path=".github/repos-config.json",
         )
-        self.assertEqual(result.skip_tests, True)
+        # changed_files is returned for TheRock to evaluate skip logic
+        self.assertEqual(sorted(result.changed_files), ["README.md", "docs/guide.md"])
         self.assertEqual(result.run_all_tests, False)
 
     @patch("configure_external_repo_ci.get_modified_paths_api")
@@ -196,7 +163,7 @@ class ConfigureTest(unittest.TestCase):
             config_path="",
         )
         self.assertEqual(result.run_all_tests, True)
-        self.assertEqual(result.skip_tests, False)
+        self.assertEqual(result.changed_files, [".github/workflows/therock-ci.yml"])
 
     @patch("configure_external_repo_ci.get_modified_paths_api")
     @patch("configure_external_repo_ci.load_repo_config")
@@ -214,7 +181,7 @@ class ConfigureTest(unittest.TestCase):
         )
         self.assertEqual(result.changed_projects, "projects/rocblas")
         self.assertEqual(result.run_all_tests, False)
-        self.assertEqual(result.skip_tests, False)
+        self.assertEqual(result.changed_files, ["projects/rocblas/src/main.cpp"])
 
     @patch("configure_external_repo_ci.get_modified_paths_api")
     def test_truncated_api_response_runs_all_tests(self, mock_api):
@@ -227,7 +194,7 @@ class ConfigureTest(unittest.TestCase):
             config_path="",
         )
         self.assertEqual(result.run_all_tests, True)
-        self.assertEqual(result.skip_tests, False)
+        self.assertEqual(result.changed_files, [])
 
     def test_no_shas_provided_runs_all_tests(self):
         result = configure(


### PR DESCRIPTION
Add support for external repos (rocm-libraries, rocm-systems) to skip multi arch CI when non relevant CI files are changed. This reduces unnecessary CI runs when external repos run this CI

The external_repo JSON can now include:
- changed_files: [...] - list of changed files for path-based filtering
- skip_ci_patterns: list of files that will skip ci

Closes #7777 

Working here: https://github.com/ROCm/rocm-libraries/actions/runs/34264097220/job/102189189882?pr=11504 in a PR test with changes here: https://github.com/ROCm/rocm-libraries/pull/11504/changes (intentionally ignored files changed)

Next: apply new inputs to external repos