### PR TITLE
ci(spirv): build and GPU-test the amdgcnspirv target in presubmit

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -306,6 +306,38 @@ amdgpu_family_info_matrix_presubmit = {
             "nightly_check_only_for_family": True,
         },
     },
+    # amdgcnspirv: architecture-independent portable SPIR-V target (family
+    # "gpugeneric"/target "amdgcnspirv" in cmake/therock_amdgpu_targets.cmake).
+    # amdgcnspirv is a portable SPIR-V IR, not a physical ISA: its device code is
+    # JIT-translated to the runner's real GPU arch (comgr/SPIR-V translator) at
+    # load time. So we test it on a physical GPU runner (gfx942), where the
+    # SPIR-V kernels are lowered and executed on real hardware. In presubmit so
+    # every PR exercises the amdgcnspirv build+test alongside the physical targets.
+    "amdgcnspirv": {
+        "linux": {
+            # Physical GPU runner that JIT-executes the SPIR-V kernels (same pool
+            # as gfx94x). Locally under `act`, run-act.sh maps this label to the
+            # local gfx90a image so SPIR-V is JIT'd to gfx90a instead.
+            "test-runs-on": "linux-gfx942-1gpu-ccs-csp-ossci-rocm",
+            "test-runs-on-labels": [
+                {"label": "linux-gfx942-1gpu-ccs-ossci-rocm", "count": 5},
+                {"label": "linux-gfx942-1gpu-ccs-csp-ossci-rocm", "count": 28},
+            ],
+            # Most device-code components are excluded for amdgcnspirv (see
+            # EXCLUDE_TARGET_PROJECTS) or have their tests gated off (prim-libs).
+            # Restrict the SPIR-V test job to what actually has runnable SPIR-V
+            # device code: rocRAND/hipRAND (sanity always runs regardless).
+            "test_labels_for_family": ["test:rocrand", "test:hiprand"],
+            "family": "amdgcnspirv",
+            "fetch-gfx-targets": ["amdgcnspirv"],
+            "build_variants": ["release"],
+            # Build-only for packaging: validated + GPU-tested here, but never
+            # shipped as a package/wheel target (no physical SPIR-V GPU). Keeps it
+            # out of fetch_package_targets output and workflow amdgpu_family choice
+            # lists (see fetch_package_targets.determine_package_targets).
+            "exclude-from-packaging": True,
+        },
+    },
 }
 
 

--- a/build_tools/github_actions/fetch_package_targets.py
+++ b/build_tools/github_actions/fetch_package_targets.py
@@ -93,6 +93,14 @@ def determine_package_targets(args):
             # Some AMDGPU families are only supported on certain platforms.
             continue
 
