### PR TITLE
[ci][torch] Fold full PyTorch tests into test levels

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -39,6 +39,12 @@ on:
           tests.
         type: string
         default: "auto"
+      test_level:
+        description: >-
+          PyTorch test coverage: 'none' stops after build-time wheel validation
+          and 'standard' runs the selected GPU suite.
+        type: string
+        default: "standard"
       python_version:
         description: Python version to build wheels for.
         type: string
@@ -114,6 +120,13 @@ on:
           tests.
         type: string
         default: "auto"
+      test_level:
+        description: PyTorch test coverage level.
+        type: choice
+        options:
+          - none
+          - standard
+        default: standard
       python_version:
         description: Python version to build wheels for (for example, "3.12").
         type: string
@@ -524,6 +537,7 @@ jobs:
           python build_tools/github_actions/configure_pytorch_test_matrix.py \
             --build-amdgpu-families "${{ inputs.amdgpu_families }}" \
             --test-amdgpu-families "${{ inputs.test_amdgpu_families }}" \
+            --test-level "${{ inputs.test_level }}" \
             --platform linux
 
       - name: Capture job summary

--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -206,7 +206,10 @@ on:
         type: string
         default: ""
 
-run-name: Build Multi-Arch Linux PyTorch Wheels (${{ inputs.release_type }}, ${{ inputs.python_version }}, ${{ inputs.pytorch_git_ref }})
+run-name: >-
+  Build Multi-Arch Linux PyTorch Wheels
+  (${{ inputs.release_type }}, py ${{ inputs.python_version }},
+  torch ${{ inputs.pytorch_git_ref }}, tests ${{ inputs.test_level }})
 
 permissions:
   contents: read
@@ -506,7 +509,7 @@ jobs:
         run: python build_tools/github_actions/capture_job_summary.py
 
   configure_pytorch_tests:
