### PR TITLE
[ci][torch] Add 'test_level' to PyTorch release workflows

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -39,6 +39,12 @@ on:
           tests.
         type: string
         default: "auto"
+      test_level:
+        description: >-
+          PyTorch test coverage: 'none' stops after build-time wheel validation
+          and 'standard' runs the selected GPU suite.
+        type: string
+        default: "standard"
       python_version:
         description: Python version to build wheels for.
         type: string
@@ -114,6 +120,13 @@ on:
           tests.
         type: string
         default: "auto"
+      test_level:
+        description: PyTorch test coverage level.
+        type: choice
+        options:
+          - none
+          - standard
+        default: standard
       python_version:
         description: Python version to build wheels for (for example, "3.12").
         type: string
@@ -524,6 +537,7 @@ jobs:
           python build_tools/github_actions/configure_pytorch_test_matrix.py \
             --build-amdgpu-families "${{ inputs.amdgpu_families }}" \
             --test-amdgpu-families "${{ inputs.test_amdgpu_families }}" \
+            --test-level "${{ inputs.test_level }}" \
             --platform linux
 
       - name: Capture job summary

--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -206,7 +206,10 @@ on:
         type: string
         default: ""
 
-run-name: Build Multi-Arch Linux PyTorch Wheels (${{ inputs.release_type }}, ${{ inputs.python_version }}, ${{ inputs.pytorch_git_ref }})
+run-name: >-
+  Build Multi-Arch Linux PyTorch Wheels
+  (${{ inputs.release_type }}, py ${{ inputs.python_version }},
+  torch ${{ inputs.pytorch_git_ref }}, tests ${{ inputs.test_level }})
 
 permissions:
   contents: read
@@ -506,7 +509,7 @@ jobs:
         run: python build_tools/github_actions/capture_job_summary.py
 
   configure_pytorch_tests:
-    name: Configure PyTorch Tests
+    name: Configure PyTorch Tests | ${{ inputs.test_level }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -546,7 +549,9 @@ jobs:
         run: python build_tools/github_actions/capture_job_summary.py
 
   test_pytorch_wheels:
-    name: Test | ${{ matrix.amdgpu_family }} | ${{ matrix.test_runs_on }}
+    # Keep this name static: GitHub does not expand matrix expressions when
+    # the job is skipped before matrix evaluation (for example, for none).
+    name: Test PyTorch Wheels
     if: ${{ needs.configure_pytorch_tests.outputs.enabled == 'true' }}
     needs: [build_pytorch_wheels, configure_pytorch_tests]
     permissions:
@@ -576,7 +581,8 @@ jobs:
   # dispatch -- a failure for one ref no longer skips testing the others (#5777).
   # Scoped to gfx94X-dcgpu Python 3.12 builds; opt in via run_full_pytorch_tests.
   dispatch_pytorch_wheels_full_test:
-    name: Dispatch PyTorch Full Test | torch ${{ inputs.pytorch_git_ref }}
+    # Keep this name static so it remains readable when the job is skipped.
+    name: Dispatch PyTorch Full Tests
     if: >-
       ${{
         inputs.run_full_pytorch_tests &&

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
@@ -39,6 +39,12 @@ on:
           tests.
         type: string
         default: "auto"
+      test_level:
+        description: >-
+          PyTorch test coverage: 'none' stops after build-time wheel validation
+          and 'standard' runs the selected GPU suite.
+        type: string
+        default: "standard"
       python_version:
         description: Python version to build wheels for.
         type: string
@@ -108,6 +114,13 @@ on:
           tests.
         type: string
         default: "auto"
+      test_level:
+        description: PyTorch test coverage level.
+        type: choice
+        options:
+          - none
+          - standard
+        default: standard
       python_version:
         description: Python version to build wheels for (for example, "3.12").
         type: string
@@ -568,6 +581,7 @@ jobs:
           python build_tools/github_actions/configure_pytorch_test_matrix.py \
             --build-amdgpu-families "${{ inputs.amdgpu_families }}" \
             --test-amdgpu-families "${{ inputs.test_amdgpu_families }}" \
+            --test-level "${{ inputs.test_level }}" \
             --platform windows
 
       - name: Capture job summary

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
@@ -195,7 +195,10 @@ on:
         type: string
         default: ""
 
-run-name: Build Multi-Arch Windows PyTorch Wheels (${{ inputs.release_type }}, ${{ inputs.python_version }}, ${{ inputs.pytorch_git_ref }})
+run-name: >-
+  Build Multi-Arch Windows PyTorch Wheels
+  (${{ inputs.release_type }}, py ${{ inputs.python_version }},
+  torch ${{ inputs.pytorch_git_ref }}, tests ${{ inputs.test_level }})
 
 permissions:
   contents: read
@@ -550,7 +553,7 @@ jobs:
         run: python build_tools/github_actions/capture_job_summary.py
 
   configure_pytorch_tests:
-    name: Configure PyTorch Tests
+    name: Configure PyTorch Tests | ${{ inputs.test_level }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -590,7 +593,9 @@ jobs:
         run: python build_tools/github_actions/capture_job_summary.py
 
   test_pytorch_wheels:
-    name: Test | ${{ matrix.amdgpu_family }} | ${{ matrix.test_runs_on }}
+    # Keep this name static: GitHub does not expand matrix expressions when
+    # the job is skipped before matrix evaluation (for example, for none).
+    name: Test PyTorch Wheels
     if: ${{ needs.configure_pytorch_tests.outputs.enabled == 'true' }}
     needs: [build_pytorch_wheels, configure_pytorch_tests]
     permissions:

--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -130,13 +130,18 @@ on:
         type: string
         default: ""
 
-run-name: Release Linux PyTorch Wheels (${{ inputs.release_type }}, ${{ inputs.rocm_version }}, ${{ inputs.amdgpu_families }})
+run-name: >-
+  Release Linux PyTorch Wheels
+  (${{ inputs.release_type }}, ${{ inputs.rocm_version }},
+  ${{ inputs.amdgpu_families }}, py ${{ inputs.python_version || 'all' }},
+  full tests ${{ inputs.run_full_pytorch_tests }})
 
 permissions:
   contents: read
 
 jobs:
   setup_matrix:
+    name: Configure PyTorch Release Matrix
     runs-on: ubuntu-24.04
     outputs:
       pytorch_matrix: ${{ steps.matrix.outputs.pytorch_matrix }}

--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -188,6 +188,7 @@ jobs:
     with:
       amdgpu_families: ${{ matrix.amdgpu_families }}
       test_amdgpu_families: ${{ matrix.test_amdgpu_families }}
+      test_level: ${{ matrix.test_level }}
       python_version: ${{ matrix.python_version }}
       pytorch_git_ref: ${{ matrix.pytorch_git_ref }}
       rocm_version: ${{ inputs.rocm_version }}

--- a/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
@@ -122,13 +122,17 @@ on:
         type: string
         default: ""
 
-run-name: Release Windows PyTorch Wheels (${{ inputs.release_type }}, ${{ inputs.rocm_version }}, ${{ inputs.amdgpu_families }})
+run-name: >-
+  Release Windows PyTorch Wheels
+  (${{ inputs.release_type }}, ${{ inputs.rocm_version }},
+  ${{ inputs.amdgpu_families }}, py ${{ inputs.python_version || 'all' }})
 
 permissions:
   contents: read
 
 jobs:
   setup_matrix:
+    name: Configure PyTorch Release Matrix
     runs-on: ubuntu-24.04
     outputs:
       pytorch_matrix: ${{ steps.matrix.outputs.pytorch_matrix }}

--- a/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
@@ -175,6 +175,7 @@ jobs:
     with:
       amdgpu_families: ${{ matrix.amdgpu_families }}
       test_amdgpu_families: ${{ matrix.test_amdgpu_families }}
+      test_level: ${{ matrix.test_level }}
       python_version: ${{ matrix.python_version }}
       pytorch_git_ref: ${{ matrix.pytorch_git_ref }}
       rocm_version: ${{ inputs.rocm_version }}

--- a/build_tools/github_actions/configure_pytorch_release_matrix.py
+++ b/build_tools/github_actions/configure_pytorch_release_matrix.py
@@ -75,6 +75,13 @@ UNSUPPORTED_AMDGPU_FAMILIES = {
     },
 }
 
+# PyTorch test levels are additive:
+#
+# * none schedules no self-hosted GPU tests. The wheel build job still runs
+#   its build-time wheel validation.
+# * standard also runs test_pytorch_wheels.yml on each selected AMDGPU family.
+PYTORCH_TEST_LEVELS = ["none", "standard"]
+
 
 def _split_values(raw: str) -> list[str]:
     """Split comma, semicolon, or whitespace-separated workflow input values."""
@@ -170,6 +177,7 @@ def generate_pytorch_matrix_for_release_type(
                 "python_version": py,
                 "pytorch_git_ref": ref,
                 "amdgpu_families": families,
+                "test_level": "standard",
                 # TODO(#7185): PyTorch nightly's requirements-ci.txt pins
                 # scikit-image==0.22.0, which has no cp314 wheel and fails to
                 # build from source. Build those wheels but skip their tests

--- a/build_tools/github_actions/configure_pytorch_release_matrix.py
+++ b/build_tools/github_actions/configure_pytorch_release_matrix.py
@@ -13,7 +13,7 @@ from pathlib import Path
 _BUILD_TOOLS_DIR = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_BUILD_TOOLS_DIR))
 
-from github_actions.github_actions_api import gha_set_output
+from github_actions.github_actions_api import gha_append_step_summary, gha_set_output
 
 RELEASE_TYPES = [
     "ci",
@@ -192,6 +192,81 @@ def generate_pytorch_matrix_for_release_type(
     return matrix
 
 
+def format_matrix_summary(
+    *,
+    release_type: str,
+    platform: str,
+    python_versions: list[str] | None,
+    pytorch_git_refs: list[str] | None,
+    amdgpu_families: str,
+    matrix: list[dict[str, str]],
+) -> str:
+    """Format the resolved release matrix for logs and the job summary."""
+
+    level_counts = {
+        level: sum(row["test_level"] == level for row in matrix)
+        for level in PYTORCH_TEST_LEVELS
+    }
+    count_summary = (
+        ", ".join(
+            f"`{level}`: {count}" for level, count in level_counts.items() if count
+        )
+        or "none"
+    )
+    lines = [
+        "## PyTorch Release Matrix",
+        "",
+        "| Setting | Value |",
+        "| --- | --- |",
+        f"| Release type | `{release_type}` |",
+        f"| Platform | `{platform}` |",
+        "| Python selection | "
+        + (
+            ", ".join(f"`{version}`" for version in python_versions)
+            if python_versions
+            else "default"
+        )
+        + " |",
+        "| PyTorch ref selection | "
+        + (
+            ", ".join(f"`{ref}`" for ref in pytorch_git_refs)
+            if pytorch_git_refs
+            else "default"
+        )
+        + " |",
+        f"| Requested AMDGPU families | `{amdgpu_families or 'none'}` |",
+        f"| Generated rows | {len(matrix)} ({count_summary}) |",
+    ]
+
+    if not matrix:
+        lines.extend(
+            [
+                "",
+                "**Decision:** No build rows remain after applying the "
+                "PyTorch-ref AMDGPU-family support filters.",
+            ]
+        )
+
+    lines.extend(
+        [
+            "",
+            "| Python | PyTorch ref | AMDGPU families | Test level |",
+            "| --- | --- | --- | --- |",
+        ]
+    )
+    for row in matrix:
+        families = ", ".join(
+            f"`{family}`" for family in _split_families(row["amdgpu_families"])
+        )
+        lines.append(
+            f"| `{row['python_version']}` | `{row['pytorch_git_ref']}` | "
+            f"{families} | `{row['test_level']}` |"
+        )
+    if not matrix:
+        lines.append("| none | none | none | none |")
+    return "\n".join(lines)
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Generate PyTorch release build matrix"
@@ -249,6 +324,16 @@ def main(argv: list[str] | None = None) -> int:
         pytorch_git_refs=pytorch_git_refs,
         amdgpu_families=args.amdgpu_families,
         platform=args.platform,
+    )
+    gha_append_step_summary(
+        format_matrix_summary(
+            release_type=args.release_type,
+            platform=args.platform,
+            python_versions=python_versions,
+            pytorch_git_refs=pytorch_git_refs,
+            amdgpu_families=args.amdgpu_families,
+            matrix=matrix,
+        )
     )
     gha_set_output({"pytorch_matrix": json.dumps(matrix)})
     return 0

--- a/build_tools/github_actions/configure_pytorch_test_matrix.py
+++ b/build_tools/github_actions/configure_pytorch_test_matrix.py
@@ -22,7 +22,7 @@ _BUILD_TOOLS_DIR = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_BUILD_TOOLS_DIR))
 
 from github_actions.amdgpu_family_matrix import get_all_families_for_trigger_types
-from github_actions.github_actions_api import gha_set_output
+from github_actions.github_actions_api import gha_append_step_summary, gha_set_output
 from configure_pytorch_release_matrix import PYTORCH_TEST_LEVELS
 
 
@@ -59,7 +59,7 @@ def build_test_matrix(
         )
         return {"include": []}
 
-    print(f"Requested {platform} AMDGPU families: {amdgpu_families}")
+    print(f"Resolved {platform} GPU test families: {amdgpu_families or 'none'}")
     include: list[dict[str, str]] = []
     for requested_family in amdgpu_families:
         test_runs_on = find_test_runs_on(
@@ -82,6 +82,74 @@ def build_test_matrix(
         )
 
     return {"include": include}
+
+
+def format_test_summary(
+    *,
+    platform: str,
+    test_level: str,
+    built_families: list[str],
+    requested_test_families: str,
+    resolved_test_families: list[str],
+    matrix: dict[str, list[dict[str, str]]],
+) -> str:
+    """Format the resolved test policy for logs and the job summary."""
+
+    def format_families(families: list[str]) -> str:
+        return ", ".join(f"`{family}`" for family in families) or "none"
+
+    include = matrix["include"]
+    lines = [
+        "## PyTorch Test Configuration",
+        "",
+        "| Setting | Value |",
+        "| --- | --- |",
+        f"| Platform | `{platform}` |",
+        f"| Test level | `{test_level}` |",
+        f"| Built AMDGPU families | {format_families(built_families)} |",
+        f"| Requested test families | `{requested_test_families}` |",
+        f"| Resolved test families | {format_families(resolved_test_families)} |",
+        f"| Self-hosted GPU test jobs | {len(include)} |",
+        "",
+    ]
+
+    if test_level == "none":
+        lines.append(
+            "**Decision:** No self-hosted GPU test jobs are scheduled because "
+            "the test level is `none`."
+        )
+    elif not resolved_test_families:
+        lines.append(
+            "**Decision:** No self-hosted GPU test jobs are scheduled because "
+            "the test-family selection resolved to none."
+        )
+    elif not include:
+        lines.append(
+            "**Decision:** No self-hosted GPU test jobs are scheduled because "
+            f"none of the selected families has a configured {platform} runner."
+        )
+    else:
+        lines.extend(
+            [
+                "**Decision:** Schedule the following self-hosted GPU tests:",
+                "",
+                "| AMDGPU family | Runner |",
+                "| --- | --- |",
+                *[
+                    f"| `{row['amdgpu_family']}` | `{row['test_runs_on']}` |"
+                    for row in include
+                ],
+            ]
+        )
+
+    lines.extend(
+        [
+            "",
+            "The build job always runs `sanity_check_wheel.py` as build-time "
+            "artifact validation before any GPU tests.",
+        ]
+    )
+    return "\n".join(lines)
 
 
 def emit_outputs(matrix: dict[str, list[dict[str, str]]]) -> None:
@@ -144,6 +212,16 @@ def main(argv: list[str]) -> None:
         amdgpu_families=test_amdgpu_families,
         platform=args.platform,
         test_level=args.test_level,
+    )
+    gha_append_step_summary(
+        format_test_summary(
+            platform=args.platform,
+            test_level=args.test_level,
+            built_families=built_families,
+            requested_test_families=args.test_amdgpu_families.strip() or "auto",
+            resolved_test_families=test_amdgpu_families,
+            matrix=matrix,
+        )
     )
     emit_outputs(matrix)
 

--- a/build_tools/github_actions/configure_pytorch_test_matrix.py
+++ b/build_tools/github_actions/configure_pytorch_test_matrix.py
@@ -23,6 +23,7 @@ sys.path.insert(0, str(_BUILD_TOOLS_DIR))
 
 from github_actions.amdgpu_family_matrix import get_all_families_for_trigger_types
 from github_actions.github_actions_api import gha_set_output
+from configure_pytorch_release_matrix import PYTORCH_TEST_LEVELS
 
 
 def split_families(value: str) -> list[str]:
@@ -47,7 +48,17 @@ def build_test_matrix(
     *,
     amdgpu_families: list[str],
     platform: str,
+    test_level: str,
 ) -> dict[str, list[dict[str, str]]]:
+    if test_level not in PYTORCH_TEST_LEVELS:
+        raise ValueError(f"Unknown PyTorch test level: {test_level!r}")
+    if test_level == "none":
+        print(
+            "Test level 'none': no self-hosted GPU test jobs will be scheduled; "
+            "the build job still runs its build-time wheel validation"
+        )
+        return {"include": []}
+
     print(f"Requested {platform} AMDGPU families: {amdgpu_families}")
     include: list[dict[str, str]] = []
     for requested_family in amdgpu_families:
@@ -98,6 +109,15 @@ def main(argv: list[str]) -> None:
         ),
     )
     parser.add_argument(
+        "--test-level",
+        choices=PYTORCH_TEST_LEVELS,
+        default="standard",
+        help=(
+            "Test coverage level. 'none' stops after build-time wheel "
+            "validation; 'standard' runs the GPU test matrix."
+        ),
+    )
+    parser.add_argument(
         "--platform",
         choices=["linux", "windows"],
         default=platform_module.system().lower(),
@@ -123,6 +143,7 @@ def main(argv: list[str]) -> None:
     matrix = build_test_matrix(
         amdgpu_families=test_amdgpu_families,
         platform=args.platform,
+        test_level=args.test_level,
     )
     emit_outputs(matrix)
 

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -1337,12 +1337,14 @@ class TestExpandBuildConfigs(unittest.TestCase):
                     "python_version": "3.12",
                     "pytorch_git_ref": "release/2.12",
                     "amdgpu_families": "gfx94X-dcgpu",
+                    "test_level": "standard",
                     "test_amdgpu_families": "auto",
                 },
                 {
                     "python_version": "3.12",
                     "pytorch_git_ref": "release/2.13",
                     "amdgpu_families": "gfx94X-dcgpu",
+                    "test_level": "standard",
                     "test_amdgpu_families": "auto",
                 },
             ],
