### PR TITLE
fix(ci): map external repo paths for test selection

### DIFF
--- a/test_tools/determine_rocm_test_dependencies.py
+++ b/test_tools/determine_rocm_test_dependencies.py
@@ -85,6 +85,7 @@ _EXTERNAL_SUBTREE_ALIASES = {
     "shared/origami": ["hipblas", "hipblaslt", "origami", "rocblas", "tensilelite"],
     "shared/stinkytofu": ["hipblas", "hipblaslt", "rocblas", "tensilelite"],
     "shared/tensile": ["hipblas", "rocblas"],
+    "dnn-providers/cmake": ["hipdnn_integration_tests"],
     "dnn-providers/hipblaslt-provider": ["hipblasltprovider"],
     "dnn-providers/hip-kernel-provider": ["hipkernelprovider"],
     "dnn-providers/integration-tests": ["hipdnn_integration_tests"],
@@ -98,6 +99,8 @@ _EXTERNAL_SUBTREE_ALIASES = {
     "projects/rocm-smi-lib": ["rocm_smi_lib"],
     "projects/rocprofiler": ["rocprofiler-sdk"],
 }
+
+_EXTERNAL_ONLY_NAMESPACES = ("shared/", "dnn-providers/", "emulation/")
 
 _CI_TEST_SELECTOR_ALIASES = {
     "hipdnn_integration_tests": ["hipdnn-integration-tests"],
@@ -427,6 +430,11 @@ def _normalize_changed_project(project: str) -> list[str]:
     project_lower = project.lower()
     if project_lower in _EXTERNAL_SUBTREE_ALIASES:
         return _EXTERNAL_SUBTREE_ALIASES[project_lower]
+    if project_lower.startswith(_EXTERNAL_ONLY_NAMESPACES):
+        raise ValueError(
+            f"'{project}' has no entry in _EXTERNAL_SUBTREE_ALIASES. Add one "
+            "before merging; this namespace has no valid self-select fallback."
+        )
     return [project_lower.removeprefix("projects/")]
 
 
@@ -532,7 +540,10 @@ def main():
     if changed:
         normalized = []
         for project in changed:
-            normalized.extend(_normalize_changed_project(project))
+            try:
+                normalized.extend(_normalize_changed_project(project))
+            except ValueError as e:
+                raise SystemExit(str(e)) from e
         changed = normalized
 
     # No projects specified → all tests

--- a/test_tools/determine_rocm_test_dependencies.py
+++ b/test_tools/determine_rocm_test_dependencies.py
@@ -87,7 +87,7 @@ _EXTERNAL_SUBTREE_ALIASES = {
     "shared/tensile": ["hipblas", "rocblas"],
     "dnn-providers/hipblaslt-provider": ["hipblasltprovider"],
     "dnn-providers/hip-kernel-provider": ["hipkernelprovider"],
-    "dnn-providers/integration-tests": ["hipdnn_integration_tests", "miopenprovider"],
+    "dnn-providers/integration-tests": ["hipdnn_integration_tests"],
     "dnn-providers/miopen-provider": ["miopenprovider"],
     "projects/clr": ["hip-clr"],
     "projects/composablekernel": ["composable_kernel"],

--- a/test_tools/determine_rocm_test_dependencies.py
+++ b/test_tools/determine_rocm_test_dependencies.py
@@ -84,7 +84,7 @@ _EXTERNAL_SUBTREE_ALIASES = {
     ],
     "shared/origami": ["hipblas", "hipblaslt", "origami", "rocblas", "tensilelite"],
     "shared/stinkytofu": ["hipblas", "hipblaslt", "rocblas", "tensilelite"],
-    "shared/tensile": ["hipblas", "hipblaslt", "rocblas", "tensilelite"],
+    "shared/tensile": ["hipblas", "rocblas"],
     "dnn-providers/hipblaslt-provider": ["hipblasltprovider"],
     "dnn-providers/hip-kernel-provider": ["hipkernelprovider"],
     "dnn-providers/integration-tests": ["hipdnn_integration_tests", "miopenprovider"],

--- a/test_tools/determine_rocm_test_dependencies.py
+++ b/test_tools/determine_rocm_test_dependencies.py
@@ -71,20 +71,41 @@ _TEST_POLICIES_NAME = "test_policies.toml"
 _TEST_TOOLS_DIR = Path(__file__).resolve().parent
 
 _EXTERNAL_SUBTREE_ALIASES = {
-    "emulation/mirage": "mirage",
-    "emulation/rocjitsu": "rocjitsu",
-    "shared/rocroller": "rocroller",
-    "shared/amdgpu-windows-interop": "hip-clr",
-    "dnn-providers/hipblaslt-provider": "hipblasltprovider",
-    "dnn-providers/hip-kernel-provider": "hipkernelprovider",
-    "dnn-providers/miopen-provider": "miopenprovider",
-    "projects/clr": "hip-clr",
-    "projects/cuid": "rdc",
-    "projects/hip": "hip-clr",
-    "projects/hipother": "hip-clr",
-    "projects/rocdbgapi": "amd-dbgapi",
-    "projects/rocm-smi-lib": "rocm_smi_lib",
-    "projects/rocprofiler": "rocprofiler-sdk",
+    "emulation/mirage": ["mirage"],
+    "emulation/rocjitsu": ["rocjitsu"],
+    "shared/rocroller": ["rocroller"],
+    "shared/amdgpu-windows-interop": ["hip-clr"],
+    "shared/mxdatagenerator": [
+        "hipblas",
+        "hipblaslt",
+        "rocblas",
+        "rocroller",
+        "tensilelite",
+    ],
+    "shared/origami": ["hipblas", "hipblaslt", "origami", "rocblas", "tensilelite"],
+    "shared/stinkytofu": ["hipblas", "hipblaslt", "rocblas", "tensilelite"],
+    "shared/tensile": ["hipblas", "hipblaslt", "rocblas", "tensilelite"],
+    "dnn-providers/hipblaslt-provider": ["hipblasltprovider"],
+    "dnn-providers/hip-kernel-provider": ["hipkernelprovider"],
+    "dnn-providers/integration-tests": ["hipdnn_integration_tests", "miopenprovider"],
+    "dnn-providers/miopen-provider": ["miopenprovider"],
+    "projects/clr": ["hip-clr"],
+    "projects/composablekernel": ["composable_kernel"],
+    "projects/cuid": ["rdc"],
+    "projects/hip": ["hip-clr"],
+    "projects/hipother": ["hip-clr"],
+    "projects/rocdbgapi": ["amd-dbgapi"],
+    "projects/rocm-smi-lib": ["rocm_smi_lib"],
+    "projects/rocprofiler": ["rocprofiler-sdk"],
+}
+
+_CI_TEST_SELECTOR_ALIASES = {
+    "hipdnn_integration_tests": ["hipdnn-integration-tests"],
+    "hipdnn_samples": ["hipdnn-samples"],
+}
+
+_TEST_ONLY_SELECTORS = {
+    "tensilelite",
 }
 
 
@@ -235,9 +256,8 @@ def get_subprojects_to_test(
     the external-repo subtree identifiers it receives from GitHub Actions by
     stripping a leading `projects/` and mapping known non-project subtree paths
     to graph keys. Callers holding other identifiers must map them to graph keys
-    first — notably, subtree paths like `projects/clr` (-> `hip-clr`) and the
-    hyphenated CI test-matrix keys (`hipdnn-integration-tests` vs the graph's
-    `hipdnn_integration_tests`). That mapping is tracked separately.
+    first — notably, subtree paths like `projects/clr` (-> `hip-clr`). The CLI
+    output path translates graph keys that have different CI test selector names.
     """
     graph = _load_consumer_graph(therock_dir)
     policies = _load_policies(therock_dir)
@@ -246,7 +266,9 @@ def get_subprojects_to_test(
 
     # Warn on unrecognized projects (typo guard).
     known = set(graph.keys())
-    unknown = [p for p in changed_lower if p not in known]
+    unknown = [
+        p for p in changed_lower if p not in known and p not in _TEST_ONLY_SELECTORS
+    ]
     if unknown:
         print(
             f"Warning: unrecognized project(s) {unknown}; "
@@ -275,7 +297,8 @@ def explain_component(component: str, therock_dir: Path | None = None) -> str:
     The final set is computed by calling the real selection function
     (`get_subprojects_to_test`) so `--explain` can never drift from what selection
     actually computes. The graph-walk line is shown separately for insight into
-    how that final set was reached.
+    how that final set was reached, and the CI selector line shows the final
+    names emitted to GitHub Actions after output-only selector translation.
     """
     graph = _load_consumer_graph(therock_dir)
     policies = _load_policies(therock_dir)
@@ -311,7 +334,10 @@ def explain_component(component: str, therock_dir: Path | None = None) -> str:
         lines.append("\ttest_exclude:\t" + ", ".join(sorted(exclude)))
     else:
         lines.append("\ttest_exclude:\t(none)")
+    ci_selectors = _to_ci_test_selectors(final)
     lines.append("\tfinal:\t" + ", ".join(sorted(final)))
+    if ci_selectors != final:
+        lines.append("\tci selectors:\t" + ", ".join(sorted(ci_selectors)))
     return "\n".join(lines)
 
 
@@ -396,12 +422,20 @@ def list_subprojects(therock_dir: Path | None = None, show_deps: bool = False):
     return sorted(graph.keys())
 
 
-def _normalize_changed_project(project: str) -> str:
+def _normalize_changed_project(project: str) -> list[str]:
     """Normalize CI subtree identifiers to consumer-graph keys for the CLI."""
     project_lower = project.lower()
     if project_lower in _EXTERNAL_SUBTREE_ALIASES:
         return _EXTERNAL_SUBTREE_ALIASES[project_lower]
-    return project_lower.removeprefix("projects/")
+    return [project_lower.removeprefix("projects/")]
+
+
+def _to_ci_test_selectors(projects: set[str]) -> set[str]:
+    """Translate graph keys to CI test-matrix selector names for CLI output."""
+    result: set[str] = set()
+    for project in projects:
+        result.update(_CI_TEST_SELECTOR_ALIASES.get(project, [project]))
+    return result
 
 
 def main():
@@ -496,7 +530,10 @@ def main():
         changed = flattened
 
     if changed:
-        changed = [_normalize_changed_project(p) for p in changed]
+        normalized = []
+        for project in changed:
+            normalized.extend(_normalize_changed_project(project))
+        changed = normalized
 
     # No projects specified → all tests
     if not changed:
@@ -507,14 +544,15 @@ def main():
         return
 
     result = get_subprojects_to_test(changed, therock_dir, level=args.level)
-    projects_to_test = ",".join(sorted(result))
+    ci_test_selectors = _to_ci_test_selectors(result)
+    projects_to_test = ",".join(sorted(ci_test_selectors))
 
     if args.gha_output:
         gha_set_output({"projects_to_test": projects_to_test})
     elif args.format == "json":
-        print(json.dumps(sorted(result)))
+        print(json.dumps(sorted(ci_test_selectors)))
     else:
-        for item in sorted(result):
+        for item in sorted(ci_test_selectors):
             print(item)
 
 

--- a/test_tools/tests/determine_rocm_test_dependencies_test.py
+++ b/test_tools/tests/determine_rocm_test_dependencies_test.py
@@ -337,12 +337,7 @@ class TestCliInputParsing(_FixtureTestCase):
                     "rocblas",
                     "tensilelite",
                 },
-                "shared/tensile": {
-                    "hipblas",
-                    "hipblaslt",
-                    "rocblas",
-                    "tensilelite",
-                },
+                "shared/tensile": {"hipblas", "rocblas"},
             }
             for changed_project, expected in cases.items():
                 with self.subTest(changed_project=changed_project):

--- a/test_tools/tests/determine_rocm_test_dependencies_test.py
+++ b/test_tools/tests/determine_rocm_test_dependencies_test.py
@@ -363,7 +363,13 @@ class TestCliInputParsing(_FixtureTestCase):
 
     def test_dnn_provider_prefixes_mapped(self) -> None:
         graph = {
-            "hipdnn_integration_tests": {"consumers": ["miopenprovider"]},
+            "hipdnn_integration_tests": {
+                "consumers": [
+                    "hipblasltprovider",
+                    "hipkernelprovider",
+                    "miopenprovider",
+                ]
+            },
             "hipblasltprovider": {"consumers": []},
             "hipkernelprovider": {"consumers": []},
             "miopenprovider": {"consumers": []},
@@ -409,7 +415,52 @@ class TestCliInputParsing(_FixtureTestCase):
             self.assertEqual(proc.returncode, 0, proc.stderr)
             self.assertEqual(
                 json.loads(proc.stdout.strip()),
-                ["hipdnn-integration-tests", "miopenprovider"],
+                [
+                    "hipblasltprovider",
+                    "hipdnn-integration-tests",
+                    "hipkernelprovider",
+                    "miopenprovider",
+                ],
+            )
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+    def test_dnn_provider_cmake_prefix_maps_to_integration_tests(self) -> None:
+        graph = {
+            "hipdnn_integration_tests": {
+                "consumers": [
+                    "hipblasltprovider",
+                    "hipkernelprovider",
+                    "miopenprovider",
+                ]
+            },
+            "hipblasltprovider": {"consumers": []},
+            "hipkernelprovider": {"consumers": []},
+            "miopenprovider": {"consumers": []},
+        }
+        root = _make_fixture(graph=graph, policies="")
+        try:
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--therock-dir",
+                    str(root),
+                    "--changed-projects",
+                    "dnn-providers/cmake",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertEqual(
+                json.loads(proc.stdout.strip()),
+                [
+                    "hipblasltprovider",
+                    "hipdnn-integration-tests",
+                    "hipkernelprovider",
+                    "miopenprovider",
+                ],
             )
         finally:
             shutil.rmtree(root, ignore_errors=True)
@@ -491,6 +542,11 @@ class TestCliInputParsing(_FixtureTestCase):
         self.assertIn("rdc", projects)  # amdsmi direct consumer
         self.assertIn("rocroller", projects)
         self.assertIn("hipblaslt", projects)  # rocroller direct consumer
+
+    def test_unmapped_external_namespace_fails(self) -> None:
+        proc = self._run("--changed-projects", "shared/not-aliased", "--level", "4")
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("no entry in _EXTERNAL_SUBTREE_ALIASES", proc.stderr)
 
     def test_empty_changed_projects_outputs_wildcard(self) -> None:
         proc = self._run()

--- a/test_tools/tests/determine_rocm_test_dependencies_test.py
+++ b/test_tools/tests/determine_rocm_test_dependencies_test.py
@@ -306,8 +306,69 @@ class TestCliInputParsing(_FixtureTestCase):
         self.assertIn("rocroller", projects)
         self.assertIn("hipblaslt", projects)
 
+    def test_shared_blas_prefixes_mapped(self) -> None:
+        graph = {
+            "hipblas": {"consumers": []},
+            "hipblaslt": {"consumers": []},
+            "origami": {"consumers": []},
+            "rocblas": {"consumers": []},
+            "rocroller": {"consumers": []},
+        }
+        root = _make_fixture(graph=graph, policies="")
+        try:
+            cases = {
+                "shared/mxdatagenerator": {
+                    "hipblas",
+                    "hipblaslt",
+                    "rocblas",
+                    "rocroller",
+                    "tensilelite",
+                },
+                "shared/origami": {
+                    "hipblas",
+                    "hipblaslt",
+                    "origami",
+                    "rocblas",
+                    "tensilelite",
+                },
+                "shared/stinkytofu": {
+                    "hipblas",
+                    "hipblaslt",
+                    "rocblas",
+                    "tensilelite",
+                },
+                "shared/tensile": {
+                    "hipblas",
+                    "hipblaslt",
+                    "rocblas",
+                    "tensilelite",
+                },
+            }
+            for changed_project, expected in cases.items():
+                with self.subTest(changed_project=changed_project):
+                    proc = subprocess.run(
+                        [
+                            sys.executable,
+                            str(SCRIPT),
+                            "--therock-dir",
+                            str(root),
+                            "--changed-projects",
+                            changed_project,
+                            "--level",
+                            "5",
+                        ],
+                        capture_output=True,
+                        text=True,
+                    )
+                    self.assertEqual(proc.returncode, 0, proc.stderr)
+                    self.assertEqual(set(json.loads(proc.stdout.strip())), expected)
+                    self.assertEqual(proc.stderr, "")
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
     def test_dnn_provider_prefixes_mapped(self) -> None:
         graph = {
+            "hipdnn_integration_tests": {"consumers": []},
             "hipblasltprovider": {"consumers": []},
             "hipkernelprovider": {"consumers": []},
             "miopenprovider": {"consumers": []},
@@ -337,6 +398,50 @@ class TestCliInputParsing(_FixtureTestCase):
                     )
                     self.assertEqual(proc.returncode, 0, proc.stderr)
                     self.assertEqual(json.loads(proc.stdout.strip()), [expected])
+
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--therock-dir",
+                    str(root),
+                    "--changed-projects",
+                    "dnn-providers/integration-tests",
+                    "--level",
+                    "5",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertEqual(
+                json.loads(proc.stdout.strip()),
+                ["hipdnn-integration-tests", "miopenprovider"],
+            )
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+    def test_composablekernel_prefix_mapped(self) -> None:
+        graph = {"composable_kernel": {"consumers": []}}
+        root = _make_fixture(graph=graph, policies="")
+        try:
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--therock-dir",
+                    str(root),
+                    "--changed-projects",
+                    "projects/composablekernel",
+                    "--level",
+                    "5",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertEqual(json.loads(proc.stdout.strip()), ["composable_kernel"])
+            self.assertEqual(proc.stderr, "")
         finally:
             shutil.rmtree(root, ignore_errors=True)
 
@@ -635,7 +740,7 @@ class TestIdentifierSpaceContract(_FixtureTestCase):
 
     def test_graph_keys_use_underscores_not_matrix_hyphens(self) -> None:
         # Selection returns graph keys (underscore-form), not the hyphenated CI
-        # matrix keys — asserting the skew a future mapping step must bridge.
+        # matrix keys. CLI output translates the skew for GitHub Actions.
         graph = {
             "miopen": {"consumers": ["hipdnn_integration_tests"]},
             "hipdnn_integration_tests": {"consumers": []},
@@ -645,6 +750,34 @@ class TestIdentifierSpaceContract(_FixtureTestCase):
             selected = get_subprojects_to_test(["miopen"], root, level=4)
             self.assertIn("hipdnn_integration_tests", selected)
             self.assertNotIn("hipdnn-integration-tests", selected)
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+    def test_cli_outputs_matrix_selector_aliases(self) -> None:
+        graph = {
+            "miopen": {"consumers": ["hipdnn_integration_tests"]},
+            "hipdnn_integration_tests": {"consumers": []},
+        }
+        root = _make_fixture(graph=graph, policies="")
+        try:
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--therock-dir",
+                    str(root),
+                    "--changed-projects",
+                    "miopen",
+                    "--level",
+                    "4",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            selected = set(json.loads(proc.stdout.strip()))
+            self.assertIn("hipdnn-integration-tests", selected)
+            self.assertNotIn("hipdnn_integration_tests", selected)
         finally:
             shutil.rmtree(root, ignore_errors=True)
 
@@ -686,6 +819,21 @@ class TestExplain(_FixtureTestCase):
         }
         selection = get_subprojects_to_test(["amdsmi"], self.root)
         self.assertEqual(final_set, selection)
+
+    def test_explain_reports_ci_selector_aliases(self) -> None:
+        graph = {
+            "miopen": {"consumers": ["hipdnn_integration_tests"]},
+            "hipdnn_integration_tests": {"consumers": []},
+        }
+        root = _make_fixture(graph=graph, policies="")
+        try:
+            text = explain_component("miopen", root)
+            self.assertIn("final:", text)
+            self.assertIn("hipdnn_integration_tests", text)
+            self.assertIn("ci selectors:", text)
+            self.assertIn("hipdnn-integration-tests", text)
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
 
     def test_explain_reports_level_3_walk_depth(self) -> None:
         text = explain_component("rocm-core", self.root)

--- a/test_tools/tests/determine_rocm_test_dependencies_test.py
+++ b/test_tools/tests/determine_rocm_test_dependencies_test.py
@@ -363,7 +363,7 @@ class TestCliInputParsing(_FixtureTestCase):
 
     def test_dnn_provider_prefixes_mapped(self) -> None:
         graph = {
-            "hipdnn_integration_tests": {"consumers": []},
+            "hipdnn_integration_tests": {"consumers": ["miopenprovider"]},
             "hipblasltprovider": {"consumers": []},
             "hipkernelprovider": {"consumers": []},
             "miopenprovider": {"consumers": []},
@@ -402,8 +402,6 @@ class TestCliInputParsing(_FixtureTestCase):
                     str(root),
                     "--changed-projects",
                     "dnn-providers/integration-tests",
-                    "--level",
-                    "5",
                 ],
                 capture_output=True,
                 text=True,


### PR DESCRIPTION
## Motivation

The rocm-libraries multi-arch CI integration uses TheRock's test dependency selector to decide which tests should run for changed external repo paths.

Some rocm-libraries paths were not mapped into TheRock's selector space, so changes under those paths could fail to select the intended runnable tests. This is a follow-up to the multi-arch CI enablement work tracked in https://github.com/ROCm/TheRock/issues/3343.

GitHub issue: https://github.com/ROCm/TheRock/issues/3343

## Technical Details

This PR updates `test_tools/determine_rocm_test_dependencies.py` to handle the rocm-libraries path gaps in TheRock rather than relying on rocm-libraries-specific workflow workarounds.

The change:
- Maps shared BLAS helper paths used by rocm-libraries:
  - `shared/stinkytofu`
  - `shared/tensile`
  - `shared/origami`
  - `shared/mxdatagenerator`
- Maps `projects/composablekernel` to the TheRock graph key `composable_kernel`.
- Maps `dnn-providers/integration-tests` to the relevant hipDNN/MIOpen provider test selectors.
- Translates hipDNN graph keys such as `hipdnn_integration_tests` and `hipdnn_samples` to the hyphenated CI test selector names consumed by the test matrix.
- Keeps `get_subprojects_to_test()` in graph-key space while translating selector names at the CLI/GitHub Actions output boundary.
- Updates `--explain` output so it reports CI selector aliases when output translation changes the emitted selector names.

## Test Plan

Run the focused unit tests for the dependency selector and pre-commit on the changed files.

## Test Result

Passed:

- `python -m pytest test_tools/tests/determine_rocm_test_dependencies_test.py -q`
- `pre-commit run --files test_tools/determine_rocm_test_dependencies.py test_tools/tests/determine_rocm_test_dependencies_test.py`

Result:
- `56 passed, 17 subtests passed`

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.