### PR TITLE
fix(ci): include gfx125x in presubmit builds

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -307,6 +307,16 @@ amdgpu_family_info_matrix_presubmit = {
             "nightly_check_only_for_family": True,
         },
     },
+    "gfx125x": {
+        "linux": {
+            # No hardware available for testing yet; build-only.
+            # PyTorch builds can be triggered manually via workflow_dispatch.
+            "test-runs-on": "",
+            "family": "gfx125X-dcgpu",
+            "fetch-gfx-targets": [],
+            "build_variants": ["release"],
+        },
+    },
 }
 
 
@@ -478,18 +488,6 @@ amdgpu_family_info_matrix_nightly = {
         "windows": {
             "test-runs-on": "",
             "family": "gfx1153",
-            "fetch-gfx-targets": [],
-            "build_variants": ["release"],
-        },
-    },
-    "gfx125x": {
-        "linux": {
-            # No hardware available for testing yet; build-only.
-            # PyTorch builds are included — workflow_dispatch can be used
-            # to trigger manually; nightly schedule runs both ROCm stack
-            # and PyTorch builds.
-            "test-runs-on": "",
-            "family": "gfx125X-dcgpu",
             "fetch-gfx-targets": [],
             "build_variants": ["release"],
         },

--- a/build_tools/github_actions/new_amdgpu_family_matrix.py
+++ b/build_tools/github_actions/new_amdgpu_family_matrix.py
@@ -59,7 +59,13 @@ Cmake targets are defined in: cmake/therock_amdgpu_targets.cmake
 
 amdgpu_family_predefined_groups = {
     # The 'presubmit' matrix runs on 'pull_request' triggers (on all PRs).
-    "amdgpu_presubmit": ["gfx94X-dcgpu", "gfx110X-all", "gfx1151", "gfx120X-all"],
+    "amdgpu_presubmit": [
+        "gfx94X-dcgpu",
+        "gfx110X-all",
+        "gfx1151",
+        "gfx120X-all",
+        "gfx125X-dcgpu",
+    ],
     # The 'postsubmit' matrix runs on 'push' triggers (for every commit to the default branch).
     "amdgpu_postsubmit": ["gfx950-dcgpu"],
     # The 'nightly' matrix runs on 'schedule' triggers.
@@ -71,7 +77,6 @@ amdgpu_family_predefined_groups = {
         "gfx1150",
         "gfx1152",
         "gfx1153",
-        "gfx125X-dcgpu",
     ],
 }
 

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -831,6 +831,8 @@ class TestSelectTargets(unittest.TestCase):
         result = cm.select_targets(inputs)
         # gfx950 is postsubmit-only, should be present for push
         self.assertIn("gfx950", result.linux_families)
+        # gfx125x is build-only, but should still be covered by default builds.
+        self.assertIn("gfx125x", result.linux_families)
 
     def test_schedule_returns_all_families(self):
         """Schedule trigger selects all families (presubmit+postsubmit+nightly)."""
@@ -895,6 +897,8 @@ class TestSelectTargets(unittest.TestCase):
         )
         result = cm.select_targets(inputs)
         self.assertGreater(len(result.linux_families), 0)
+        # gfx125x is build-only, but should still be covered by default builds.
+        self.assertIn("gfx125x", result.linux_families)
         # gfx950 is postsubmit-only, should NOT be in PR defaults
         self.assertNotIn("gfx950", result.linux_families)
 


### PR DESCRIPTION
## Motivation

TheRock has `gfx125X-dcgpu` support in the multi-arch family matrix, but it is currently only selected by nightly/schedule defaults. This leaves default PR and push multi-arch builds without `gfx125x` build coverage.

GitHub issue: https://github.com/ROCm/TheRock/issues/3343

## Technical Details

This PR moves `gfx125x`/`gfx125X-dcgpu` into the presubmit/default family set so it is selected for pull request and push builds.

The family definition remains Linux build-only:
- no test runner is added;
- no Windows family coverage is added;
- the existing `gfx125X-dcgpu` build family definition is otherwise unchanged.

The new and current family matrix definitions are kept in sync.

## Test Plan

Run the focused multi-arch CI configuration tests and pre-commit on the changed files.

## Test Result

Passed:

- `python -m pytest build_tools/github_actions/tests/configure_multi_arch_ci_test.py -q`
- `pre-commit run --files build_tools/github_actions/amdgpu_family_matrix.py build_tools/github_actions/new_amdgpu_family_matrix.py build_tools/github_actions/tests/configure_multi_arch_ci_test.py`

Spot-check result:

- PR defaults now include Linux `gfx125x`.
- Push defaults now include Linux `gfx125x`.
- Windows defaults are unchanged.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