@@ -1354,6 +1356,7 @@ class TestExpandBuildConfigs(unittest.TestCase):
                     "python_version": "3.12",
                     "pytorch_git_ref": "release/2.12",
                     "amdgpu_families": "gfx110X-all",
+                    "test_level": "standard",
                     "test_amdgpu_families": "auto",
                 }
             ],

--- a/build_tools/github_actions/tests/configure_pytorch_release_matrix_test.py
+++ b/build_tools/github_actions/tests/configure_pytorch_release_matrix_test.py
@@ -184,6 +184,30 @@ class ConfigurePytorchReleaseMatrixTest(unittest.TestCase):
                 self.assertEqual(len(matrix), 1)
                 self.assertEqual(matrix[0]["test_amdgpu_families"], "auto")
 
+    def test_summary_lists_generated_rows_and_test_levels(self):
+        matrix = m.generate_pytorch_matrix_for_release_type(
+            release_type="dev",
+            python_versions=["3.12"],
+            pytorch_git_refs=["release/2.12", "nightly"],
+            amdgpu_families="gfx94X-dcgpu",
+            platform="linux",
+        )
+
+        summary = m.format_matrix_summary(
+            release_type="dev",
+            platform="linux",
+            python_versions=["3.12"],
+            pytorch_git_refs=["release/2.12", "nightly"],
+            amdgpu_families="gfx94X-dcgpu",
+            matrix=matrix,
+        )
+
+        self.assertIn("| Generated rows | 2 (`standard`: 2) |", summary)
+        self.assertIn(
+            "| `3.12` | `release/2.12` | `gfx94X-dcgpu` | `standard` |",
+            summary,
+        )
+
     def test_generated_rows_cover_workflow_matrix_inputs(self):
         # The generate_pytorch_matrix_for_release_type script produces matrix
         # JSON for use in workflow files like:

--- a/build_tools/github_actions/tests/configure_pytorch_release_matrix_test.py
+++ b/build_tools/github_actions/tests/configure_pytorch_release_matrix_test.py
@@ -35,12 +35,14 @@ class ConfigurePytorchReleaseMatrixTest(unittest.TestCase):
                     "python_version": "3.12",
                     "pytorch_git_ref": "release/2.12",
                     "amdgpu_families": "gfx94X-dcgpu",
+                    "test_level": "standard",
                     "test_amdgpu_families": "auto",
                 },
                 {
                     "python_version": "3.12",
                     "pytorch_git_ref": "release/2.13",
                     "amdgpu_families": "gfx94X-dcgpu",
+                    "test_level": "standard",
                     "test_amdgpu_families": "auto",
                 },
             ],
@@ -64,6 +66,7 @@ class ConfigurePytorchReleaseMatrixTest(unittest.TestCase):
                     "python_version": "3.12",
                     "pytorch_git_ref": "release/2.12",
                     "amdgpu_families": "gfx110X-all",
+                    "test_level": "standard",
                     "test_amdgpu_families": "auto",
                 },
             ],
@@ -85,6 +88,7 @@ class ConfigurePytorchReleaseMatrixTest(unittest.TestCase):
                     "python_version": "3.13",
                     "pytorch_git_ref": "nightly",
                     "amdgpu_families": "gfx94X-dcgpu",