+        if platform_for_key.get("exclude-from-packaging"):
+            # Build-only targets (e.g. amdgcnspirv, a portable SPIR-V target with
+            # no physical GPU) are validated by the build matrix but are not
+            # shipped as package/wheel targets, so they must not appear in
+            # produced package targets (nor in workflow amdgpu_family choice
+            # lists). Skip them here.
+            continue
+
         family = platform_for_key.get("family")
         test_machine = platform_for_key.get("test-runs-on")
 

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -524,7 +524,11 @@ test_matrix = {
     "rocrand": {
         "job_name": "rocrand",
         "fetch_artifact_args": "--rand --tests",
-        "timeout_minutes": 15,
+        # amdgcnspirv runs these via SPIR-V->ISA JIT at first kernel launch, which
+        # is much slower than a native code object (seconds per distinct kernel).
+        # The physical-target runs finish in a couple of minutes, but the JIT
+        # overhead pushes the SPIR-V run past the old 15 min cap, so raise it.
+        "timeout_minutes": 120,
         "test_script": f"python {_get_script_path('test_runner.py')}",
         "platform": ["linux", "windows"],
         "total_shards_dict": {
@@ -535,7 +539,8 @@ test_matrix = {
     "hiprand": {
         "job_name": "hiprand",
         "fetch_artifact_args": "--rand --tests",
-        "timeout_minutes": 5,
+        # Raised to absorb amdgcnspirv SPIR-V->ISA JIT overhead (see rocrand).
+        "timeout_minutes": 60,
         "test_script": f"python {_get_script_path('test_runner.py')}",
         "platform": ["linux", "windows"],
         "total_shards_dict": {

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -1201,7 +1201,7 @@ class TestExpandBuildConfigs(unittest.TestCase):
             "test-runs-on",
             "sanity_check_only_for_family",
         }
-        optional_keys = {"test-runs-on-labels"}
+        optional_keys = {"test-runs-on-labels", "test_labels_for_family"}
         for config in [result.linux, result.windows]:
             self.assertIsNotNone(config)
             per_family = config.per_family_info

--- a/cmake/therock_amdgpu_targets.cmake
+++ b/cmake/therock_amdgpu_targets.cmake
@@ -272,7 +272,6 @@ therock_add_amdgpu_target(amdgcnspirv "AMDGPU portable SPIR-V" FAMILY gpugeneric
     hip-tests #?
     hipDNN_samples #<
     hipFFT #*
-    hipRAND #*
     hipSOLVER #<
     hipSPARSE #<
     hipSPARSELt #<
@@ -323,6 +322,10 @@ therock_add_amdgpu_target(amdgcnspirv "AMDGPU portable SPIR-V" FAMILY gpugeneric
     # rocPRIM #< ADDSPV: un-excluded; builds clean for amdgcnspirv (verified local + CI)
     # rocPRIM_tests #< ADDSPV: un-excluded; compiles for amdgcnspirv (verified local)
     # rocRAND #* ADDSPV: un-excluded; builds clean for amdgcnspirv (verified local + CI)
+    # hipRAND #* ADDSPV: un-excluded; thin wrapper over rocRAND (which is
+    #   un-excluded). Was excluded only by inertia in the initial per-arch
+    #   sweep, not for a proven reason. Needed so test_hiprand_kernel has
+    #   amdgcnspirv device code (else kpack error 5 / no kernel at runtime).
     # hipfile #!
     # hipblasltprovider #<
     # ROCR-Runtime #!


### PR DESCRIPTION
> **Stacked PR (3/3).** Base: `users/idubinov/spirv-c2-pershard-gates` (#7837).
> Review/merge #7836 and #7837 first.

## Motivation

With the target declared (#7836) and not-yet-SPIR-V subprojects gated (#7837),
wire `amdgcnspirv` into CI so every PR builds it and runs its SPIR-V device code
on a physical GPU (portable SPIR-V is JIT-lowered to the runner's real ISA at
load time).

## Change

- **`amdgpu_family_matrix.py`**: add the `amdgcnspirv` family — built in
  presubmit, tested on a physical gfx942 runner pool. Restrict its test job to
  the subprojects that actually have runnable SPIR-V device code
  (rocRAND/hipRAND; sanity always runs) via a new `test_labels_for_family`.
  Mark `exclude-from-packaging`: validated + GPU-tested, but never shipped as a
  package/wheel (no physical SPIR-V GPU).
- **`fetch_package_targets.py`**: skip `exclude-from-packaging` targets so
  amdgcnspirv doesn't appear in package targets / amdgpu_family choice lists.
- **`fetch_test_configurations.py`**: raise rocRAND (15→120 min) and hipRAND
  (5→60 min) test timeouts — on amdgcnspirv these run via SPIR-V→ISA JIT at
  first kernel launch (seconds per distinct kernel), which physical-target runs
  don't incur.
- **`tests/configure_multi_arch_ci_test.py`**: allow the new optional
  `test_labels_for_family` key.
- **`cmake/therock_amdgpu_targets.cmake`**: un-exclude hipRAND for amdgcnspirv —
  a thin wrapper over rocRAND (already enabled), its only device-code test
  (`test_hiprand_kernel`) lowers to SPIR-V cleanly. Without this the test has no
  amdgcnspirv device code and fails at runtime with kpack error 5.

## Testing

Verified end-to-end on real gfx942: amdgcnspirv rocRAND (22 min) + hipRAND
(7 min) PASS via SPIR-V JIT; native gfx94X rocRAND/hipRAND/sanity unaffected;
ROCm wheel tests py3.11/3.12 pass. No regressions attributable to this change.

> **Note:** touches `fetch_test_configurations.py`, which #7728 also edits (in
> non-overlapping sections). Whichever lands first, the other needs a trivial
> rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