-    name: Configure PyTorch Tests
+    name: Configure PyTorch Tests | ${{ inputs.test_level }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -546,7 +549,9 @@ jobs:
         run: python build_tools/github_actions/capture_job_summary.py
 
   test_pytorch_wheels:
-    name: Test | ${{ matrix.amdgpu_family }} | ${{ matrix.test_runs_on }}
+    # Keep this name static: GitHub does not expand matrix expressions when
+    # the job is skipped before matrix evaluation (for example, for none).
+    name: Test PyTorch Wheels
     if: ${{ needs.configure_pytorch_tests.outputs.enabled == 'true' }}
     needs: [build_pytorch_wheels, configure_pytorch_tests]
     permissions:
@@ -576,7 +581,8 @@ jobs:
   # dispatch -- a failure for one ref no longer skips testing the others (#5777).
   # Scoped to gfx94X-dcgpu Python 3.12 builds; opt in via run_full_pytorch_tests.
   dispatch_pytorch_wheels_full_test:
-    name: Dispatch PyTorch Full Test | torch ${{ inputs.pytorch_git_ref }}
+    # Keep this name static so it remains readable when the job is skipped.
+    name: Dispatch PyTorch Full Tests
     if: >-
       ${{
         inputs.run_full_pytorch_tests &&

--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -42,7 +42,8 @@ on:
       test_level:
         description: >-
           PyTorch test coverage: 'none' stops after build-time wheel validation
-          and 'standard' runs the selected GPU suite.
+          in the build job, 'standard' runs the selected GPU suite, and 'full'
+          also dispatches the full suite when the build includes gfx94X-dcgpu.
         type: string
         default: "standard"
       python_version:
@@ -91,12 +92,6 @@ on:
         description: "Build runner label (selected by configure script with weighted distribution)"
         type: string
         default: "aws-linux-scale-rocm-prod"
-      run_full_pytorch_tests:
-        description: >-
-          Dispatch the full PyTorch test suite after a successful build.
-          Only takes effect for gfx94X-dcgpu Python 3.12 builds.
-        type: boolean
-        default: false
       quartz_tracking_id:
         description: >-
           Leave empty. Internal Quartz tracking id, set automatically by the
@@ -126,6 +121,7 @@ on:
         options:
           - none
           - standard
+          - full
         default: standard
       python_version:
         description: Python version to build wheels for (for example, "3.12").
@@ -192,12 +188,6 @@ on:
         description: "Build runner label (selected by configure script with weighted distribution)"
         type: string
         default: "aws-linux-scale-rocm-prod"
-      run_full_pytorch_tests:
-        description: >-
-          Dispatch the full PyTorch test suite after a successful build.
-          Only takes effect for gfx94X-dcgpu Python 3.12 builds.
-        type: boolean
-        default: false
       quartz_tracking_id:
         description: >-
           Leave empty. Internal Quartz tracking id, set automatically by the
@@ -579,14 +569,16 @@ jobs:
   # workflow builds a single (python_version, pytorch_git_ref), the build job's
   # torch_version output is unambiguous and only this build's success gates the
   # dispatch -- a failure for one ref no longer skips testing the others (#5777).
-  # Scoped to gfx94X-dcgpu Python 3.12 builds; opt in via run_full_pytorch_tests.
+  # Full-suite dispatch currently targets gfx94X-dcgpu because the runner
+  # inputs below are gfx942-specific. The caller controls the Python version
+  # and test level. Generalize this to a per-family runner matrix as more
+  # full-test runner configurations are enabled.
   dispatch_pytorch_wheels_full_test:
     # Keep this name static so it remains readable when the job is skipped.
     name: Dispatch PyTorch Full Tests
     if: >-
       ${{
-        inputs.run_full_pytorch_tests &&
-        inputs.python_version == '3.12' &&
+        inputs.test_level == 'full' &&
         contains(inputs.amdgpu_families, 'gfx94X-dcgpu')
       }}
     needs: [build_pytorch_wheels]
@@ -594,21 +586,8 @@ jobs:
     permissions:
       actions: write
       contents: read
-    env:
-      PYTORCH_GIT_REF: ${{ inputs.pytorch_git_ref }}
     steps:
-      - name: Check full test cadence
-        id: cadence
-        # Release branches test daily; the nightly branch tests weekly (Sunday).
-        run: |
-          if [ "${PYTORCH_GIT_REF}" != "nightly" ] || [ "$(date -u +%u)" = "7" ]; then
-            echo "dispatch=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "dispatch=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Dispatch full PyTorch test workflow
-        if: ${{ steps.cadence.outputs.dispatch == 'true' }}
         uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26 # v1.3.2
         with:
           workflow: test_pytorch_wheels_full.yml

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
@@ -39,6 +39,12 @@ on:
           tests.
         type: string
         default: "auto"
+      test_level:
+        description: >-
+          PyTorch test coverage: 'none' stops after build-time wheel validation
+          and 'standard' runs the selected GPU suite.
+        type: string
+        default: "standard"
       python_version:
         description: Python version to build wheels for.
         type: string
@@ -108,6 +114,13 @@ on:
           tests.
         type: string
         default: "auto"
+      test_level:
+        description: PyTorch test coverage level.
+        type: choice
+        options:
+          - none
+          - standard
+        default: standard
       python_version:
         description: Python version to build wheels for (for example, "3.12").
         type: string
@@ -568,6 +581,7 @@ jobs:
           python build_tools/github_actions/configure_pytorch_test_matrix.py \
             --build-amdgpu-families "${{ inputs.amdgpu_families }}" \
             --test-amdgpu-families "${{ inputs.test_amdgpu_families }}" \
+            --test-level "${{ inputs.test_level }}" \
             --platform windows
 
       - name: Capture job summary

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
@@ -195,7 +195,10 @@ on:
         type: string
         default: ""
 
-run-name: Build Multi-Arch Windows PyTorch Wheels (${{ inputs.release_type }}, ${{ inputs.python_version }}, ${{ inputs.pytorch_git_ref }})
+run-name: >-
+  Build Multi-Arch Windows PyTorch Wheels
+  (${{ inputs.release_type }}, py ${{ inputs.python_version }},
+  torch ${{ inputs.pytorch_git_ref }}, tests ${{ inputs.test_level }})
 
 permissions:
   contents: read
@@ -550,7 +553,7 @@ jobs:
         run: python build_tools/github_actions/capture_job_summary.py
 
   configure_pytorch_tests:
-    name: Configure PyTorch Tests
+    name: Configure PyTorch Tests | ${{ inputs.test_level }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -590,7 +593,9 @@ jobs:
         run: python build_tools/github_actions/capture_job_summary.py
 
   test_pytorch_wheels:
-    name: Test | ${{ matrix.amdgpu_family }} | ${{ matrix.test_runs_on }}
+    # Keep this name static: GitHub does not expand matrix expressions when
+    # the job is skipped before matrix evaluation (for example, for none).
+    name: Test PyTorch Wheels
     if: ${{ needs.configure_pytorch_tests.outputs.enabled == 'true' }}
     needs: [build_pytorch_wheels, configure_pytorch_tests]
     permissions:

--- a/.github/workflows/multi_arch_release.yml
+++ b/.github/workflows/multi_arch_release.yml
@@ -44,7 +44,9 @@ on:
         type: string
         default: ""
       run_full_pytorch_tests:
-        description: Run full PyTorch tests after scheduled nightly Linux PyTorch wheel builds complete.
+        description: >-
+          Request full PyTorch tests for stable refs daily and the nightly ref
+          on Sundays.
         type: boolean
         default: false
       build_pytorch:
@@ -93,7 +95,9 @@ on:
         type: string
         default: "gfx110x"
       run_full_pytorch_tests:
-        description: Run full PyTorch tests after scheduled nightly Linux PyTorch wheel builds complete.
+        description: >-
+          Request full PyTorch tests for stable refs daily and the nightly ref
+          on Sundays.
         type: boolean
         default: false
       build_pytorch:
@@ -126,6 +130,7 @@ run-name: >-
   Multi-Arch Release (${{ inputs.release_type }})
   | Linux: ${{ inputs.linux_amdgpu_families || 'none' }}
   | Windows: ${{ inputs.windows_amdgpu_families || 'none' }}
+  | PyTorch full tests: ${{ inputs.run_full_pytorch_tests }}
 
 jobs:
   notify_quartz_start:

--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -53,7 +53,9 @@ on:
         type: string
         default: ""
       run_full_pytorch_tests:
-        description: Run full PyTorch tests after scheduled nightly wheel builds complete.
+        description: >-
+          Request full PyTorch tests for stable refs daily and the nightly ref
+          on Sundays.
         type: boolean
         default: false
       build_runs_on:
@@ -115,7 +117,9 @@ on:
         type: string
         default: ""
       run_full_pytorch_tests:
-        description: Run full PyTorch tests after scheduled nightly wheel builds complete.
+        description: >-
+          Request full PyTorch tests for stable refs daily and the nightly ref
+          on Sundays.
         type: boolean
         default: false
       build_runs_on:
@@ -171,7 +175,8 @@ jobs:
             --python-versions="${{ inputs.python_version }}" \
             --platform=linux \
             --release-type="${{ inputs.release_type }}" \
-            --amdgpu-families="${{ inputs.amdgpu_families }}"
+            --amdgpu-families="${{ inputs.amdgpu_families }}" \
+            ${{ inputs.run_full_pytorch_tests && '--run-full-pytorch-tests' || '' }}
 
   build_pytorch_wheels:
     needs: setup_matrix
@@ -204,10 +209,6 @@ jobs:
       ref: ${{ inputs.ref }}
       cache_type: ${{ inputs.cache_type }}
       build_runs_on: ${{ inputs.build_runs_on }}
-      # The reusable build workflow dispatches the full PyTorch test suite for
-      # each successfully built (nightly, gfx94X-dcgpu, py3.12) ref using that
-      # build's own torch_version output (#5777).
-      run_full_pytorch_tests: ${{ inputs.run_full_pytorch_tests }}
       quartz_tracking_id: ${{ inputs.quartz_tracking_id }}
 
   notify_quartz_completed:

--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -130,13 +130,18 @@ on:
         type: string
         default: ""
 
-run-name: Release Linux PyTorch Wheels (${{ inputs.release_type }}, ${{ inputs.rocm_version }}, ${{ inputs.amdgpu_families }})
+run-name: >-
+  Release Linux PyTorch Wheels
+  (${{ inputs.release_type }}, ${{ inputs.rocm_version }},
+  ${{ inputs.amdgpu_families }}, py ${{ inputs.python_version || 'all' }},
+  full tests ${{ inputs.run_full_pytorch_tests }})
 
 permissions:
   contents: read
 
 jobs:
   setup_matrix:
+    name: Configure PyTorch Release Matrix
     runs-on: ubuntu-24.04
     outputs:
       pytorch_matrix: ${{ steps.matrix.outputs.pytorch_matrix }}

--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -188,6 +188,7 @@ jobs:
     with:
       amdgpu_families: ${{ matrix.amdgpu_families }}
       test_amdgpu_families: ${{ matrix.test_amdgpu_families }}
+      test_level: ${{ matrix.test_level }}
       python_version: ${{ matrix.python_version }}
       pytorch_git_ref: ${{ matrix.pytorch_git_ref }}
       rocm_version: ${{ inputs.rocm_version }}

--- a/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
@@ -122,13 +122,17 @@ on:
         type: string
         default: ""
 
-run-name: Release Windows PyTorch Wheels (${{ inputs.release_type }}, ${{ inputs.rocm_version }}, ${{ inputs.amdgpu_families }})
+run-name: >-
+  Release Windows PyTorch Wheels
+  (${{ inputs.release_type }}, ${{ inputs.rocm_version }},
+  ${{ inputs.amdgpu_families }}, py ${{ inputs.python_version || 'all' }})
 
 permissions:
   contents: read
 
 jobs:
   setup_matrix:
+    name: Configure PyTorch Release Matrix
     runs-on: ubuntu-24.04
     outputs:
       pytorch_matrix: ${{ steps.matrix.outputs.pytorch_matrix }}

--- a/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
@@ -175,6 +175,7 @@ jobs:
     with:
       amdgpu_families: ${{ matrix.amdgpu_families }}
       test_amdgpu_families: ${{ matrix.test_amdgpu_families }}
+      test_level: ${{ matrix.test_level }}
       python_version: ${{ matrix.python_version }}
       pytorch_git_ref: ${{ matrix.pytorch_git_ref }}
       rocm_version: ${{ inputs.rocm_version }}

--- a/build_tools/github_actions/configure_multi_arch_ci_summary.py
+++ b/build_tools/github_actions/configure_multi_arch_ci_summary.py
@@ -222,6 +222,9 @@ def _append_build_rocm(
 
 
 def _append_build_pytorch(lines: list[str], outputs: CIOutputs) -> None:
+    # TODO(#7731): Show each row's test level once multi_arch_ci consumes it to
+    # schedule PyTorch tests. Today these CI jobs stop after build-time wheel
+    # validation even though the generated matrix carries a test level.
     lines.append("| Platform | Python | PyTorch ref | Families |")
     lines.append("|----------|--------|-------------|----------|")
 

--- a/build_tools/github_actions/configure_pytorch_release_matrix.py
+++ b/build_tools/github_actions/configure_pytorch_release_matrix.py
@@ -75,6 +75,13 @@ UNSUPPORTED_AMDGPU_FAMILIES = {
     },
 }
 
+# PyTorch test levels are additive:
+#
+# * none schedules no self-hosted GPU tests. The wheel build job still runs
+#   its build-time wheel validation.
+# * standard also runs test_pytorch_wheels.yml on each selected AMDGPU family.
+PYTORCH_TEST_LEVELS = ["none", "standard"]
+
 
 def _split_values(raw: str) -> list[str]:
     """Split comma, semicolon, or whitespace-separated workflow input values."""
@@ -170,6 +177,7 @@ def generate_pytorch_matrix_for_release_type(
                 "python_version": py,
                 "pytorch_git_ref": ref,
                 "amdgpu_families": families,
+                "test_level": "standard",
                 # TODO(#7185): PyTorch nightly's requirements-ci.txt pins
                 # scikit-image==0.22.0, which has no cp314 wheel and fails to
                 # build from source. Build those wheels but skip their tests

--- a/build_tools/github_actions/configure_pytorch_release_matrix.py
+++ b/build_tools/github_actions/configure_pytorch_release_matrix.py
@@ -225,15 +225,7 @@ def generate_pytorch_matrix_for_release_type(
                     python_version=py,
                     pytorch_git_ref=ref,
                 ),
-                # TODO(#7185): PyTorch nightly's requirements-ci.txt pins
-                # scikit-image==0.22.0, which has no cp314 wheel and fails to
-                # build from source. Build those wheels but skip their tests
-                # until that is fixed.
-                "test_amdgpu_families": (
-                    "none"
-                    if (platform, ref, py) == ("windows", "nightly", "3.14")
-                    else "auto"
-                ),
+                "test_amdgpu_families": "auto",
             }
             matrix.append(row)
     return matrix

--- a/build_tools/github_actions/configure_pytorch_release_matrix.py
+++ b/build_tools/github_actions/configure_pytorch_release_matrix.py
@@ -8,6 +8,7 @@ import argparse
 import json
 import platform as platform_module
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 _BUILD_TOOLS_DIR = Path(__file__).resolve().parent.parent
@@ -86,7 +87,9 @@ UNSUPPORTED_AMDGPU_FAMILIES = {
 # * none schedules no self-hosted GPU tests. The wheel build job still runs
 #   its build-time wheel validation.
 # * standard also runs test_pytorch_wheels.yml on each selected AMDGPU family.
-PYTORCH_TEST_LEVELS = ["none", "standard"]
+# * full also dispatches test_pytorch_wheels_full.yml, which runs the much
+#   larger upstream PyTorch test suite and can take several hours.
+PYTORCH_TEST_LEVELS = ["none", "standard", "full"]
 
 # Release workflows limit standard GPU testing to the oldest Python version
 # supported by each PyTorch ref. Match upstream's trunk test version and
@@ -99,6 +102,14 @@ PYTORCH_PRIMARY_TEST_PYTHON_VERSIONS = {
     "release/2.14": "3.10",
     "nightly": "3.10",
 }
+
+# The full PyTorch test suite can take several hours, so release workflows run
+# it on only one representative platform and AMDGPU family. The build workflow
+# still accepts direct full-test dispatches for this family on any Python
+# version; the release policy additionally limits full coverage to the primary
+# Python version selected above.
+PYTORCH_FULL_TEST_PLATFORM = "linux"
+PYTORCH_FULL_TEST_AMDGPU_FAMILY = "gfx94X-dcgpu"
 
 
 def _split_values(raw: str) -> list[str]:
@@ -153,15 +164,33 @@ def _primary_test_python_version(pytorch_git_ref: str) -> str:
 
 
 def _select_test_level(
-    *, release_type: str, python_version: str, pytorch_git_ref: str
+    *,
+    release_type: str,
+    python_version: str,
+    pytorch_git_ref: str,
+    platform: str,
+    amdgpu_families: list[str],
+    run_full_pytorch_tests: bool,
+    run_nightly_full_pytorch_tests: bool,
 ) -> str:
     # multi_arch_ci does not schedule PyTorch GPU tests yet. Preserve its
     # standard level until that workflow's test policy is selected explicitly.
     if release_type == "ci":
         return "standard"
-    if python_version == _primary_test_python_version(pytorch_git_ref):
-        return "standard"
-    return "none"
+    if python_version != _primary_test_python_version(pytorch_git_ref):
+        return "none"
+
+    full_tests_due_for_ref = run_full_pytorch_tests and (
+        pytorch_git_ref != "nightly" or run_nightly_full_pytorch_tests
+    )
+    if (
+        full_tests_due_for_ref
+        and platform == PYTORCH_FULL_TEST_PLATFORM
+        and PYTORCH_FULL_TEST_AMDGPU_FAMILY.lower()
+        in {family.lower() for family in amdgpu_families}
+    ):
+        return "full"
+    return "standard"
 
 
 def generate_pytorch_matrix_for_release_type(
@@ -171,6 +200,8 @@ def generate_pytorch_matrix_for_release_type(
     platform: str,
     python_versions: list[str] | None = None,
     pytorch_git_refs: list[str] | None = None,
+    run_full_pytorch_tests: bool = False,
+    run_nightly_full_pytorch_tests: bool = False,
 ) -> list[dict[str, str]]:
     if release_type not in RELEASE_TYPES:
         raise ValueError(f"Unknown release_type: {release_type!r}")
@@ -224,6 +255,10 @@ def generate_pytorch_matrix_for_release_type(
                     release_type=release_type,
                     python_version=py,
                     pytorch_git_ref=ref,
+                    platform=platform,
+                    amdgpu_families=_split_families(families),
+                    run_full_pytorch_tests=run_full_pytorch_tests,
+                    run_nightly_full_pytorch_tests=run_nightly_full_pytorch_tests,
                 ),
                 "test_amdgpu_families": "auto",
             }
@@ -238,6 +273,8 @@ def format_matrix_summary(
     python_versions: list[str] | None,
     pytorch_git_refs: list[str] | None,
     amdgpu_families: str,
+    run_full_pytorch_tests: bool,
+    run_nightly_full_pytorch_tests: bool,
     matrix: list[dict[str, str]],
 ) -> str:
     """Format the resolved release matrix for logs and the job summary."""
@@ -281,6 +318,7 @@ def format_matrix_summary(
         )
         + " |",
         f"| Requested AMDGPU families | `{amdgpu_families or 'none'}` |",
+        f"| Full tests requested | `{'yes' if run_full_pytorch_tests else 'no'}` |",
         f"| Generated rows | {len(matrix)} ({count_summary}) |",
     ]
 
@@ -314,8 +352,20 @@ def format_matrix_summary(
         lines.extend(
             [
                 "",
-                "All generated rows use `none` because none uses its "
+                "All generated rows use `none` because no row uses its "
                 "PyTorch ref's primary test Python version.",
+            ]
+        )
+
+    if matrix and run_full_pytorch_tests:
+        lines.extend(
+            [
+                "",
+                "`full` is selected only for primary-version Linux rows that "
+                f"include `{PYTORCH_FULL_TEST_AMDGPU_FAMILY}`. Stable refs are "
+                "eligible daily; the nightly ref is eligible on Sunday. "
+                f"Nightly full tests are due now: "
+                f"`{'yes' if run_nightly_full_pytorch_tests else 'no'}`.",
             ]
         )
 
@@ -376,6 +426,14 @@ def main(argv: list[str] | None = None) -> int:
         help="Release type selecting default PyTorch/Python matrix (default: dev)",
     )
     parser.add_argument(
+        "--run-full-pytorch-tests",
+        action="store_true",
+        help=(
+            "Use the full test level for eligible stable-ref rows and for "
+            "eligible nightly rows on Sunday"
+        ),
+    )
+    parser.add_argument(
         "--amdgpu-families",
         type=str,
         default="",
@@ -390,12 +448,17 @@ def main(argv: list[str] | None = None) -> int:
     python_versions = _split_values(args.python_versions) or None
     pytorch_git_refs = _split_values(args.pytorch_git_refs) or None
 
+    run_nightly_full_pytorch_tests = (
+        args.run_full_pytorch_tests and datetime.now(timezone.utc).isoweekday() == 7
+    )
     matrix = generate_pytorch_matrix_for_release_type(
         release_type=args.release_type,
         python_versions=python_versions,
         pytorch_git_refs=pytorch_git_refs,
         amdgpu_families=args.amdgpu_families,
         platform=args.platform,
+        run_full_pytorch_tests=args.run_full_pytorch_tests,
+        run_nightly_full_pytorch_tests=run_nightly_full_pytorch_tests,
     )
     gha_append_step_summary(
         format_matrix_summary(
@@ -404,6 +467,8 @@ def main(argv: list[str] | None = None) -> int:
             python_versions=python_versions,
             pytorch_git_refs=pytorch_git_refs,
             amdgpu_families=args.amdgpu_families,
+            run_full_pytorch_tests=args.run_full_pytorch_tests,
+            run_nightly_full_pytorch_tests=run_nightly_full_pytorch_tests,
             matrix=matrix,
         )
     )

--- a/build_tools/github_actions/configure_pytorch_release_matrix.py
+++ b/build_tools/github_actions/configure_pytorch_release_matrix.py
@@ -15,6 +15,7 @@ sys.path.insert(0, str(_BUILD_TOOLS_DIR))
 
 from github_actions.github_actions_api import gha_append_step_summary, gha_set_output
 
+# Build matrix configuration.
 RELEASE_TYPES = [
     "ci",
     "dev",
@@ -27,6 +28,9 @@ RELEASE_TYPES = [
 # TODO: add opt-ins for CI runs to use python versions and pytorch refs normally
 #       only included in release runs
 
+# All configured refs currently share this build-version range. When upstream
+# support windows diverge, replace it with an ordered per-ref version map and
+# derive each ref's primary test version from the oldest entry in that map.
 RELEASE_PYTHON_VERSIONS = ["3.10", "3.11", "3.12", "3.13", "3.14"]
 CI_PYTHON_VERSIONS = {
     "linux": ["3.12"],
@@ -75,12 +79,26 @@ UNSUPPORTED_AMDGPU_FAMILIES = {
     },
 }
 
+# Test coverage configuration.
+#
 # PyTorch test levels are additive:
 #
 # * none schedules no self-hosted GPU tests. The wheel build job still runs
 #   its build-time wheel validation.
 # * standard also runs test_pytorch_wheels.yml on each selected AMDGPU family.
 PYTORCH_TEST_LEVELS = ["none", "standard"]
+
+# Release workflows limit standard GPU testing to the oldest Python version
+# supported by each PyTorch ref. Match upstream's trunk test version and
+# release support policy:
+# https://github.com/pytorch/pytorch/blob/main/.github/workflows/trunk.yml
+# https://github.com/pytorch/pytorch/blob/main/RELEASE.md#python
+PYTORCH_PRIMARY_TEST_PYTHON_VERSIONS = {
+    "release/2.12": "3.10",
+    "release/2.13": "3.10",
+    "release/2.14": "3.10",
+    "nightly": "3.10",
+}
 
 
 def _split_values(raw: str) -> list[str]:
@@ -123,6 +141,29 @@ def _filter_families(families_str: str, exclude: set[str]) -> str:
     )
 
 
+def _primary_test_python_version(pytorch_git_ref: str) -> str:
+    """Return the primary test version for a PyTorch ref.
+
+    Unknown explicit refs use the nightly policy because bring-up branches
+    generally track upstream main.
+    """
+    return PYTORCH_PRIMARY_TEST_PYTHON_VERSIONS.get(
+        pytorch_git_ref, PYTORCH_PRIMARY_TEST_PYTHON_VERSIONS["nightly"]
+    )
+
+
+def _select_test_level(
+    *, release_type: str, python_version: str, pytorch_git_ref: str
+) -> str:
+    # multi_arch_ci does not schedule PyTorch GPU tests yet. Preserve its
+    # standard level until that workflow's test policy is selected explicitly.
+    if release_type == "ci":
+        return "standard"
+    if python_version == _primary_test_python_version(pytorch_git_ref):
+        return "standard"
+    return "none"
+
+
 def generate_pytorch_matrix_for_release_type(
     *,
     release_type: str,
@@ -154,13 +195,15 @@ def generate_pytorch_matrix_for_release_type(
     #   {
     #     "python_version": "3.10",
     #     "pytorch_git_ref": "release/2.12",
-    #     "amdgpu_families": "gfx94X-dcgpu"
+    #     "amdgpu_families": "gfx94X-dcgpu",
+    #     "test_level": "standard"
     #   },
     #   ...
     #   {
     #     "python_version": "3.14",
     #     "pytorch_git_ref": "nightly",
-    #     "amdgpu_families": "gfx94X-dcgpu"
+    #     "amdgpu_families": "gfx94X-dcgpu",
+    #     "test_level": "none"
     #   }
     # ]
     matrix: list[dict[str, str]] = []
@@ -177,7 +220,11 @@ def generate_pytorch_matrix_for_release_type(
                 "python_version": py,
                 "pytorch_git_ref": ref,
                 "amdgpu_families": families,
-                "test_level": "standard",
+                "test_level": _select_test_level(
+                    release_type=release_type,
+                    python_version=py,
+                    pytorch_git_ref=ref,
+                ),
                 # TODO(#7185): PyTorch nightly's requirements-ci.txt pins
                 # scikit-image==0.22.0, which has no cp314 wheel and fails to
                 # build from source. Build those wheels but skip their tests
@@ -213,6 +260,13 @@ def format_matrix_summary(
         )
         or "none"
     )
+    selected_refs = list(dict.fromkeys(row["pytorch_git_ref"] for row in matrix))
+    primary_versions = (
+        ", ".join(
+            f"`{ref}`: `{_primary_test_python_version(ref)}`" for ref in selected_refs
+        )
+        or "none"
+    )
     lines = [
         "## PyTorch Release Matrix",
         "",
@@ -244,6 +298,32 @@ def format_matrix_summary(
                 "",
                 "**Decision:** No build rows remain after applying the "
                 "PyTorch-ref AMDGPU-family support filters.",
+            ]
+        )
+    elif release_type == "ci":
+        lines.extend(
+            [
+                "",
+                "CI rows remain `standard` until multi-arch CI schedules "
+                "PyTorch GPU tests and selects its test policy explicitly.",
+            ]
+        )
+    else:
+        lines.extend(
+            [
+                "",
+                "Standard GPU testing is assigned only to each PyTorch ref's "
+                f"primary Python version: {primary_versions}. Other versions "
+                "use `none`.",
+            ]
+        )
+
+    if matrix and level_counts["none"] == len(matrix):
+        lines.extend(
+            [
+                "",
+                "All generated rows use `none` because none uses its "
+                "PyTorch ref's primary test Python version.",
             ]
         )
 

--- a/build_tools/github_actions/configure_pytorch_release_matrix.py
+++ b/build_tools/github_actions/configure_pytorch_release_matrix.py
@@ -13,7 +13,7 @@ from pathlib import Path
 _BUILD_TOOLS_DIR = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_BUILD_TOOLS_DIR))
 
-from github_actions.github_actions_api import gha_set_output
+from github_actions.github_actions_api import gha_append_step_summary, gha_set_output
 
 RELEASE_TYPES = [
     "ci",
@@ -192,6 +192,81 @@ def generate_pytorch_matrix_for_release_type(
     return matrix
 
 
+def format_matrix_summary(
+    *,
+    release_type: str,
+    platform: str,
+    python_versions: list[str] | None,
+    pytorch_git_refs: list[str] | None,
+    amdgpu_families: str,
+    matrix: list[dict[str, str]],
+) -> str:
+    """Format the resolved release matrix for logs and the job summary."""
+
+    level_counts = {
+        level: sum(row["test_level"] == level for row in matrix)
+        for level in PYTORCH_TEST_LEVELS
+    }
+    count_summary = (
+        ", ".join(
+            f"`{level}`: {count}" for level, count in level_counts.items() if count
+        )
+        or "none"
+    )
+    lines = [
+        "## PyTorch Release Matrix",
+        "",
+        "| Setting | Value |",
+        "| --- | --- |",
+        f"| Release type | `{release_type}` |",
+        f"| Platform | `{platform}` |",
+        "| Python selection | "
+        + (
+            ", ".join(f"`{version}`" for version in python_versions)
+            if python_versions
+            else "default"
+        )
+        + " |",
+        "| PyTorch ref selection | "
+        + (
+            ", ".join(f"`{ref}`" for ref in pytorch_git_refs)
+            if pytorch_git_refs
+            else "default"
+        )
+        + " |",
+        f"| Requested AMDGPU families | `{amdgpu_families or 'none'}` |",
+        f"| Generated rows | {len(matrix)} ({count_summary}) |",
+    ]
+
+    if not matrix:
+        lines.extend(
+            [
+                "",
+                "**Decision:** No build rows remain after applying the "
+                "PyTorch-ref AMDGPU-family support filters.",
+            ]
+        )
+
+    lines.extend(
+        [
+            "",
+            "| Python | PyTorch ref | AMDGPU families | Test level |",
+            "| --- | --- | --- | --- |",
+        ]
+    )
+    for row in matrix:
+        families = ", ".join(
+            f"`{family}`" for family in _split_families(row["amdgpu_families"])
+        )
+        lines.append(
+            f"| `{row['python_version']}` | `{row['pytorch_git_ref']}` | "
+            f"{families} | `{row['test_level']}` |"
+        )
+    if not matrix:
+        lines.append("| none | none | none | none |")
+    return "\n".join(lines)
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Generate PyTorch release build matrix"
@@ -249,6 +324,16 @@ def main(argv: list[str] | None = None) -> int:
         pytorch_git_refs=pytorch_git_refs,
         amdgpu_families=args.amdgpu_families,
         platform=args.platform,
+    )
+    gha_append_step_summary(
+        format_matrix_summary(
+            release_type=args.release_type,
+            platform=args.platform,
+            python_versions=python_versions,
+            pytorch_git_refs=pytorch_git_refs,
+            amdgpu_families=args.amdgpu_families,
+            matrix=matrix,
+        )
     )
     gha_set_output({"pytorch_matrix": json.dumps(matrix)})
     return 0

--- a/build_tools/github_actions/configure_pytorch_test_matrix.py
+++ b/build_tools/github_actions/configure_pytorch_test_matrix.py
@@ -149,6 +149,11 @@ def format_test_summary(
             "artifact validation before any GPU tests.",
         ]
     )
+    if test_level == "full":
+        lines.append(
+            "The build workflow dispatches the additional full suite "
+            "separately from this standard GPU test matrix."
+        )
     return "\n".join(lines)
 
 
@@ -182,7 +187,7 @@ def main(argv: list[str]) -> None:
         default="standard",
         help=(
             "Test coverage level. 'none' stops after build-time wheel "
-            "validation; 'standard' runs the GPU test matrix."
+            "validation; 'standard' and 'full' run the standard GPU matrix."
         ),
     )
     parser.add_argument(

--- a/build_tools/github_actions/configure_pytorch_test_matrix.py
+++ b/build_tools/github_actions/configure_pytorch_test_matrix.py
@@ -22,7 +22,7 @@ _BUILD_TOOLS_DIR = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_BUILD_TOOLS_DIR))
 
 from github_actions.amdgpu_family_matrix import get_all_families_for_trigger_types
-from github_actions.github_actions_api import gha_set_output
+from github_actions.github_actions_api import gha_append_step_summary, gha_set_output
 from configure_pytorch_release_matrix import PYTORCH_TEST_LEVELS
 
 
@@ -59,7 +59,7 @@ def build_test_matrix(
         )
         return {"include": []}
 
-    print(f"Requested {platform} AMDGPU families: {amdgpu_families}")
+    print(f"Resolved {platform} GPU test families: {amdgpu_families or 'none'}")
     include: list[dict[str, str]] = []
     for requested_family in amdgpu_families:
         test_runs_on = find_test_runs_on(
@@ -82,6 +82,74 @@ def build_test_matrix(
         )
 
     return {"include": include}
+
+
+def format_test_summary(
+    *,
+    platform: str,
+    test_level: str,
+    built_families: list[str],
+    requested_test_families: str,
+    resolved_test_families: list[str],
+    matrix: dict[str, list[dict[str, str]]],
+) -> str:
+    """Format the resolved test policy for logs and the job summary."""
+
+    def format_families(families: list[str]) -> str:
+        return ", ".join(f"`{family}`" for family in families) or "none"
+
+    include = matrix["include"]
+    lines = [
+        "## PyTorch Test Configuration",
+        "",
+        "| Setting | Value |",
+        "| --- | --- |",
+        f"| Platform | `{platform}` |",
+        f"| Test level | `{test_level}` |",
+        f"| Built AMDGPU families | {format_families(built_families)} |",
+        f"| Requested test families | `{requested_test_families}` |",
+        f"| Resolved test families | {format_families(resolved_test_families)} |",
+        f"| Self-hosted GPU test jobs | {len(include)} |",
+        "",
+    ]
+
+    if test_level == "none":
+        lines.append(
+            "**Decision:** No self-hosted GPU test jobs are scheduled because "
+            "the test level is `none`."
+        )
+    elif not resolved_test_families:
+        lines.append(
+            "**Decision:** No self-hosted GPU test jobs are scheduled because "
+            "the test-family selection resolved to none."
+        )
+    elif not include:
+        lines.append(
+            "**Decision:** No self-hosted GPU test jobs are scheduled because "
+            f"none of the selected families has a configured {platform} runner."
+        )
+    else:
+        lines.extend(
+            [
+                "**Decision:** Schedule the following self-hosted GPU tests:",
+                "",
+                "| AMDGPU family | Runner |",
+                "| --- | --- |",
+                *[
+                    f"| `{row['amdgpu_family']}` | `{row['test_runs_on']}` |"
+                    for row in include
+                ],
+            ]
+        )
+
+    lines.extend(
+        [
+            "",
+            "The build job always runs `sanity_check_wheel.py` as build-time "
+            "artifact validation before any GPU tests.",
+        ]
+    )
+    return "\n".join(lines)
 
 
 def emit_outputs(matrix: dict[str, list[dict[str, str]]]) -> None:
@@ -144,6 +212,16 @@ def main(argv: list[str]) -> None:
         amdgpu_families=test_amdgpu_families,
         platform=args.platform,
         test_level=args.test_level,
+    )
+    gha_append_step_summary(
+        format_test_summary(
+            platform=args.platform,
+            test_level=args.test_level,
+            built_families=built_families,
+            requested_test_families=args.test_amdgpu_families.strip() or "auto",
+            resolved_test_families=test_amdgpu_families,
+            matrix=matrix,
+        )
     )
     emit_outputs(matrix)
 

--- a/build_tools/github_actions/configure_pytorch_test_matrix.py
+++ b/build_tools/github_actions/configure_pytorch_test_matrix.py
@@ -23,6 +23,7 @@ sys.path.insert(0, str(_BUILD_TOOLS_DIR))
 
 from github_actions.amdgpu_family_matrix import get_all_families_for_trigger_types
 from github_actions.github_actions_api import gha_set_output
+from configure_pytorch_release_matrix import PYTORCH_TEST_LEVELS
 
 
 def split_families(value: str) -> list[str]:
@@ -47,7 +48,17 @@ def build_test_matrix(
     *,
     amdgpu_families: list[str],
     platform: str,
+    test_level: str,
 ) -> dict[str, list[dict[str, str]]]:
+    if test_level not in PYTORCH_TEST_LEVELS:
+        raise ValueError(f"Unknown PyTorch test level: {test_level!r}")
+    if test_level == "none":
+        print(
+            "Test level 'none': no self-hosted GPU test jobs will be scheduled; "
+            "the build job still runs its build-time wheel validation"
+        )
+        return {"include": []}
+
     print(f"Requested {platform} AMDGPU families: {amdgpu_families}")
     include: list[dict[str, str]] = []
     for requested_family in amdgpu_families:
@@ -98,6 +109,15 @@ def main(argv: list[str]) -> None:
         ),
     )
     parser.add_argument(
+        "--test-level",
+        choices=PYTORCH_TEST_LEVELS,
+        default="standard",
+        help=(
+            "Test coverage level. 'none' stops after build-time wheel "
+            "validation; 'standard' runs the GPU test matrix."
+        ),
+    )
+    parser.add_argument(
         "--platform",
         choices=["linux", "windows"],
         default=platform_module.system().lower(),
@@ -123,6 +143,7 @@ def main(argv: list[str]) -> None:
     matrix = build_test_matrix(
         amdgpu_families=test_amdgpu_families,
         platform=args.platform,
+        test_level=args.test_level,
     )
     emit_outputs(matrix)
 

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -1337,12 +1337,14 @@ class TestExpandBuildConfigs(unittest.TestCase):
                     "python_version": "3.12",
                     "pytorch_git_ref": "release/2.12",
                     "amdgpu_families": "gfx94X-dcgpu",
+                    "test_level": "standard",
                     "test_amdgpu_families": "auto",
                 },
                 {
                     "python_version": "3.12",
                     "pytorch_git_ref": "release/2.13",
                     "amdgpu_families": "gfx94X-dcgpu",
+                    "test_level": "standard",
                     "test_amdgpu_families": "auto",
                 },
             ],
@@ -1354,6 +1356,7 @@ class TestExpandBuildConfigs(unittest.TestCase):
                     "python_version": "3.12",
                     "pytorch_git_ref": "release/2.12",
                     "amdgpu_families": "gfx110X-all",
+                    "test_level": "standard",
                     "test_amdgpu_families": "auto",
                 }
             ],

