### PR TITLE
fix(spirv): per-shard gate not-yet-SPIR-V subprojects on the amdgcnspirv shard

### DIFF
--- a/cmake/therock_artifacts.cmake
+++ b/cmake/therock_artifacts.cmake
@@ -64,6 +64,39 @@ function(therock_provide_artifact slice_name)
     endif()
   endif()
 
+  # If every one of this shard's AMDGPU targets is excluded (via
+  # EXCLUDE_TARGET_PROJECTS in therock_amdgpu_targets.cmake) for ALL of the
+  # artifact's subprojects, then the artifact carries no device code for this
+  # shard's arch: the subprojects only built for a DEFAULT_GPU_TARGETS fallback.
+  # Splitting with --gpu-targets=<shard arch> would then fail in
+  # split_artifacts.py with "no device code objects matched --gpu-targets ...
+  # Refusing to emit an untransformed generic artifact." Fall back to the
+  # non-split path so the (fallback) artifact is still produced without trying
+  # to peel out arch-specific device code that does not exist for this shard.
+  # A target counts as supported if at least one subproject does not exclude it.
+  # This must run before any consumer of _should_split below.
+  if(_should_split AND ARG_SUBPROJECT_DEPS AND THEROCK_AMDGPU_TARGETS
+     AND NOT "${THEROCK_AMDGPU_TARGETS}" STREQUAL "THEROCK_AMDGPU_TARGETS-NOTFOUND")
+    set(_artifact_supported_targets)
+    foreach(_tgt ${THEROCK_AMDGPU_TARGETS})
+      foreach(_subproj ${ARG_SUBPROJECT_DEPS})
+        get_property(_subproj_excludes GLOBAL PROPERTY
+          "THEROCK_AMDGPU_PROJECT_TARGET_EXCLUDES_${_subproj}")
+        if(NOT "${_tgt}" IN_LIST _subproj_excludes)
+          list(APPEND _artifact_supported_targets "${_tgt}")
+          break()
+        endif()
+      endforeach()
+    endforeach()
+    if(NOT _artifact_supported_targets)
+      message(STATUS
+        "Artifact '${slice_name}': all AMDGPU targets (${THEROCK_AMDGPU_TARGETS}) "
+        "are excluded for every subproject (${ARG_SUBPROJECT_DEPS}); disabling "
+        "kpack split (no arch-specific device code for this shard).")
+      set(_should_split FALSE)
+    endif()
+  endif()
+
   # Record artifact→subprojects mapping for manifest generation.
   # This allows Python scripts to dynamically discover which subprojects
   # belong to each artifact without hardcoding in BUILD_TOPOLOGY.toml.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -37,6 +37,54 @@ endif()
 # cpp-sdk-user project requires HIP (LANGUAGES CXX HIP), so skip when
 # HIP is not enabled (e.g. in early multi-arch CI stages) or when
 # sanitizers are enabled (sanitizer builds do not install HIP).
