### PR TITLE
feat(ci): improving granular artifact re-use with `shared/` components

### DIFF
--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -74,7 +74,8 @@
 #       to this artifact. Used for granular CI artifact reuse: when only specific
 #       source paths change in an external repo (e.g., rocm-libraries), only affected
 #       artifacts rebuild while others reuse baseline. Path names are directory
-#       basenames within projects/ or shared/ subdirs. Defaults to [artifact_name]
+#       basenames within projects/ or shared/ subdirs. Multiple artifacts can share
+#       the same source_path (e.g., shared libraries). Defaults to [artifact_name]
 #       if omitted.
 #
 # ==============================================================================
@@ -542,7 +543,7 @@ feature_name = "CORE_RUNTIME"
 feature_group = "CORE"
 disable_platforms_if_flags_not_set = { windows = "HSA_WINDOWS_SHARED_RUNTIME" }
 test_artifacts = ["core-hiptests", "rocrtst"]  # When building ROCR, also build hip-tests and rocrtst
-source_paths = ["rocr-runtime", "rocminfo"]
+source_paths = ["rocr-runtime", "rocminfo", "amdgpu-windows-interop"]
 
 [artifacts.wsl-rocdxg]
 artifact_group = "wsl-rocdxg"
@@ -575,7 +576,7 @@ artifact_deps = ["core-runtime", "amd-llvm", "core-kpack"]
 feature_name = "HIP_RUNTIME"
 feature_group = "CORE"  # Part of core, enabled by default
 test_artifacts = ["core-hiptests"]  # When building HIP, also build hip-tests
-source_paths = ["clr", "hip"]
+source_paths = ["clr", "hip", "amdgpu-windows-interop"]
 
 [artifacts.core-ocl-icd]
 artifact_group = "opencl-runtime"
@@ -629,13 +630,13 @@ artifact_group = "math-libs"
 type = "target-specific"
 artifact_deps = ["core-runtime", "core-hip", "core-amdsmi", "host-blas", "rocprofiler-sdk", "spdlog"]
 split_databases = ["rocblas", "hipblaslt"]
-source_paths = ["rocblas", "hipblas", "hipblas-common", "hipblaslt", "rocroller", "origami"]
+source_paths = ["rocblas", "hipblas", "hipblas-common", "hipblaslt", "rocroller", "origami", "tensile", "stinkytofu"]
 
 [artifacts.rand]
 artifact_group = "math-libs"
 type = "target-specific"
 artifact_deps = ["core-runtime", "core-hip"]
-source_paths = ["rocrand", "hiprand"]
+source_paths = ["rocrand", "hiprand", "primbench"]
 
 [artifacts.fft]
 artifact_group = "math-libs"
@@ -647,7 +648,7 @@ source_paths = ["rocfft", "hipfft"]
 artifact_group = "math-libs"
 type = "target-specific"
 artifact_deps = ["core-runtime", "core-hip", "rand"]
-source_paths = ["rocprim", "hipcub", "rocthrust"]
+source_paths = ["rocprim", "hipcub", "rocthrust", "primbench"]
 
 [artifacts.sparse]
 artifact_group = "math-libs"
@@ -897,6 +898,7 @@ type = "target-neutral"
 artifact_deps = []
 feature_group = "EMULATION"
 disable_platforms = ["windows"]
+source_paths = ["rocjitsu", "machine-readable-isa"]
 
 [artifacts.rocjitsu-hotswap]
 artifact_group = "rocjitsu"

--- a/build_tools/_therock_utils/build_topology.py
+++ b/build_tools/_therock_utils/build_topology.py
@@ -133,7 +133,7 @@ class Artifact:
     )  # Artifacts needed for testing this artifact (e.g., ["core-hiptests"])
     source_paths: List[str] = field(
         default_factory=list
-    )  # Monorepo source paths for granular CI reuse (e.g., ["rocblas", "hipblas"])
+    )  # Monorepo source paths for granular CI reuse (e.g., ["rocblas", "hipblas", "origami"])
 
 
 class BuildTopology:
@@ -1348,17 +1348,20 @@ class BuildTopology:
         """Get all build stage names."""
         return set(self.build_stages.keys())
 
-    def get_source_path_to_artifact_map(self) -> Dict[str, str]:
-        """Return {source_path_name: artifact_name} mapping."""
-        mapping: Dict[str, str] = {}
+    def get_source_path_to_artifacts_map(self) -> Dict[str, List[str]]:
+        """Return {source_path_name: [artifact_name, ...]} mapping.
+
+        Multiple artifacts can share the same source path (e.g., shared libraries).
+        """
+        mapping: Dict[str, List[str]] = {}
         for artifact_name, artifact in self.artifacts.items():
             for source_path in artifact.source_paths:
-                mapping[source_path] = artifact_name
+                mapping.setdefault(source_path, []).append(artifact_name)
         return mapping
 
-    def get_artifact_for_source_path(self, source_path_name: str) -> Optional[str]:
-        """Look up artifact name for a source path directory name."""
-        return self.get_source_path_to_artifact_map().get(source_path_name)
+    def get_artifacts_for_source_path(self, source_path_name: str) -> List[str]:
+        """Look up artifact names for a source path directory name."""
+        return self.get_source_path_to_artifacts_map().get(source_path_name, [])
 
     def get_source_sets_with_source_paths(self) -> List[str]:
         """Get source sets that support granular artifact analysis."""
@@ -1381,14 +1384,20 @@ class BuildTopology:
 
     @staticmethod
     def extract_source_path_from_path(path: str) -> Optional[str]:
-        """Extract source path name from projects/NAME/... or shared/NAME/... path."""
+        """Extract source path name from projects/NAME/..., shared/NAME/..., or dnn-providers/NAME/... path."""
         match = re.match(r"^(?:projects|shared|dnn-providers)/([^/]+)(?:/|$)", path)
         return match.group(1) if match else None
 
-    def get_artifact_for_path(self, path: str) -> Optional[str]:
-        """Map submodule path to artifact. Returns None if source path not found."""
+    def get_artifacts_for_path(self, path: str) -> List[str]:
+        """Map submodule path to artifacts. Returns empty list if not found.
+
+        Works for both projects/ and shared/ paths - looks up source_paths mapping.
+        Multiple artifacts can share the same source path.
+        """
         source_path = self.extract_source_path_from_path(path)
-        return self.get_artifact_for_source_path(source_path) if source_path else None
+        if source_path is None:
+            return []
+        return self.get_artifacts_for_source_path(source_path)
 
     @staticmethod
     def parse_changed_path(changed_path: str) -> Tuple[Optional[str], Optional[str]]:

--- a/build_tools/github_actions/stage_impact.py
+++ b/build_tools/github_actions/stage_impact.py
@@ -356,9 +356,12 @@ class StageImpactAnalyzer:
             if submodule is None or submodule not in granular_source_sets:
                 continue
 
-            artifact = self.topology.get_artifact_for_path(subpath)
-            if artifact is not None:
-                impacted.add(artifact)
+            # get_artifacts_for_path handles both project and shared paths:
+            # - For project paths, returns the single artifact that owns the path
+            # - For shared paths, returns all artifacts that declare this shared_dep
+            artifacts = self.topology.get_artifacts_for_path(subpath)
+            if artifacts:
+                impacted.update(artifacts)
             else:
                 # Path affects all artifacts in this source set
                 is_conservative = True

--- a/build_tools/github_actions/tests/stage_impact_test.py
+++ b/build_tools/github_actions/tests/stage_impact_test.py
@@ -673,5 +673,172 @@ class ArtifactLevelAnalysisTest(unittest.TestCase):
         self.assertFalse(result.artifact_level_analysis)
 
 
