### PR TITLE
ci: reuse unaffected build stages on pull requests

### DIFF
--- a/.github/workflows/multi_arch_ci.yml
+++ b/.github/workflows/multi_arch_ci.yml
@@ -121,7 +121,9 @@ jobs:
       windows_test_labels: ${{ inputs.windows_test_labels || '' }}
       prebuilt_stages: ${{ inputs.prebuilt_stages || '' }}
       baseline_run_id: ${{ inputs.baseline_run_id || '' }}
-      stage_reuse_mode: ${{ inputs.stage_reuse_mode || 'dry-run' }}
+      # Pull requests reuse the stages their diff does not affect. Pushes stay
+      # on dry-run so every main commit builds the stages a PR later reuses.
+      stage_reuse_mode: ${{ inputs.stage_reuse_mode || (github.event_name == 'pull_request' && 'reuse-stage') || 'dry-run' }}
       stage_reuse_max_age_hours: ${{ inputs.stage_reuse_max_age_hours || '72' }}
       stage_reuse_commit_history: ${{ inputs.stage_reuse_commit_history || '50' }}
       build_python_packages: ${{ github.event_name != 'workflow_dispatch' || inputs.build_python_packages }}

--- a/.github/workflows/setup_multi_arch.yml
+++ b/.github/workflows/setup_multi_arch.yml
@@ -238,8 +238,10 @@ jobs:
           # Which repo to query for baseline_run_id. Defaults to THEROCK_REPOSITORY.
           BASELINE_REPOSITORY: ${{ inputs.baseline_repository }}
           STAGE_REUSE_MODE: ${{ inputs.stage_reuse_mode }}
-          # The checkout commit is used for commit-compatibility checking.
-          STAGE_REUSE_CURRENT_SHA: ${{ steps.checkout.outputs.commit }}
+          # The checkout commit is used for commit-compatibility checking. A
+          # pull request checks out a merge commit that is not on the baseline
+          # branch, so ancestry is established from its base commit instead.
+          STAGE_REUSE_CURRENT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || steps.checkout.outputs.commit }}
           STAGE_REUSE_MAX_AGE_HOURS: ${{ inputs.stage_reuse_max_age_hours }}
           STAGE_REUSE_COMMIT_HISTORY: ${{ inputs.stage_reuse_commit_history }}
           # For baseline run selection, use repository input (defaults to GITHUB_REPOSITORY).