+# ADDSPV: the cpp-sdk-user smoke test does find_package(<lib> CONFIG REQUIRED)
+# for every enabled feature group. In a shard where a library is arch-excluded
+# (e.g. amdgcnspirv, where rocBLAS/rocSPARSE/rocSOLVER/rocFFT/rocALUTION and
+# their hip* wrappers are gated out per-shard in math-libs), the package is not
+# in dist, so REQUIRED fails and the packaging test errors even though the build
+# is clean. Recompute the feature flags passed to the test per-shard: flip a
+# flag OFF when its key subproject has no surviving gfx targets for this shard.
+# Same EXCLUDE_TARGET_PROJECTS metadata / filter pattern used elsewhere. On
+# non-spirv shards (gfx90a, etc.) every filter is non-empty, so flags are
+# unchanged. Pairs: feature flag -> representative subproject.
+set(_sdk_flag_projects
+  "BLAS=rocBLAS"
+  "FFT=rocFFT"
+  "SPARSE=rocSPARSE"
+  "SOLVER=rocSOLVER"
+  "ROCALUTION=rocALUTION"
+  "ROCWMMA=rocWMMA"
+  "MIOPEN=MIOpen"
+  "HIPTENSOR=hipTensor"
+  "RCCL=rccl"
+  "LIBHIPCXX=libhipcxx"
+)
+foreach(_pair IN LISTS _sdk_flag_projects)
+  string(REPLACE "=" ";" _pair_list "${_pair}")
+  list(GET _pair_list 0 _flag)
+  list(GET _pair_list 1 _proj)
+  set(_sdk_enable_${_flag} ${THEROCK_ENABLE_${_flag}})
+  if(_sdk_enable_${_flag} AND THEROCK_AMDGPU_TARGETS
+     AND NOT "${THEROCK_AMDGPU_TARGETS}" MATCHES "-NOTFOUND$")
+    therock_filter_amdgpu_targets(_sdk_targets ${_proj} ${THEROCK_AMDGPU_TARGETS})
+    if(NOT _sdk_targets)
+      message(STATUS
+        "cpp-sdk-user: ${_proj} is excluded for this shard "
+        "(THEROCK_AMDGPU_TARGETS='${THEROCK_AMDGPU_TARGETS}'); disabling "
+        "THEROCK_ENABLE_${_flag} for the SDK smoke test.")
+      set(_sdk_enable_${_flag} OFF)
+    endif()
+  endif()
+endforeach()
+
+# hipTensor additionally requires composable_kernel (a hard build dependency);
+# _hiptensor_available (above) is OFF when CK/hipTensor were filtered out for the
+# selected gfx targets. Fold that into the per-shard flag so the smoke test does
+# not find_package() a hiptensor that was not built even on non-spirv shards.
+if(NOT _hiptensor_available)
+  set(_sdk_enable_HIPTENSOR OFF)
+endif()
+
 if(THEROCK_ENABLE_HIP_RUNTIME AND "${THEROCK_SANITIZER}" STREQUAL "")
   add_test(
     NAME therock-examples-cpp-sdk-user
@@ -46,21 +94,20 @@ if(THEROCK_ENABLE_HIP_RUNTIME AND "${THEROCK_SANITIZER}" STREQUAL "")
           "-DSOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}/cpp-sdk-user"
           "-DBINARY_DIR=${CMAKE_CURRENT_BINARY_DIR}/cpp-sdk-user"
           "-DGENERATOR=${CMAKE_GENERATOR}"
-          "-DTHEROCK_ENABLE_BLAS=${THEROCK_ENABLE_BLAS}"
-          "-DTHEROCK_ENABLE_FFT=${THEROCK_ENABLE_FFT}"
+          "-DTHEROCK_ENABLE_BLAS=${_sdk_enable_BLAS}"
+          "-DTHEROCK_ENABLE_FFT=${_sdk_enable_FFT}"
           "-DTHEROCK_ENABLE_HIP=${THEROCK_ENABLE_HIP_RUNTIME}"
           "-DTHEROCK_ENABLE_HIPDNN=${THEROCK_ENABLE_HIPDNN}"
-          "-DTHEROCK_ENABLE_LIBHIPCXX=${THEROCK_ENABLE_LIBHIPCXX}"
-          "-DTHEROCK_ENABLE_MIOPEN=${THEROCK_ENABLE_MIOPEN}"
-          "-DTHEROCK_ENABLE_HIPTENSOR=${_hiptensor_available}"
+          "-DTHEROCK_ENABLE_LIBHIPCXX=${_sdk_enable_LIBHIPCXX}"
+          "-DTHEROCK_ENABLE_MIOPEN=${_sdk_enable_MIOPEN}"
+          "-DTHEROCK_ENABLE_HIPTENSOR=${_sdk_enable_HIPTENSOR}"
           "-DTHEROCK_ENABLE_PRIM=${THEROCK_ENABLE_PRIM}"
           "-DTHEROCK_ENABLE_RAND=${THEROCK_ENABLE_RAND}"
-          "-DTHEROCK_ENABLE_RCCL=${THEROCK_ENABLE_RCCL}"
-          "-DTHEROCK_ENABLE_ROCWMMA=${THEROCK_ENABLE_ROCWMMA}"
-          "-DTHEROCK_ENABLE_ROCALUTION=${THEROCK_ENABLE_ROCALUTION}"
-          "-DTHEROCK_ENABLE_LIBHIPCXX=${THEROCK_ENABLE_LIBHIPCXX}"
-          "-DTHEROCK_ENABLE_SOLVER=${THEROCK_ENABLE_SOLVER}"
-          "-DTHEROCK_ENABLE_SPARSE=${THEROCK_ENABLE_SPARSE}"
+          "-DTHEROCK_ENABLE_RCCL=${_sdk_enable_RCCL}"
+          "-DTHEROCK_ENABLE_ROCWMMA=${_sdk_enable_ROCWMMA}"
+          "-DTHEROCK_ENABLE_ROCALUTION=${_sdk_enable_ROCALUTION}"
+          "-DTHEROCK_ENABLE_SOLVER=${_sdk_enable_SOLVER}"
+          "-DTHEROCK_ENABLE_SPARSE=${_sdk_enable_SPARSE}"
           ${HIP_CMAKE_ARGS}
         -P "${CMAKE_CURRENT_SOURCE_DIR}/clean_configure_test_project.cmake"
   )

