### PR TITLE
feat(ci): skip gfx90a tests on submodule bumps

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -211,6 +211,7 @@ amdgpu_family_info_matrix dictionary fields:
 - run-full-tests-only: (optional) if enabled, only run full tests for this architecture
 - nightly_check_only_for_family (optional): if enabled, only run CI nightly tests for this architecture
 - submodule_bump_tests_only (optional): if enabled, only run tests when submodule changes are detected or on workflow_dispatch (builds always run)
+- skip_tests_on_submodule_bump (optional): if enabled, skip tests when submodule changes are detected (inverse of submodule_bump_tests_only). Useful for architectures with limited hardware where submodule bumps are tested elsewhere.
 """
 # The 'presubmit' matrix runs on 'pull_request' triggers (on all PRs).
 amdgpu_family_info_matrix_presubmit = {
@@ -317,6 +318,7 @@ amdgpu_family_info_matrix_postsubmit = {
             "family": "gfx90a",
             "fetch-gfx-targets": ["gfx90a"],
             "build_variants": ["release"],
+            "skip_tests_on_submodule_bump": True,
         },
         "windows": {
             "test-runs-on": "",

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -1393,6 +1393,20 @@ def _expand_build_config_for_platform(
                 f"disabling tests (no submodule changes detected)"
             )
 
+        # If skip_tests_on_submodule_bump is set, skip tests when submodule changes
+        # are detected. This is the inverse of submodule_bump_tests_only - useful for
+        # architectures with limited hardware where submodule bumps are tested elsewhere.
+        if (
+            platform_info.get("skip_tests_on_submodule_bump", False)
+            and not ci_inputs.is_workflow_dispatch
+            and git_context.has_submodule_changes is True
+        ):
+            test_runs_on = ""
+            print(
+                f"  {family_name}: skip_tests_on_submodule_bump flag set, "
+                f"disabling tests (submodule changes detected)"
+            )
+
         family_info = {
             "amdgpu_family": platform_info["family"],
             "amdgpu_targets": ",".join(platform_info["fetch-gfx-targets"]),

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -1937,11 +1937,11 @@ class TestBuildConfigWorkflowContract(unittest.TestCase):
 class TestFamilyTestFilters(unittest.TestCase):
     """Tests for run-full-tests-only and nightly_check_only_for_family behavior."""
 
-    def test_real_family_gfx90a_postsubmit(self):
-        """Integration test: gfx90a is in postsubmit matrix with submodule changes."""
+    def test_real_family_gfx90a_postsubmit_no_submodule_changes(self):
+        """Integration test: gfx90a runs tests on push without submodule changes."""
         # gfx90a is in postsubmit matrix, so it runs on push events.
-        # It has submodule_bump_tests_only=True, so tests only run when
-        # submodule changes are detected.
+        # It has skip_tests_on_submodule_bump=True, so tests run on regular
+        # pushes but are skipped when submodule changes are detected.
         ci_inputs = cm.CIInputs(
             run_id="12345",
             event_name="push",
@@ -1949,8 +1949,37 @@ class TestFamilyTestFilters(unittest.TestCase):
             base_ref="HEAD^",
             build_variant="release",
         )
-        # gfx90a has submodule_bump_tests_only=True, so we need submodule changes
-        # for tests to be enabled. Simulate a submodule bump.
+        # No submodule changes - regular CI change
+        git_context = cm.GitContext(
+            changed_files=["CMakeLists.txt"],
+            submodule_paths=["rocm-systems", "rocm-libraries"],
+        )
+        outputs = cm.configure(ci_inputs, git_context)
+
+        # Find gfx90a in the linux build config
+        gfx90a_info = None
+        if outputs.builds.linux:
+            for family_info in outputs.builds.linux.per_family_info:
+                if family_info["amdgpu_family"] == "gfx90a":
+                    gfx90a_info = family_info
+                    break
+
+        self.assertIsNotNone(gfx90a_info)
+        # gfx90a should have tests enabled on regular pushes (no submodule changes)
+        self.assertNotEqual(gfx90a_info["test-runs-on"], "")
+
+    def test_real_family_gfx90a_postsubmit_with_submodule_changes(self):
+        """Integration test: gfx90a skips tests on push with submodule changes."""
+        # gfx90a has skip_tests_on_submodule_bump=True, so tests are skipped
+        # when submodule changes are detected.
+        ci_inputs = cm.CIInputs(
+            run_id="12345",
+            event_name="push",
+            commit_ref="main",
+            base_ref="HEAD^",
+            build_variant="release",
+        )
+        # Simulate a submodule bump
         git_context = cm.GitContext(
             changed_files=["some-submodule"],
             submodule_paths=["some-submodule"],
@@ -1966,8 +1995,8 @@ class TestFamilyTestFilters(unittest.TestCase):
                     break
 
         self.assertIsNotNone(gfx90a_info)
-        # gfx90a should have test-runs-on set in postsubmit when submodule changes
-        self.assertNotEqual(gfx90a_info["test-runs-on"], "")
+        # gfx90a should have tests DISABLED on submodule bumps
+        self.assertEqual(gfx90a_info["test-runs-on"], "")
 
     def test_workflow_dispatch_allows_gfx90a(self):
         """workflow_dispatch should allow testing gfx90a."""


### PR DESCRIPTION
Add skip_tests_on_submodule_bump flag as the inverse of submodule_bump_tests_only. For gfx90a, this skips tests when submodule changes are detected but runs them on all other postsubmit scenarios.

This is due gfx90a of having a bad kernel. We still want to utilize machines and get signal, but not on critical workflows like submodule bumps