--- a/build_tools/github_actions/tests/stage_reuse_pr_defaults_test.py
+++ b/build_tools/github_actions/tests/stage_reuse_pr_defaults_test.py
@@ -1,0 +1,68 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests the stage-reuse wiring that makes pull request CI skip build stages.
+
+Both settings under test are workflow expressions with no coverage anywhere
+else: nothing at parse or actionlint time notices if they are edited back to
+the defaults, and the only symptom would be pull requests quietly rebuilding
+stages they do not affect again.
+
+* `multi_arch_ci.yml` selects `reuse-stage` for pull requests. Pushes stay on
+  `dry-run`, because a push that reused stages would not produce the artifacts
+  a later pull request reuses.
+* `setup_multi_arch.yml` establishes commit ancestry from the pull request base
+  commit. A pull request checks out a merge commit that is not on the baseline
+  branch, so `validate_commit_compatibility` cannot place it in the branch
+  history and rejects every candidate baseline as `unknown`.
+"""
+
+import unittest
+
+from workflow_utils import WORKFLOWS_DIR, get_workflow_job, load_workflow
+
+CI_WORKFLOW = "multi_arch_ci.yml"
+SETUP_WORKFLOW = "setup_multi_arch.yml"
+
+
+class StageReuseModeTest(unittest.TestCase):
+    """Verifies the stage_reuse_mode passed from multi_arch_ci.yml to setup."""
+
+    def setUp(self):
+        workflow = load_workflow(WORKFLOWS_DIR / CI_WORKFLOW)
+        self.expression = get_workflow_job(workflow, "setup")["with"][
+            "stage_reuse_mode"
+        ]
+
+    def test_pull_requests_select_reuse_stage(self):
+        self.assertIn("pull_request", self.expression)
+        self.assertIn("reuse-stage", self.expression)
+
+    def test_pushes_keep_building_every_stage(self):
+        self.assertIn("dry-run", self.expression)
+
+    def test_workflow_dispatch_input_still_wins(self):
+        self.assertTrue(
+            self.expression.strip().startswith("${{ inputs.stage_reuse_mode ||"),
+            f"dispatch input no longer overrides the default: {self.expression!r}",
+        )
+
+
+class StageReuseCurrentShaTest(unittest.TestCase):
+    """Verifies ancestry uses a commit that is on the baseline branch."""
+
+    def setUp(self):
+        workflow = load_workflow(WORKFLOWS_DIR / SETUP_WORKFLOW)
+        steps = get_workflow_job(workflow, "setup")["steps"]
+        configure = next(step for step in steps if step.get("id") == "configure")
+        self.expression = configure["env"]["STAGE_REUSE_CURRENT_SHA"]
+
+    def test_pull_requests_use_the_base_commit(self):
+        self.assertIn("github.event.pull_request.base.sha", self.expression)
+
+    def test_other_events_use_the_checkout_commit(self):
+        self.assertIn("steps.checkout.outputs.commit", self.expression)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/development/stage_reuse.md
+++ b/docs/development/stage_reuse.md
@@ -53,15 +53,19 @@ selected.
 
 Automatic reuse is **disabled** when no build platform is selected.
 
+In Multi-Arch CI, pull requests run in `reuse-stage` and every other trigger
+runs in `dry-run`. Pushes deliberately keep building every stage: a push that
+reused stages would not produce the artifacts a later pull request reuses.
+
 ### Inputs
 
-| Input                        | Default   | Purpose                                                                                                |
-| ---------------------------- | --------- | ------------------------------------------------------------------------------------------------------ |
-| `stage_reuse_mode`           | `dry-run` | `dry-run` (report only) or `reuse-stage` (auto-reuse unaffected stages).                               |
-| `stage_reuse_max_age_hours`  | `72`      | Reject baseline runs older than this many hours (recency window).                                      |
-| `stage_reuse_commit_history` | `50`      | Number of recent branch commits to fetch when establishing ancestry for the commit-compatibility rule. |
-| `prebuilt_stages`            | `""`      | Manual, comma-separated stages to reuse (or `all`). Always honored, independent of `stage_reuse_mode`. |
-| `baseline_run_id`            | `""`      | Run ID to copy manually-listed `prebuilt_stages` artifacts from.                                       |
+| Input                        | Default   | Purpose                                                                                                                        |
+| ---------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `stage_reuse_mode`           | `dry-run` | `dry-run` (report only) or `reuse-stage` (auto-reuse unaffected stages). Multi-Arch CI passes `reuse-stage` for pull requests. |
+| `stage_reuse_max_age_hours`  | `72`      | Reject baseline runs older than this many hours (recency window).                                                              |
+| `stage_reuse_commit_history` | `50`      | Number of recent branch commits to fetch when establishing ancestry for the commit-compatibility rule.                         |
+| `prebuilt_stages`            | `""`      | Manual, comma-separated stages to reuse (or `all`). Always honored, independent of `stage_reuse_mode`.                         |
+| `baseline_run_id`            | `""`      | Run ID to copy manually-listed `prebuilt_stages` artifacts from.                                                               |
 
 Example `workflow_call` from a component CI:
 
@@ -86,7 +90,10 @@ A baseline run is only used when it is:
   (default `multi_arch_ci.yml`),
 - recent enough (`stage_reuse_max_age_hours`),
 - commit-compatible — its commit is the same as, or an ancestor of, the current
-  commit (established from the last `stage_reuse_commit_history` commits), and
+  commit (established from the last `stage_reuse_commit_history` commits). On a
+  pull request the "current commit" is the base commit rather than the checked
+  out merge commit, which is not on the baseline branch and so cannot be placed
+  in that history; and
 - healthy — its `Build` jobs succeeded and it contains every required artifact
   for every platform being built.
 


### PR DESCRIPTION
ISSUE ID : https://github.com/ROCm/TheRock/issues/3399

Split out of #7912 at @ScottTodd's request so the JAX Bazel cache and this change can be reviewed and rolled out separately. Draft: this is a repository-wide behaviour change that wants deliberate testing, and #7346 may be the better tool for the JAX/PyTorch case since it can reuse ROCm packages too.

## Motivation

- Every pull request rebuilds ROCm from source even when its diff cannot change ROCm.
- The stage-reuse analysis already runs on every pull request: it maps the diff through `BUILD_TOPOLOGY.toml`, finds the unaffected stages, verifies their artifacts exist in a healthy `main` baseline, prints all of it to the step summary, and then rebuilds them anyway, because `pull_request` passes `dry-run`.
- The beneficiaries are pull requests whose diff maps to a narrow source set, e.g. a change under one `rocm-libraries/projects/<project>/`, which today still rebuilds the full Linux and Windows graph.
- Pull requests touching `.github/`, `build_tools/`, `docs/` or `scripts/` are **not** beneficiaries: `stage_impact.full_ci_prefixes` treats those as conservative full-CI triggers, so they keep rebuilding everything.

## Technical Details

- `multi_arch_ci.yml` passes `reuse-stage` for `pull_request` and keeps every other trigger on `dry-run`. Manual `workflow_dispatch` still wins.
- Pushes deliberately keep rebuilding: a push that reused stages would stop producing the artifacts a later pull request reuses.
- Flipping the mode alone would be close to a no-op. `STAGE_REUSE_CURRENT_SHA` was the checkout commit, which on a pull request is a merge commit that is not on the baseline branch, so `validate_commit_compatibility` returned `unknown` and rejected every candidate baseline.
- `setup_multi_arch.yml` now establishes ancestry from the pull request base commit, which is on `main` and is by construction an ancestor of the merge commit, so the gate stays as conservative as it is for pushes.
- Both gates are otherwise unchanged; reuse still fails safe toward a full build when no recent, healthy, commit-compatible baseline exists.

## Test Plan

- `pytest build_tools/github_actions/tests` for the new test and the existing stage-reuse and baseline-selection suites.
- `pre-commit run --all-files`, including `actionlint`.
- This pull request **cannot** exercise the change end to end: its own diff is entirely `.github/`, `build_tools/` and `docs/`, which are conservative full-CI triggers. Demonstrating reuse needs a separate branch touching submodule source.

## Test Result

- Unit tests: 909 passed. One pre-existing failure unrelated to this change (`post_stage_upload_test.py::TestCreateCcacheLogArchive`, also fails on `main` in the same container). `pre-commit`: all hooks pass.
- Both workflow edits take effect, per this PR's own setup job:

```
[STAGE-REUSE] mode=reuse-stage
STAGE_REUSE_CURRENT_SHA: 171a4748c9cf57d843a25eed683f9b871bfdd776   # a main commit, not the merge commit
```

- Reuse then correctly declined to engage, because this PR's own paths are conservative full-CI triggers:

```
[STAGE-REUSE] conservative full rebuild: no stages eligible for reuse.
  reason: 'build_tools/github_actions/tests/stage_reuse_pr_defaults_test.py' matches a conservative full-CI trigger
  reason: 'docs/development/stage_reuse.md' matches a conservative full-CI trigger
- baseline run checked: _none_
```

- **Still unproven:** baseline selection and the commit-compatibility gate never ran, so the base-commit fix has no end-to-end evidence yet. That needs a branch whose diff maps to a narrow source set.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