--- a/math-libs/BLAS/CMakeLists.txt
+++ b/math-libs/BLAS/CMakeLists.txt
@@ -15,6 +15,30 @@ if(THEROCK_FLAG_INCLUDE_PROFILER)
   list(APPEND optional_profiler_deps roctracer rocprofiler-sdk)
 endif()
 
+# ADDSPV: rocBLAS and its dependent chain (hipBLASLt, rocSPARSE, hipSPARSE,
+# hipSPARSELt, rocSOLVER, hipSOLVER, hipBLAS) are excluded for amdgcnspirv.
+# EXCLUDE_TARGET_PROJECTS only strips device archs; the subprojects are still
+# declared and their client tests built. rocBLAS's own configure hard-fails on
+# an unsupported target (rocblas/CMakeLists.txt:150 "Unsupported target ... by
+# compiler" -- Tensile/rocm_check_target_ids has no amdgcnspirv). Since hipBLAS
+# and the SPARSE/SOLVER libs depend on rocBLAS, they can't build without it.
+# Gate the whole rocBLAS chain per-shard, same pattern as composable_kernel /
+# rocWMMA / FFT: if no gfx targets survive filtering for rocBLAS, skip rocBLAS
+# and everything that depends on it for this shard. hipBLAS-common and origami
+# (target-neutral leaf libs) still build. Non-spirv shards (gfx90a, etc.) are
+# unaffected -- tests are NOT touched there.
+set(_blas_core_enabled ON)
+if(THEROCK_AMDGPU_TARGETS AND NOT "${THEROCK_AMDGPU_TARGETS}" MATCHES "-NOTFOUND$")
+  therock_filter_amdgpu_targets(_rocblas_targets rocBLAS ${THEROCK_AMDGPU_TARGETS})
+  if(NOT _rocblas_targets)
+    message(STATUS
+      "BLAS: no supported gfx targets remain after filtering for rocBLAS "
+      "(THEROCK_AMDGPU_TARGETS='${THEROCK_AMDGPU_TARGETS}'); skipping rocBLAS "
+      "and its dependent chain (hipBLASLt/SPARSE/SOLVER/hipBLAS) for this shard.")
+    set(_blas_core_enabled OFF)
+  endif()
+endif()
+
 
 ##############################################################################
 # hipBLAS-common
@@ -51,7 +75,7 @@ else()
   set(_enable_rocRoller "ON")
 endif()
 
-if(_enable_rocRoller)
+if(_enable_rocRoller AND _blas_core_enabled)
   therock_cmake_subproject_declare(rocRoller
     EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/shared/rocroller"
     BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rocRoller"
@@ -155,6 +179,7 @@ if(_enable_rocRoller)
   )
 endif()
 