--- a/build_tools/github_actions/tests/configure_pytorch_release_matrix_test.py
+++ b/build_tools/github_actions/tests/configure_pytorch_release_matrix_test.py
@@ -170,6 +170,8 @@ class ConfigurePytorchReleaseMatrixTest(unittest.TestCase):
             python_versions=["3.12"],
             pytorch_git_refs=["release/2.12", "nightly"],
             amdgpu_families="gfx94X-dcgpu",
+            run_full_pytorch_tests=False,
+            run_nightly_full_pytorch_tests=False,
             matrix=matrix,
         )
 
@@ -180,6 +182,52 @@ class ConfigurePytorchReleaseMatrixTest(unittest.TestCase):
         self.assertIn(
             "| `3.12` | `release/2.12` | `gfx94X-dcgpu` | `none` |",
             summary,
+        )
+
+    def test_full_tests_run_for_primary_stable_configuration(self):
+        matrix = m.generate_pytorch_matrix_for_release_type(
+            release_type="nightly",
+            python_versions=["3.10"],
+            pytorch_git_refs=["release/2.13"],
+            amdgpu_families="gfx94X-dcgpu;gfx110X-all",
+            platform="linux",
+            run_full_pytorch_tests=True,
+        )
+
+        self.assertEqual(matrix[0]["test_level"], "full")
+
+    def test_nightly_full_tests_run_only_when_weekly_tests_are_due(self):
+        common_args = {
+            "release_type": "nightly",
+            "python_versions": ["3.10"],
+            "pytorch_git_refs": ["nightly"],
+            "amdgpu_families": "gfx94X-dcgpu",
+            "platform": "linux",
+            "run_full_pytorch_tests": True,
+        }
+
+        daily_matrix = m.generate_pytorch_matrix_for_release_type(**common_args)
+        weekly_matrix = m.generate_pytorch_matrix_for_release_type(
+            **common_args,
+            run_nightly_full_pytorch_tests=True,
+        )
+
+        self.assertEqual(daily_matrix[0]["test_level"], "standard")
+        self.assertEqual(weekly_matrix[0]["test_level"], "full")
+
+    def test_full_request_does_not_expand_eligible_configuration(self):
+        matrix = m.generate_pytorch_matrix_for_release_type(
+            release_type="nightly",
+            python_versions=["3.10", "3.12"],
+            pytorch_git_refs=["release/2.13"],
+            amdgpu_families="gfx110X-all",
+            platform="linux",
+            run_full_pytorch_tests=True,
+        )
+
+        self.assertEqual(
+            [(row["python_version"], row["test_level"]) for row in matrix],
+            [("3.10", "standard"), ("3.12", "none")],
         )
 
     def test_generated_rows_cover_workflow_matrix_inputs(self):

