### PR TITLE
feat(ci): clearer logging for stage reuse in multi-arch external repos

### DIFF
--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -1151,9 +1151,26 @@ def decide_jobs(
     else:
         # Explicit prebuilt stages are honored in dry-run and reuse-stage modes.
         stage_decisions = {}
+        explicit_prebuilt_stages: list[str] = []
         if ci_inputs.prebuilt_stages:
-            for stage in _parse_prebuilt_stages(ci_inputs.prebuilt_stages):
+            explicit_prebuilt_stages = _parse_prebuilt_stages(ci_inputs.prebuilt_stages)
+            for stage in explicit_prebuilt_stages:
                 stage_decisions[stage] = JobAction.PREBUILT
+
+        # Log explicit baseline configuration when provided.
+        if ci_inputs.baseline_run_id and explicit_prebuilt_stages:
+            baseline_repo_info = (
+                f" from {ci_inputs.baseline_repository}"
+                if ci_inputs.baseline_repository
+                else ""
+            )
+            logging.info(
+                "[STAGE-REUSE] using explicit baseline_run_id=%s%s for "
+                "prebuilt_stages: %s",
+                ci_inputs.baseline_run_id,
+                baseline_repo_info,
+                ", ".join(explicit_prebuilt_stages),
+            )
 
         # In dry-run, automatic reuse is analyzed but not applied. In
         # reuse-stage, eligible stages are added to stage_decisions.

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -1179,6 +1179,7 @@ def decide_jobs(
             mode=stage_reuse_mode,
             linux_amdgpu_families=targets.linux_families,
             windows_amdgpu_families=targets.windows_families,
+            explicit_prebuilt_stages=explicit_prebuilt_stages,
         )
 
         baseline_repository = ci_inputs.baseline_repository

--- a/build_tools/github_actions/stage_reuse_decision.py
+++ b/build_tools/github_actions/stage_reuse_decision.py
@@ -135,6 +135,8 @@ class AutoStageReuse:
     reasons: tuple[str, ...]
     report_lines: tuple[str, ...] = field(default_factory=tuple)
     platform_available: dict[str, tuple[str, ...]] = field(default_factory=dict)
+    # Tracks which platforms had no commit-compatible baseline (vs missing artifacts)
+    platforms_no_compatible_baseline: tuple[str, ...] = field(default_factory=tuple)
     # Granular artifact-level reuse fields
     reusable_artifacts: tuple[str, ...] = field(default_factory=tuple)
     rebuild_artifacts: tuple[str, ...] = field(default_factory=tuple)
@@ -425,6 +427,9 @@ def compute_auto_stage_reuse(
     platform_baseline_urls: dict[str, str | None] = {}
     per_platform_available: dict[str, tuple[str, ...]] = {}
     baseline_error: str | None = None
+    # Track platforms where no commit-compatible baseline was found (distinct
+    # from platforms where a baseline exists but artifacts are missing).
+    platforms_no_compatible_baseline: list[str] = []
 
     for platform in platforms:
         platform_families = _platform_target_families(
@@ -479,6 +484,11 @@ def compute_auto_stage_reuse(
         platform_baseline_urls[platform] = (
             baseline.html_url if baseline is not None else None
         )
+
+        # Track when no baseline was found (likely due to commit incompatibility
+        # when building from an older/external repo commit).
+        if baseline is None and baseline_error is None:
+            platforms_no_compatible_baseline.append(platform)
 
         available_filenames = _matched_filenames(baseline)
         available_here: list[str] = []
@@ -575,6 +585,7 @@ def compute_auto_stage_reuse(
         verified_reusable = plan.reusable_artifacts
         verified_rebuild = plan.impacted_artifacts
 
+    platforms_no_baseline_t = tuple(platforms_no_compatible_baseline)
     lines = _format_report(
         mode=mode,
         candidates=candidates,
@@ -587,6 +598,7 @@ def compute_auto_stage_reuse(
         baseline_error=baseline_error,
         platforms=platforms,
         platform_available=per_platform_available,
+        platforms_no_compatible_baseline=platforms_no_baseline_t,
         # Include artifact-level info in the report
         artifact_level_analysis=artifact_level_analysis,
         impacted_artifacts=verified_rebuild,
@@ -606,6 +618,7 @@ def compute_auto_stage_reuse(
             reasons=plan.reasons,
             report_lines=lines,
             platform_available=per_platform_available,
+            platforms_no_compatible_baseline=platforms_no_baseline_t,
             # Granular artifact-level reuse fields (verified against baseline)
             reusable_artifacts=verified_reusable,
             rebuild_artifacts=verified_rebuild,
@@ -767,6 +780,7 @@ def _format_report(
     baseline_error: str | None = None,
     platforms: Sequence[str] = (),
     platform_available: dict[str, tuple[str, ...]] | None = None,
+    platforms_no_compatible_baseline: Sequence[str] = (),
     # Granular artifact-level analysis fields
     artifact_level_analysis: bool = False,
     impacted_artifacts: Sequence[str] = (),
@@ -793,6 +807,15 @@ def _format_report(
         )
     elif baseline_run_id:
         lines.append(f"{LOG_PREFIX} baseline run for artifact check: {baseline_run_id}")
+    elif platforms_no_compatible_baseline:
+        # Clarify that the issue is commit incompatibility, not missing artifacts.
+        # This typically happens when building from an external repo pinned to an
+        # older TheRock commit - all main branch runs are newer (descendants).
+        lines.append(
+            f"{LOG_PREFIX} no commit-compatible baseline run found; "
+            f"all candidate runs are newer than current commit "
+            f"(platforms: {', '.join(platforms_no_compatible_baseline)})"
+        )
     else:
         lines.append(
             f"{LOG_PREFIX} no baseline run contains artifacts for all "
@@ -809,6 +832,7 @@ def _format_report(
     for stage in unavailable:
         # Call out WHICH platforms are missing the artifacts so the mismatch
         # (e.g. present on linux, absent on windows) is visible in the log.
+        # Also clarify whether the issue is no compatible baseline vs missing artifacts.
         if len(platforms) > 1:
             missing = [
                 platform
@@ -818,9 +842,16 @@ def _format_report(
             where = f" (missing on: {', '.join(missing)})" if missing else ""
         else:
             where = ""
+
+        # Determine why artifacts aren't available
+        if platforms_no_compatible_baseline and all(
+            p in platforms_no_compatible_baseline for p in platforms
+        ):
+            reason = "no commit-compatible baseline"
+        else:
+            reason = "artifacts not in baseline"
         lines.append(
-            f"{LOG_PREFIX} stage '{stage}' unaffected but artifacts "
-            f"NOT available -> rebuild{where}"
+            f"{LOG_PREFIX} stage '{stage}' unaffected but {reason} -> rebuild{where}"
         )
     if rebuild:
         lines.append(f"{LOG_PREFIX} stages rebuilding (impacted): {', '.join(rebuild)}")

--- a/build_tools/github_actions/stage_reuse_decision.py
+++ b/build_tools/github_actions/stage_reuse_decision.py
@@ -320,6 +320,7 @@ def compute_auto_stage_reuse(
     topology: BuildTopology | None = None,
     baseline_selector: BaselineSelector | None = None,
     baseline_selector_factory: Callable[[str], BaselineSelector] | None = None,
+    explicit_prebuilt_stages: Sequence[str] = (),
 ) -> AutoStageReuse:
     """Compute auto stage-reuse decisions, verified against a baseline run.
 
@@ -330,6 +331,9 @@ def compute_auto_stage_reuse(
     ``windows_amdgpu_families`` implies ``windows``. This guards against the
     case where a stage available only in the Linux baseline is skipped on
     Windows. The report lines are logged before returning.
+
+    Stages in ``explicit_prebuilt_stages`` are excluded from automatic analysis
+    reporting since they will be satisfied by an explicit baseline_run_id input.
     """
     if mode is StageReuseMode.OFF:
         return _log_and_return(
@@ -599,6 +603,7 @@ def compute_auto_stage_reuse(
         platforms=platforms,
         platform_available=per_platform_available,
         platforms_no_compatible_baseline=platforms_no_baseline_t,
+        explicit_prebuilt_stages=explicit_prebuilt_stages,
         # Include artifact-level info in the report
         artifact_level_analysis=artifact_level_analysis,
         impacted_artifacts=verified_rebuild,
@@ -781,12 +786,14 @@ def _format_report(
     platforms: Sequence[str] = (),
     platform_available: dict[str, tuple[str, ...]] | None = None,
     platforms_no_compatible_baseline: Sequence[str] = (),
+    explicit_prebuilt_stages: Sequence[str] = (),
     # Granular artifact-level analysis fields
     artifact_level_analysis: bool = False,
     impacted_artifacts: Sequence[str] = (),
     reusable_artifacts: Sequence[str] = (),
 ) -> tuple[str, ...]:
     platform_available = platform_available or {}
+    explicit_set = set(explicit_prebuilt_stages)
     lines: list[str] = [f"{LOG_PREFIX} mode={mode.value}"]
     if platforms:
         lines.append(f"{LOG_PREFIX} platforms verified: {', '.join(platforms)}")
@@ -829,7 +836,9 @@ def _format_report(
             f"{LOG_PREFIX} stage '{stage}' unaffected AND available in "
             f"baseline on all platforms -> {verb}"
         )
-    for stage in unavailable:
+    # Filter out stages that are explicitly prebuilt - they're already logged separately.
+    unavailable_for_report = [s for s in unavailable if s not in explicit_set]
+    for stage in unavailable_for_report:
         # Call out WHICH platforms are missing the artifacts so the mismatch
         # (e.g. present on linux, absent on windows) is visible in the log.
         # Also clarify whether the issue is no compatible baseline vs missing artifacts.

--- a/build_tools/github_actions/tests/stage_reuse_decision_test.py
+++ b/build_tools/github_actions/tests/stage_reuse_decision_test.py
@@ -191,7 +191,7 @@ class AvailabilityGateTest(unittest.TestCase):
         self.assertIn("compiler-runtime", result.unavailable_stages)
         self.assertEqual(result.available_stages, ())
         joined = "\n".join(result.report_lines)
-        self.assertIn("artifacts NOT available", joined)
+        self.assertIn("artifacts not in baseline", joined)
 
     def test_no_baseline_found_rebuilds_candidates(self):
         result = compute_auto_stage_reuse(
@@ -205,7 +205,8 @@ class AvailabilityGateTest(unittest.TestCase):
         self.assertEqual(result.available_stages, ())
         self.assertIsNone(result.baseline_run_id)
         joined = "\n".join(result.report_lines)
-        self.assertIn("no baseline run contains artifacts", joined)
+        # When no baseline is found, we now report it as "no commit-compatible baseline"
+        self.assertIn("no commit-compatible baseline", joined)
 
     def test_partial_family_availability_rebuilds(self):
         # Needs base for a real family + generic; baseline only has the generic


### PR DESCRIPTION
Previously in multi-arch external repos, we are seeing logs such as:
```
[STAGE-REUSE] baseline lookup result: platform=windows run_id=none
[STAGE-REUSE] mode=reuse-stage
[STAGE-REUSE] platforms verified: linux, windows
[STAGE-REUSE] no baseline run contains artifacts for all candidate stages; rebuilding all candidates.
[STAGE-REUSE] stage 'comm-libs' unaffected but artifacts NOT available -> rebuild (missing on: linux, windows)
[STAGE-REUSE] stage 'compiler-runtime' unaffected but artifacts NOT available -> rebuild (missing on: linux, windows)
[STAGE-REUSE] stage 'dctools-core' unaffected but artifacts NOT available -> rebuild (missing on: linux, windows)
[STAGE-REUSE] stage 'debug-tools' unaffected but artifacts NOT available -> rebuild (missing on: linux, windows)
[STAGE-REUSE] stage 'media-libs' unaffected but artifacts NOT available -> rebuild (missing on: linux, windows)
```
In the example: https://github.com/ROCm/rocm-libraries/actions/runs/33558572933/job/100026635603?pr=10487, we actually copy artifacts and do not rebuild. artifacts are also available, so a bit confusing

with these updates, we now provide more context with:
```
[STAGE-REUSE] using explicit baseline_run_id=33012920661 from ROCm/TheRock for prebuilt_stages: runtime-tests, comm-libs, cv-libs, storage-libs, debug-tools, dctools-core, profiler-apps, media-libs, wsl-rocdxg

[STAGE-REUSE] no commit-compatible baseline run found; all candidate runs are newer than current commit (platforms: linux, windows)
[STAGE-REUSE] stage 'compiler-runtime' unaffected but no commit-compatible baseline -> rebuild (missing on: linux, windows)
[STAGE-REUSE] stages rebuilding (impacted): cv-libs, math-libs
```

from test run here: https://github.com/ROCm/rocm-libraries/actions/runs/33558389558/job/100025219093?pr=11504