### PR TITLE
chore: add rocm-docs as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -38,3 +38,7 @@
 	path = debug-tools/rocgdb/source
 	url = https://github.com/ROCm/rocgdb.git
 	branch = amd-staging-rocgdb-16
+[submodule "rocm-docs"]
+	path = rocm-docs
+	url = https://github.com/ROCm/rocm-docs.git
+	branch = develop

--- a/build_tools/github_actions/configure_ci_path_filters.py
+++ b/build_tools/github_actions/configure_ci_path_filters.py
@@ -208,6 +208,7 @@ def is_ci_run_required(paths: Optional[Iterable[str]]) -> bool:
 # Changes matching these patterns shouldn't affect CI build/test workflows.
 _SKIPPABLE_PATH_PATTERNS = [
     "docs/*",
+    "rocm-docs",
     "*.gitignore",
     "*.md",
     "*.mdc",


### PR DESCRIPTION
## Motivation

Add ROCm/rocm-docs as a submodule to TheRock repo.

JIRA ID: AIROCDOC-4300

## Technical Details

Left it out of `fetch_sources.py` since rocm-docs is documentation only and does not belong to any project list.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