+if(_blas_core_enabled)
 therock_cmake_subproject_declare(hipBLASLt
   EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/hipblaslt"
   BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/hipBLASLt"
@@ -197,12 +222,14 @@ therock_cmake_subproject_glob_c_sources(hipBLASLt
 therock_cmake_subproject_provide_package(hipBLASLt hipblaslt lib/cmake/hipblaslt)
 therock_cmake_subproject_activate(hipBLASLt)
 list(APPEND _blas_subproject_names hipBLASLt)
+endif() # _blas_core_enabled (hipBLASLt)
 
 
 ##############################################################################
 # rocBLAS
 ##############################################################################
 
+if(_blas_core_enabled)
 set(rocBLAS_optional_runtime_deps)
 if(NOT WIN32)
   # rocBLAS is hard-coded to not expect rocm-smi.
@@ -563,6 +590,8 @@ SUBDIRS
 therock_cmake_subproject_provide_package(hipBLAS hipblas lib/cmake/hipblas)
 therock_cmake_subproject_activate(hipBLAS)
 list(APPEND _blas_subproject_names hipBLAS)
+
+endif() # _blas_core_enabled (rocBLAS + SPARSE/SOLVER + hipBLAS chain)
 
 
 ##############################################################################

--- a/math-libs/CMakeLists.txt
+++ b/math-libs/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
+set(_primlibs_build_tests ${THEROCK_BUILD_TESTING})
 set(_primlibs_benchmark_enable ${THEROCK_BUILD_TESTING})
 set(_primlibs_benchmark_deps)
 set(_primlibs_benchmark_includes)
@@ -14,6 +15,27 @@ if(NOT WIN32)
   else()
     set(_primlibs_benchmark_deps amdsmi)
     set(_primlibs_benchmark_includes therock_primlibs_benchmark_deps.cmake)
+  endif()
+endif()
+
+# ADDSPV: rocPRIM/hipCUB/rocThrust libs build fine for amdgcnspirv, but their
+# client tests/benchmarks compile device code with --offload-arch=amdgcnspirv
+# that crashes the SPIR-V backend (segfault in LLVM SPIRVEmitIntrinsics /
+# SPIRVGlobalRegistry::buildAssignPtr, e.g. rocThrust test_pair_scan.cpp).
+# EXCLUDE_TARGET_PROJECTS keeps the libs building; here we additionally drop the
+# prim-lib tests/benchmarks for a shard whose only target is amdgcnspirv, using
+# the same per-shard detection as the gates below. Non-spirv shards keep
+# tests/benchmarks. Upstream compiler bug tracked separately.
+if(THEROCK_AMDGPU_TARGETS AND NOT "${THEROCK_AMDGPU_TARGETS}" MATCHES "-NOTFOUND$")
+  set(_primlibs_non_spirv_targets ${THEROCK_AMDGPU_TARGETS})
+  list(REMOVE_ITEM _primlibs_non_spirv_targets amdgcnspirv)
+  if(NOT _primlibs_non_spirv_targets)
+    message(STATUS
+      "prim-libs: shard targets '${THEROCK_AMDGPU_TARGETS}' are SPIR-V only; "
+      "disabling rocPRIM/hipCUB/rocThrust tests and benchmarks (SPIR-V backend "
+      "crashes compiling their device test code).")
+    set(_primlibs_build_tests "OFF")
+    set(_primlibs_benchmark_enable "OFF")
   endif()
 endif()
 
@@ -127,7 +149,7 @@ if(THEROCK_ENABLE_PRIM)
   therock_cmake_subproject_provide_package(rocPRIM rocprim lib/cmake/rocprim)
   therock_cmake_subproject_activate(rocPRIM)
 
-  if(THEROCK_BUILD_TESTING)
+  if(_primlibs_build_tests)
     ##############################################################################
     # rocPRIM tests
     ##############################################################################
@@ -174,7 +196,7 @@ if(THEROCK_ENABLE_PRIM)
       -DHIP_PLATFORM=amd
       -DROCM_PATH=
       -DROCM_DIR=
-      -DBUILD_TEST=${THEROCK_BUILD_TESTING}
+      -DBUILD_TEST=${_primlibs_build_tests}
       -DBUILD_BENCHMARK=${_primlibs_benchmark_enable}
     CMAKE_INCLUDES
       ${_primlibs_benchmark_includes}
@@ -203,7 +225,7 @@ if(THEROCK_ENABLE_PRIM)
       -DHIP_PLATFORM=amd
       -DROCM_PATH=
       -DROCM_DIR=
-      -DBUILD_TEST=${THEROCK_BUILD_TESTING}
+      -DBUILD_TEST=${_primlibs_build_tests}
       -DBUILD_BENCHMARK=${_primlibs_benchmark_enable}
     CMAKE_INCLUDES
       ${_primlibs_benchmark_includes}
@@ -232,7 +254,7 @@ if(THEROCK_ENABLE_PRIM)
     rocThrust
   )
 
-  if(THEROCK_BUILD_TESTING)
+  if(_primlibs_build_tests)
     list(APPEND _prim_subproject_deps rocPRIM_tests)
   endif()
 
@@ -248,7 +270,27 @@ if(THEROCK_ENABLE_PRIM)
   )
 endif(THEROCK_ENABLE_PRIM)
 
