### PR TITLE
feat(ci): disable rocminfo test for gfx125X-dcgpu

### DIFF
--- a/tests/test_rocm_sanity.py
+++ b/tests/test_rocm_sanity.py
@@ -61,6 +61,11 @@ class TestROCmSanity:
     @pytest.mark.skipif(
         is_asan(), reason="rocminfo test fails with ASAN build, see TheRock#3312"
     )
+    # TODO(#7659): Re-enable once rocminfo is fixed for gfx125X-dcgpu
+    @pytest.mark.skipif(
+        AMDGPU_FAMILIES and "gfx125X-dcgpu" in AMDGPU_FAMILIES,
+        reason="rocminfo test is disabled for gfx125X-dcgpu due to kernel bug, see #7659",
+    )
     @pytest.mark.parametrize(
         "to_search",
         [


### PR DESCRIPTION
Skips the rocminfo sanity check test for gfx125X-dcgpu family due to a known kernel bug. it's bricking CI jobs and providing unclear signal. I'm working with the kernel team to fix

ISSUE ID: #7659

We are aware that sanity checks are vital, but so we are working closely with team and will resolve this ASAP.