### PR TITLE
Move unrelated utils out of github_actions_api.py

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,9 +8,6 @@
 # New patches are strongly discouraged. See patches/README.md.
 /patches/               @ScottTodd @marbre @skganesan008
 
-# This file accumulated unrelated code, tighten reviews until cleaned up.
-/build_tools/github_actions/github_actions_api.py       @ScottTodd
-
 # Python packages. Changes to these paths must align with
 # https://github.com/ROCm/TheRock/blob/main/docs/packaging/python_packaging.md
 /build_tools/packaging/python           @ScottTodd @marbre

--- a/build_tools/github_actions/github_actions_api.py
+++ b/build_tools/github_actions/github_actions_api.py
@@ -15,10 +15,8 @@ import base64
 import binascii
 from enum import Enum, auto
 import json
-import logging
 import os
 from pathlib import Path
-import re
 import shutil
 import subprocess
 import sys
@@ -1005,49 +1003,3 @@ def str2bool(value: str | None) -> bool:
     ):
         return False
     raise ValueError(f"Invalid string value for boolean conversion: {value}")
-
-
-# TODO: Move get_visible_gpu_count and get_first_gpu_architecture to a
-# GPU/rocminfo utils module. They are not specific to GitHub Actions.
-# TODO(#3489): Refactor get_visible_gpu_count and get_first_gpu_architecture to share a
-# common helper that runs rocminfo and returns matching lines; both functions duplicate the first ~12 lines.
-def get_visible_gpu_count(env=None, therock_bin_dir: str | None = None) -> int:
-    rocminfo = Path(therock_bin_dir) / "rocminfo"
-    rocminfo_cmd = str(rocminfo) if rocminfo.exists() else "rocminfo"
-
-    result = subprocess.run(
-        [rocminfo_cmd],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        env=env,
-        check=False,
-    )
-
-    pattern = re.compile(r"^\s*Name:\s+gfx[0-9a-z]+$", re.IGNORECASE)
-
-    return sum(1 for line in result.stdout.splitlines() if pattern.match(line.strip()))
-
-
-def get_first_gpu_architecture(env=None, therock_bin_dir: str | None = None) -> str:
-    """Return the first visible GPU architecture (e.g. 'gfx942') from rocminfo."""
-    rocminfo = Path(therock_bin_dir) / "rocminfo"
-    rocminfo_cmd = str(rocminfo) if rocminfo.exists() else "rocminfo"
-
-    result = subprocess.run(
-        [rocminfo_cmd],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        env=env,
-        check=True,
-    )
-
-    pattern = re.compile(r"^\s*Name:\s+(gfx[0-9a-z]+)$", re.IGNORECASE)
-    for line in result.stdout.splitlines():
-        m = pattern.match(line.strip())
-        if m:
-            gpu_arch = m.group(1).lower()
-            logging.info(f"Detected GPU architecture: {gpu_arch}")
-            return gpu_arch
-    raise RuntimeError("No GPU architecture found in rocminfo output")

--- a/build_tools/github_actions/test_executable_scripts/test_rccl.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rccl.py
@@ -3,14 +3,11 @@
 
 import logging
 import os
+import re
 import shlex
 import subprocess
-import sys
 from pathlib import Path
 import pytest
-
-sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
-from github_actions_api import get_visible_gpu_count
 
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -18,12 +15,30 @@ THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 logging.basicConfig(level=logging.INFO)
 
 
+def _get_visible_gpu_count(env=None, therock_bin_dir: str | None = None) -> int:
+    rocminfo = Path(therock_bin_dir) / "rocminfo"
+    rocminfo_cmd = str(rocminfo) if rocminfo.exists() else "rocminfo"
+
+    result = subprocess.run(
+        [rocminfo_cmd],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+    pattern = re.compile(r"^\s*Name:\s+gfx[0-9a-z]+$", re.IGNORECASE)
+
+    return sum(1 for line in result.stdout.splitlines() if pattern.match(line.strip()))
+
+
 class TestRCCL:
     def test_rccl_unittests(self):
         # Executing rccl gtest from rccl repo
         environ_vars = os.environ.copy()
         # Expect at least 2 GPUs for RCCL collectives
-        gpu_count = get_visible_gpu_count(
+        gpu_count = _get_visible_gpu_count(
             env=environ_vars, therock_bin_dir=THEROCK_BIN_DIR
         )
         logging.info(f"Visible GPU count: {gpu_count}")

--- a/tests/extended_tests/benchmark/scripts/test_rccl_benchmark.py
+++ b/tests/extended_tests/benchmark/scripts/test_rccl_benchmark.py
@@ -9,6 +9,7 @@ Runs RCCL collective communication benchmarks, collects results, and uploads to 
 
 import json
 import re
+import subprocess
 import sys
 from pathlib import Path
 from typing import Dict, List, Tuple, Any
@@ -17,8 +18,25 @@ from prettytable import PrettyTable
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))  # For extended_tests/utils
 sys.path.insert(0, str(Path(__file__).parent))  # For benchmark_base
 from benchmark_base import BenchmarkBase, run_benchmark_main
-from github_actions_api import get_visible_gpu_count
 from utils.logger import log
