### PR TITLE
Move tarball packaging code under `build_tools/packaging/archives`

### DIFF
--- a/.github/workflows/multi_arch_build_tarballs.yml
+++ b/.github/workflows/multi_arch_build_tarballs.yml
@@ -134,7 +134,7 @@ jobs:
             EXTRA_ARGS+=(--include-test-tarballs)
           fi
 
-          python build_tools/build_tarballs.py \
+          python build_tools/packaging/archives/build_tarballs.py \
             --run-id="${{ env.ARTIFACT_RUN_ID }}" \
             --run-github-repo="${{ inputs.artifact_github_repo }}" \
             --dist-amdgpu-families="${{ inputs.dist_amdgpu_families }}" \

--- a/build_tools/github_actions/configure_ci_path_filters.py
+++ b/build_tools/github_actions/configure_ci_path_filters.py
@@ -238,6 +238,7 @@ _SKIPPABLE_PATH_PATTERNS = [
     # directory roots: other test paths exercise built ROCm packages in CI.
     "build_tools/tests/*",
     "build_tools/github_actions/tests/*",
+    "build_tools/packaging/archives/tests/*",
     "build_tools/packaging/linux/tests/*",
     "build_tools/packaging/python/tests/*",
     "build_tools/third_party/s3_management/tests/*",

--- a/build_tools/github_actions/tests/configure_ci_path_filters_test.py
+++ b/build_tools/github_actions/tests/configure_ci_path_filters_test.py
@@ -72,6 +72,7 @@ class ConfigureCIPathFiltersTest(unittest.TestCase):
         unit_test_paths = [
             "build_tools/tests/example_test.py",
             "build_tools/github_actions/tests/example_test.py",
+            "build_tools/packaging/archives/tests/example_test.py",
             "build_tools/packaging/linux/tests/example_test.py",
             "build_tools/packaging/python/tests/example_test.py",
             "build_tools/third_party/s3_management/tests/example_test.py",
@@ -106,8 +107,8 @@ class ConfigureCIPathFiltersTest(unittest.TestCase):
         # Exclusions for skipping unit tests do not take priority over
         # inclusions for modifying script files.
         paths = [
-            "build_tools/build_tarballs.py",
-            "build_tools/tests/build_tarballs_test.py",
+            "build_tools/packaging/archives/build_tarballs.py",
+            "build_tools/packaging/archives/tests/build_tarballs_test.py",
         ]
         self.assertTrue(is_ci_run_required(paths))
 

--- a/build_tools/packaging/archives/README.md
+++ b/build_tools/packaging/archives/README.md
@@ -1,0 +1,106 @@
+# ROCm SDK archive packaging
+
+This directory contains tools for creating ROCm SDK archives - file-tree
+representations of an SDK installation that can be extracted and used directly.
+
+Each archive contains a flattened set of ROCm build
+[artifacts](/docs/development/artifacts.md) including code from all ROCm
+subprojects:
+
+```bash
+install/      # Arbitrary file path the archive is extracted to
+  .kpack/
+  bin/
+  clients/
+  include/
+  lib/
+  libexec/
+  share/
+```
+
+Archives are _just_ these raw files. They do not come with "install" steps
+such as setting environment variables.
+
+## Archive formats
+
+Currently both Linux and Windows archives use the `.tar.gz` format ("tarballs").
+See [PR#4438](https://github.com/ROCm/TheRock/pull/4438) for proposed changes to
+archive layout, naming, portability, and integrity requirements.
+
+## Generating archives
+
+### Using the `build_tarballs.py` script
+
+[`build_tarballs.py`](./build_tarballs.py) fetches ROCm build artifacts from a
+GitHub Actions workflow run, flattens them into an install-prefix-like layout,
+and creates `.tar.gz` archives. It can create per-family archives and, for
+builds using split kernel-pack artifacts, a combined multi-architecture archive.
+
+From the repository root, run:
+
+```bash
+python build_tools/packaging/archives/build_tarballs.py \
+  --run-id=<run-id> \
+  --dist-amdgpu-families="gfx94X-dcgpu;gfx110X-all" \
+  --platform=linux \
+  --package-version=<version> \
+  --output-dir=<output-directory>
+```
+
+### Creating an archive directly from CI artifacts
+
+For manual packaging, `artifact_manager.py fetch --flatten` can download and
+merge the artifact slices from a CI run into one SDK-root directory. That
+directory can then be compressed directly:
+
+```bash
+python build_tools/artifact_manager.py fetch \
+  --run-id=<run-id> \
+  --run-github-repo=ROCm/TheRock \
+  --stage=all \
+  --amdgpu-families=gfx110X-all \
+  --expand-family-to-targets \
+  --platform=linux \
+  --exclude-components=test \
+  --exclude-artifacts=fftw3 \
+  --output-dir=build/archive-root \
+  --flatten
+
+tar -czf build/rocm-sdk-ci-linux.tar.gz -C build/archive-root .
+```
+
+Remove the two `--exclude-*` options to include test and FFTW artifacts. The
+output archive contains the flattened SDK tree at its root, without a wrapping
+`archive-root/` directory.
+
+### Creating an archive directly from a local build
+
+For a configured local build, the `therock-dist` target directly populates
+`build/dist/rocm/`, which has the SDK-root layout expected in an archive:
+
+```bash
+cmake --build build --target therock-dist
+
+tar -czf build/rocm-sdk-local-linux.tar.gz -C build/dist/rocm .
+```
+
+To exercise artifact creation and flattening as part of the test, build
+`therock-artifacts` instead. This creates the separate artifact slices under
+`build/artifacts/` and also populates their flattened distribution under
+`build/dist/rocm/`:
+
+```bash
+cmake --build build --target therock-artifacts
+
+tar -czf build/rocm-sdk-local-linux.tar.gz -C build/dist/rocm .
+```
+
+The archive contents reflect the projects, GPU targets, and optional components
+enabled in the local CMake configuration. Do not archive `build/artifacts/`
+itself: that directory contains separate build-tree-shaped artifact slices, not
+the flattened SDK layout.
+
+## Using archives
+
+Current release usage is documented in
+[RELEASES.md](../../../RELEASES.md#installing-multi-arch-tarballs).

--- a/build_tools/packaging/archives/README.md
+++ b/build_tools/packaging/archives/README.md
@@ -4,8 +4,8 @@ This directory contains tools for creating ROCm SDK archives - file-tree
 representations of an SDK installation that can be extracted and used directly.
 
 Each archive contains a flattened set of ROCm build
-[artifacts](/docs/development/artifacts.md) including code from all ROCm
-subprojects:
+[artifacts](/docs/development/artifacts.md) from the ROCm subprojects included
+in the build:
 
 ```bash
 install/      # Arbitrary file path the archive is extracted to
@@ -36,37 +36,50 @@ GitHub Actions workflow run, flattens them into an install-prefix-like layout,
 and creates `.tar.gz` archives. It can create per-family archives and, for
 builds using split kernel-pack artifacts, a combined multi-architecture archive.
 
-From the repository root, run:
+From the repository root, run. This example uses artifacts from
+[rockrel release run 33697653391](https://github.com/ROCm/rockrel/actions/runs/33697653391):
 
 ```bash
+RUN_ID=33697653391
+RUN_GITHUB_REPO=ROCm/rockrel
+PACKAGE_VERSION=10.1.0a20260903
+DIST_AMDGPU_FAMILIES="gfx94X-dcgpu;gfx110X-all;gfx1151;gfx120X-all;gfx90a;gfx950-dcgpu;gfx900;gfx90c;gfx906;gfx908;gfx101X-dgpu;gfx103X-all;gfx1150;gfx1152;gfx1153;gfx125X-dcgpu"
+OUTPUT_DIR=build/tarballs
+
 python build_tools/packaging/archives/build_tarballs.py \
-  --run-id=<run-id> \
-  --dist-amdgpu-families="gfx94X-dcgpu;gfx110X-all" \
+  --run-id="$RUN_ID" \
+  --run-github-repo="$RUN_GITHUB_REPO" \
+  --dist-amdgpu-families="$DIST_AMDGPU_FAMILIES" \
   --platform=linux \
-  --package-version=<version> \
-  --output-dir=<output-directory>
+  --package-version="$PACKAGE_VERSION" \
+  --output-dir="$OUTPUT_DIR"
 ```
 
-### Creating an archive directly from CI artifacts
+### Creating an archive directly from workflow run artifacts
 
 For manual packaging, `artifact_manager.py fetch --flatten` can download and
-merge the artifact slices from a CI run into one SDK-root directory. That
+merge the artifact slices from a CI/CD run into one SDK-root directory. That
 directory can then be compressed directly:
 
 ```bash
+RUN_ID=33697653391
+RUN_GITHUB_REPO=ROCm/rockrel
+ARCHIVE_ROOT=build/archive-root
+ARCHIVE_PATH=build/rocm-sdk-ci-linux.tar.gz
+
 python build_tools/artifact_manager.py fetch \
-  --run-id=<run-id> \
-  --run-github-repo=ROCm/TheRock \
+  --run-id="$RUN_ID" \
+  --run-github-repo="$RUN_GITHUB_REPO" \
   --stage=all \
   --amdgpu-families=gfx110X-all \
   --expand-family-to-targets \
   --platform=linux \
   --exclude-components=test \
   --exclude-artifacts=fftw3 \
-  --output-dir=build/archive-root \
+  --output-dir="$ARCHIVE_ROOT" \
   --flatten
 
-tar -czf build/rocm-sdk-ci-linux.tar.gz -C build/archive-root .
+tar -czf "$ARCHIVE_PATH" -C "$ARCHIVE_ROOT" .
 ```
 
 Remove the two `--exclude-*` options to include test and FFTW artifacts. The

--- a/build_tools/packaging/archives/build_tarballs.py
+++ b/build_tools/packaging/archives/build_tarballs.py
@@ -27,7 +27,7 @@ Tarball naming follows the existing release convention:
 
 Example
 -------
-    python build_tools/build_tarballs.py \\
+    python build_tools/packaging/archives/build_tarballs.py \\
         --run-id=24104028483 \\
         --dist-amdgpu-families="gfx94X-dcgpu;gfx110X-all" \\
         --platform=linux \\
@@ -64,6 +64,8 @@ import time
 from pathlib import Path
 
 from zlib_ng import gzip_ng_threaded
+
+_BUILD_TOOLS_DIR = Path(__file__).resolve().parents[2]
 
 DEFAULT_EXCLUDED_ARTIFACTS: list[str] = ["fftw3"]
 DEFAULT_EXCLUDED_COMPONENTS: list[str] = ["test"]
@@ -147,7 +149,7 @@ def fetch_and_flatten(
 
     cmd = [
         sys.executable,
-        "build_tools/artifact_manager.py",
+        _BUILD_TOOLS_DIR / "artifact_manager.py",
         "fetch",
         f"--run-id={run_id}",
         "--stage=all",

--- a/build_tools/packaging/archives/tests/build_tarballs_test.py
+++ b/build_tools/packaging/archives/tests/build_tarballs_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Unit tests for build_tarballs.py."""
+"""Unit tests for the archive tarball builder."""
 
 import json
 import os

--- a/build_tools/pyproject.toml
+++ b/build_tools/pyproject.toml
@@ -2,6 +2,7 @@
 testpaths = [
     "tests",
     "github_actions/tests",
+    "packaging/archives/tests",
     "packaging/linux/tests",
     "packaging/python/tests",
     "third_party/s3_management/tests",
@@ -15,6 +16,7 @@ source = ["."]
 omit = [
     "tests/*",
     "github_actions/tests/*",
+    "packaging/archives/tests/*",
     "packaging/linux/tests/*",
     "packaging/python/tests/*",
     "third_party/s3_management/tests/*",


### PR DESCRIPTION
## Motivation

Tarballs have been a "package type" since early in the project but the code for working with them has not received the same level of organization as python and native linux/windows packages. By moving this code into its own `packaging/` directory we can prepare for changes to archive packaging (https://github.com/ROCm/TheRock/pull/4438) and add dedicated CODEOWNERS for changes to archives/tarballs.

## Test Plan

Trigger `.github/workflows/multi_arch_build_tarballs.yml` directly: https://github.com/ROCm/TheRock/actions/runs/34892132172

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.

@skip-pr-bot (PR link is sufficient for context, no issue needed)