--- a/build_tools/github_actions/tests/configure_pytorch_release_matrix_test.py
+++ b/build_tools/github_actions/tests/configure_pytorch_release_matrix_test.py
@@ -184,6 +184,30 @@ class ConfigurePytorchReleaseMatrixTest(unittest.TestCase):
                 self.assertEqual(len(matrix), 1)
                 self.assertEqual(matrix[0]["test_amdgpu_families"], "auto")
 
+    def test_summary_lists_generated_rows_and_test_levels(self):
+        matrix = m.generate_pytorch_matrix_for_release_type(
+            release_type="dev",
+            python_versions=["3.12"],
+            pytorch_git_refs=["release/2.12", "nightly"],
+            amdgpu_families="gfx94X-dcgpu",
+            platform="linux",
+        )
+
+        summary = m.format_matrix_summary(
+            release_type="dev",
+            platform="linux",
+            python_versions=["3.12"],
+            pytorch_git_refs=["release/2.12", "nightly"],
+            amdgpu_families="gfx94X-dcgpu",
+            matrix=matrix,
+        )
+
+        self.assertIn("| Generated rows | 2 (`standard`: 2) |", summary)
+        self.assertIn(
+            "| `3.12` | `release/2.12` | `gfx94X-dcgpu` | `standard` |",
+            summary,
+        )
+
     def test_generated_rows_cover_workflow_matrix_inputs(self):
         # The generate_pytorch_matrix_for_release_type script produces matrix
         # JSON for use in workflow files like:

