### PR TITLE
Add Joseph to CODEOWNERS for CI configuration code

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,8 +28,8 @@
 
 # A few central CI system components that must align with
 # https://github.com/ROCm/TheRock/blob/main/docs/development/ci_overview.md
-/.github/workflows/setup_multi_arch.yml                   @ScottTodd
-/build_tools/github_actions/configure_multi_arch_ci.py    @ScottTodd
+/.github/workflows/setup_multi_arch.yml                   @ScottTodd @jayhawk-commits
+/build_tools/github_actions/configure_multi_arch_ci.py    @ScottTodd @jayhawk-commits
 
 # Debug tools configs and ROCgdb cmake wrapper.
 /debug-tools            @ROCm/TheRock-infra-write @ROCm/ROCm-DevTools-Debugger


### PR DESCRIPTION
## Motivation

We should have at least 2 CODEOWNERS for each area so there is enough coverage across working hours, time off, etc.

I want to keep this covered by dedicated reviewers while these CI files are under active development for features such as:
* https://github.com/ROCm/TheRock/issues/3343
* https://github.com/ROCm/TheRock/issues/6624
* https://github.com/ROCm/TheRock/issues/6572
* Feature flags

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
