### PR TITLE
Add Ethan to CODEOWNERS for pytorch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,7 +15,7 @@
 # https://github.com/ROCm/TheRock/blob/main/docs/packaging/python_packaging.md
 /build_tools/packaging/python           @ScottTodd @marbre
 /build_tools/build_python_packages.py   @ScottTodd @marbre
-/external-builds/pytorch                @ScottTodd
+/external-builds/pytorch                @ScottTodd @ethanwee1
 
 # Native Linux packages.
 /build_tools/packaging/linux                                     @nunnikri @raramakr @arvindcheru


### PR DESCRIPTION
## Motivation

We should have at least 2 CODEOWNERS for each area so there is enough coverage across working hours, time off, etc.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.

@skip-pr-bot