--- a/build_tools/github_actions/tests/configure_pytorch_release_matrix_test.py
+++ b/build_tools/github_actions/tests/configure_pytorch_release_matrix_test.py
@@ -141,49 +141,6 @@ class ConfigurePytorchReleaseMatrixTest(unittest.TestCase):
             ],
         )
 
-    def test_windows_nightly_python_314_skips_tests(self):
-        matrix = m.generate_pytorch_matrix_for_release_type(
-            release_type="nightly",
-            python_versions=["3.14"],
-            pytorch_git_refs=["nightly"],
-            amdgpu_families="gfx110X-all",
-            platform="windows",
-        )
-
-        # The row still builds and publishes wheels; only its tests are skipped.
-        self.assertEqual(
-            matrix,
-            [
-                {
-                    "python_version": "3.14",
-                    "pytorch_git_ref": "nightly",
-                    "amdgpu_families": "gfx110X-all",
-                    "test_level": "none",
-                    "test_amdgpu_families": "none",
-                }
-            ],
-        )
-
-    def test_only_windows_nightly_python_314_skips_tests(self):
-        # Each neighbor of the skipped (platform, ref, python version) keeps the
-        # normal "auto" behavior.
-        for platform, ref, python_version in (
-            ("linux", "nightly", "3.14"),
-            ("windows", "nightly", "3.13"),
-            ("windows", "release/2.13", "3.14"),
-        ):
-            with self.subTest(platform=platform, ref=ref, py=python_version):
-                matrix = m.generate_pytorch_matrix_for_release_type(
-                    release_type="nightly",
-                    python_versions=[python_version],
-                    pytorch_git_refs=[ref],
-                    amdgpu_families="gfx110X-all",
-                    platform=platform,
-                )
-
-                self.assertEqual(len(matrix), 1)
-                self.assertEqual(matrix[0]["test_amdgpu_families"], "auto")
-
     def test_release_uses_primary_python_version_for_standard_tests(self):
         matrix = m.generate_pytorch_matrix_for_release_type(
             release_type="nightly",

--- a/build_tools/github_actions/tests/configure_pytorch_release_matrix_test.py
+++ b/build_tools/github_actions/tests/configure_pytorch_release_matrix_test.py
@@ -35,12 +35,14 @@ class ConfigurePytorchReleaseMatrixTest(unittest.TestCase):
                     "python_version": "3.12",
                     "pytorch_git_ref": "release/2.12",
                     "amdgpu_families": "gfx94X-dcgpu",
+                    "test_level": "standard",
                     "test_amdgpu_families": "auto",
                 },
                 {
                     "python_version": "3.12",
                     "pytorch_git_ref": "release/2.13",
                     "amdgpu_families": "gfx94X-dcgpu",
+                    "test_level": "standard",
                     "test_amdgpu_families": "auto",
                 },
             ],