+class SharedSourcePathsAnalysisTest(unittest.TestCase):
+    """Test cases for shared/ paths in source_paths artifact-level analysis."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".toml", delete=False
+        ) as temp_file:
+            self.topology_path = temp_file.name
+
+    def tearDown(self):
+        """Clean up test fixtures."""
+        if os.path.exists(self.topology_path):
+            os.unlink(self.topology_path)
+
+    def write_topology(self, content: str) -> None:
+        """Write topology content to temp file."""
+        with open(self.topology_path, "w", encoding="utf-8") as f:
+            f.write(textwrap.dedent(content))
+
+    def write_shared_source_paths_topology(self) -> None:
+        """Write a topology with shared paths in source_paths."""
+        self.write_topology(
+            """
+            [source_sets.rocm-libraries]
+            description = "ROCm libraries"
+            submodules = ["rocm-libraries"]
+
+            [artifact_groups.math-libs]
+            description = "Math libs"
+            type = "per-arch"
+            source_sets = ["rocm-libraries"]
+
+            [build_stages.math-libs]
+            description = "Math libs stage"
+            artifact_groups = ["math-libs"]
+            type = "per-arch"
+
+            [artifacts.blas]
+            artifact_group = "math-libs"
+            type = "target-specific"
+            source_paths = ["rocblas", "hipblas", "origami", "blas-common"]
+
+            [artifacts.fft]
+            artifact_group = "math-libs"
+            type = "target-specific"
+            source_paths = ["rocfft", "hipfft"]
+
+            [artifacts.prim]
+            artifact_group = "math-libs"
+            type = "target-specific"
+            source_paths = ["rocprim", "hipcub", "rocthrust"]
+
+            [artifacts.rand]
+            artifact_group = "math-libs"
+            type = "target-specific"
+            source_paths = ["rocrand", "hiprand"]
+            """
+        )
+
+    def test_shared_path_maps_to_artifact(self):
+        """A shared/ change with source_paths mapping should identify the artifact."""
+        self.write_shared_source_paths_topology()
+
+        topology = BuildTopology(self.topology_path)
+        result = analyze_stage_impact(
+            ["rocm-libraries/shared/origami/foo.hpp"],
+            topology=topology,
+        )
+
+        self.assertFalse(result.full_rebuild_required)
+        self.assertTrue(result.artifact_level_analysis)
+        self.assertIn("blas", result.impacted_artifacts)
+        # Other artifacts should be reusable
+        self.assertIn("fft", result.reusable_artifacts)
+        self.assertIn("prim", result.reusable_artifacts)
+        self.assertIn("rand", result.reusable_artifacts)
+
+    def test_unmapped_shared_disables_artifact_analysis(self):
+        """A shared/ change without source_paths mapping should be conservative."""
+        self.write_shared_source_paths_topology()
+
+        topology = BuildTopology(self.topology_path)
+        result = analyze_stage_impact(
+            ["rocm-libraries/shared/unknown-shared/foo.hpp"],
+            topology=topology,
+        )
+
+        self.assertFalse(result.full_rebuild_required)
+        # Artifact-level analysis should NOT be enabled due to conservative fallback
+        self.assertFalse(result.artifact_level_analysis)
+        self.assertEqual(result.impacted_artifacts, ())
+        self.assertEqual(result.reusable_artifacts, ())
+
+    def test_shared_source_path_with_multiple_artifacts(self):
+        """A source_path used by multiple artifacts should impact all of them."""
+        self.write_topology(
+            """
+            [source_sets.rocm-libraries]
+            description = "ROCm libraries"
+            submodules = ["rocm-libraries"]
+
+            [artifact_groups.math-libs]
+            description = "Math libs"
+            type = "per-arch"
+            source_sets = ["rocm-libraries"]
+
+            [build_stages.math-libs]
+            description = "Math libs stage"
+            artifact_groups = ["math-libs"]
+            type = "per-arch"
+
+            [artifacts.blas]
+            artifact_group = "math-libs"
+            type = "target-specific"
+            source_paths = ["rocblas", "common-utils"]
+
+            [artifacts.fft]
+            artifact_group = "math-libs"
+            type = "target-specific"
+            source_paths = ["rocfft", "common-utils"]
+
+            [artifacts.rand]
+            artifact_group = "math-libs"
+            type = "target-specific"
+            source_paths = ["rocrand"]
+            """
+        )
+
+        topology = BuildTopology(self.topology_path)
+        result = analyze_stage_impact(
+            ["rocm-libraries/shared/common-utils/helper.hpp"],
+            topology=topology,
+        )
+
+        self.assertFalse(result.full_rebuild_required)
+        self.assertTrue(result.artifact_level_analysis)
+        # Both blas and fft should be impacted
+        self.assertIn("blas", result.impacted_artifacts)
+        self.assertIn("fft", result.impacted_artifacts)
+        # Only rand should be reusable
+        self.assertIn("rand", result.reusable_artifacts)
+        self.assertEqual(len(result.reusable_artifacts), 1)
+
+    def test_mixed_project_and_shared_changes(self):
+        """Mixed project and shared changes should union impacted artifacts."""
+        self.write_shared_source_paths_topology()
+
+        topology = BuildTopology(self.topology_path)
+        result = analyze_stage_impact(
+            [
+                "rocm-libraries/projects/rocfft/src/foo.cpp",
+                "rocm-libraries/shared/origami/bar.hpp",
+            ],
+            topology=topology,
+        )
+
+        self.assertFalse(result.full_rebuild_required)
+        self.assertTrue(result.artifact_level_analysis)
+        # fft from project path, blas from source_paths
+        self.assertIn("fft", result.impacted_artifacts)
+        self.assertIn("blas", result.impacted_artifacts)
+        # prim and rand should be reusable
+        self.assertIn("prim", result.reusable_artifacts)
+        self.assertIn("rand", result.reusable_artifacts)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/build_tools/github_actions/tests/stage_reuse_decision_test.py
+++ b/build_tools/github_actions/tests/stage_reuse_decision_test.py
@@ -77,8 +77,8 @@ class FakeTopology:
     def parse_changed_path(self, path):
         return (None, None)
 
-    def get_artifact_for_path(self, path):
-        return None
+    def get_artifacts_for_path(self, path):
+        return []
 
 
 def _baseline(run_id, matched_filenames):

--- a/build_tools/tests/build_topology_test.py
+++ b/build_tools/tests/build_topology_test.py
@@ -1155,28 +1155,40 @@ class ExtractSourcePathFromPathTest(unittest.TestCase):
         self.assertIsNone(BuildTopology.extract_source_path_from_path("CMakeLists.txt"))
 
 
-class GetArtifactForSourcePathTest(unittest.TestCase):
+class GetArtifactsForSourcePathTest(unittest.TestCase):
     """Tests for artifact lookup by source_path."""
 
     def setUp(self):
         self.topology = get_topology()
 
     def test_rocblas_maps_to_blas(self):
-        self.assertEqual(self.topology.get_artifact_for_source_path("rocblas"), "blas")
-
-    def test_hipblas_maps_to_blas(self):
-        self.assertEqual(self.topology.get_artifact_for_source_path("hipblas"), "blas")
-
-    def test_rocrand_maps_to_rand(self):
-        self.assertEqual(self.topology.get_artifact_for_source_path("rocrand"), "rand")
-
-    def test_unknown_source_path_returns_none(self):
-        self.assertIsNone(
-            self.topology.get_artifact_for_source_path("unknown-source-path")
+        self.assertEqual(
+            self.topology.get_artifacts_for_source_path("rocblas"), ["blas"]
         )
 
+    def test_hipblas_maps_to_blas(self):
+        self.assertEqual(
+            self.topology.get_artifacts_for_source_path("hipblas"), ["blas"]
+        )
 
-class GetArtifactForPathTest(unittest.TestCase):
+    def test_rocrand_maps_to_rand(self):
+        self.assertEqual(
+            self.topology.get_artifacts_for_source_path("rocrand"), ["rand"]
+        )
+
+    def test_unknown_source_path_returns_empty(self):
+        self.assertEqual(
+            self.topology.get_artifacts_for_source_path("unknown-source-path"), []
+        )
+
+    def test_shared_source_path_multiple_artifacts(self):
+        # primbench is used by both rand and prim
+        artifacts = self.topology.get_artifacts_for_source_path("primbench")
+        self.assertIn("rand", artifacts)
+        self.assertIn("prim", artifacts)
+
+
+class GetArtifactsForPathTest(unittest.TestCase):
     """Tests for artifact lookup by full file path."""
 
     def setUp(self):
@@ -1184,24 +1196,31 @@ class GetArtifactForPathTest(unittest.TestCase):
 
     def test_rocblas_maps_to_blas(self):
         self.assertEqual(
-            self.topology.get_artifact_for_path("projects/rocblas/src/foo.cpp"),
-            "blas",
+            self.topology.get_artifacts_for_path("projects/rocblas/src/foo.cpp"),
+            ["blas"],
         )
 
     def test_rocfft_maps_to_fft(self):
         self.assertEqual(
-            self.topology.get_artifact_for_path("projects/rocfft/src/kernel.cpp"),
-            "fft",
+            self.topology.get_artifacts_for_path("projects/rocfft/src/kernel.cpp"),
+            ["fft"],
         )
 
     def test_shared_rocroller_maps_to_blas(self):
         self.assertEqual(
-            self.topology.get_artifact_for_path("shared/rocroller/src/foo.cpp"),
-            "blas",
+            self.topology.get_artifacts_for_path("shared/rocroller/src/foo.cpp"),
+            ["blas"],
         )
 
-    def test_unknown_path_returns_none(self):
-        self.assertIsNone(self.topology.get_artifact_for_path("cmake/FindHIP.cmake"))
+    def test_shared_primbench_maps_to_multiple(self):
+        artifacts = self.topology.get_artifacts_for_path("shared/primbench/bench.hpp")
+        self.assertIn("rand", artifacts)
+        self.assertIn("prim", artifacts)
+
+    def test_unknown_path_returns_empty(self):
+        self.assertEqual(
+            self.topology.get_artifacts_for_path("cmake/FindHIP.cmake"), []
+        )
 
 
 class ParseChangedPathTest(unittest.TestCase):


### PR DESCRIPTION
from PR comment https://github.com/ROCm/TheRock/pull/7243#discussion_r3907211935, we want to expand artifact re-use to shared components

In this PR, we are adding shared components to also be covered. I ran a test here: https://github.com/ROCm/rocm-libraries/pull/11616/changes with results: https://github.com/ROCm/rocm-libraries/actions/runs/33654071468/job/100339528508?pr=11616#step:14:9 working properly for our test of "tensile" files change