-if(THEROCK_ENABLE_FFT)
+# ADDSPV: rocFFT/hipFFT are excluded for amdgcnspirv (EXCLUDE_TARGET_PROJECTS in
+# therock_amdgpu_targets.cmake), but EXCLUDE only strips device archs -- it does
+# not stop the subproject (or its clients/tests) from being declared/built. In a
+# shard whose only targets are excluded for rocFFT (e.g. the amdgcnspirv shard),
+# rocFFT still links rocfft-test and fails. Gate the whole FFT block per-shard,
+# same pattern as composable_kernel / rocWMMA below: if no gfx targets survive
+# filtering, skip rocFFT/hipFFT and the fft artifact entirely for this shard.
+# Non-spirv shards (gfx90a, etc.) are unaffected -- tests are NOT touched there.
+set(_fft_enabled ${THEROCK_ENABLE_FFT})
+if(_fft_enabled AND THEROCK_AMDGPU_TARGETS AND NOT "${THEROCK_AMDGPU_TARGETS}" MATCHES "-NOTFOUND$")
+  therock_filter_amdgpu_targets(_fft_targets rocFFT ${THEROCK_AMDGPU_TARGETS})
+  if(NOT _fft_targets)
+    message(STATUS
+      "FFT: no supported gfx targets remain after filtering "
+      "(THEROCK_AMDGPU_TARGETS='${THEROCK_AMDGPU_TARGETS}'); skipping "
+      "rocFFT/hipFFT and the fft artifact for this shard.")
+    set(_fft_enabled OFF)
+  endif()
+endif()
+
+if(_fft_enabled)
   if(WIN32)
     # TODO(#36): enable once `rocfft_aot_helper.exe` can access hiprtc0605.dll
     #   "The code execution cannot proceed because hiprtc0605.dll was not found."
@@ -343,7 +385,7 @@ if(THEROCK_ENABLE_FFT)
       test
     SUBPROJECT_DEPS ${_fft_subproject_names}
   )
-endif(THEROCK_ENABLE_FFT)
+endif(_fft_enabled)
 
 if(THEROCK_ENABLE_BLAS)
   add_subdirectory(support)
@@ -355,6 +397,26 @@ if(THEROCK_ENABLE_ROCWMMA)
   set(_rocwmma_build_tests ${THEROCK_BUILD_TESTING})
   set(_rocwmma_enable_benchmarks ${THEROCK_ROCWMMA_ENABLE_BENCHMARKS})
   set(_rocwmma_artifact_components dbg dev lib test)