+                    "test_level": "standard",
                     "test_amdgpu_families": "auto",
                 }
             ],
@@ -109,6 +113,7 @@ class ConfigurePytorchReleaseMatrixTest(unittest.TestCase):
                             "python_version": "3.12",
                             "pytorch_git_ref": pytorch_git_ref,
                             "amdgpu_families": "gfx125X-dcgpu",
+                            "test_level": "standard",
                             "test_amdgpu_families": "auto",
                         }
                     ],
@@ -130,6 +135,7 @@ class ConfigurePytorchReleaseMatrixTest(unittest.TestCase):
                     "python_version": "3.12",
                     "pytorch_git_ref": "users/alice/gfx125x-bringup",
                     "amdgpu_families": "gfx125X-dcgpu",
+                    "test_level": "standard",
                     "test_amdgpu_families": "auto",
                 }
             ],
@@ -152,6 +158,7 @@ class ConfigurePytorchReleaseMatrixTest(unittest.TestCase):
                     "python_version": "3.14",
                     "pytorch_git_ref": "nightly",
                     "amdgpu_families": "gfx110X-all",
+                    "test_level": "standard",
                     "test_amdgpu_families": "none",
                 }
             ],

--- a/build_tools/github_actions/tests/configure_pytorch_test_matrix_test.py
+++ b/build_tools/github_actions/tests/configure_pytorch_test_matrix_test.py
@@ -47,6 +47,7 @@ class ConfigurePyTorchTestMatrixTest(unittest.TestCase):
         matrix = m.build_test_matrix(
             amdgpu_families=[],
             platform="linux",
+            test_level="standard",
         )
         self.assertEqual(matrix, {"include": []})
 
