### PR TITLE
package the librocdxg.so in the py installer

### DIFF
--- a/build_tools/_therock_utils/py_packaging.py
+++ b/build_tools/_therock_utils/py_packaging.py
@@ -39,8 +39,8 @@ assert DIST_INFO_PATH.exists()
 
 ENABLED_VLOG_LEVEL: int = 5
 
-# Libraries that are dlopen'd by unversioned name at runtime
-# runtime wheel will include them and not just the devel
+# Libraries dlopen'd by unversioned name at runtime (ROCM-29954).
+# The unversioned namelink is included in the runtime wheel, not just devel.
 RUNTIME_DLOPEN_ALIASES: set[str] = {
     "librocdxg",
 }
@@ -364,11 +364,8 @@ class PopulatedDistPackage:
         needed by runtime packages. Specifically, this impacts shared library symlinks,
         which only populate the soname variant in the link farm.
 
-        Non-SONAME shared library names (e.g. the unversioned namelink
-        ``librocdxg.so`` or the full-version file ``librocdxg.so.1.1.0``) are
-        recorded as soname aliases and emitted as relative symlinks pointing at
-        the SONAME file so that runtime ``dlopen`` by any of the three names
-        succeeds.
+        Libraries listed in ``RUNTIME_DLOPEN_ALIASES`` also get their
+        unversioned namelink emitted (see ``_emit_soname_alias_symlinks``).
         """
         log(
             f"::: Populating runtime files {self.logical_name}[{self.target_family}]: "

--- a/build_tools/_therock_utils/py_packaging.py
+++ b/build_tools/_therock_utils/py_packaging.py
@@ -39,6 +39,12 @@ assert DIST_INFO_PATH.exists()
 
 ENABLED_VLOG_LEVEL: int = 5
 
+# Libraries that are dlopen'd by unversioned name at runtime
+# runtime wheel will include them and not just the devel
+RUNTIME_DLOPEN_ALIASES: set[str] = {
+    "librocdxg",
+}
+
 
 def log(*args, vlog: int = 0, **kwargs):
     if vlog > ENABLED_VLOG_LEVEL:
@@ -499,15 +505,15 @@ class PopulatedDistPackage:
         self._populate_file(relpath, dest_path, src_entry, resolve_src=True)
 
     def _emit_soname_alias_symlinks(self, package_dest_dir: Path):
-        """Create relative symlinks for soname aliases in the runtime tree.
-
-        After the main population pass, every non-SONAME shared library entry
-        (the unversioned namelink and the full-version real file) is recorded
-        in ``soname_aliases`` as ``{relpath: soname}``.  For each alias whose
-        SONAME target was materialized, emit a relative symlink so that
-        ``dlopen`` by any of the three conventional names succeeds at runtime.
-        """
+        """Emit unversioned namelinks for libraries in RUNTIME_DLOPEN_ALIASES."""
         for relpath, soname in self.files.soname_aliases.items():
+            filename = Path(relpath).name
+            basename = filename.split(".so")[0]
+            if basename not in RUNTIME_DLOPEN_ALIASES:
+                continue
+            suffix = filename[len(basename) :]
+            if suffix != ".so":
+                continue
             soname_relpath = str(Path(relpath).parent / soname)
             if not self.files.has(soname_relpath):
                 continue

--- a/build_tools/_therock_utils/py_packaging.py
+++ b/build_tools/_therock_utils/py_packaging.py
@@ -357,6 +357,12 @@ class PopulatedDistPackage:
         In this context, "runtime" means that we are only populating a subset of files
         needed by runtime packages. Specifically, this impacts shared library symlinks,
         which only populate the soname variant in the link farm.
+
+        Non-SONAME shared library names (e.g. the unversioned namelink
+        ``librocdxg.so`` or the full-version file ``librocdxg.so.1.1.0``) are
+        recorded as soname aliases and emitted as relative symlinks pointing at
+        the SONAME file so that runtime ``dlopen`` by any of the three names
+        succeeds.
         """
         log(
             f"::: Populating runtime files {self.logical_name}[{self.target_family}]: "
@@ -393,6 +399,8 @@ class PopulatedDistPackage:
                         continue
                 # Otherwise, just copy the file.
                 self._populate_file(relpath, dest_path, dir_entry, resolve_src=True)
+
+        self._emit_soname_alias_symlinks(package_dest_dir)
         self.params.populated_packages.append(self)
         return self
 
@@ -489,6 +497,27 @@ class PopulatedDistPackage:
             return
         # Case 4: Copy.
         self._populate_file(relpath, dest_path, src_entry, resolve_src=True)
+
+    def _emit_soname_alias_symlinks(self, package_dest_dir: Path):
+        """Create relative symlinks for soname aliases in the runtime tree.
+
+        After the main population pass, every non-SONAME shared library entry
+        (the unversioned namelink and the full-version real file) is recorded
+        in ``soname_aliases`` as ``{relpath: soname}``.  For each alias whose
+        SONAME target was materialized, emit a relative symlink so that
+        ``dlopen`` by any of the three conventional names succeeds at runtime.
+        """
+        for relpath, soname in self.files.soname_aliases.items():
+            soname_relpath = str(Path(relpath).parent / soname)
+            if not self.files.has(soname_relpath):
+                continue
+            dest_path = package_dest_dir / relpath
+            if dest_path.exists() or dest_path.is_symlink():
+                continue
+            dest_path.parent.mkdir(parents=True, exist_ok=True)
+            log(f"  SONAME_ALIAS: {relpath} -> {soname}", vlog=2)
+            dest_path.symlink_to(soname)
+            self.files.mark_populated(self, relpath, dest_path)
 
     def _populate_file(
         self,

--- a/build_tools/tests/py_packaging_test.py
+++ b/build_tools/tests/py_packaging_test.py
@@ -443,25 +443,25 @@ class MultiArchPackagingTest(TmpDirTestCase):
         self.assertFalse(core.files.has("lib/librocdxg.so.1.1.0"))
 
     def test_emit_soname_alias_skips_when_soname_not_materialized(self):
-        """Aliases whose SONAME target was not materialized are left alone."""
+        """Allowlisted alias is skipped when its SONAME target is absent."""
         artifact_dir = self.temp_dir / "artifacts"
         self._add_artifact(
-            artifact_dir, "orphan", "lib", "generic", {"lib/dummy.txt": "x"}
+            artifact_dir, "wsl-rocdxg", "lib", "generic", {"lib/dummy.txt": "x"}
         )
 
         params = self._make_params(artifact_dir)
         pkg = PopulatedDistPackage(params, logical_name="core")
         pkg.populate_runtime_files(
-            params.filter_artifacts(lambda an: an.name == "orphan")
+            params.filter_artifacts(lambda an: an.name == "wsl-rocdxg")
         )
 
-        # Alias recorded but SONAME file was never materialized.
-        pkg.files.soname_aliases["lib/liborphan.so"] = "liborphan.so.2"
+        # librocdxg is allowlisted but its SONAME file was never materialized.
+        pkg.files.soname_aliases["lib/librocdxg.so"] = "librocdxg.so.1"
 
         pkg._emit_soname_alias_symlinks(pkg.platform_dir)
 
-        self.assertFalse((pkg.platform_dir / "lib" / "liborphan.so").exists())
-        self.assertFalse(pkg.files.has("lib/liborphan.so"))
+        self.assertFalse((pkg.platform_dir / "lib" / "librocdxg.so").exists())
+        self.assertFalse(pkg.files.has("lib/librocdxg.so"))
 
     def test_emit_soname_alias_skips_non_allowlisted_libraries(self):
         """Only libraries in RUNTIME_DLOPEN_ALIASES get runtime aliases."""

--- a/build_tools/tests/py_packaging_test.py
+++ b/build_tools/tests/py_packaging_test.py
@@ -436,11 +436,11 @@ class MultiArchPackagingTest(TmpDirTestCase):
         self.assertEqual(os.readlink(namelink), "librocdxg.so.1")
         self.assertTrue(core.files.has("lib/librocdxg.so"))
 
-        # Full-version file should also be a symlink to the SONAME.
+        # Full-version file should NOT be emitted (nothing dlopen's it,
+        # and bdist_wheel would expand it into a multi-MB duplicate).
         fullver = core.platform_dir / "lib" / "librocdxg.so.1.1.0"
-        self.assertTrue(fullver.is_symlink())
-        self.assertEqual(os.readlink(fullver), "librocdxg.so.1")
-        self.assertTrue(core.files.has("lib/librocdxg.so.1.1.0"))
+        self.assertFalse(fullver.exists())
+        self.assertFalse(core.files.has("lib/librocdxg.so.1.1.0"))
 
     def test_emit_soname_alias_skips_when_soname_not_materialized(self):
         """Aliases whose SONAME target was not materialized are left alone."""
@@ -462,6 +462,31 @@ class MultiArchPackagingTest(TmpDirTestCase):
 
         self.assertFalse((pkg.platform_dir / "lib" / "liborphan.so").exists())
         self.assertFalse(pkg.files.has("lib/liborphan.so"))
+
+    def test_emit_soname_alias_skips_non_allowlisted_libraries(self):
+        """Only libraries in RUNTIME_DLOPEN_ALIASES get runtime aliases."""
+        artifact_dir = self.temp_dir / "artifacts"
+        self._add_artifact(
+            artifact_dir, "blas", "lib", "generic", {"lib/dummy.txt": "x"}
+        )
+
+        params = self._make_params(artifact_dir)
+        pkg = PopulatedDistPackage(params, logical_name="core")
+        pkg.populate_runtime_files(
+            params.filter_artifacts(lambda an: an.name == "blas")
+        )
+
+        soname_file = pkg.platform_dir / "lib" / "librocblas.so.5"
+        soname_file.parent.mkdir(parents=True, exist_ok=True)
+        soname_file.write_text("fake soname file")
+        pkg.files.mark_populated(pkg, "lib/librocblas.so.5", soname_file)
+
+        pkg.files.soname_aliases["lib/librocblas.so"] = "librocblas.so.5"
+
+        pkg._emit_soname_alias_symlinks(pkg.platform_dir)
+
+        self.assertFalse((pkg.platform_dir / "lib" / "librocblas.so").exists())
+        self.assertFalse(pkg.files.has("lib/librocblas.so"))
 
 
 # ---------------------------------------------------------------------------

--- a/build_tools/tests/py_packaging_test.py
+++ b/build_tools/tests/py_packaging_test.py
@@ -400,6 +400,70 @@ class MultiArchPackagingTest(TmpDirTestCase):
         )
 
 
+    def test_emit_soname_alias_symlinks_creates_runtime_symlinks(self):
+        """Soname aliases with a materialized SONAME target get symlinks in the
+        runtime package so dlopen by unversioned name succeeds (ROCM-29954)."""
+        artifact_dir = self.temp_dir / "artifacts"
+        self._add_artifact(
+            artifact_dir,
+            "wsl-rocdxg",
+            "lib",
+            "generic",
+            {"lib/placeholder.txt": "x"},
+        )
+
+        params = self._make_params(artifact_dir)
+        core = PopulatedDistPackage(params, logical_name="core")
+        core.populate_runtime_files(
+            params.filter_artifacts(lambda an: an.name == "wsl-rocdxg")
+        )
+
+        # Simulate what populate_runtime_files does for a versioned .so:
+        # the SONAME file is materialized, the others become aliases.
+        soname_file = core.platform_dir / "lib" / "librocdxg.so.1"
+        soname_file.parent.mkdir(parents=True, exist_ok=True)
+        soname_file.write_text("fake soname file")
+        core.files.mark_populated(core, "lib/librocdxg.so.1", soname_file)
+
+        core.files.soname_aliases["lib/librocdxg.so"] = "librocdxg.so.1"
+        core.files.soname_aliases["lib/librocdxg.so.1.1.0"] = "librocdxg.so.1"
+
+        core._emit_soname_alias_symlinks(core.platform_dir)
+
+        # Unversioned namelink should now be a symlink to the SONAME.
+        namelink = core.platform_dir / "lib" / "librocdxg.so"
+        self.assertTrue(namelink.is_symlink())
+        self.assertEqual(os.readlink(namelink), "librocdxg.so.1")
+        self.assertTrue(core.files.has("lib/librocdxg.so"))
+
+        # Full-version file should also be a symlink to the SONAME.
+        fullver = core.platform_dir / "lib" / "librocdxg.so.1.1.0"
+        self.assertTrue(fullver.is_symlink())
+        self.assertEqual(os.readlink(fullver), "librocdxg.so.1")
+        self.assertTrue(core.files.has("lib/librocdxg.so.1.1.0"))
+
+    def test_emit_soname_alias_skips_when_soname_not_materialized(self):
+        """Aliases whose SONAME target was not materialized are left alone."""
+        artifact_dir = self.temp_dir / "artifacts"
+        self._add_artifact(
+            artifact_dir, "orphan", "lib", "generic", {"lib/dummy.txt": "x"}
+        )
+
+        params = self._make_params(artifact_dir)
+        pkg = PopulatedDistPackage(params, logical_name="core")
+        pkg.populate_runtime_files(
+            params.filter_artifacts(lambda an: an.name == "orphan")
+        )
+
+        # Alias recorded but SONAME file was never materialized.
+        pkg.files.soname_aliases["lib/liborphan.so"] = "liborphan.so.2"
+
+        pkg._emit_soname_alias_symlinks(pkg.platform_dir)
+
+        self.assertFalse((pkg.platform_dir / "lib" / "liborphan.so").exists())
+        self.assertFalse(pkg.files.has("lib/liborphan.so"))
+
+
 # ---------------------------------------------------------------------------
 # Tests for Parameters construction edge cases
 # ---------------------------------------------------------------------------

--- a/build_tools/tests/py_packaging_test.py
+++ b/build_tools/tests/py_packaging_test.py
@@ -399,7 +399,7 @@ class MultiArchPackagingTest(TmpDirTestCase):
             "core (generic) file must be reachable from arch-specific devel",
         )
 
-
+    @unittest.skipIf(sys.platform == "win32", "SONAME symlinks are Linux-only")
     def test_emit_soname_alias_symlinks_creates_runtime_symlinks(self):
         """Soname aliases with a materialized SONAME target get symlinks in the
         runtime package so dlopen by unversioned name succeeds (ROCM-29954)."""


### PR DESCRIPTION
## Motivation
Emit soname-alias symlinks in runtime wheels so dlopen by unversioned name (e.g. librocdxg.so) resolves to the materialized SONAME file.

JIRA ID : ROCM-29954

## Technical Details
Add _emit_soname_alias_symlinks() to materialize unversioned namelinks
for libraries listed in RUNTIME_DLOPEN_ALIASES after the main population
pass. Scoped to librocdxg only to avoid wheel size bloat from bdist_wheel
expanding symlinks into full copies.

## Test Plan
new tests passes and python -c "import jax; print(jax.devices())" passes

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