+
+  # ADDSPV: rocWMMA validates/benchmarks against rocBLAS (RUNTIME_DEPS rocBLAS +
+  # ROCWMMA_VALIDATE_WITH_ROCBLAS). In a shard where rocBLAS is excluded (e.g.
+  # amdgcnspirv) that target does not exist, so referencing it fails configure
+  # with "non-existent target rocBLAS". Make the rocBLAS dependency conditional
+  # on rocBLAS surviving the per-shard filter; the host/API rocWMMA lib itself
+  # still builds. Non-spirv shards keep validation ON.
+  set(_rocwmma_rocblas_deps rocBLAS)
+  set(_rocwmma_validate_with_rocblas ON)
+  if(THEROCK_AMDGPU_TARGETS AND NOT "${THEROCK_AMDGPU_TARGETS}" MATCHES "-NOTFOUND$")
+    therock_filter_amdgpu_targets(_rocwmma_rocblas_targets rocBLAS ${THEROCK_AMDGPU_TARGETS})
+    if(NOT _rocwmma_rocblas_targets)
+      message(STATUS
+        "rocWMMA: rocBLAS is excluded for this shard "
+        "(THEROCK_AMDGPU_TARGETS='${THEROCK_AMDGPU_TARGETS}'); dropping the "
+        "rocBLAS dependency and disabling rocBLAS validation.")
+      set(_rocwmma_rocblas_deps)
+      set(_rocwmma_validate_with_rocblas OFF)
+    endif()
+  endif()
 
   # rocWMMA intentionally supports only targets with MFMA/WMMA instructions.
   # Use the same target filtering metadata as CK to recognize all-filtered
@@ -397,7 +459,7 @@ if(THEROCK_ENABLE_ROCWMMA)
       -DROCM_DIR=
       "-DROCWMMA_BUILD_SAMPLES=$<BOOL:${_rocwmma_build_samples}>"
       "-DROCWMMA_BUILD_TESTS=$<BOOL:${_rocwmma_build_tests}>"
-      "-DROCWMMA_VALIDATE_WITH_ROCBLAS=ON"
+      "-DROCWMMA_VALIDATE_WITH_ROCBLAS=$<BOOL:${_rocwmma_validate_with_rocblas}>"
       "-DROCWMMA_BENCHMARK_WITH_ROCBLAS=$<BOOL:${_rocwmma_enable_benchmarks}>"
       "-DROCWMMA_BUILD_BENCHMARK_TESTS=$<BOOL:${_rocwmma_enable_benchmarks}>"
       -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON # Needed for Ninja build
@@ -411,7 +473,7 @@ if(THEROCK_ENABLE_ROCWMMA)
       therock-googletest
     RUNTIME_DEPS
       hip-clr
-      rocBLAS
+      ${_rocwmma_rocblas_deps}
       ${_rocwmma_optional_deps}
   )
   therock_cmake_subproject_glob_c_sources(rocWMMA
@@ -430,7 +492,24 @@ if(THEROCK_ENABLE_ROCWMMA)
   )
 endif(THEROCK_ENABLE_ROCWMMA)
 
-if(THEROCK_ENABLE_ROCALUTION)
+# ADDSPV: rocALUTION functionally requires rocBLAS + rocSPARSE (RUNTIME_DEPS and
+# link-time). Both are excluded in the amdgcnspirv shard, so the subproject
+# can't build there and referencing them fails configure with "non-existent
+# target rocBLAS/rocSPARSE". rocALUTION is a leaf lib (nothing in-tree depends
+# on it), so gate the whole block per-shard on rocBLAS availability. Non-spirv
+# shards (gfx90a, etc.) build it as before.
+set(_rocalution_enabled ${THEROCK_ENABLE_ROCALUTION})
+if(_rocalution_enabled AND THEROCK_AMDGPU_TARGETS AND NOT "${THEROCK_AMDGPU_TARGETS}" MATCHES "-NOTFOUND$")
+  therock_filter_amdgpu_targets(_rocalution_rocblas_targets rocBLAS ${THEROCK_AMDGPU_TARGETS})
+  if(NOT _rocalution_rocblas_targets)
+    message(STATUS
+      "rocALUTION: rocBLAS/rocSPARSE are excluded for this shard "
+      "(THEROCK_AMDGPU_TARGETS='${THEROCK_AMDGPU_TARGETS}'); skipping rocALUTION.")
+    set(_rocalution_enabled OFF)
+  endif()
+endif()
+
+if(_rocalution_enabled)
   ##############################################################################
   # rocALUTION
   ##############################################################################