@@ -64,6 +66,7 @@ class ConfigurePytorchReleaseMatrixTest(unittest.TestCase):
                     "python_version": "3.12",
                     "pytorch_git_ref": "release/2.12",
                     "amdgpu_families": "gfx110X-all",
+                    "test_level": "standard",
                     "test_amdgpu_families": "auto",
                 },
             ],
@@ -85,6 +88,7 @@ class ConfigurePytorchReleaseMatrixTest(unittest.TestCase):
                     "python_version": "3.13",
                     "pytorch_git_ref": "nightly",
                     "amdgpu_families": "gfx94X-dcgpu",
+                    "test_level": "standard",
                     "test_amdgpu_families": "auto",
                 }
             ],
@@ -109,6 +113,7 @@ class ConfigurePytorchReleaseMatrixTest(unittest.TestCase):
                             "python_version": "3.12",
                             "pytorch_git_ref": pytorch_git_ref,
                             "amdgpu_families": "gfx125X-dcgpu",
+                            "test_level": "standard",
                             "test_amdgpu_families": "auto",
                         }
                     ],
@@ -130,6 +135,7 @@ class ConfigurePytorchReleaseMatrixTest(unittest.TestCase):
                     "python_version": "3.12",
                     "pytorch_git_ref": "users/alice/gfx125x-bringup",
                     "amdgpu_families": "gfx125X-dcgpu",