+
+
+def _get_visible_gpu_count(env=None, therock_bin_dir: str | None = None) -> int:
+    rocminfo = Path(therock_bin_dir) / "rocminfo"
+    rocminfo_cmd = str(rocminfo) if rocminfo.exists() else "rocminfo"
+
+    result = subprocess.run(
+        [rocminfo_cmd],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+    pattern = re.compile(r"^\s*Name:\s+gfx[0-9a-z]+$", re.IGNORECASE)
+
+    return sum(1 for line in result.stdout.splitlines() if pattern.match(line.strip()))
 
 
 class RCCLBenchmark(BenchmarkBase):
@@ -27,7 +45,7 @@ class RCCLBenchmark(BenchmarkBase):
     def __init__(self):
         super().__init__(benchmark_name="rccl", display_name="RCCL")
         self.log_file = self.script_dir / "rccl_bench.log"
-        self.ngpu = get_visible_gpu_count(therock_bin_dir=self.therock_bin_dir)
+        self.ngpu = _get_visible_gpu_count(therock_bin_dir=self.therock_bin_dir)
 
         # Validate OpenMPI is available (from base class)
         self._validate_openmpi()

--- a/tests/extended_tests/functional/README.md
+++ b/tests/extended_tests/functional/README.md
@@ -102,11 +102,6 @@ class YourTest(FunctionalBase):
         """Run functional tests and save results to JSON."""
         log.info(f"Running {self.display_name}")
 
-        # Optional: Get GPU architecture for GPU-specific behavior
-        from github_actions_api import get_first_gpu_architecture
-
-        gfx_id = get_first_gpu_architecture(therock_bin_dir=self.therock_bin_dir)
-
         all_results = []
         for test_case in self.test_cases:
             # Execute test, capture result

--- a/tests/extended_tests/functional/scripts/test_miopendriver_conv.py
+++ b/tests/extended_tests/functional/scripts/test_miopendriver_conv.py
@@ -9,7 +9,9 @@ correct functionality across different GPU architectures.
 """
 
 import json
+import re
 import shlex
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any, Dict, List
@@ -19,7 +21,30 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))  # For functional_base
 from functional_base import FunctionalBase, run_functional_main
 from utils.logger import log
 from utils.exceptions import TestExecutionError
-from github_actions_api import get_first_gpu_architecture
+
+
+def _get_first_gpu_architecture(env=None, therock_bin_dir: str | None = None) -> str:
+    """Return the first visible GPU architecture (e.g. 'gfx942') from rocminfo."""
+    rocminfo = Path(therock_bin_dir) / "rocminfo"
+    rocminfo_cmd = str(rocminfo) if rocminfo.exists() else "rocminfo"
+
+    result = subprocess.run(
+        [rocminfo_cmd],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+        check=True,
+    )
+
+    pattern = re.compile(r"^\s*Name:\s+(gfx[0-9a-z]+)$", re.IGNORECASE)
+    for line in result.stdout.splitlines():
+        m = pattern.match(line.strip())
+        if m:
+            gpu_arch = m.group(1).lower()
+            log.info(f"Detected GPU architecture: {gpu_arch}")
+            return gpu_arch
+    raise RuntimeError("No GPU architecture found in rocminfo output")
 
 
 class MIOpenDriverConvTest(FunctionalBase):
@@ -52,7 +77,7 @@ class MIOpenDriverConvTest(FunctionalBase):
         log.info(f"Running {self.display_name} Tests")
 
         # Detect GPU architecture
-        gfx_id = get_first_gpu_architecture(therock_bin_dir=self.therock_bin_dir)
+        gfx_id = _get_first_gpu_architecture(therock_bin_dir=self.therock_bin_dir)
 
         miopen_driver = Path(self.therock_bin_dir) / "MIOpenDriver"
         if not miopen_driver.exists():

--- a/tests/extended_tests/utils/extended_test_base.py
+++ b/tests/extended_tests/utils/extended_test_base.py
@@ -24,6 +24,10 @@ from .logger import log
 from .exceptions import TestExecutionError
 from .extended_test_client import ExtendedTestClient
 
+from github_actions_api import (
+    gha_append_step_summary,
+)
+
 
 class ExtendedTestBase:
     """Base class providing shared infrastructure for extended tests."""

--- a/tests/extended_tests/utils/extended_test_base.py
+++ b/tests/extended_tests/utils/extended_test_base.py
@@ -24,10 +24,6 @@ from .logger import log
 from .exceptions import TestExecutionError
 from .extended_test_client import ExtendedTestClient
 
-from github_actions_api import (
-    gha_append_step_summary,
-)
-
 
 class ExtendedTestBase:
     """Base class providing shared infrastructure for extended tests."""


### PR DESCRIPTION
## Motivation

This GPU management code has nothing to do with the github actions API and does not belong in `github_actions_api.py`. As each function has only one use they can be inlined into the files that need them.

* Fixes https://github.com/ROCm/TheRock/issues/3489

## Technical Details

The `test_rccl.py` script has been partly migrated to https://github.com/ROCm/rocm-systems/blob/develop/test/therock/test_rccl.py where it still attempts `from github_actions_api import get_visible_gpu_count`. That should be updated separately.

See also:
* https://github.com/ROCm/TheRock/pull/4045
   * This would require updating the code in rocm-systems first, and indicates why these cross-repository python script imports are difficult to support
* https://github.com/ROCm/TheRock/pull/4563

## Test Plan

* Test scripts are exercised by CI

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