@@ -480,7 +559,7 @@ if(THEROCK_ENABLE_ROCALUTION)
     SUBPROJECT_DEPS
       rocALUTION
   )
-endif(THEROCK_ENABLE_ROCALUTION)
+endif(_rocalution_enabled)
 
 if(THEROCK_ENABLE_LIBHIPCXX)
   ##############################################################################

--- a/ml-libs/CMakeLists.txt
+++ b/ml-libs/CMakeLists.txt
@@ -8,7 +8,30 @@ if(THEROCK_FLAG_INCLUDE_PROFILER)
   list(APPEND optional_profiler_deps roctracer rocprofiler-sdk)
 endif()
 
-if(THEROCK_ENABLE_MIOPEN)
+# ADDSPV: MIOpen / miopenprovider / hipblasltprovider (and hipDNN_samples via
+# miopenprovider) declare rocBLAS / hipBLAS / hipBLASLt / MIOpen as deps. In the
+# amdgcnspirv shard those BLAS libs are gated out (math-libs/BLAS/CMakeLists.txt)
+# and MIOpen itself is excluded, so CMake configure fails with
+# "get_target_property() called with non-existent target 'rocBLAS'/'hipBLAS'/
+# 'hipBLASLt'". EXCLUDE_TARGET_PROJECTS only strips device archs; it does not
+# drop the subproject declaration or its deps. Gate the BLAS/MIOpen-dependent
+# blocks per-shard on the same rocBLAS target filter used in math-libs/BLAS:
+# if no gfx targets survive for rocBLAS, skip them for this shard. Non-spirv
+# shards (gfx90a, etc.) are unaffected. hipDNN / hipdnn_integration_tests /
+# hipkernelprovider have no BLAS deps and are left alone.
+set(_ml_blas_deps_available ON)
+if(THEROCK_AMDGPU_TARGETS AND NOT "${THEROCK_AMDGPU_TARGETS}" MATCHES "-NOTFOUND$")
+  therock_filter_amdgpu_targets(_ml_rocblas_targets rocBLAS ${THEROCK_AMDGPU_TARGETS})
+  if(NOT _ml_rocblas_targets)
+    message(STATUS
+      "ml-libs: rocBLAS/hipBLAS/hipBLASLt are excluded for this shard "
+      "(THEROCK_AMDGPU_TARGETS='${THEROCK_AMDGPU_TARGETS}'); skipping MIOpen, "
+      "miopenprovider, hipblasltprovider and hipDNN samples for this shard.")
+    set(_ml_blas_deps_available OFF)
+  endif()
+endif()
+
+if(THEROCK_ENABLE_MIOPEN AND _ml_blas_deps_available)
   # MIOpen's CK use is gated on both the per-arch CK availability
   # (math-libs/CMakeLists.txt) and the user-facing
   # THEROCK_MIOPEN_USE_COMPOSABLE_KERNEL opt-out, which lets
@@ -194,7 +217,7 @@ if(THEROCK_ENABLE_HIPDNN_INTEGRATION_TESTS)
 
 endif(THEROCK_ENABLE_HIPDNN_INTEGRATION_TESTS)
 
-if(THEROCK_ENABLE_MIOPENPROVIDER)
+if(THEROCK_ENABLE_MIOPENPROVIDER AND _ml_blas_deps_available)
   ##############################################################################
   # hipDNN MIOpen provider
   ##############################################################################
@@ -241,7 +264,7 @@ if(THEROCK_ENABLE_MIOPENPROVIDER)
   )
 endif(THEROCK_ENABLE_MIOPENPROVIDER)
 