+                    "test_level": "standard",
                     "test_amdgpu_families": "auto",
                 }
             ],
@@ -152,6 +158,7 @@ class ConfigurePytorchReleaseMatrixTest(unittest.TestCase):
                     "python_version": "3.14",
                     "pytorch_git_ref": "nightly",
                     "amdgpu_families": "gfx110X-all",
+                    "test_level": "standard",
                     "test_amdgpu_families": "none",
                 }
             ],

--- a/build_tools/github_actions/tests/configure_pytorch_release_matrix_test.py
+++ b/build_tools/github_actions/tests/configure_pytorch_release_matrix_test.py
@@ -88,7 +88,7 @@ class ConfigurePytorchReleaseMatrixTest(unittest.TestCase):
                     "python_version": "3.13",
                     "pytorch_git_ref": "nightly",
                     "amdgpu_families": "gfx94X-dcgpu",
-                    "test_level": "standard",
+                    "test_level": "none",
                     "test_amdgpu_families": "auto",
                 }
             ],
@@ -113,7 +113,7 @@ class ConfigurePytorchReleaseMatrixTest(unittest.TestCase):
                             "python_version": "3.12",
                             "pytorch_git_ref": pytorch_git_ref,
                             "amdgpu_families": "gfx125X-dcgpu",
-                            "test_level": "standard",
+                            "test_level": "none",
                             "test_amdgpu_families": "auto",
                         }
                     ],
@@ -135,7 +135,7 @@ class ConfigurePytorchReleaseMatrixTest(unittest.TestCase):
                     "python_version": "3.12",
                     "pytorch_git_ref": "users/alice/gfx125x-bringup",
                     "amdgpu_families": "gfx125X-dcgpu",
-                    "test_level": "standard",
+                    "test_level": "none",
                     "test_amdgpu_families": "auto",
                 }
             ],
@@ -158,7 +158,7 @@ class ConfigurePytorchReleaseMatrixTest(unittest.TestCase):
                     "python_version": "3.14",
                     "pytorch_git_ref": "nightly",
                     "amdgpu_families": "gfx110X-all",
-                    "test_level": "standard",
+                    "test_level": "none",
                     "test_amdgpu_families": "none",
                 }
             ],
@@ -184,7 +184,21 @@ class ConfigurePytorchReleaseMatrixTest(unittest.TestCase):
                 self.assertEqual(len(matrix), 1)
                 self.assertEqual(matrix[0]["test_amdgpu_families"], "auto")
 
