### PR TITLE
test(build_tools): add import test for print_driver_gpu_info

### DIFF
--- a/build_tools/tests/print_driver_gpu_info_test.py
+++ b/build_tools/tests/print_driver_gpu_info_test.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for build_tools/print_driver_gpu_info.py."""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+
+class ImportTest(unittest.TestCase):
+    def test_module_imports_on_any_platform(self):
+        """The module must be importable without error on any OS.
+
+        fcntl is a Unix-only stdlib module used inside print_driver_gpu_info.
+        Importing it at the top level causes a ModuleNotFoundError on Windows.
+        This test catches that class of mistake by running on CPU-only runners
+        before any GPU job has a chance to fail.
+        """
+        import print_driver_gpu_info  # noqa: F401
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/build_tools/tests/print_driver_gpu_info_test.py
+++ b/build_tools/tests/print_driver_gpu_info_test.py
@@ -17,7 +17,7 @@ class ImportTest(unittest.TestCase):
 
         fcntl is a Unix-only stdlib module used inside print_driver_gpu_info.
         Importing it at the top level causes a ModuleNotFoundError on Windows.
-        This test catches that class of mistake by running on CPU-only runners
+        This test catches that class of mistakes by running on CPU-only runners
         before any GPU job has a chance to fail.
         """
         import print_driver_gpu_info  # noqa: F401


### PR DESCRIPTION
## Summary

Adds a test that imports `print_driver_gpu_info` on any platform. This catches top-level use of Unix-only stdlib modules (like `fcntl`) that would crash a Windows job at import time. The test runs on CPU-only runners and blocks a merge before any GPU job has a chance to fail.

Follows up on the discussion in #7360.

🤖 Generated with [Claude Code](https://claude.com/claude-code)