@@ -57,6 +58,7 @@ class ConfigurePyTorchTestMatrixTest(unittest.TestCase):
             matrix = m.build_test_matrix(
                 amdgpu_families=["gfxnorunner"],
                 platform="linux",
+                test_level="standard",
             )
         self.assertEqual(matrix, {"include": []})
 
@@ -67,6 +69,7 @@ class ConfigurePyTorchTestMatrixTest(unittest.TestCase):
             matrix = m.build_test_matrix(
                 amdgpu_families=["gfxalpha-all"],
                 platform="linux",
+                test_level="standard",
             )
         # FAKE_FAMILY_MATRIX also has a windows-alpha runner. The Linux
         # request should only use the Linux platform entry and canonical family.
@@ -89,7 +92,16 @@ class ConfigurePyTorchTestMatrixTest(unittest.TestCase):
             m.build_test_matrix(
                 amdgpu_families=["not-a-family"],
                 platform="linux",
+                test_level="standard",
             )
+
+    def test_none_level_skips_gpu_tests(self) -> None:
+        matrix = m.build_test_matrix(
+            amdgpu_families=["not-a-family"],
+            platform="linux",
+            test_level="none",
+        )
+        self.assertEqual(matrix, {"include": []})
 
     def test_main_writes_outputs(self) -> None:
         with mock.patch.object(
@@ -164,6 +176,7 @@ class ConfigurePyTorchTestMatrixTest(unittest.TestCase):
         matrix = m.build_test_matrix(
             amdgpu_families=["gfx950-dcgpu"],
             platform="linux",
+            test_level="standard",
         )
         include = matrix["include"]
         self.assertEqual(len(include), 1)

--- a/build_tools/github_actions/tests/configure_pytorch_test_matrix_test.py
+++ b/build_tools/github_actions/tests/configure_pytorch_test_matrix_test.py
@@ -172,6 +172,41 @@ class ConfigurePyTorchTestMatrixTest(unittest.TestCase):
         self.assertEqual(outputs["enabled"], "false")
         self.assertEqual(json.loads(outputs["matrix"]), {"include": []})
 
+    def test_none_summary_explains_no_gpu_tests(self) -> None:
+        summary = m.format_test_summary(
+            platform="linux",
+            test_level="none",
+            built_families=["gfxalpha-all"],
+            requested_test_families="auto",
+            resolved_test_families=["gfxalpha-all"],
+            matrix={"include": []},
+        )
+
+        self.assertIn("| Test level | `none` |", summary)
+        self.assertIn("| Self-hosted GPU test jobs | 0 |", summary)
+        self.assertIn("because the test level is `none`", summary)
+        self.assertIn("`sanity_check_wheel.py` as build-time", summary)
+
+    def test_standard_summary_lists_family_runner_mapping(self) -> None:
+        summary = m.format_test_summary(
+            platform="linux",
+            test_level="standard",
+            built_families=["gfxalpha-all"],
+            requested_test_families="auto",
+            resolved_test_families=["gfxalpha-all"],
+            matrix={
+                "include": [
+                    {
+                        "amdgpu_family": "gfxalpha-all",
+                        "test_runs_on": "linux-alpha",
+                    }
+                ]
+            },
+        )
+
+        self.assertIn("| Self-hosted GPU test jobs | 1 |", summary)
+        self.assertIn("| `gfxalpha-all` | `linux-alpha` |", summary)
+
     def test_real_family_matrix_finds_gfx950_runner(self) -> None:
         matrix = m.build_test_matrix(
             amdgpu_families=["gfx950-dcgpu"],


### PR DESCRIPTION
## Motivation

* Progress on https://github.com/ROCm/TheRock/issues/7731

This prepares the workflows to set different test levels across the matrix of [GPU test runner, Python version, PyTorch version, Platform].

## Technical Details

The planned sequence of changes is:
1. (This PR) Plumbing for 'test_level', keeping existing behavior by default. Direct runs via `workflow_dispatch` can set the test level to 'none' to skip tests entirely
2. Switch all but one Python version to test level 'none'
3. Fold 'full tests' into the 'test_level' scheme and remove the separate schedule-based code

## Test Plan

`workflow_dispatch` of relevant workflow files on this branch

workflow | options | logs
-- | -- | --
multi_arch_build_portable_linux_pytorch_wheels.yml | py 3.12<br>'none' | https://github.com/ROCm/TheRock/actions/runs/34888365540
multi_arch_build_portable_linux_pytorch_wheels.yml | py 3.12<br>'standard' | https://github.com/ROCm/TheRock/actions/runs/34888469006 
multi_arch_release_linux_pytorch_wheels.yml | py 3.11 | https://github.com/ROCm/TheRock/actions/runs/34888912154

Test level 'none' should not schedule GPU test jobs while 'standard' should. Release should run tests on any python version (until the second PR in the stack).

(Tests job failures due to https://dev.repo.amd.com/rocm/whl-next/ missing the CI packages used to test are fine)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