-    def test_summary_lists_generated_rows_and_test_levels(self):
+    def test_release_uses_primary_python_version_for_standard_tests(self):
+        matrix = m.generate_pytorch_matrix_for_release_type(
+            release_type="nightly",
+            python_versions=["3.10", "3.12"],
+            pytorch_git_refs=["release/2.13"],
+            amdgpu_families="gfx94X-dcgpu",
+            platform="linux",
+        )
+
+        self.assertEqual(
+            [(row["python_version"], row["test_level"]) for row in matrix],
+            [("3.10", "standard"), ("3.12", "none")],
+        )
+
+    def test_summary_explains_an_all_none_matrix(self):
         matrix = m.generate_pytorch_matrix_for_release_type(
             release_type="dev",
             python_versions=["3.12"],
@@ -202,9 +216,12 @@ class ConfigurePytorchReleaseMatrixTest(unittest.TestCase):
             matrix=matrix,
         )
 
-        self.assertIn("| Generated rows | 2 (`standard`: 2) |", summary)
+        self.assertIn("| Generated rows | 2 (`none`: 2) |", summary)
+        self.assertIn("`release/2.12`: `3.10`", summary)
+        self.assertIn("`nightly`: `3.10`", summary)
+        self.assertIn("All generated rows use `none`", summary)
         self.assertIn(
-            "| `3.12` | `release/2.12` | `gfx94X-dcgpu` | `standard` |",
+            "| `3.12` | `release/2.12` | `gfx94X-dcgpu` | `none` |",
             summary,
         )
 

--- a/build_tools/github_actions/tests/configure_pytorch_test_matrix_test.py
+++ b/build_tools/github_actions/tests/configure_pytorch_test_matrix_test.py
@@ -207,6 +207,27 @@ class ConfigurePyTorchTestMatrixTest(unittest.TestCase):
         self.assertIn("| Self-hosted GPU test jobs | 1 |", summary)
         self.assertIn("| `gfxalpha-all` | `linux-alpha` |", summary)
 
+    def test_full_level_includes_standard_gpu_matrix(self) -> None:
+        with mock.patch.object(
+            m, "get_all_families_for_trigger_types", side_effect=_fake_family_matrix
+        ):
+            matrix = m.build_test_matrix(
+                amdgpu_families=["gfxalpha-all"],
+                platform="linux",
+                test_level="full",
+            )
+
+        self.assertEqual(matrix["include"][0]["test_runs_on"], "linux-alpha")
+        summary = m.format_test_summary(
+            platform="linux",
+            test_level="full",
+            built_families=["gfxalpha-all"],
+            requested_test_families="auto",
+            resolved_test_families=["gfxalpha-all"],
+            matrix=matrix,
+        )
+        self.assertIn("dispatches the additional full suite", summary)
+
     def test_real_family_matrix_finds_gfx950_runner(self) -> None:
         matrix = m.build_test_matrix(
             amdgpu_families=["gfx950-dcgpu"],

--- a/build_tools/github_actions/tests/configure_pytorch_test_matrix_test.py
+++ b/build_tools/github_actions/tests/configure_pytorch_test_matrix_test.py
@@ -47,6 +47,7 @@ class ConfigurePyTorchTestMatrixTest(unittest.TestCase):
         matrix = m.build_test_matrix(
             amdgpu_families=[],
             platform="linux",
+            test_level="standard",
         )
         self.assertEqual(matrix, {"include": []})
 
@@ -57,6 +58,7 @@ class ConfigurePyTorchTestMatrixTest(unittest.TestCase):
             matrix = m.build_test_matrix(
                 amdgpu_families=["gfxnorunner"],
                 platform="linux",
+                test_level="standard",
             )
         self.assertEqual(matrix, {"include": []})
 
@@ -67,6 +69,7 @@ class ConfigurePyTorchTestMatrixTest(unittest.TestCase):
             matrix = m.build_test_matrix(
                 amdgpu_families=["gfxalpha-all"],
                 platform="linux",
+                test_level="standard",
             )
         # FAKE_FAMILY_MATRIX also has a windows-alpha runner. The Linux
         # request should only use the Linux platform entry and canonical family.
@@ -89,7 +92,16 @@ class ConfigurePyTorchTestMatrixTest(unittest.TestCase):
             m.build_test_matrix(
                 amdgpu_families=["not-a-family"],
                 platform="linux",
+                test_level="standard",
             )
+
+    def test_none_level_skips_gpu_tests(self) -> None:
+        matrix = m.build_test_matrix(
+            amdgpu_families=["not-a-family"],
+            platform="linux",
+            test_level="none",
+        )
+        self.assertEqual(matrix, {"include": []})
 
     def test_main_writes_outputs(self) -> None:
         with mock.patch.object(
@@ -164,6 +176,7 @@ class ConfigurePyTorchTestMatrixTest(unittest.TestCase):
         matrix = m.build_test_matrix(
             amdgpu_families=["gfx950-dcgpu"],
             platform="linux",
+            test_level="standard",
         )
         include = matrix["include"]
         self.assertEqual(len(include), 1)

--- a/build_tools/github_actions/tests/configure_pytorch_test_matrix_test.py
+++ b/build_tools/github_actions/tests/configure_pytorch_test_matrix_test.py
@@ -172,6 +172,41 @@ class ConfigurePyTorchTestMatrixTest(unittest.TestCase):
         self.assertEqual(outputs["enabled"], "false")
         self.assertEqual(json.loads(outputs["matrix"]), {"include": []})
 
+    def test_none_summary_explains_no_gpu_tests(self) -> None:
+        summary = m.format_test_summary(
+            platform="linux",
+            test_level="none",
+            built_families=["gfxalpha-all"],
+            requested_test_families="auto",
+            resolved_test_families=["gfxalpha-all"],
+            matrix={"include": []},
+        )
+
+        self.assertIn("| Test level | `none` |", summary)
+        self.assertIn("| Self-hosted GPU test jobs | 0 |", summary)
+        self.assertIn("because the test level is `none`", summary)
+        self.assertIn("`sanity_check_wheel.py` as build-time", summary)
+
+    def test_standard_summary_lists_family_runner_mapping(self) -> None:
+        summary = m.format_test_summary(
+            platform="linux",
+            test_level="standard",
+            built_families=["gfxalpha-all"],
+            requested_test_families="auto",
+            resolved_test_families=["gfxalpha-all"],
+            matrix={
+                "include": [
+                    {
+                        "amdgpu_family": "gfxalpha-all",
+                        "test_runs_on": "linux-alpha",
+                    }
+                ]
+            },
+        )
+
+        self.assertIn("| Self-hosted GPU test jobs | 1 |", summary)
+        self.assertIn("| `gfxalpha-all` | `linux-alpha` |", summary)
+
     def test_real_family_matrix_finds_gfx950_runner(self) -> None:
         matrix = m.build_test_matrix(
             amdgpu_families=["gfx950-dcgpu"],


### PR DESCRIPTION
## Motivation

* Progress on https://github.com/ROCm/TheRock/issues/7731
* See also https://github.com/ROCm/TheRock/pull/7273

This merges the existing "run_full_pytorch_tests" option into the new "test_level" option so we can centralize test level selection across our matrix and support triggering full tests on configurations other than Linux gfx942.

## Test Plan

* `workflow_dispatch` of relevant workflow files on this branch
    * TODO

(needs some more extensive testing)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