-if(THEROCK_ENABLE_HIPBLASLTPROVIDER)
+if(THEROCK_ENABLE_HIPBLASLTPROVIDER AND _ml_blas_deps_available)
   ##############################################################################
   # hipDNN hipBLASLt provider
   ##############################################################################
@@ -337,7 +360,8 @@ if(THEROCK_ENABLE_HIPKERNELPROVIDER)
   )
 endif(THEROCK_ENABLE_HIPKERNELPROVIDER)
 
-if(THEROCK_ENABLE_HIPDNN_SAMPLES)
+if(THEROCK_ENABLE_HIPDNN_SAMPLES AND _ml_blas_deps_available)
+  # hipDNN_samples RUNTIME_DEPS miopenprovider, which is gated above; skip too.
   ##############################################################################
   # hipDNN samples
   ##############################################################################

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -401,7 +401,9 @@ if(THEROCK_ENABLE_ROCPROFSYS)
     if (THEROCK_TEST_AMDGPU_TARGETS STREQUAL "THEROCK_TEST_AMDGPU_TARGETS-NOTFOUND")
       set(_ROCPROFSYS_GFX_TARGETS_ESCAPED "")
     else()
-      string(REPLACE ";" "\\;" _ROCPROFSYS_GFX_TARGETS_ESCAPED "${THEROCK_TEST_AMDGPU_TARGETS}")
+      therock_filter_amdgpu_targets(_ROCPROFSYS_GFX_TARGETS
+        rocprofiler-systems-examples ${THEROCK_TEST_AMDGPU_TARGETS})
+      string(REPLACE ";" "\\;" _ROCPROFSYS_GFX_TARGETS_ESCAPED "${_ROCPROFSYS_GFX_TARGETS}")
     endif()
 
     therock_cmake_subproject_declare(rocprofiler-systems-examples


### PR DESCRIPTION
> **Stacked PR (2/3).** Base: `users/idubinov/spirv-c1-declare-target` (#7836).
> Review/merge #7836 first. GitHub shows only this PR's own diff.

## Motivation

`EXCLUDE_TARGET_PROJECTS` (from #7836) only strips device archs from a
subproject — it does **not** stop the subproject, its clients, or its tests from
being declared and built. On a shard whose only target is `amdgcnspirv`, several
excluded subprojects therefore still try to configure/link and fail.

## Change

Gate those blocks per-shard using the existing `therock_filter_amdgpu_targets()`
metadata: if no gfx targets survive filtering for a subproject on this shard,
skip it (and its dependents) for this shard only. **Non-SPIR-V shards are
unaffected** — every filter is non-empty there, so nothing changes. Each gate
mirrors the existing `composable_kernel` / `rocWMMA` pattern.

| File | Gated |
| --- | --- |
| `math-libs/BLAS/CMakeLists.txt` | rocBLAS chain (hipBLASLt, roc/hipSPARSE, hipSPARSELt, roc/hipSOLVER, hipBLAS) — rocBLAS configure hard-fails (Tensile has no amdgcnspirv) |
| `math-libs/CMakeLists.txt` | rocFFT/hipFFT block; prim-lib (rocPRIM/hipCUB/rocThrust) tests+benchmarks (libs build, client test device code crashes the SPIR-V backend) |
| `ml-libs/CMakeLists.txt` | MIOpen / miopenprovider / hipblasltprovider blocks depending on the gated-out BLAS libs |
| `examples/CMakeLists.txt` | recompute cpp-sdk-user smoke-test feature flags per-shard so it doesn't `find_package()` a gated-out library |
| `cmake/therock_artifacts.cmake` | disable kpack split when every AMDGPU target is excluded for all of an artifact's subprojects (no arch device code to peel out) |
| `profiler/CMakeLists.txt` | filter the rocprofiler-systems-examples offload targets |

## Scope

Build-gating only; no CI wiring yet (that's 3/3). Non-SPIR-V shards: no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
