### PR TITLE
fix(ci): guard Unix-only fcntl import in Windows driver/GPU sanity check

### DIFF
--- a/build_tools/print_driver_gpu_info.py
+++ b/build_tools/print_driver_gpu_info.py
@@ -20,7 +20,6 @@ cannot be queried. A version above the supported maximum produces a warning
 but does not fail.
 """
 
-import fcntl
 import os
 from pathlib import Path
 import platform
@@ -41,6 +40,11 @@ _KFD_VERSION_MAX = (2, 0)  # exclusive
 
 
 def _get_kfd_version() -> Tuple[int, int]:
+    # fcntl is a Unix-only stdlib module and is only needed for this Linux
+    # KFD ioctl query. Import it lazily so the Windows sanity check does not
+    # crash at import time with ModuleNotFoundError: No module named 'fcntl'.
+    import fcntl
+
     fd = os.open(_KFD_DEVICE, os.O_RDWR)
     try:
         buf = bytearray(8)


### PR DESCRIPTION
## Motivation

#7360 added a module-level `import fcntl` to
`build_tools/print_driver_gpu_info.py`. `fcntl` is a **Unix-only** stdlib module,
so the `Driver / GPU sanity check` step (which runs this script) now crashes at
import time on **every Windows CI runner**:

```
Traceback (most recent call last):
  File "...\build_tools\print_driver_gpu_info.py", line 23, in <module>
    import fcntl
ModuleNotFoundError: No module named 'fcntl'
```

That fails the Windows sanity job and skips every downstream Windows component
test. The only use of `fcntl` is in `_get_kfd_version()`, which reads the KFD
ioctl version from `/dev/kfd` and is only reached on the Linux path -- Windows
should never have imported the module.

ISSUE ID: N/A (regression from #7360)

## Technical Details

Move `import fcntl` out of module scope into `_get_kfd_version()`, its sole user.
That function only runs on Linux, so the Unix-only import now happens only where
it is valid. No functional change on Linux.

## Test Plan

- Import + run `print_driver_gpu_info.py` on Windows Server 2025, before vs after.
- Confirm the Linux KFD path is unchanged (import still resolves inside the
  function that uses it).

## Test Result

- Windows, **before**: `ModuleNotFoundError: No module named 'fcntl'` at import.
- Windows, **after**: script imports and runs to completion (exit 0), taking the
  `hipInfo.exe` path and skipping the Linux-only KFD block.
- The equivalent pre-#7360 sanity path (identical apart from this import) already
  passes `Driver / GPU sanity check` and runs the `origami` gfx1201 component test
  green on a Windows R9700 runner.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
