### PR TITLE
Code Coverage for Nightly

### DIFF
--- a/.github/workflows/coverage_nightly.yml
+++ b/.github/workflows/coverage_nightly.yml
@@ -17,8 +17,10 @@
 #   - baseline_run_id is supplied by hand (RFC option B1). Manual coordination
 #     is acceptable for initial validation, which is the whole point of the
 #     PoC; automating it is a later phase's problem.
-#   - No changes to the production nightly, and nothing triggers this
-#     automatically, so it can fail or be abandoned without consequence.
+#   - No changes to the production nightly. The only thing that triggers this
+#     automatically is coverage_nightly_pr_check.yml, which exists to validate
+#     this workflow before it merges and is deleted once it has, so coverage
+#     can fail or be abandoned without consequence.
 #
 # This is deliberately a separate workflow rather than an extension of the
 # regular nightly:
@@ -36,6 +38,61 @@
 name: Nightly Code Coverage
 
 on:
+  # Exposed so a caller can run this from a branch. A workflow_dispatch has to
+  # exist on the default branch before it can be triggered at all, which makes
+  # it useless for validating this workflow before it merges; a caller resolves
+  # ./.github/workflows paths against its own commit, so it runs the branch's
+  # copy. See coverage_nightly_pr_check.yml.
+  workflow_call:
+    inputs:
+      baseline_run_id:
+        description: "Regular nightly run_id to take non-instrumented dependencies from."
+        type: string
+        required: true
+      baseline_repository:
+        description: >-
+          Repository owning baseline_run_id, when it is not this one. Release
+          nightlies live in ROCm/rockrel, for example.
+        type: string
+        default: ""
+      baseline_release_type:
+        description: >-
+          Release type the baseline run published under, which selects the
+          bucket its artifacts are read from. Use "nightly" for a ROCm/rockrel
+          release nightly; "ci" for a regular ROCm/TheRock CI run.
+        type: string
+        default: "ci"
+      amdgpu_family:
+        description: "Single GPU family to build and test coverage on."
+        type: string
+        default: "gfx94x"
+      coverage_projects:
+        description: >-
+          Projects to instrument, comma or semicolon separated, in any casing
+          (e.g. "hiprand"). Empty instruments every rocm-libraries component.
+        type: string
+        default: "hiprand"
+      test_labels:
+        description: >-
+          Components to run coverage tests for, comma separated (e.g.
+          "hiprand"). Empty runs every component available for the family.
+        type: string
+        default: "hiprand"
+      prebuilt_stages:
+        description: >-
+          Build stages to copy from baseline_run_id instead of building
+          instrumented. The default reuses everything except math-libs, so only
+          the stage holding the projects under test is built.
+        type: string
+        default: "compiler-runtime,emulation,runtime-tests,wsl-rocdxg,comm-libs,storage-libs,debug-tools,dctools-core,profiler-apps,cv-libs,media-libs"
+      repository:
+        description: "Repository to checkout. Defaults to github.repository."
+        type: string
+        default: ""
+      ref:
+        description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
+        type: string
+        default: ""
   workflow_dispatch:
     inputs:
       baseline_run_id:

--- a/.github/workflows/coverage_nightly.yml
+++ b/.github/workflows/coverage_nightly.yml
@@ -42,6 +42,19 @@ on:
         description: "Regular nightly run_id to take non-instrumented dependencies from."
         type: string
         required: true
+      baseline_repository:
+        description: >-
+          Repository owning baseline_run_id, when it is not this one. Release
+          nightlies live in ROCm/rockrel, for example.
+        type: string
+        default: ""
+      baseline_release_type:
+        description: >-
+          Release type the baseline run published under, which selects the
+          bucket its artifacts are read from. Use "nightly" for a ROCm/rockrel
+          release nightly; "ci" for a regular ROCm/TheRock CI run.
+        type: string
+        default: "ci"
       amdgpu_family:
         description: "Single GPU family to build and test coverage on."
         type: string
@@ -104,6 +117,7 @@ jobs:
       linux_test_labels: ${{ inputs.test_labels }}
       prebuilt_stages: ${{ inputs.prebuilt_stages != 'none' && inputs.prebuilt_stages || '' }}
       baseline_run_id: ${{ inputs.baseline_run_id }}
+      baseline_repository: ${{ inputs.baseline_repository }}
       # dry-run honors the prebuilt_stages listed above while only reporting
       # what automatic reuse could additionally do. Applying it is not safe
       # here: reusing a stage that holds a project under test would substitute
@@ -152,6 +166,10 @@ jobs:
         with:
           release_type: ci
 
+      # RELEASE_TYPE governs where artifacts are written, which is always this
+      # run's ci bucket. --source-release-type governs where they are read from,
+      # which is wherever the baseline published: a ROCm/rockrel release nightly
+      # writes to the nightly bucket, not the ci one.
       - name: Copy baseline stage artifacts
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -160,6 +178,7 @@ jobs:
           python build_tools/artifact_manager.py copy \
             --source-run-id=${{ fromJSON(needs.setup.outputs.linux_build_config).baseline_run_id }} \
             --source-repository=${{ fromJSON(needs.setup.outputs.linux_build_config).baseline_repository }} \
+            --source-release-type="${{ inputs.baseline_release_type }}" \
             --stage="${{ fromJSON(needs.setup.outputs.linux_build_config).prebuilt_stages }}" \
             --amdgpu-families="${{ fromJSON(needs.setup.outputs.linux_build_config).dist_amdgpu_families }}" \
             --expand-family-to-targets

--- a/.github/workflows/coverage_nightly.yml
+++ b/.github/workflows/coverage_nightly.yml
@@ -1,11 +1,24 @@
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-# Nightly Code Coverage (Phase 1)
+# Nightly Code Coverage (RFC0014 phase 1 PoC, option B1)
 #
 # Builds an instrumented ROCm stack, runs the component test suites against it,
 # and publishes one merged lcov report per component. See RFC0014 and
 # docs/development/code_coverage.md.
+#
+# Scope is the phase 1 proof of concept and nothing beyond it. The point is to
+# prove the instrumented build and the coverage report work end to end in
+# isolation, before anything is automated on top of them:
+#
+#   - Host-side coverage. Device-side counters would need the compiler-rt
+#     profile runtime, which is out of scope here.
+#   - Single default architecture (gfx94x/gfx942).
+#   - baseline_run_id is supplied by hand (RFC option B1). Manual coordination
+#     is acceptable for initial validation, which is the whole point of the
+#     PoC; automating it is a later phase's problem.
+#   - No changes to the production nightly, and nothing triggers this
+#     automatically, so it can fail or be abandoned without consequence.
 #
 # This is deliberately a separate workflow rather than an extension of the
 # regular nightly:
@@ -19,13 +32,6 @@
 #   - A separate workflow means a separate run id, which puts coverage artifacts
 #     in their own S3 namespace and removes any chance of a coverage build being
 #     consumed as if it were a regular one.
-#
-# Phase 1 scope:
-#   - Single default architecture (gfx94x/gfx942). Architecture-specific
-#     coverage comes later, once arch-specific change detection exists.
-#   - baseline_run_id is supplied by hand (RFC option B1). Phase 2 replaces this
-#     with a downstream trigger from the regular nightly that passes its own
-#     run id automatically, so nothing here should assume a human typed it.
 
 name: Nightly Code Coverage
 
@@ -55,11 +61,8 @@ on:
       prebuilt_stages:
         description: >-
           Build stages to copy from baseline_run_id instead of building
-          instrumented. The default reuses everything except math-libs, which
-          keeps a PoC run affordable but limits coverage to host code, since
-          device-side counters need the compiler-runtime stage rebuilt with
-          THEROCK_COMPILER_RT_BUILD_PROFILE_ROCM. Set to "none" to build the
-          whole instrumented stack.
+          instrumented. The default reuses everything except math-libs, so only
+          the stage holding the projects under test is built.
         type: string
         default: "compiler-runtime,emulation,runtime-tests,wsl-rocdxg,comm-libs,storage-libs,debug-tools,dctools-core,profiler-apps,cv-libs,media-libs"
       repository:
@@ -68,33 +71,6 @@ on:
         default: ""
       ref:
         description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
-        type: string
-        default: ""
-
-  # Phase 2 entry point: the regular nightly calls this after its build stages
-  # finish and passes its own run id as baseline_run_id.
-  workflow_call:
-    inputs:
-      baseline_run_id:
-        description: "Regular nightly run_id to take non-instrumented dependencies from."
-        type: string
-        required: true
-      amdgpu_family:
-        type: string
-        default: "gfx94x"
-      coverage_projects:
-        type: string
-        default: "hiprand"
-      test_labels:
-        type: string
-        default: "hiprand"
-      prebuilt_stages:
-        type: string
-        default: "compiler-runtime,emulation,runtime-tests,wsl-rocdxg,comm-libs,storage-libs,debug-tools,dctools-core,profiler-apps,cv-libs,media-libs"
-      repository:
-        type: string
-        default: ""
-      ref:
         type: string
         default: ""
 

--- a/.github/workflows/coverage_nightly.yml
+++ b/.github/workflows/coverage_nightly.yml
@@ -1,0 +1,245 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# Nightly Code Coverage (Phase 1)
+#
+# Builds an instrumented ROCm stack, runs the component test suites against it,
+# and publishes one merged lcov report per component. See RFC0014 and
+# docs/development/code_coverage.md.
+#
+# This is deliberately a separate workflow rather than an extension of the
+# regular nightly:
+#
+#   - Instrumented binaries are not the binaries anyone wants to ship or
+#     benchmark. Coverage disables optimizations and adds counters, so folding
+#     it into the regular nightly would change what that nightly tests.
+#   - Coverage is slow. Instrumented rocPRIM tests take roughly 3 hours against
+#     20 minutes uninstrumented, so coverage needs to be able to fail, be
+#     retried, or be skipped without holding up the regular nightly.
+#   - A separate workflow means a separate run id, which puts coverage artifacts
+#     in their own S3 namespace and removes any chance of a coverage build being
+#     consumed as if it were a regular one.
+#
+# Phase 1 scope:
+#   - Single default architecture (gfx94x/gfx942). Architecture-specific
+#     coverage comes later, once arch-specific change detection exists.
+#   - baseline_run_id is supplied by hand (RFC option B1). Phase 2 replaces this
+#     with a downstream trigger from the regular nightly that passes its own
+#     run id automatically, so nothing here should assume a human typed it.
+
+name: Nightly Code Coverage
+
+on:
+  workflow_dispatch:
+    inputs:
+      baseline_run_id:
+        description: "Regular nightly run_id to take non-instrumented dependencies from."
+        type: string
+        required: true
+      amdgpu_family:
+        description: "Single GPU family to build and test coverage on."
+        type: string
+        default: "gfx94x"
+      coverage_projects:
+        description: >-
+          Projects to instrument, comma or semicolon separated, in any casing
+          (e.g. "hiprand"). Empty instruments every rocm-libraries component.
+        type: string
+        default: "hiprand"
+      test_labels:
+        description: >-
+          Components to run coverage tests for, comma separated (e.g.
+          "hiprand"). Empty runs every component available for the family.
+        type: string
+        default: "hiprand"
+      prebuilt_stages:
+        description: >-
+          Build stages to copy from baseline_run_id instead of building
+          instrumented. The default reuses everything except math-libs, which
+          keeps a PoC run affordable but limits coverage to host code, since
+          device-side counters need the compiler-runtime stage rebuilt with
+          THEROCK_COMPILER_RT_BUILD_PROFILE_ROCM. Set to "none" to build the
+          whole instrumented stack.
+        type: string
+        default: "compiler-runtime,emulation,runtime-tests,wsl-rocdxg,comm-libs,storage-libs,debug-tools,dctools-core,profiler-apps,cv-libs,media-libs"
+      repository:
+        description: "Repository to checkout. Defaults to github.repository."
+        type: string
+        default: ""
+      ref:
+        description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
+        type: string
+        default: ""
+
+  # Phase 2 entry point: the regular nightly calls this after its build stages
+  # finish and passes its own run id as baseline_run_id.
+  workflow_call:
+    inputs:
+      baseline_run_id:
+        description: "Regular nightly run_id to take non-instrumented dependencies from."
+        type: string
+        required: true
+      amdgpu_family:
+        type: string
+        default: "gfx94x"
+      coverage_projects:
+        type: string
+        default: "hiprand"
+      test_labels:
+        type: string
+        default: "hiprand"
+      prebuilt_stages:
+        type: string
+        default: "compiler-runtime,emulation,runtime-tests,wsl-rocdxg,comm-libs,storage-libs,debug-tools,dctools-core,profiler-apps,cv-libs,media-libs"
+      repository:
+        type: string
+        default: ""
+      ref:
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+  actions: read # setup_multi_arch queries workflow runs to resolve the baseline
+
+run-name: >-
+  Nightly Code Coverage
+  (${{ inputs.amdgpu_family }},
+  ${{ inputs.coverage_projects || 'all rocm-libraries' }},
+  baseline ${{ inputs.baseline_run_id }})
+
+concurrency:
+  # Two instrumented builds of the same family would race for build nodes for
+  # hours to produce the same report.
+  group: coverage-nightly-${{ github.ref }}-${{ inputs.amdgpu_family }}
+  cancel-in-progress: false
+
+jobs:
+  setup:
+    uses: ./.github/workflows/setup_multi_arch.yml
+    secrets: inherit
+    permissions:
+      contents: read
+      actions: read
+    with:
+      build_variant: "coverage"
+      linux_amdgpu_families: ${{ inputs.amdgpu_family }}
+      windows_amdgpu_families: "none"
+      linux_test_labels: ${{ inputs.test_labels }}
+      prebuilt_stages: ${{ inputs.prebuilt_stages != 'none' && inputs.prebuilt_stages || '' }}
+      baseline_run_id: ${{ inputs.baseline_run_id }}
+      # dry-run honors the prebuilt_stages listed above while only reporting
+      # what automatic reuse could additionally do. Applying it is not safe
+      # here: reusing a stage that holds a project under test would substitute
+      # non-instrumented binaries and produce an empty report rather than an
+      # error. ("off" would discard prebuilt_stages entirely and rebuild the
+      # whole stack instrumented.)
+      stage_reuse_mode: "dry-run"
+      # Nothing downstream of the instrumented artifacts is wanted: wheels,
+      # distro packages and framework builds are all consumers of a shippable
+      # stack, which this is not.
+      build_python_packages: false
+      build_pytorch: false
+      build_jax: false
+      build_native_linux: false
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref }}
+
+  # Copies the baseline nightly's non-instrumented stages into this run's
+  # artifact namespace. Combined with the instrumented stage built below, this
+  # run then holds a complete stack in which only the projects under test are
+  # instrumented, so the test jobs can fetch everything from a single run id
+  # and dependencies contribute no counters to the report.
+  copy_baseline_stages:
+    name: Copy Baseline Stages
+    needs: setup
+    if: ${{ inputs.prebuilt_stages != 'none' && needs.setup.outputs.linux_build_config != '' }}
+    runs-on: aws-linux-scale-rocm-prod
+    permissions:
+      contents: read
+      id-token: write
+    container:
+      image: python:3.12-slim
+    steps:
+      - name: Checking out repository
+        timeout-minutes: 15
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ needs.setup.outputs.ref }}
+
+      - name: Install artifact manager dependencies
+        run: pip install boto3
+
+      - name: Configure AWS credentials for artifact uploads
+        uses: ./.github/actions/configure_aws_artifacts_credentials
+        with:
+          release_type: ci
+
+      - name: Copy baseline stage artifacts
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          RELEASE_TYPE: ci
+        run: |
+          python build_tools/artifact_manager.py copy \
+            --source-run-id=${{ fromJSON(needs.setup.outputs.linux_build_config).baseline_run_id }} \
+            --source-repository=${{ fromJSON(needs.setup.outputs.linux_build_config).baseline_repository }} \
+            --stage="${{ fromJSON(needs.setup.outputs.linux_build_config).prebuilt_stages }}" \
+            --amdgpu-families="${{ fromJSON(needs.setup.outputs.linux_build_config).dist_amdgpu_families }}" \
+            --expand-family-to-targets
+
+  build_instrumented_stack:
+    name: Build Instrumented Stack
+    needs: [setup, copy_baseline_stages]
+    if: ${{ !cancelled() && !failure() && needs.setup.outputs.linux_build_config != '' }}
+    uses: ./.github/workflows/multi_arch_build_portable_linux.yml
+    secrets: inherit
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      matrix_per_family_json: ${{ toJSON(fromJSON(needs.setup.outputs.linux_build_config).per_family_info) }}
+      dist_amdgpu_families: ${{ fromJSON(needs.setup.outputs.linux_build_config).dist_amdgpu_families }}
+      artifact_group: ${{ fromJSON(needs.setup.outputs.linux_build_config).artifact_group }}
+      build_variant_label: ${{ fromJSON(needs.setup.outputs.linux_build_config).build_variant_label }}
+      build_variant_cmake_preset: ${{ fromJSON(needs.setup.outputs.linux_build_config).build_variant_cmake_preset }}
+      build_variant_suffix: ${{ fromJSON(needs.setup.outputs.linux_build_config).build_variant_suffix }}
+      # The preset instruments every rocm-libraries component, which is what a
+      # full nightly wants. A project list narrows that down, so the group flag
+      # has to be turned back off or it would keep instrumenting everything.
+      extra_cmake_options: >-
+        ${{ inputs.coverage_projects != ''
+            && format('-DTHEROCK_COVERAGE_ROCM_LIBRARIES_ALL=OFF -DTHEROCK_COVERAGE_PROJECTS={0}', inputs.coverage_projects)
+            || '' }}
+      prebuilt_stages: ${{ fromJSON(needs.setup.outputs.linux_build_config).prebuilt_stages }}
+      skip_stages: ${{ fromJSON(needs.setup.outputs.linux_build_config).skip_stages }}
+      build_runs_on: ${{ fromJSON(needs.setup.outputs.linux_build_config).build_runs_on }}
+      rocm_package_version: ${{ needs.setup.outputs.rocm_package_version }}
+      release_type: ci
+      repository: ${{ inputs.repository }}
+      ref: ${{ needs.setup.outputs.ref }}
+
+  test_coverage:
+    name: Coverage Tests
+    needs: [setup, build_instrumented_stack]
+    if: ${{ !cancelled() && !failure() }}
+    strategy:
+      fail-fast: false
+      matrix:
+        family_info: ${{ fromJSON(needs.setup.outputs.linux_build_config).per_family_info }}
+    uses: ./.github/workflows/test_artifacts.yml
+    secrets: inherit
+    with:
+      artifact_group: ${{ fromJSON(needs.setup.outputs.linux_build_config).artifact_group }}
+      amdgpu_families: ${{ matrix.family_info.amdgpu_family }}
+      amdgpu_targets: ${{ matrix.family_info.amdgpu_targets }}
+      test_runs_on: ${{ matrix.family_info.test-runs-on }}
+      # Coverage is only worth measuring against the full suite; a partial run
+      # reports a component as less covered than it is.
+      test_type: full
+      test_labels: ${{ needs.setup.outputs.linux_test_labels }}
+      coverage_enabled: true
+      release_type: ci
+      build_variant: ${{ fromJSON(needs.setup.outputs.linux_build_config).build_variant_label }}
+      repository: ${{ inputs.repository }}
+      ref: ${{ needs.setup.outputs.ref }}

--- a/.github/workflows/coverage_nightly.yml
+++ b/.github/workflows/coverage_nightly.yml
@@ -51,8 +51,13 @@ on:
         required: true
       baseline_repository:
         description: >-
-          Repository owning baseline_run_id, when it is not this one. Release
-          nightlies live in ROCm/rockrel, for example.
+          Repository owning baseline_run_id, when it is not this one. Prefer
+          leaving this empty. Artifacts embed the absolute path of the workspace
+          they were built in, which GitHub derives from the repository name, and
+          the CMake package configs inside them resolve against it. A baseline
+          from another repository therefore only works if its checkout path
+          matches this one's, so a ROCm/rockrel baseline breaks a ROCm/TheRock
+          build.
         type: string
         default: ""
       baseline_release_type:
@@ -101,8 +106,13 @@ on:
         required: true
       baseline_repository:
         description: >-
-          Repository owning baseline_run_id, when it is not this one. Release
-          nightlies live in ROCm/rockrel, for example.
+          Repository owning baseline_run_id, when it is not this one. Prefer
+          leaving this empty. Artifacts embed the absolute path of the workspace
+          they were built in, which GitHub derives from the repository name, and
+          the CMake package configs inside them resolve against it. A baseline
+          from another repository therefore only works if its checkout path
+          matches this one's, so a ROCm/rockrel baseline breaks a ROCm/TheRock
+          build.
         type: string
         default: ""
       baseline_release_type:

--- a/.github/workflows/coverage_nightly_pr_check.yml
+++ b/.github/workflows/coverage_nightly_pr_check.yml
@@ -1,0 +1,67 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# TEMPORARY. Delete this file before merging the coverage PR.
+#
+# coverage_nightly.yml is triggered by hand, but a workflow_dispatch only
+# appears once it is on the default branch, so there is no way to run it from a
+# branch and no way to see it in a PR's checks. That leaves the phase 1 PoC
+# unable to demonstrate the one thing it exists to demonstrate.
+#
+# A caller has no such restriction: ./.github/workflows paths resolve against
+# the caller's own commit, so this runs the branch's coverage_nightly.yml, and
+# its jobs show up under this PR's checks.
+#
+# This is scaffolding, not the design. Nothing in the phase 1 scope wants
+# coverage on presubmit: an instrumented build plus a full test suite is hours
+# of machine time, which is why coverage is a separate manually triggered
+# workflow in the first place. Leaving this file in place would quietly make
+# every PR touching coverage pay that cost, so it goes away once the PoC has
+# been shown to work end to end.
+
+name: Coverage Nightly PR Check
+
+on:
+  pull_request:
+    # Narrow on purpose. Every run here is a multi-hour instrumented build, so
+    # only the files that carry coverage logic are worth spending one on.
+    paths:
+      - ".github/workflows/coverage_nightly.yml"
+      - ".github/workflows/coverage_nightly_pr_check.yml"
+      - ".github/workflows/test_component.yml"
+      - "cmake/therock_coverage.cmake"
+      - "cmake/therock_subproject.cmake"
+      - "build_tools/github_actions/coverage_report.py"
+
+concurrency:
+  # A later push supersedes this run. Queueing multi-hour instrumented builds
+  # behind each other to report on code that has already been replaced only
+  # occupies build nodes the rest of CI needs.
+  group: coverage-nightly-pr-check-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  coverage:
+    name: Coverage
+    uses: ./.github/workflows/coverage_nightly.yml
+    secrets: inherit
+    # A called workflow cannot hold more than its caller, so these have to be
+    # granted here even though coverage_nightly.yml also declares them:
+    # id-token for the AWS role the artifact copy assumes, actions:read for the
+    # baseline run lookup.
+    permissions:
+      contents: read
+      actions: read
+      id-token: write
+    with:
+      # The 2026-09-03 ROCm/rockrel release nightly, which built math-libs for
+      # gfx94X-dcgpu. Pinned rather than resolved: a PoC wants the same baseline
+      # every run so a change in the report means a change in this branch.
+      # rockrel publishes under the nightly release type, so its artifacts live
+      # in the nightly bucket rather than this run's ci one.
+      baseline_run_id: "33697653391"
+      baseline_repository: "ROCm/rockrel"
+      baseline_release_type: "nightly"
+      amdgpu_family: "gfx94x"
+      coverage_projects: "hiprand"
+      test_labels: "hiprand"

--- a/.github/workflows/coverage_nightly_pr_check.yml
+++ b/.github/workflows/coverage_nightly_pr_check.yml
@@ -54,14 +54,22 @@ jobs:
       actions: read
       id-token: write
     with:
-      # The 2026-09-03 ROCm/rockrel release nightly, which built math-libs for
-      # gfx94X-dcgpu. Pinned rather than resolved: a PoC wants the same baseline
-      # every run so a change in the report means a change in this branch.
-      # rockrel publishes under the nightly release type, so its artifacts live
-      # in the nightly bucket rather than this run's ci one.
-      baseline_run_id: "33697653391"
-      baseline_repository: "ROCm/rockrel"
-      baseline_release_type: "nightly"
+      # A ROCm/TheRock Multi-Arch CI run, pinned rather than resolved so that a
+      # change in the report means a change in this branch.
+      #
+      # It has to come from this repository, which rules out the release
+      # nightlies. Artifacts embed the absolute path of the workspace they were
+      # built in, and the CMake package configs inside them resolve against it,
+      # so a rockrel baseline hands this build configs pointing at
+      # /__w/rockrel/rockrel, which does not exist here. rocFFT was the first
+      # consumer to notice, resolving FFTW3 to fftw3_libs-NOTFOUND and failing
+      # its configure. A ROCm/TheRock baseline shares this run's
+      # /__w/TheRock/TheRock, so the embedded paths land where the artifacts
+      # were actually unpacked.
+      #
+      # This run's own test jobs failed, which does not matter: only its build
+      # stages are consumed, and those all succeeded.
+      baseline_run_id: "33990288042"
       amdgpu_family: "gfx94x"
       coverage_projects: "hiprand"
       test_labels: "hiprand"

--- a/.github/workflows/multi_arch_build_portable_linux.yml
+++ b/.github/workflows/multi_arch_build_portable_linux.yml
@@ -34,6 +34,14 @@ on:
         type: string
       build_variant_cmake_preset:
         type: string
+      extra_cmake_options:
+        type: string
+        default: ""
+        description: >-
+          Additional -D options appended to each stage's configure command. Used
+          by build variants whose settings vary per run and so cannot live in a
+          preset (e.g. -DTHEROCK_COVERAGE_PROJECTS=hiprand). Not forwarded to
+          the WSL ROCDXG stage, which is unrelated to any such variant.
       build_variant_suffix:
         type: string
       rocm_package_version:
@@ -111,6 +119,7 @@ jobs:
       dist_amdgpu_families: ${{ inputs.dist_amdgpu_families }}
       rocm_package_version: ${{ inputs.rocm_package_version }}
       build_variant_cmake_preset: ${{ inputs.build_variant_cmake_preset }}
+      extra_cmake_options: ${{ inputs.extra_cmake_options }}
       build_runs_on: ${{ inputs.build_runs_on }}
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
@@ -136,6 +145,7 @@ jobs:
       dist_amdgpu_families: ${{ inputs.dist_amdgpu_families }}
       rocm_package_version: ${{ inputs.rocm_package_version }}
       build_variant_cmake_preset: ${{ inputs.build_variant_cmake_preset }}
+      extra_cmake_options: ${{ inputs.extra_cmake_options }}
       build_runs_on: ${{ inputs.build_runs_on }}
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
@@ -161,6 +171,7 @@ jobs:
       dist_amdgpu_families: ${{ inputs.dist_amdgpu_families }}
       rocm_package_version: ${{ inputs.rocm_package_version }}
       build_variant_cmake_preset: ${{ inputs.build_variant_cmake_preset }}
+      extra_cmake_options: ${{ inputs.extra_cmake_options }}
       build_runs_on: ${{ inputs.build_runs_on }}
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
@@ -220,6 +231,7 @@ jobs:
       dist_amdgpu_families: ${{ inputs.dist_amdgpu_families }}
       rocm_package_version: ${{ inputs.rocm_package_version }}
       build_variant_cmake_preset: ${{ inputs.build_variant_cmake_preset }}
+      extra_cmake_options: ${{ inputs.extra_cmake_options }}
       build_runs_on: ${{ inputs.build_runs_on }}
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
@@ -250,6 +262,7 @@ jobs:
       dist_amdgpu_families: ${{ inputs.dist_amdgpu_families }}
       rocm_package_version: ${{ inputs.rocm_package_version }}
       build_variant_cmake_preset: ${{ inputs.build_variant_cmake_preset }}
+      extra_cmake_options: ${{ inputs.extra_cmake_options }}
       build_runs_on: ${{ inputs.build_runs_on }}
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
@@ -277,6 +290,7 @@ jobs:
       dist_amdgpu_families: ${{ inputs.dist_amdgpu_families }}
       rocm_package_version: ${{ inputs.rocm_package_version }}
       build_variant_cmake_preset: ${{ inputs.build_variant_cmake_preset }}
+      extra_cmake_options: ${{ inputs.extra_cmake_options }}
       build_runs_on: ${{ inputs.build_runs_on }}
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
@@ -302,6 +316,7 @@ jobs:
       dist_amdgpu_families: ${{ inputs.dist_amdgpu_families }}
       rocm_package_version: ${{ inputs.rocm_package_version }}
       build_variant_cmake_preset: ${{ inputs.build_variant_cmake_preset }}
+      extra_cmake_options: ${{ inputs.extra_cmake_options }}
       build_runs_on: ${{ inputs.build_runs_on }}
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
@@ -327,6 +342,7 @@ jobs:
       dist_amdgpu_families: ${{ inputs.dist_amdgpu_families }}
       rocm_package_version: ${{ inputs.rocm_package_version }}
       build_variant_cmake_preset: ${{ inputs.build_variant_cmake_preset }}
+      extra_cmake_options: ${{ inputs.extra_cmake_options }}
       build_runs_on: ${{ inputs.build_runs_on }}
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
@@ -352,6 +368,7 @@ jobs:
       dist_amdgpu_families: ${{ inputs.dist_amdgpu_families }}
       rocm_package_version: ${{ inputs.rocm_package_version }}
       build_variant_cmake_preset: ${{ inputs.build_variant_cmake_preset }}
+      extra_cmake_options: ${{ inputs.extra_cmake_options }}
       build_runs_on: ${{ inputs.build_runs_on }}
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
@@ -377,6 +394,7 @@ jobs:
       dist_amdgpu_families: ${{ inputs.dist_amdgpu_families }}
       rocm_package_version: ${{ inputs.rocm_package_version }}
       build_variant_cmake_preset: ${{ inputs.build_variant_cmake_preset }}
+      extra_cmake_options: ${{ inputs.extra_cmake_options }}
       build_runs_on: ${{ inputs.build_runs_on }}
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
@@ -402,6 +420,7 @@ jobs:
       dist_amdgpu_families: ${{ inputs.dist_amdgpu_families }}
       rocm_package_version: ${{ inputs.rocm_package_version }}
       build_variant_cmake_preset: ${{ inputs.build_variant_cmake_preset }}
+      extra_cmake_options: ${{ inputs.extra_cmake_options }}
       build_runs_on: ${{ inputs.build_runs_on }}
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}

--- a/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
@@ -73,6 +73,13 @@ on:
         description: "Comma-separated artifact names to build (granular reuse). Empty = build all artifacts in stage."
         type: string
         default: ""
+      extra_cmake_options:
+        description: >-
+          Additional -D options appended to the configure command, for build
+          variants that need per-run settings a preset cannot express (e.g.
+          -DTHEROCK_COVERAGE_PROJECTS=hiprand).
+        type: string
+        default: ""
       quartz_tracking_id:
         type: string
         default: ""
@@ -194,7 +201,8 @@ jobs:
             ${{ inputs.build_variant_cmake_preset && format('--preset={0}', inputs.build_variant_cmake_preset) }} \
             ${{ inputs.external_repo_config != '' && format('-DTHEROCK_{0}_SOURCE_DIR={1}', fromJSON(inputs.external_repo_config).source_package, fromJSON(inputs.external_repo_config).checkout_path) || '' }} \
             ${{ inputs.external_repo_config != '' && fromJSON(inputs.external_repo_config).extra_cmake_options || '' }} \
-            ${{ steps.stage_config.outputs.cmake_args }}
+            ${{ steps.stage_config.outputs.cmake_args }} \
+            ${{ inputs.extra_cmake_options }}
 
       - name: Build stage
         run: |

--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -109,6 +109,13 @@ on:
         description: "Build variant (e.g., release, asan)."
         type: string
         default: "release"
+      coverage_enabled:
+        description: >-
+          When true, each component collects llvm profraw during its test run
+          and publishes a merged coverage report. Requires artifacts from an
+          instrumented build; see docs/development/code_coverage.md.
+        type: boolean
+        default: false
       quartz_tracking_id:
         type: string
         default: ""
@@ -210,6 +217,8 @@ jobs:
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
       build_variant: ${{ inputs.build_variant }}
+      # The sanity check only proves the artifacts are usable, so there is
+      # nothing worth reporting coverage for.
       quartz_tracking_id: ${{ inputs.quartz_tracking_id }}
 
   test_components:
@@ -267,6 +276,7 @@ jobs:
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
       build_variant: ${{ inputs.build_variant }}
+      coverage_enabled: ${{ inputs.coverage_enabled }}
       quartz_tracking_id: ${{ inputs.quartz_tracking_id }}
 
   notify_quartz_completed:

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -35,6 +35,13 @@ on:
         description: "Build variant (e.g., release, asan). Used to skip tests incompatible with certain builds."
         type: string
         default: "release"
+      coverage_enabled:
+        description: >-
+          When true, collect llvm profraw from the test run and generate a
+          coverage report for this component. Only meaningful against an
+          instrumented build; see docs/development/code_coverage.md.
+        type: boolean
+        default: false
       default_container_image:
         type: string
         default: "ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:4150afe4759d14822f0e3f8930e1124f26e11f68b5c7b91ec9a02b20b1ebbb98"
@@ -86,6 +93,9 @@ jobs:
       ARTIFACT_RUN_ID: "${{ inputs.artifact_run_id != '' && inputs.artifact_run_id || github.run_id }}"
       OUTPUT_ARTIFACTS_DIR: "./build"
       THEROCK_BIN_DIR: "./build/bin"
+      COVERAGE_PROFRAW_DIR: "${{ github.workspace }}/coverage-report/profraw"
+      COVERAGE_ARTIFACT_NAME: >-
+        coverage-profraw-${{ fromJSON(inputs.component).job_name }}-${{ inputs.amdgpu_families }}
       AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
       AMDGPU_TARGETS: ${{ inputs.amdgpu_targets }}
       ARTIFACT_GROUP: ${{ inputs.artifact_group }}
@@ -178,6 +188,21 @@ jobs:
           echo "HSA_XNACK=1" >> $GITHUB_ENV
           echo "ASAN_SYMBOLIZER_PATH=${{ env.OUTPUT_ARTIFACTS_DIR }}/llvm/bin/llvm-symbolizer" >> $GITHUB_ENV
 
+      # Instrumented binaries write their counters wherever LLVM_PROFILE_FILE
+      # points, so it has to be set before any test runs. %p (process id) and
+      # %m (binary signature) are expanded by the profile runtime and keep
+      # concurrent test processes from overwriting each other's output; the
+      # shard index keeps this shard's files distinct from the other shards'
+      # once they are all downloaded into one directory for merging.
+      - name: Prepare coverage profile directory
+        if: ${{ inputs.coverage_enabled }}
+        env:
+          TEST_COMPONENT: ${{ fromJSON(inputs.component).test_component || fromJSON(inputs.component).job_name }}
+          SHARD_INDEX: ${{ matrix.shard }}
+        run: |
+          mkdir -p "${COVERAGE_PROFRAW_DIR}"
+          echo "LLVM_PROFILE_FILE=${COVERAGE_PROFRAW_DIR}/${TEST_COMPONENT}-shard${SHARD_INDEX}-%p-%m.profraw" >> "${GITHUB_ENV}"
+
       # Set thread limits from KUBE_CPU_REQUEST (Kubernetes-injected) to avoid oversubscription.
       # Must be done at runtime since container env vars aren't in GitHub's env context.
       - name: Set thread limits
@@ -222,6 +247,18 @@ jobs:
         run: |
           ${{ fromJSON(inputs.component).test_script }}
 
+      # Uploaded unmerged: merging here would produce a report covering only
+      # this shard's slice of the suite. The coverage_report job merges every
+      # shard's files into a single report.
+      - name: Upload coverage profraw
+        if: ${{ !cancelled() && inputs.coverage_enabled }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ env.COVERAGE_ARTIFACT_NAME }}-shard${{ matrix.shard }}
+          path: ${{ env.COVERAGE_PROFRAW_DIR }}
+          retention-days: 3
+          if-no-files-found: error
+
       - name: Print test reproduction command
         if: ${{ failure() && steps.test.outcome == 'failure' }}
         run: |
@@ -265,3 +302,76 @@ jobs:
           workflow_step_outputs: ${{ toJSON(steps) }}
           gh_app_client_id: ${{ secrets.GH_APP_HAULY_CID }}
           gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
+
+  # A component's coverage is only complete once every shard has reported, so
+  # this runs after the whole matrix rather than inside it. It needs no GPU: it
+  # only reads profraw files and the instrumented binaries.
+  coverage_report:
+    name: >-
+      Coverage ${{ fromJSON(inputs.component).job_name }}
+      (${{ inputs.amdgpu_families }})
+    needs: test_component
+    if: ${{ !cancelled() && inputs.coverage_enabled }}
+    runs-on: aws-linux-scale-rocm-prod
+    timeout-minutes: 60
+    container:
+      image: ${{ inputs.default_container_image }}
+    defaults:
+      run:
+        shell: bash
+    env:
+      VENV_DIR: ${{ github.workspace }}/.venv
+      ARTIFACT_RUN_ID: "${{ inputs.artifact_run_id != '' && inputs.artifact_run_id || github.run_id }}"
+      OUTPUT_ARTIFACTS_DIR: "./build"
+      COVERAGE_REPORT_DIR: coverage-report
+      COVERAGE_ARTIFACT_NAME: >-
+        coverage-profraw-${{ fromJSON(inputs.component).job_name }}-${{ inputs.amdgpu_families }}
+      TEST_COMPONENT: ${{ fromJSON(inputs.component).test_component || fromJSON(inputs.component).job_name }}
+    steps:
+      - name: Checking out repository
+        timeout-minutes: 15
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}
+
+      # The instrumented binaries are the objects the report is generated
+      # against, and their build's llvm-profdata/llvm-cov are the only tools
+      # guaranteed to understand the profile format they emitted.
+      - name: Run setup test environment workflow
+        timeout-minutes: 15
+        uses: './.github/actions/setup_test_environment'
+        with:
+          ARTIFACT_RUN_ID: ${{ env.ARTIFACT_RUN_ID }}
+          ARTIFACT_GROUP: ${{ inputs.amdgpu_families }}
+          AMDGPU_TARGETS: ${{ inputs.amdgpu_targets }}
+          OUTPUT_ARTIFACTS_DIR: ${{ env.OUTPUT_ARTIFACTS_DIR }}
+          VENV_DIR: ${{ env.VENV_DIR }}
+          FETCH_ARTIFACT_ARGS: ${{ fromJSON(inputs.component).fetch_artifact_args }}
+          RELEASE_TYPE: ${{ inputs.release_type }}
+
+      - name: Download coverage profraw from all shards
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: ${{ env.COVERAGE_ARTIFACT_NAME }}-shard*
+          merge-multiple: true
+          path: ${{ env.COVERAGE_REPORT_DIR }}/profraw
+
+      - name: Generate coverage report
+        run: |
+          python ./build_tools/github_actions/coverage_report.py \
+            --component "${TEST_COMPONENT}" \
+            --rocm-dir "${OUTPUT_ARTIFACTS_DIR}" \
+            --profraw-dir "${COVERAGE_REPORT_DIR}/profraw" \
+            --output-dir "${COVERAGE_REPORT_DIR}"
+
+      - name: Upload coverage report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-report-${{ fromJSON(inputs.component).job_name }}-${{ inputs.amdgpu_families }}
+          path: |
+            ${{ env.COVERAGE_REPORT_DIR }}/coverage.info
+            ${{ env.COVERAGE_REPORT_DIR }}/coverage.txt
+          retention-days: 14
+          if-no-files-found: error

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -327,6 +327,9 @@ jobs:
       COVERAGE_ARTIFACT_NAME: >-
         coverage-profraw-${{ fromJSON(inputs.component).job_name }}-${{ inputs.amdgpu_families }}
       TEST_COMPONENT: ${{ fromJSON(inputs.component).test_component || fromJSON(inputs.component).job_name }}
+      # Phase 1 instruments rocm-libraries components, whose sources all live at
+      # <submodule>/projects/<component>.
+      COVERAGE_SOURCE_SUBMODULE: rocm-libraries
     steps:
       - name: Checking out repository
         timeout-minutes: 15
@@ -357,13 +360,37 @@ jobs:
           merge-multiple: true
           path: ${{ env.COVERAGE_REPORT_DIR }}/profraw
 
+      # The annotated HTML report opens the source files at the absolute paths
+      # recorded in the profile, so they have to exist under this workspace.
+      # Checking out the rocm-libraries submodule normally would fetch ~7GB for
+      # the sake of one component, so this materializes just that component's
+      # directory: a partial clone (no blobs) plus a sparse checkout means only
+      # its files are downloaded. Failure is not fatal -- the lcov and text
+      # reports do not need source, and the HTML one degrades to reporting that
+      # it could not find it.
+      - name: Check out component sources for the annotated report
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          submodule_sha="$(git rev-parse "HEAD:${COVERAGE_SOURCE_SUBMODULE}")"
+          submodule_url="$(git config --file .gitmodules --get "submodule.${COVERAGE_SOURCE_SUBMODULE}.url")"
+          mkdir -p "${COVERAGE_SOURCE_SUBMODULE}"
+          cd "${COVERAGE_SOURCE_SUBMODULE}"
+          git init --quiet
+          git remote add origin "${submodule_url}"
+          git sparse-checkout init --cone
+          git sparse-checkout set "projects/${TEST_COMPONENT}"
+          git fetch --quiet --depth 1 --filter=blob:none origin "${submodule_sha}"
+          git checkout --quiet FETCH_HEAD
+
       - name: Generate coverage report
         run: |
           python ./build_tools/github_actions/coverage_report.py \
             --component "${TEST_COMPONENT}" \
             --rocm-dir "${OUTPUT_ARTIFACTS_DIR}" \
             --profraw-dir "${COVERAGE_REPORT_DIR}/profraw" \
-            --output-dir "${COVERAGE_REPORT_DIR}"
+            --output-dir "${COVERAGE_REPORT_DIR}" \
+            --html
 
       - name: Upload coverage report
         if: ${{ !cancelled() }}
@@ -373,5 +400,6 @@ jobs:
           path: |
             ${{ env.COVERAGE_REPORT_DIR }}/coverage.info
             ${{ env.COVERAGE_REPORT_DIR }}/coverage.txt
+            ${{ env.COVERAGE_REPORT_DIR }}/coverage.html
           retention-days: 14
           if-no-files-found: error

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,11 +215,6 @@ cmake_dependent_option(
 option(THEROCK_SPLIT_DEBUG_INFO "Enables splitting of debug info into dbg artifacts (and strips primary packages)" OFF)
 option(THEROCK_MINIMAL_DEBUG_INFO "Enables compiler-specific flags for minimal debug symbols suitable for shipping in packages" OFF)
 option(THEROCK_COMPILER_RT_DEBUG "Enables compiler-rt debug build" OFF)
-# Device-side coverage needs the profiler runtime compiled into instrumented
-# device code, which compiler-rt only builds when asked. Coverage builds enable
-# this via the linux-release-coverage preset; it is off by default because it is
-# dead weight for every other build.
-option(THEROCK_COMPILER_RT_BUILD_PROFILE_ROCM "Builds the compiler-rt device-side profile runtime, required for device code coverage" OFF)
 option(THEROCK_QUIET_INSTALL "Enable quiet install logging (install logs only go to the logfile)" ON)
 option(THEROCK_USE_SAFE_DEPENDENCY_PROVIDER "Enable the safe dependency provider, performing strict package checks" ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ include(therock_detect_python_versions)
 include(therock_amdgpu_targets)
 include(therock_artifacts)
 include(therock_compiler_config)
+include(therock_coverage)
 include(therock_external_source)
 include(therock_features)
 include(therock_sanitizers)
@@ -156,6 +157,11 @@ set(THEROCK_ROCM_SYSTEMS_SOURCE_DIR_DEFAULT "${THEROCK_SOURCE_DIR}/rocm-systems"
 set(THEROCK_ROCM_SYSTEMS_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR_DEFAULT}" CACHE STRING "Path to rocm-systems superrepo")
 cmake_path(ABSOLUTE_PATH THEROCK_ROCM_SYSTEMS_SOURCE_DIR NORMALIZE)
 
+# Code coverage requests are resolved against the monorepo source directories
+# above, so this must run after they are known and before any sub-project is
+# declared.
+therock_coverage_init()
+
 # Allow specifying alternative source locations for ROCgdb, amd-dbgapi
 # and rocr-debug-agent (and rocr-debug-agent-tests as a consequence).
 therock_enable_external_source("rocgdb" "${THEROCK_SOURCE_DIR}/debug-tools/rocgdb/source" OFF)
@@ -209,6 +215,11 @@ cmake_dependent_option(
 option(THEROCK_SPLIT_DEBUG_INFO "Enables splitting of debug info into dbg artifacts (and strips primary packages)" OFF)
 option(THEROCK_MINIMAL_DEBUG_INFO "Enables compiler-specific flags for minimal debug symbols suitable for shipping in packages" OFF)
 option(THEROCK_COMPILER_RT_DEBUG "Enables compiler-rt debug build" OFF)
+# Device-side coverage needs the profiler runtime compiled into instrumented
+# device code, which compiler-rt only builds when asked. Coverage builds enable
+# this via the linux-release-coverage preset; it is off by default because it is
+# dead weight for every other build.
+option(THEROCK_COMPILER_RT_BUILD_PROFILE_ROCM "Builds the compiler-rt device-side profile runtime, required for device code coverage" OFF)
 option(THEROCK_QUIET_INSTALL "Enable quiet install logging (install logs only go to the logfile)" ON)
 option(THEROCK_USE_SAFE_DEPENDENCY_PROVIDER "Enable the safe dependency provider, performing strict package checks" ON)
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -107,6 +107,21 @@
       }
     },
     {
+      "name": "linux-release-coverage",
+      "displayName": "Linux code coverage build",
+      "description": "Nightly code coverage: instruments every rocm-libraries component and builds the device-side profile runtime. Pass -DTHEROCK_COVERAGE_PROJECTS=<projects> to narrow the scope to individual components.",
+      "generator": "Ninja",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "amd-llvm_BUILD_TYPE": "Release",
+        "therock-host-blas_BUILD_TYPE": "Release",
+        "therock-SuiteSparse_BUILD_TYPE": "Release",
+        "THEROCK_COVERAGE_ROCM_LIBRARIES_ALL": "ON",
+        "THEROCK_COMPILER_RT_BUILD_PROFILE_ROCM": "ON",
+        "THEROCK_FLAG_STAMP_LIBRARY_GIT_VERSIONS": "ON"
+      }
+    },
+    {
       "name": "linux-release-tsan",
       "displayName": "Linux release tsan build",
       "description": "Ninja generator, default compiler, RelWithDebInfo and TSAN for most runtime subprojects",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -109,7 +109,7 @@
     {
       "name": "linux-release-coverage",
       "displayName": "Linux code coverage build",
-      "description": "Nightly code coverage: instruments every rocm-libraries component and builds the device-side profile runtime. Pass -DTHEROCK_COVERAGE_PROJECTS=<projects> to narrow the scope to individual components.",
+      "description": "Nightly host-side code coverage. Instruments every rocm-libraries component; pass -DTHEROCK_COVERAGE_PROJECTS=<projects> to narrow the scope to individual components.",
       "generator": "Ninja",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
@@ -117,7 +117,6 @@
         "therock-host-blas_BUILD_TYPE": "Release",
         "therock-SuiteSparse_BUILD_TYPE": "Release",
         "THEROCK_COVERAGE_ROCM_LIBRARIES_ALL": "ON",
-        "THEROCK_COMPILER_RT_BUILD_PROFILE_ROCM": "ON",
         "THEROCK_FLAG_STAMP_LIBRARY_GIT_VERSIONS": "ON"
       }
     },

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -109,13 +109,10 @@
     {
       "name": "linux-release-coverage",
       "displayName": "Linux code coverage build",
-      "description": "Nightly host-side code coverage. Instruments every rocm-libraries component; pass -DTHEROCK_COVERAGE_PROJECTS=<projects> to narrow the scope to individual components.",
+      "description": "Nightly host-side code coverage. Instruments every rocm-libraries component; pass -DTHEROCK_COVERAGE_PROJECTS=<projects> to narrow the scope to individual components. CMAKE_BUILD_TYPE must stay Release to match the prebuilt baseline; see docs/development/code_coverage.md.",
       "generator": "Ninja",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
-        "amd-llvm_BUILD_TYPE": "Release",
-        "therock-host-blas_BUILD_TYPE": "Release",
-        "therock-SuiteSparse_BUILD_TYPE": "Release",
+        "CMAKE_BUILD_TYPE": "Release",
         "THEROCK_COVERAGE_ROCM_LIBRARIES_ALL": "ON",
         "THEROCK_FLAG_STAMP_LIBRARY_GIT_VERSIONS": "ON"
       }

--- a/build_tools/artifact_manager.py
+++ b/build_tools/artifact_manager.py
@@ -993,6 +993,7 @@ def _create_source_backend(
     platform: str,
     source_run_id: str,
     source_repository: Optional[str],
+    source_release_type: Optional[str],
     local_staging_dir: Optional[Path],
 ) -> ArtifactBackend:
     """Create a backend for the source run ID.
@@ -1017,6 +1018,7 @@ def _create_source_backend(
         platform=platform,
         github_repository=source_repository,
         lookup_workflow_run=True,
+        release_type=source_release_type,
     )
     return S3Backend(output_root=output_root)
 
@@ -1066,6 +1068,7 @@ def do_copy(args: argparse.Namespace):
         platform=args.platform,
         source_run_id=args.source_run_id,
         source_repository=args.source_repository,
+        source_release_type=args.source_release_type or None,
         local_staging_dir=args.local_staging_dir,
     )
     dest_backend = create_backend_from_env(
@@ -1408,6 +1411,15 @@ def main(argv: Optional[List[str]] = None):
         default=os.environ.get("GITHUB_REPOSITORY", "ROCm/TheRock"),
         help="GitHub repository for source-run-id in 'owner/repo' format "
         "(default: GITHUB_REPOSITORY or 'ROCm/TheRock').",
+    )
+    copy_parser.add_argument(
+        "--source-release-type",
+        type=str,
+        default="",
+        help="Release type of the source run, when it differs from this run's "
+        "RELEASE_TYPE (e.g. copying from a 'nightly' release run into a 'ci' "
+        "run). The release type selects the source bucket. Defaults to "
+        "RELEASE_TYPE, i.e. the same bucket family as the destination.",
     )
     copy_parser.add_argument(
         "--stage",

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -184,7 +184,8 @@ all_build_variants = {
         },
         # Code coverage builds run from the nightly coverage workflow only. The
         # suffix keeps their artifacts in a separate S3 namespace so a coverage
-        # run can never be mistaken for a regular one.
+        # run can never be mistaken for a regular one. Phase 1 covers a single
+        # default architecture, so only gfx94x lists this variant.
         "coverage": {
             "build_variant_label": "coverage",
             "build_variant_suffix": "coverage",
@@ -343,7 +344,7 @@ amdgpu_family_info_matrix_postsubmit = {
             "test-runs-on-multi-gpu": "linux-gfx950-8gpu-ccs-ossci-rocm",
             "family": "gfx950-dcgpu",
             "fetch-gfx-targets": ["gfx950"],
-            "build_variants": ["release", "asan", "asan-debug", "tsan", "coverage"],
+            "build_variants": ["release", "asan", "asan-debug", "tsan"],
             # Only run tests on submodule bumps (builds always run)
             "submodule_bump_tests_only": True,
         }

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -182,6 +182,14 @@ all_build_variants = {
             "build_variant_suffix": "tsan",
             "build_variant_cmake_preset": "linux-release-tsan",
         },
+        # Code coverage builds run from the nightly coverage workflow only. The
+        # suffix keeps their artifacts in a separate S3 namespace so a coverage
+        # run can never be mistaken for a regular one.
+        "coverage": {
+            "build_variant_label": "coverage",
+            "build_variant_suffix": "coverage",
+            "build_variant_cmake_preset": "linux-release-coverage",
+        },
     },
     "windows": {
         "release": {
@@ -246,6 +254,7 @@ amdgpu_family_info_matrix_presubmit = {
                 "host-asan",
                 "host-asan-debug",
                 "tsan",
+                "coverage",
             ],
         }
     },
@@ -334,7 +343,7 @@ amdgpu_family_info_matrix_postsubmit = {
             "test-runs-on-multi-gpu": "linux-gfx950-8gpu-ccs-ossci-rocm",
             "family": "gfx950-dcgpu",
             "fetch-gfx-targets": ["gfx950"],
-            "build_variants": ["release", "asan", "asan-debug", "tsan"],
+            "build_variants": ["release", "asan", "asan-debug", "tsan", "coverage"],
             # Only run tests on submodule bumps (builds always run)
             "submodule_bump_tests_only": True,
         }

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -1430,7 +1430,12 @@ def _expand_build_config_for_platform(
     # ASAN builds native Linux packages (deb/rpm) but not Python packages.
     # The build_python_packages input allows callers to disable Python packages.
     is_asan = suffix in ("asan", "host-asan")
-    build_python_packages = ci_inputs.build_python_packages and not is_asan
+    # Coverage artifacts are only consumed by the coverage test and report jobs,
+    # so building wheels or distro packages from them is wasted node time.
+    is_coverage = suffix == "coverage"
+    build_python_packages = (
+        ci_inputs.build_python_packages and not is_asan and not is_coverage
+    )
     test_python_packages_matrix = (
         build_rocm_python_test_matrix(
             per_family_info=per_family_info,
@@ -1439,7 +1444,7 @@ def _expand_build_config_for_platform(
         if build_python_packages
         else []
     )
-    build_native_linux = ci_inputs.build_native_linux
+    build_native_linux = ci_inputs.build_native_linux and not is_coverage
 
     # When stages are skipped (partial build), disable package builds since
     # they require a complete artifact set. Prebuilt/reused stages are OK

--- a/build_tools/github_actions/coverage_report.py
+++ b/build_tools/github_actions/coverage_report.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Aggregate llvm profraw output from test shards into one coverage report.
+
+Components in rocm-libraries generate coverage with an in-tree `coverage` make
+target that runs the tests and reports on them in the same CMake tree. TheRock
+splits build and test across nodes and shards the test suite, so that target has
+nothing to run against: the tree is gone by test time and no single node has run
+more than a slice of the suite. This script performs the equivalent steps from
+the artifacts instead, on a node that has collected the profraw files from every
+shard:
+
+    llvm-profdata merge -sparse <all shards>/*.profraw -o coverage.profdata
+    llvm-cov export -format=lcov -object <objects> -instr-profile=coverage.profdata
+
+Merging across shards is what makes the number meaningful. Each shard only runs
+its slice of the suite, so a per-shard report would claim roughly
+100/<shard count> percent coverage no matter how complete the suite is.
+
+Objects are discovered rather than configured. A component that installs a
+shared library is reported against that library. Header-only components (such as
+rocPRIM and hipCUB) have no library to point at because their code is compiled
+into the test binaries, so those binaries become the objects, and test sources
+are filtered out of the report so that testing code does not count as covered
+product code.
+
+Usage:
+    python coverage_report.py \\
+        --component hiprand \\
+        --rocm-dir build \\
+        --profraw-dir coverage-profraw \\
+        --output-dir coverage-report
+"""
+
+import argparse
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from github_actions_api import gha_append_step_summary
+
+# Job names do not always match the directory a component installs its tests
+# into. Only the mismatches need an entry here.
+COMPONENT_TEST_DIR_OVERRIDES = {
+    "hipcub": "hipcub",
+    "hiprand": "hipRAND",
+    "rocprim": "rocprim",
+    "rocrand": "rocRAND",
+    "rocthrust": "rocthrust",
+}
+
+# Paths that describe how a component is tested rather than what it ships.
+# Counting them would let a component raise its coverage by adding test code.
+DEFAULT_IGNORE_REGEX = r"(/test/|/tests/|/googletest/|/benchmark/|/_deps/)"
+
+
+def log(*args):
+    print(*args)
+    sys.stdout.flush()
+
+
+def find_llvm_tool(rocm_dir: Path, name: str) -> Path:
+    """Locate an LLVM tool, preferring the toolchain that built the artifacts.
+
+    Coverage data is only readable by a tool at least as new as the compiler
+    that produced it, so the bundled toolchain is the correct one to use and a
+    system llvm-cov is a fallback for local runs.
+    """
+    bundled = rocm_dir / "lib" / "llvm" / "bin" / name
+    if bundled.is_file():
+        return bundled
+    system = shutil.which(name)
+    if system:
+        log(f"[WARN] {bundled} not found, falling back to {system}")
+        return Path(system)
+    raise FileNotFoundError(
+        f"Could not find {name} in {bundled.parent} or on PATH. The coverage "
+        f"report needs the LLVM tools from the instrumented build's artifacts."
+    )
+
+
+def collect_profraw_files(profraw_dir: Path) -> list[Path]:
+    """Collect profraw files from every shard's uploaded directory."""
+    files = sorted(p for p in profraw_dir.rglob("*.profraw") if p.stat().st_size > 0)
+    if not files:
+        raise FileNotFoundError(
+            f"No non-empty .profraw files found under {profraw_dir}. Either the "
+            f"binaries under test were not instrumented, or LLVM_PROFILE_FILE "
+            f"did not point at the collected directory during the test run."
+        )
+    log(f"[INFO] Found {len(files)} profraw file(s) under {profraw_dir}")
+    return files
+
+
+def merge_profraw(
+    llvm_profdata: Path, profraw_files: list[Path], output_file: Path
+) -> Path:
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    cmd = [str(llvm_profdata), "merge", "-sparse", "-o", str(output_file)]
+    cmd += [str(p) for p in profraw_files]
+    log(f"[INFO] Merging profraw into {output_file}")
+    subprocess.run(cmd, check=True)
+    return output_file
+
+
+def resolve_test_dir(rocm_dir: Path, component: str) -> Path:
+    dir_name = COMPONENT_TEST_DIR_OVERRIDES.get(component, component)
+    return rocm_dir / "bin" / dir_name
+
+
+def discover_objects(rocm_dir: Path, component: str) -> list[Path]:
+    """Find the binaries to report coverage for.
+
+    A shared library is preferred: it is the component's product and reporting
+    against it keeps test binaries out of the numbers automatically. Only when
+    no library exists (header-only components) do the test binaries stand in for
+    it, since that is where the component's code actually got compiled.
+    """
+    lib_dir = rocm_dir / "lib"
+    library = lib_dir / f"lib{component}.so"
+    if library.is_file():
+        log(f"[INFO] Reporting against shared library {library}")
+        return [library]
+
+    test_dir = resolve_test_dir(rocm_dir, component)
+    # llvm-cov's -object flag takes one path and does not expand globs, so every
+    # test binary has to be listed explicitly.
+    tests = sorted(
+        p
+        for p in test_dir.glob("test_*")
+        if p.is_file() and not p.suffix and p.stat().st_mode & 0o111
+    )
+    if tests:
+        log(
+            f"[INFO] No lib{component}.so found; reporting against "
+            f"{len(tests)} test binaries in {test_dir}"
+        )
+        return tests
+
+    raise FileNotFoundError(
+        f"Found neither {library} nor test binaries in {test_dir}. Cannot "
+        f"determine what to report coverage for."
+    )
+
+
+def run_llvm_cov(
+    llvm_cov: Path,
+    subcommand: str,
+    objects: list[Path],
+    profdata: Path,
+    ignore_regex: str,
+    extra_args: list[str] | None = None,
+) -> str:
+    cmd = [str(llvm_cov), subcommand]
+    for obj in objects:
+        cmd += ["-object", str(obj)]
+    cmd += [f"-instr-profile={profdata}"]
+    if ignore_regex:
+        cmd += [f"--ignore-filename-regex={ignore_regex}"]
+    cmd += extra_args or []
+    log(f"[INFO] Running llvm-cov {subcommand}")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        # llvm-cov explains mismatched profiles and unreadable objects on
+        # stderr, which is captured here because stdout is the report itself.
+        log(result.stderr)
+        raise subprocess.CalledProcessError(result.returncode, cmd)
+    return result.stdout
+
+
+def extract_total_line(report_text: str) -> str:
+    for line in report_text.splitlines():
+        if line.strip().startswith("TOTAL"):
+            return re.sub(r"\s+", " ", line.strip())
+    return ""
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--component",
+        required=True,
+        help="Component under test, as named by the test job (e.g. hiprand).",
+    )
+    parser.add_argument(
+        "--rocm-dir",
+        type=Path,
+        default=Path("build"),
+        help="Directory the instrumented ROCm artifacts were unpacked into.",
+    )
+    parser.add_argument(
+        "--profraw-dir",
+        type=Path,
+        required=True,
+        help="Directory holding the profraw files downloaded from every shard.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("coverage-report"),
+        help="Directory to write coverage.profdata and coverage.info into.",
+    )
+    parser.add_argument(
+        "--object",
+        dest="objects",
+        type=Path,
+        action="append",
+        default=[],
+        help="Binary to report against, repeatable. Overrides auto-discovery.",
+    )
+    parser.add_argument(
+        "--ignore-filename-regex",
+        default=DEFAULT_IGNORE_REGEX,
+        help="Exclude matching source paths from the report.",
+    )
+    args = parser.parse_args(argv)
+
+    rocm_dir = args.rocm_dir.resolve()
+    output_dir = args.output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    llvm_profdata = find_llvm_tool(rocm_dir, "llvm-profdata")
+    llvm_cov = find_llvm_tool(rocm_dir, "llvm-cov")
+
+    profraw_files = collect_profraw_files(args.profraw_dir.resolve())
+    profdata = merge_profraw(
+        llvm_profdata, profraw_files, output_dir / "coverage.profdata"
+    )
+
+    objects = args.objects or discover_objects(rocm_dir, args.component)
+
+    lcov = run_llvm_cov(
+        llvm_cov,
+        "export",
+        objects,
+        profdata,
+        args.ignore_filename_regex,
+        ["--format=lcov"],
+    )
+    lcov_file = output_dir / "coverage.info"
+    lcov_file.write_text(lcov)
+    log(f"[INFO] Wrote {lcov_file} ({len(lcov.splitlines())} lines)")
+
+    report = run_llvm_cov(
+        llvm_cov, "report", objects, profdata, args.ignore_filename_regex
+    )
+    (output_dir / "coverage.txt").write_text(report)
+    log(report)
+
+    total = extract_total_line(report)
+    summary = [f"### Code coverage: {args.component}", ""]
+    if total:
+        summary.append(f"`{total}`")
+        summary.append("")
+    summary.append(
+        f"Merged {len(profraw_files)} profraw file(s) from all test shards over "
+        f"{len(objects)} object(s)."
+    )
+    gha_append_step_summary("\n".join(summary))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main(sys.argv[1:]))
+    except (FileNotFoundError, subprocess.CalledProcessError) as e:
+        log(f"[ERROR] {e}")
+        sys.exit(1)

--- a/build_tools/github_actions/coverage_report.py
+++ b/build_tools/github_actions/coverage_report.py
@@ -173,6 +173,32 @@ def run_llvm_cov(
     return result.stdout
 
 
+def sources_from_lcov(lcov: str) -> list[Path]:
+    """Source files the report covers, as recorded in the profile."""
+    return [
+        Path(line[len("SF:") :]) for line in lcov.splitlines() if line.startswith("SF:")
+    ]
+
+
+def warn_on_missing_sources(lcov: str) -> None:
+    """Warns when the annotated report will not be able to show source.
+
+    `export` and `report` only read the coverage mapping embedded in the
+    binaries, but `show` opens the source files at the absolute paths recorded
+    there. Those come from the build machine, so they are only present if the
+    component's sources were checked out to the same location.
+    """
+    sources = sources_from_lcov(lcov)
+    missing = [p for p in sources if not p.is_file()]
+    if not missing:
+        return
+    log(
+        f"[WARN] {len(missing)} of {len(sources)} source file(s) are not present "
+        f"at the paths recorded in the profile, so the HTML report will show "
+        f"'source not found' for them. First missing: {missing[0]}"
+    )
+
+
 def extract_total_line(report_text: str) -> str:
     for line in report_text.splitlines():
         if line.strip().startswith("TOTAL"):
@@ -218,6 +244,14 @@ def main(argv: list[str]) -> int:
         default=DEFAULT_IGNORE_REGEX,
         help="Exclude matching source paths from the report.",
     )
+    parser.add_argument(
+        "--html",
+        action="store_true",
+        help="Also write coverage.html, a single-file report with the source "
+        "annotated line by line. Needs the component's sources present at the "
+        "paths recorded in the profile; without them the report still renders "
+        "but cannot show source.",
+    )
     args = parser.parse_args(argv)
 
     rocm_dir = args.rocm_dir.resolve()
@@ -245,6 +279,23 @@ def main(argv: list[str]) -> int:
     lcov_file = output_dir / "coverage.info"
     lcov_file.write_text(lcov)
     log(f"[INFO] Wrote {lcov_file} ({len(lcov.splitlines())} lines)")
+
+    if args.html:
+        warn_on_missing_sources(lcov)
+        # No --output-dir, so llvm-cov writes one self-contained document to
+        # stdout rather than a directory tree, which keeps the artifact to a
+        # single file that opens straight from a download.
+        html = run_llvm_cov(
+            llvm_cov,
+            "show",
+            objects,
+            profdata,
+            args.ignore_filename_regex,
+            ["--format=html"],
+        )
+        html_file = output_dir / "coverage.html"
+        html_file.write_text(html)
+        log(f"[INFO] Wrote {html_file} ({len(html)} bytes)")
 
     report = run_llvm_cov(
         llvm_cov, "report", objects, profdata, args.ignore_filename_regex

--- a/build_tools/github_actions/tests/coverage_report_test.py
+++ b/build_tools/github_actions/tests/coverage_report_test.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python
+"""Unit tests for coverage_report.py.
+
+The LLVM tools are replaced with scripts that record their own argv, so these
+tests assert on the commands the report builds rather than on coverage numbers.
+That is where the behaviour that matters lives: which profraw files get merged,
+which binaries end up as -object arguments, and which situations must fail the
+job instead of publishing a misleading report.
+"""
+
+import os
+from pathlib import Path
+import stat
+import sys
+import tempfile
+import unittest
+
+# Add build_tools to path so _therock_utils is importable.
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent.parent))
+# Add github_actions to path so coverage_report is importable.
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
+
+import coverage_report
+
+# Emulates just enough of each tool: `merge` creates the file named by -o,
+# `report` prints a TOTAL line, and `export` prints an lcov record.
+STUB_TOOL = """#!/bin/bash
+echo "$(basename $0) $@" >> "{log}"
+if [[ "$1" == "merge" ]]; then
+  while [[ $# -gt 0 ]]; do [[ "$1" == "-o" ]] && touch "$2"; shift; done
+  exit 0
+fi
+if [[ "$1" == "report" ]]; then
+  echo "Filename Regions Missed Cover"
+  echo "TOTAL        120     30 75.00%"
+  exit 0
+fi
+echo "SF:/src/component.cpp"
+echo "end_of_record"
+"""
+
+
+class CoverageReportTestCase(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+
+        self.rocm_dir = self.root / "build"
+        self.profraw_dir = self.root / "profraw"
+        self.output_dir = self.root / "coverage-report"
+        self.call_log = self.root / "calls.log"
+
+        bin_dir = self.rocm_dir / "lib" / "llvm" / "bin"
+        bin_dir.mkdir(parents=True)
+        for tool in ("llvm-profdata", "llvm-cov"):
+            path = bin_dir / tool
+            path.write_text(STUB_TOOL.format(log=self.call_log))
+            path.chmod(path.stat().st_mode | stat.S_IEXEC)
+
+        self.profraw_dir.mkdir()
+
+    def write_profraw(self, name: str) -> Path:
+        path = self.profraw_dir / name
+        path.write_bytes(b"profraw")
+        return path
+
+    def write_executable(self, path: Path) -> Path:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("#!/bin/true\n")
+        path.chmod(path.stat().st_mode | stat.S_IEXEC)
+        return path
+
+    def run_report(self, component: str, extra_args: list[str] | None = None) -> int:
+        return coverage_report.main(
+            [
+                "--component",
+                component,
+                "--rocm-dir",
+                os.fspath(self.rocm_dir),
+                "--profraw-dir",
+                os.fspath(self.profraw_dir),
+                "--output-dir",
+                os.fspath(self.output_dir),
+            ]
+            + (extra_args or [])
+        )
+
+    def calls(self) -> list[str]:
+        return self.call_log.read_text().splitlines()
+
+
+class TestSharedLibraryComponent(CoverageReportTestCase):
+    """A component that ships a shared library is reported against it."""
+
+    def setUp(self):
+        super().setUp()
+        (self.rocm_dir / "lib").mkdir(parents=True, exist_ok=True)
+        self.library = self.rocm_dir / "lib" / "libhiprand.so"
+        self.library.write_text("")
+
+    def test_merges_profraw_from_every_shard(self):
+        # A per-shard report would only reflect that shard's slice of the
+        # suite, so every shard's files have to reach the merge.
+        self.write_profraw("hiprand-shard1-1-a.profraw")
+        self.write_profraw("hiprand-shard2-2-b.profraw")
+
+        self.assertEqual(self.run_report("hiprand"), 0)
+
+        merge = next(c for c in self.calls() if c.startswith("llvm-profdata merge"))
+        self.assertIn("hiprand-shard1-1-a.profraw", merge)
+        self.assertIn("hiprand-shard2-2-b.profraw", merge)
+        self.assertIn("-sparse", merge)
+
+    def test_reports_against_shared_library(self):
+        self.write_profraw("hiprand-shard1-1-a.profraw")
+
+        self.assertEqual(self.run_report("hiprand"), 0)
+
+        export = next(c for c in self.calls() if c.startswith("llvm-cov export"))
+        self.assertIn(f"-object {self.library}", export)
+        self.assertIn("--format=lcov", export)
+
+    def test_writes_lcov_and_text_reports(self):
+        self.write_profraw("hiprand-shard1-1-a.profraw")
+
+        self.assertEqual(self.run_report("hiprand"), 0)
+
+        self.assertIn(
+            "SF:/src/component.cpp", (self.output_dir / "coverage.info").read_text()
+        )
+        self.assertIn("TOTAL", (self.output_dir / "coverage.txt").read_text())
+
+    def test_excludes_test_sources_by_default(self):
+        # Otherwise a component could raise its coverage by adding test code.
+        self.write_profraw("hiprand-shard1-1-a.profraw")
+
+        self.assertEqual(self.run_report("hiprand"), 0)
+
+        export = next(c for c in self.calls() if c.startswith("llvm-cov export"))
+        self.assertIn("--ignore-filename-regex=", export)
+        self.assertIn("/test/", export)
+
+    def test_explicit_object_overrides_discovery(self):
+        self.write_profraw("hiprand-shard1-1-a.profraw")
+        other = self.write_executable(self.rocm_dir / "bin" / "custom_binary")
+
+        self.assertEqual(self.run_report("hiprand", ["--object", os.fspath(other)]), 0)
+
+        export = next(c for c in self.calls() if c.startswith("llvm-cov export"))
+        self.assertIn(f"-object {other}", export)
+        self.assertNotIn(os.fspath(self.library), export)
+
+
+class TestHeaderOnlyComponent(CoverageReportTestCase):
+    """Header-only components have no library, so test binaries stand in."""
+
+    def test_expands_each_test_binary_into_its_own_object_flag(self):
+        # llvm-cov's -object takes a single path and does not expand globs.
+        self.write_profraw("rocprim-shard1-1-a.profraw")
+        test_a = self.write_executable(self.rocm_dir / "bin" / "rocprim" / "test_a")
+        test_b = self.write_executable(self.rocm_dir / "bin" / "rocprim" / "test_b")
+
+        self.assertEqual(self.run_report("rocprim"), 0)
+
+        export = next(c for c in self.calls() if c.startswith("llvm-cov export"))
+        self.assertIn(f"-object {test_a}", export)
+        self.assertIn(f"-object {test_b}", export)
+
+    def test_ignores_non_test_files_in_the_test_directory(self):
+        self.write_profraw("rocprim-shard1-1-a.profraw")
+        test_a = self.write_executable(self.rocm_dir / "bin" / "rocprim" / "test_a")
+        data = self.rocm_dir / "bin" / "rocprim" / "CTestTestfile.cmake"
+        data.write_text("")
+
+        self.assertEqual(self.run_report("rocprim"), 0)
+
+        export = next(c for c in self.calls() if c.startswith("llvm-cov export"))
+        self.assertIn(f"-object {test_a}", export)
+        self.assertNotIn("CTestTestfile", export)
+
+    def test_uses_installed_directory_name_when_it_differs_from_job_name(self):
+        # The hiprand job installs its tests under bin/hipRAND.
+        self.write_profraw("hiprand-shard1-1-a.profraw")
+        test_a = self.write_executable(self.rocm_dir / "bin" / "hipRAND" / "test_a")
+
+        self.assertEqual(self.run_report("hiprand"), 0)
+
+        export = next(c for c in self.calls() if c.startswith("llvm-cov export"))
+        self.assertIn(f"-object {test_a}", export)
+
+
+class TestFailureModes(CoverageReportTestCase):
+    """Coverage problems must fail the job, not publish a misleading number."""
+
+    def test_missing_profraw_fails(self):
+        # No profraw at all means the binaries were not instrumented or
+        # LLVM_PROFILE_FILE was wrong. Reporting 0% would hide that.
+        (self.rocm_dir / "lib" / "libhiprand.so").write_text("")
+
+        with self.assertRaises(FileNotFoundError):
+            self.run_report("hiprand")
+
+    def test_empty_profraw_files_do_not_count_as_output(self):
+        (self.rocm_dir / "lib" / "libhiprand.so").write_text("")
+        (self.profraw_dir / "hiprand-shard1-1-a.profraw").write_bytes(b"")
+
+        with self.assertRaises(FileNotFoundError):
+            self.run_report("hiprand")
+
+    def test_no_library_and_no_tests_fails(self):
+        self.write_profraw("rocblas-shard1-1-a.profraw")
+
+        with self.assertRaises(FileNotFoundError):
+            self.run_report("rocblas")
+
+    def test_missing_llvm_tools_fails(self):
+        for tool in ("llvm-profdata", "llvm-cov"):
+            (self.rocm_dir / "lib" / "llvm" / "bin" / tool).unlink()
+
+        with self.assertRaises(FileNotFoundError):
+            coverage_report.find_llvm_tool(self.rocm_dir, "llvm-profdata")
+
+
+class TestTotalLineExtraction(unittest.TestCase):
+    def test_extracts_and_normalizes_total_line(self):
+        report = "Filename Regions\nfoo.cpp 10\nTOTAL      120     30    75.00%\n"
+        self.assertEqual(
+            coverage_report.extract_total_line(report), "TOTAL 120 30 75.00%"
+        )
+
+    def test_returns_empty_when_absent(self):
+        self.assertEqual(coverage_report.extract_total_line("no totals here"), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/build_tools/github_actions/tests/coverage_report_test.py
+++ b/build_tools/github_actions/tests/coverage_report_test.py
@@ -8,6 +8,8 @@ which binaries end up as -object arguments, and which situations must fail the
 job instead of publishing a misleading report.
 """
 
+import contextlib
+import io
 import os
 from pathlib import Path
 import shutil
@@ -159,6 +161,67 @@ class TestSharedLibraryComponent(CoverageReportTestCase):
         export = next(c for c in self.calls() if c.startswith("llvm-cov export"))
         self.assertIn(f"-object {other}", export)
         self.assertNotIn(os.fspath(self.library), export)
+
+
+class TestHtmlReport(CoverageReportTestCase):
+    """The annotated HTML report is opt-in, since it needs the sources."""
+
+    def setUp(self):
+        super().setUp()
+        (self.rocm_dir / "lib").mkdir(parents=True, exist_ok=True)
+        (self.rocm_dir / "lib" / "libhiprand.so").write_text("")
+        self.write_profraw("hiprand-shard1-1-a.profraw")
+
+    def test_html_is_not_written_unless_requested(self):
+        self.assertEqual(self.run_report("hiprand"), 0)
+
+        self.assertFalse((self.output_dir / "coverage.html").exists())
+        self.assertNotIn("llvm-cov show", "\n".join(self.calls()))
+
+    def test_html_flag_writes_a_single_annotated_file(self):
+        # A directory tree would have to be unzipped and browsed; one file
+        # opens straight from the artifact download.
+        self.assertEqual(self.run_report("hiprand", ["--html"]), 0)
+
+        show = next(c for c in self.calls() if c.startswith("llvm-cov show"))
+        self.assertIn("--format=html", show)
+        self.assertNotIn("--output-dir", show)
+        self.assertTrue((self.output_dir / "coverage.html").is_file())
+
+
+class TestSourceAvailability(unittest.TestCase):
+    """Whether `show` will be able to annotate the sources it was given."""
+
+    LCOV = "SF:/absent/one.cpp\nend_of_record\nSF:/absent/two.cpp\nend_of_record\n"
+
+    def test_parses_source_paths_from_lcov(self):
+        self.assertEqual(
+            coverage_report.sources_from_lcov(self.LCOV),
+            [Path("/absent/one.cpp"), Path("/absent/two.cpp")],
+        )
+
+    @staticmethod
+    def capture(*args) -> str:
+        """Returns what warn_on_missing_sources logged, which goes to stdout."""
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            coverage_report.warn_on_missing_sources(*args)
+        return buffer.getvalue()
+
+    def test_warns_when_sources_are_not_at_the_recorded_paths(self):
+        # The paths come from the build machine, so a report job that did not
+        # check the sources out produces an HTML report with no source in it.
+        output = self.capture(self.LCOV)
+
+        self.assertIn("[WARN]", output)
+        self.assertIn("2 of 2 source file(s)", output)
+
+    def test_silent_when_every_source_is_present(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            present = Path(tmp) / "present.cpp"
+            present.write_text("int main() { return 0; }\n")
+
+            self.assertEqual(self.capture(f"SF:{present}\n"), "")
 
 
 class TestHeaderOnlyComponent(CoverageReportTestCase):

--- a/build_tools/github_actions/tests/coverage_report_test.py
+++ b/build_tools/github_actions/tests/coverage_report_test.py
@@ -10,10 +10,12 @@ job instead of publishing a misleading report.
 
 import os
 from pathlib import Path
+import shutil
 import stat
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 # Add build_tools to path so _therock_utils is importable.
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent.parent))
@@ -40,6 +42,13 @@ echo "end_of_record"
 """
 
 
+@unittest.skipIf(
+    sys.platform == "win32",
+    "The tool stubs are POSIX shell scripts. Coverage is Linux-only: "
+    "coverage_nightly.yml builds portable Linux, so coverage_report.py never "
+    "runs on Windows, and teaching find_llvm_tool to look for .bat stubs would "
+    "mean changing production code for a platform it is not used on.",
+)
 class CoverageReportTestCase(unittest.TestCase):
     def setUp(self):
         self._tmp = tempfile.TemporaryDirectory()
@@ -214,12 +223,46 @@ class TestFailureModes(CoverageReportTestCase):
         with self.assertRaises(FileNotFoundError):
             self.run_report("rocblas")
 
-    def test_missing_llvm_tools_fails(self):
-        for tool in ("llvm-profdata", "llvm-cov"):
-            (self.rocm_dir / "lib" / "llvm" / "bin" / tool).unlink()
 
-        with self.assertRaises(FileNotFoundError):
-            coverage_report.find_llvm_tool(self.rocm_dir, "llvm-profdata")
+class TestLlvmToolDiscovery(unittest.TestCase):
+    """Where the LLVM tools are taken from.
+
+    This needs no tool stubs, only paths, so unlike the cases above it is
+    meaningful on every platform.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.rocm_dir = Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+        self.bin_dir = self.rocm_dir / "lib" / "llvm" / "bin"
+        self.bin_dir.mkdir(parents=True)
+
+    def test_prefers_the_toolchain_that_built_the_artifacts(self):
+        # Coverage data is only readable by a tool at least as new as the
+        # compiler that produced it, so a system tool must not win.
+        bundled = self.bin_dir / "llvm-profdata"
+        bundled.write_text("")
+
+        with mock.patch.object(shutil, "which", return_value="/usr/bin/llvm-profdata"):
+            self.assertEqual(
+                coverage_report.find_llvm_tool(self.rocm_dir, "llvm-profdata"), bundled
+            )
+
+    def test_falls_back_to_path_for_local_runs(self):
+        with mock.patch.object(shutil, "which", return_value="/usr/bin/llvm-profdata"):
+            self.assertEqual(
+                coverage_report.find_llvm_tool(self.rocm_dir, "llvm-profdata"),
+                Path("/usr/bin/llvm-profdata"),
+            )
+
+    def test_missing_llvm_tools_fails(self):
+        # shutil.which is stubbed rather than left to the machine: hosted
+        # Windows runners ship LLVM on PATH, so a real lookup would find a tool
+        # and this would assert on whether the runner has LLVM installed.
+        with mock.patch.object(shutil, "which", return_value=None):
+            with self.assertRaises(FileNotFoundError):
+                coverage_report.find_llvm_tool(self.rocm_dir, "llvm-profdata")
 
 
 class TestTotalLineExtraction(unittest.TestCase):

--- a/build_tools/tests/therock_coverage_test.py
+++ b/build_tools/tests/therock_coverage_test.py
@@ -1,0 +1,175 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for `cmake/therock_coverage.cmake`.
+
+These drive a miniature superproject through `therock_cmake_subproject_activate`
+and inspect the `project_init.cmake` it generates for the sub-project, which is
+where the coverage link options land.
+"""
+
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+THEROCK_ROOT = Path(__file__).resolve().parents[2]
+
+# The subset of TheRock's CMake modules that therock_subproject.cmake needs to
+# be usable outside the superproject.
+HARNESS_INCLUDES = (
+    "therock_globals",
+    "therock_sanitizers",
+    "therock_flag_utils",
+    "therock_default_targets",
+    "therock_coverage",
+    "therock_subproject",
+)
+
+
+def write_harness(source_dir: Path) -> None:
+    """Writes a one-subproject superproject into `source_dir`.
+
+    `main_project` is given an EXTERNAL_SOURCE_DIR under a stand-in
+    rocm-libraries tree so that the monorepo group flags resolve for it the way
+    they would for a real component.
+    """
+    includes = "\n".join(f"include({name})" for name in HARNESS_INCLUDES)
+    write_file(
+        source_dir / "CMakeLists.txt",
+        f"""
+        cmake_minimum_required(VERSION 3.25)
+        project(therock_coverage_harness NONE)
+
+        set(THEROCK_SOURCE_DIR "{THEROCK_ROOT.as_posix()}")
+        set(THEROCK_BINARY_DIR "${{CMAKE_BINARY_DIR}}")
+        list(APPEND CMAKE_MODULE_PATH "${{THEROCK_SOURCE_DIR}}/cmake")
+        find_package(Python3 COMPONENTS Interpreter REQUIRED)
+
+        # therock_subproject.cmake fingerprints this file. The harness declares
+        # no flags, so an empty state file is enough.
+        set(ROCM_BUILD_FLAGS_STATE_FILE "${{CMAKE_BINARY_DIR}}/rocm_build_flags_state.cmake")
+        file(WRITE "${{ROCM_BUILD_FLAGS_STATE_FILE}}" "# no flags\\n")
+
+        {includes}
+
+        set(THEROCK_ROCM_LIBRARIES_SOURCE_DIR "${{CMAKE_CURRENT_SOURCE_DIR}}/rocm-libraries")
+        therock_coverage_init()
+
+        therock_cmake_subproject_declare(main_project
+          EXTERNAL_SOURCE_DIR "${{THEROCK_ROCM_LIBRARIES_SOURCE_DIR}}/projects/main"
+          BINARY_DIR "${{CMAKE_CURRENT_BINARY_DIR}}/main"
+        )
+        therock_cmake_subproject_activate(main_project)
+        """,
+    )
+    write_file(
+        source_dir / "rocm-libraries" / "projects" / "main" / "CMakeLists.txt",
+        """
+        cmake_minimum_required(VERSION 3.25)
+        project(main_project NONE)
+        """,
+    )
+
+
+def write_file(path: Path, contents: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(contents), encoding="utf-8")
+
+
+def run(*args: str) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        args,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    if result.returncode != 0:
+        raise AssertionError(" ".join(args) + "\n" + result.stdout)
+    return result
+
+
+class CoverageInitStanzaTest(unittest.TestCase):
+    def _project_init_contents(self, *cmake_args: str) -> str:
+        """Configures the harness and returns main_project's project_init file."""
+        with tempfile.TemporaryDirectory() as temp_dir_str:
+            temp_dir = Path(temp_dir_str)
+            source_dir = temp_dir / "source"
+            build_dir = temp_dir / "build"
+            write_harness(source_dir)
+
+            run(
+                "cmake",
+                "-S",
+                str(source_dir),
+                "-B",
+                str(build_dir),
+                "-GNinja",
+                *cmake_args,
+            )
+
+            # The file is named from the sub-project's build dir, so find it
+            # rather than restating the naming scheme here.
+            init_files = list((build_dir / "main").glob("*_init.cmake"))
+            self.assertEqual(
+                len(init_files),
+                1,
+                f"expected one project_init file, got {init_files}",
+            )
+            return init_files[0].read_text(encoding="utf-8")
+
+    def test_no_coverage_does_not_link_dl(self):
+        # Control: an uninstrumented sub-project must not pick up link options it
+        # has no use for.
+        self.assertNotIn("link_libraries", self._project_init_contents())
+
+    @unittest.skipUnless(
+        sys.platform.startswith("linux"), "CMAKE_DL_LIBS is only set on Linux"
+    )
+    def test_per_project_option_links_dl(self):
+        # Regression: the profile runtime that -fprofile-instr-generate links
+        # calls dlsym and dladdr, which come from libdl before glibc 2.34. A
+        # shared library missing it still links, and the first executable to
+        # link against that library then fails --no-allow-shlib-undefined.
+        self.assertIn(
+            "link_libraries(dl)",
+            self._project_init_contents("-DMAIN_PROJECT_ENABLE_COVERAGE=ON"),
+        )
+
+    @unittest.skipUnless(
+        sys.platform.startswith("linux"), "CMAKE_DL_LIBS is only set on Linux"
+    )
+    def test_project_list_links_dl(self):
+        # The path CI actually takes: coverage_nightly.yml passes a project list
+        # rather than the per-project option.
+        self.assertIn(
+            "link_libraries(dl)",
+            self._project_init_contents("-DTHEROCK_COVERAGE_PROJECTS=main_project"),
+        )
+
+    @unittest.skipUnless(
+        sys.platform.startswith("linux"), "CMAKE_DL_LIBS is only set on Linux"
+    )
+    def test_monorepo_group_flag_links_dl(self):
+        self.assertIn(
+            "link_libraries(dl)",
+            self._project_init_contents("-DTHEROCK_COVERAGE_ROCM_LIBRARIES_ALL=ON"),
+        )
+
+    def test_explicit_opt_out_beats_group_flag(self):
+        # A nightly run instruments a whole monorepo except for one component,
+        # so an explicit OFF has to win over the group flag.
+        self.assertNotIn(
+            "link_libraries",
+            self._project_init_contents(
+                "-DTHEROCK_COVERAGE_ROCM_LIBRARIES_ALL=ON",
+                "-DMAIN_PROJECT_ENABLE_COVERAGE=OFF",
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/build_tools/tests/therock_coverage_test.py
+++ b/build_tools/tests/therock_coverage_test.py
@@ -127,9 +127,20 @@ def probe_profile_runtime_deps() -> list[str]:
 class CoverageInitStanzaTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.expected_link_libraries = (
-            f"link_libraries({' '.join(probe_profile_runtime_deps())})"
-        )
+        cls.profile_runtime_deps = probe_profile_runtime_deps()
+
+    def _assert_links_profile_runtime_deps(self, contents: str) -> None:
+        """Asserts the stanza links what the profile runtime needs here.
+
+        On a host where it needs nothing -- Windows, or glibc 2.34 and newer,
+        where both libraries are folded into libc -- the correct stanza is no
+        `link_libraries()` call at all rather than an empty one.
+        """
+        if self.profile_runtime_deps:
+            expected = f"link_libraries({' '.join(self.profile_runtime_deps)})"
+            self.assertIn(expected, contents)
+        else:
+            self.assertNotIn("link_libraries", contents)
 
     def _project_init_contents(self, *cmake_args: str) -> str:
         """Configures the harness and returns main_project's project_init file."""
@@ -170,22 +181,19 @@ class CoverageInitStanzaTest(unittest.TestCase):
         # pthread_getattr_np), which are separate libraries before glibc 2.34. A
         # shared library missing them still links, and the first executable to
         # link against that library then fails --no-allow-shlib-undefined.
-        self.assertIn(
-            self.expected_link_libraries,
+        self._assert_links_profile_runtime_deps(
             self._project_init_contents("-DMAIN_PROJECT_ENABLE_COVERAGE=ON"),
         )
 
     def test_project_list_links_profile_runtime_deps(self):
         # The path CI actually takes: coverage_nightly.yml passes a project list
         # rather than the per-project option.
-        self.assertIn(
-            self.expected_link_libraries,
+        self._assert_links_profile_runtime_deps(
             self._project_init_contents("-DTHEROCK_COVERAGE_PROJECTS=main_project"),
         )
 
     def test_monorepo_group_flag_links_profile_runtime_deps(self):
-        self.assertIn(
-            self.expected_link_libraries,
+        self._assert_links_profile_runtime_deps(
             self._project_init_contents("-DTHEROCK_COVERAGE_ROCM_LIBRARIES_ALL=ON"),
         )
 

--- a/build_tools/tests/therock_coverage_test.py
+++ b/build_tools/tests/therock_coverage_test.py
@@ -8,8 +8,8 @@ and inspect the `project_init.cmake` it generates for the sub-project, which is
 where the coverage link options land.
 """
 
+import re
 import subprocess
-import sys
 import tempfile
 import textwrap
 import unittest
@@ -41,7 +41,9 @@ def write_harness(source_dir: Path) -> None:
         source_dir / "CMakeLists.txt",
         f"""
         cmake_minimum_required(VERSION 3.25)
-        project(therock_coverage_harness NONE)
+        # C is enabled because FindThreads, which decides whether the profile
+        # runtime needs a separate thread library, is a hard error without it.
+        project(therock_coverage_harness C)
 
         set(THEROCK_SOURCE_DIR "{THEROCK_ROOT.as_posix()}")
         set(THEROCK_BINARY_DIR "${{CMAKE_BINARY_DIR}}")
@@ -92,7 +94,43 @@ def run(*args: str) -> subprocess.CompletedProcess[str]:
     return result
 
 
+def probe_profile_runtime_deps() -> list[str]:
+    """Returns the libraries the coverage stanza is expected to link here.
+
+    The answer is platform-dependent -- libdl and libpthread are folded into
+    libc from glibc 2.34, and neither applies on Windows -- so it is taken from
+    CMake rather than assumed, and the same values the stanza is built from are
+    the ones asserted against.
+    """
+    with tempfile.TemporaryDirectory() as temp_dir_str:
+        temp_dir = Path(temp_dir_str)
+        source_dir = temp_dir / "source"
+        write_file(
+            source_dir / "CMakeLists.txt",
+            """
+            cmake_minimum_required(VERSION 3.25)
+            project(therock_coverage_probe C)
+            find_package(Threads QUIET)
+            message(STATUS "PROBE=[${CMAKE_DL_LIBS}][${CMAKE_THREAD_LIBS_INIT}]")
+            """,
+        )
+        output = run(
+            "cmake", "-S", str(source_dir), "-B", str(temp_dir / "build"), "-GNinja"
+        ).stdout
+
+    match = re.search(r"PROBE=\[(.*)\]\[(.*)\]", output)
+    if not match:
+        raise AssertionError(f"probe did not report its libraries:\n{output}")
+    return [lib for lib in match.groups() if lib]
+
+
 class CoverageInitStanzaTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.expected_link_libraries = (
+            f"link_libraries({' '.join(probe_profile_runtime_deps())})"
+        )
+
     def _project_init_contents(self, *cmake_args: str) -> str:
         """Configures the harness and returns main_project's project_init file."""
         with tempfile.TemporaryDirectory() as temp_dir_str:
@@ -121,41 +159,33 @@ class CoverageInitStanzaTest(unittest.TestCase):
             )
             return init_files[0].read_text(encoding="utf-8")
 
-    def test_no_coverage_does_not_link_dl(self):
+    def test_no_coverage_does_not_link_profile_runtime_deps(self):
         # Control: an uninstrumented sub-project must not pick up link options it
         # has no use for.
         self.assertNotIn("link_libraries", self._project_init_contents())
 
-    @unittest.skipUnless(
-        sys.platform.startswith("linux"), "CMAKE_DL_LIBS is only set on Linux"
-    )
-    def test_per_project_option_links_dl(self):
+    def test_per_project_option_links_profile_runtime_deps(self):
         # Regression: the profile runtime that -fprofile-instr-generate links
-        # calls dlsym and dladdr, which come from libdl before glibc 2.34. A
-        # shared library missing it still links, and the first executable to
+        # calls into libdl (dlsym, dladdr) and libpthread (pthread_once,
+        # pthread_getattr_np), which are separate libraries before glibc 2.34. A
+        # shared library missing them still links, and the first executable to
         # link against that library then fails --no-allow-shlib-undefined.
         self.assertIn(
-            "link_libraries(dl)",
+            self.expected_link_libraries,
             self._project_init_contents("-DMAIN_PROJECT_ENABLE_COVERAGE=ON"),
         )
 
-    @unittest.skipUnless(
-        sys.platform.startswith("linux"), "CMAKE_DL_LIBS is only set on Linux"
-    )
-    def test_project_list_links_dl(self):
+    def test_project_list_links_profile_runtime_deps(self):
         # The path CI actually takes: coverage_nightly.yml passes a project list
         # rather than the per-project option.
         self.assertIn(
-            "link_libraries(dl)",
+            self.expected_link_libraries,
             self._project_init_contents("-DTHEROCK_COVERAGE_PROJECTS=main_project"),
         )
 
-    @unittest.skipUnless(
-        sys.platform.startswith("linux"), "CMAKE_DL_LIBS is only set on Linux"
-    )
-    def test_monorepo_group_flag_links_dl(self):
+    def test_monorepo_group_flag_links_profile_runtime_deps(self):
         self.assertIn(
-            "link_libraries(dl)",
+            self.expected_link_libraries,
             self._project_init_contents("-DTHEROCK_COVERAGE_ROCM_LIBRARIES_ALL=ON"),
         )
 

--- a/build_tools/tests/therock_subproject_prebuilt_test.py
+++ b/build_tools/tests/therock_subproject_prebuilt_test.py
@@ -33,6 +33,7 @@ HARNESS_INCLUDES = (
     "therock_sanitizers",
     "therock_flag_utils",
     "therock_default_targets",
+    "therock_coverage",
     "therock_subproject",
 )
 

--- a/cmake/therock_coverage.cmake
+++ b/cmake/therock_coverage.cmake
@@ -1,0 +1,168 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# Code coverage instrumentation for sub-projects.
+#
+# Coverage has to be scoped to the component being measured. Instrumented code
+# emits .profraw files whenever it runs, so instrumenting a dependency of the
+# component under test folds that dependency's counters into the report and
+# makes the coverage denominator move whenever the dependency changes. A single
+# shared option name (such as the BUILD_CODE_COVERAGE that rocm-libraries
+# projects define today) cannot express that scoping: every sub-project reading
+# it would be instrumented as well. Coverage is therefore requested per project,
+# through an option named after the project's logical target name in upper case
+# (hipDNN -> HIPDNN_ENABLE_COVERAGE).
+#
+# Three request mechanisms are supported, in decreasing order of precedence:
+#
+#   1. -D<PROJECT>_ENABLE_COVERAGE=ON|OFF
+#      Direct per-project request, for local builds of a known project. An
+#      explicit OFF also opts one project out of the group flags below.
+#
+#   2. -DTHEROCK_COVERAGE_PROJECTS="hiprand;rocFFT"
+#      Case-insensitive project list, so that CI can forward the project names
+#      it detected as changed without knowing how each flag is spelled. Accepts
+#      a comma- or semicolon-separated list plus the values "all" and "none".
+#
+#   3. -DTHEROCK_COVERAGE_ROCM_LIBRARIES_ALL=ON
+#      -DTHEROCK_COVERAGE_ROCM_SYSTEMS_ALL=ON
+#      -DTHEROCK_COVERAGE_ALL=ON
+#      Instrument every component of a monorepo. Nightly coverage runs use
+#      these to build one instrumented stack and then measure each component
+#      separately. The two monorepo flags are independent so that a nightly run
+#      can instrument the libraries without paying to instrument the whole ROCm
+#      system stack; THEROCK_COVERAGE_ALL enables both.
+#
+# See docs/development/code_coverage.md.
+
+option(THEROCK_COVERAGE_ALL
+  "Enable code coverage instrumentation for all rocm-libraries and rocm-systems components" OFF)
+option(THEROCK_COVERAGE_ROCM_LIBRARIES_ALL
+  "Enable code coverage instrumentation for all rocm-libraries components (math-libs, ml-libs, cv-libs, ...)" OFF)
+option(THEROCK_COVERAGE_ROCM_SYSTEMS_ALL
+  "Enable code coverage instrumentation for all rocm-systems components (base, core, profiler, ...)" OFF)
+set(THEROCK_COVERAGE_PROJECTS "" CACHE STRING
+  "Case-insensitive list of projects to instrument for code coverage (also accepts 'all' or 'none')")
+
+# therock_coverage_init
+# Expands the coarse coverage requests into the per-project form that
+# therock_coverage_get_subproject_args consumes. Must be called from the
+# top-level CMakeLists.txt before any sub-project is declared.
+function(therock_coverage_init)
+  # Normalize the project list. CI passes whatever casing its change detection
+  # produced ("hiprand", "hipRAND", "HIPRAND"), so fold to upper case here
+  # rather than making every caller match the target's casing.
+  set(_projects "${THEROCK_COVERAGE_PROJECTS}")
+  string(REPLACE "," ";" _projects "${_projects}")
+  set(_enabled_projects)
+  foreach(_project IN LISTS _projects)
+    string(STRIP "${_project}" _project)
+    if(NOT _project)
+      continue()
+    endif()
+    string(TOUPPER "${_project}" _project)
+    if(_project STREQUAL "NONE")
+      continue()
+    elseif(_project STREQUAL "ALL")
+      set(THEROCK_COVERAGE_ALL ON)
+      set(THEROCK_COVERAGE_ALL ON PARENT_SCOPE)
+      continue()
+    endif()
+    set("${_project}_ENABLE_COVERAGE" ON PARENT_SCOPE)
+    list(APPEND _enabled_projects "${_project}")
+  endforeach()
+
+  # THEROCK_COVERAGE_ALL is defined as "both monorepos", not "every sub-project
+  # in the super-build": instrumenting amd-llvm or the bundled third-party
+  # dependencies costs build time and contributes nothing to a component report.
+  if(THEROCK_COVERAGE_ALL)
+    set(THEROCK_COVERAGE_ROCM_LIBRARIES_ALL ON PARENT_SCOPE)
+    set(THEROCK_COVERAGE_ROCM_SYSTEMS_ALL ON PARENT_SCOPE)
+  endif()
+
+  if(_enabled_projects OR THEROCK_COVERAGE_ALL
+     OR THEROCK_COVERAGE_ROCM_LIBRARIES_ALL OR THEROCK_COVERAGE_ROCM_SYSTEMS_ALL)
+    message(STATUS "Code coverage instrumentation enabled:")
+    if(_enabled_projects)
+      message(STATUS "  projects: ${_enabled_projects}")
+    endif()
+    if(THEROCK_COVERAGE_ALL OR THEROCK_COVERAGE_ROCM_LIBRARIES_ALL)
+      message(STATUS "  all rocm-libraries components")
+    endif()
+    if(THEROCK_COVERAGE_ALL OR THEROCK_COVERAGE_ROCM_SYSTEMS_ALL)
+      message(STATUS "  all rocm-systems components")
+    endif()
+  endif()
+endfunction()
+
+# therock_coverage_source_group
+# Reports which monorepo a sub-project's sources come from: "rocm-libraries",
+# "rocm-systems", or empty for in-tree and third-party sources. There is no
+# declared grouping to consult, but a component's monorepo is exactly what its
+# EXTERNAL_SOURCE_DIR points into.
+function(therock_coverage_source_group out_var external_source_dir)
+  set("${out_var}" "" PARENT_SCOPE)
+  if(NOT external_source_dir)
+    return()
+  endif()
+  if(THEROCK_ROCM_LIBRARIES_SOURCE_DIR)
+    cmake_path(IS_PREFIX THEROCK_ROCM_LIBRARIES_SOURCE_DIR "${external_source_dir}"
+      NORMALIZE _is_rocm_libraries)
+    if(_is_rocm_libraries)
+      set("${out_var}" "rocm-libraries" PARENT_SCOPE)
+      return()
+    endif()
+  endif()
+  if(THEROCK_ROCM_SYSTEMS_SOURCE_DIR)
+    cmake_path(IS_PREFIX THEROCK_ROCM_SYSTEMS_SOURCE_DIR "${external_source_dir}"
+      NORMALIZE _is_rocm_systems)
+    if(_is_rocm_systems)
+      set("${out_var}" "rocm-systems" PARENT_SCOPE)
+    endif()
+  endif()
+endfunction()
+
+# therock_coverage_get_subproject_args
+# Sets out_var to the coverage options to add to a sub-project's configure
+# command line, or to an empty list when the sub-project is not being measured.
+function(therock_coverage_get_subproject_args
+    out_var
+    logical_target_name
+    external_source_dir)
+  set("${out_var}" "" PARENT_SCOPE)
+
+  string(TOUPPER "${logical_target_name}" _project_name)
+  set(_coverage_var_name "${_project_name}_ENABLE_COVERAGE")
+
+  if(DEFINED ${_coverage_var_name})
+    # An explicit request wins over the group flags, in both directions, so that
+    # a nightly run can instrument a whole monorepo except for one component.
+    set(_enabled "${${_coverage_var_name}}")
+  else()
+    set(_enabled OFF)
+    therock_coverage_source_group(_group "${external_source_dir}")
+    if(THEROCK_COVERAGE_ROCM_LIBRARIES_ALL AND _group STREQUAL "rocm-libraries")
+      set(_enabled ON)
+    elseif(THEROCK_COVERAGE_ROCM_SYSTEMS_ALL AND _group STREQUAL "rocm-systems")
+      set(_enabled ON)
+    endif()
+  endif()
+
+  if(NOT _enabled)
+    return()
+  endif()
+
+  # The project-specific option from the RFC, which components are moving to.
+  set(_args "-D${_coverage_var_name}=ON")
+
+  # Compatibility with the option names components define today, for example
+  # BUILD_CODE_COVERAGE in hipRAND and CODE_COVERAGE in rocRAND. Passing them
+  # here is safe precisely because these arguments only reach the configure
+  # command of the sub-project being measured, so they cannot instrument a
+  # dependency the way a super-build-wide -DBUILD_CODE_COVERAGE would. Drop
+  # these once every component accepts <PROJECT>_ENABLE_COVERAGE.
+  list(APPEND _args "-DBUILD_CODE_COVERAGE=ON" "-DCODE_COVERAGE=ON")
+
+  message(STATUS "  ENABLE CODE COVERAGE: ${logical_target_name}")
+  set("${out_var}" "${_args}" PARENT_SCOPE)
+endfunction()

--- a/cmake/therock_coverage.cmake
+++ b/cmake/therock_coverage.cmake
@@ -122,6 +122,32 @@ function(therock_coverage_source_group out_var external_source_dir)
   endif()
 endfunction()
 
+# _therock_coverage_is_enabled
+# Resolves whether a sub-project is being measured, from its per-project option
+# and the monorepo group flags.
+function(_therock_coverage_is_enabled
+    out_var
+    logical_target_name
+    external_source_dir)
+  string(TOUPPER "${logical_target_name}" _project_name)
+
+  if(DEFINED ${_project_name}_ENABLE_COVERAGE)
+    # An explicit request wins over the group flags, in both directions, so that
+    # a nightly run can instrument a whole monorepo except for one component.
+    set("${out_var}" "${${_project_name}_ENABLE_COVERAGE}" PARENT_SCOPE)
+    return()
+  endif()
+
+  set(_enabled OFF)
+  therock_coverage_source_group(_group "${external_source_dir}")
+  if(THEROCK_COVERAGE_ROCM_LIBRARIES_ALL AND _group STREQUAL "rocm-libraries")
+    set(_enabled ON)
+  elseif(THEROCK_COVERAGE_ROCM_SYSTEMS_ALL AND _group STREQUAL "rocm-systems")
+    set(_enabled ON)
+  endif()
+  set("${out_var}" "${_enabled}" PARENT_SCOPE)
+endfunction()
+
 # therock_coverage_get_subproject_args
 # Sets out_var to the coverage options to add to a sub-project's configure
 # command line, or to an empty list when the sub-project is not being measured.
@@ -131,26 +157,14 @@ function(therock_coverage_get_subproject_args
     external_source_dir)
   set("${out_var}" "" PARENT_SCOPE)
 
-  string(TOUPPER "${logical_target_name}" _project_name)
-  set(_coverage_var_name "${_project_name}_ENABLE_COVERAGE")
-
-  if(DEFINED ${_coverage_var_name})
-    # An explicit request wins over the group flags, in both directions, so that
-    # a nightly run can instrument a whole monorepo except for one component.
-    set(_enabled "${${_coverage_var_name}}")
-  else()
-    set(_enabled OFF)
-    therock_coverage_source_group(_group "${external_source_dir}")
-    if(THEROCK_COVERAGE_ROCM_LIBRARIES_ALL AND _group STREQUAL "rocm-libraries")
-      set(_enabled ON)
-    elseif(THEROCK_COVERAGE_ROCM_SYSTEMS_ALL AND _group STREQUAL "rocm-systems")
-      set(_enabled ON)
-    endif()
-  endif()
-
+  _therock_coverage_is_enabled(_enabled
+    "${logical_target_name}" "${external_source_dir}")
   if(NOT _enabled)
     return()
   endif()
+
+  string(TOUPPER "${logical_target_name}" _project_name)
+  set(_coverage_var_name "${_project_name}_ENABLE_COVERAGE")
 
   # The project-specific option from the RFC, which components are moving to.
   set(_args "-D${_coverage_var_name}=ON")
@@ -165,4 +179,46 @@ function(therock_coverage_get_subproject_args
 
   message(STATUS "  ENABLE CODE COVERAGE: ${logical_target_name}")
   set("${out_var}" "${_args}" PARENT_SCOPE)
+endfunction()
+
+# therock_coverage_get_init_stanza
+# Sets out_var to CMake code to add to a sub-project's project_init file, or to
+# an empty string when the sub-project is not being measured.
+function(therock_coverage_get_init_stanza
+    out_var
+    logical_target_name
+    external_source_dir)
+  set("${out_var}" "" PARENT_SCOPE)
+
+  _therock_coverage_is_enabled(_enabled
+    "${logical_target_name}" "${external_source_dir}")
+  if(NOT _enabled)
+    return()
+  endif()
+
+  # Linking -fprofile-instr-generate pulls in the static profile runtime, which
+  # calls dlsym and dladdr. Those moved into libc in glibc 2.34, but the
+  # portable Linux build targets manylinux_2_28, so they still have to come from
+  # libdl. A shared library that does not link it is accepted anyway, because
+  # shared libraries are allowed undefined symbols, and the failure surfaces at
+  # the first executable to link against it, which is where lld applies
+  # --no-allow-shlib-undefined:
+  #
+  #   ld.lld: error: undefined reference: dlsym
+  #   >>> referenced by library/libhiprand.so.1.1
+  #
+  # Components declare the coverage flags but not this dependency of them, so it
+  # is added here for whichever component is being measured.
+  #
+  # This cannot go through CMAKE_<TYPE>_LINKER_FLAGS_INIT in the toolchain file,
+  # for the same reason the driver build options cannot: the private link dir
+  # handling appends to CMAKE_<TYPE>_LINKER_FLAGS before enable_language() has
+  # populated it from *_INIT, which shadows the cache value and drops it.
+  #
+  # CMAKE_DL_LIBS is resolved here rather than emitted as a reference because
+  # project_init runs before the sub-project has enabled a language, so the
+  # variable is not necessarily set yet on the other side.
+  if(CMAKE_DL_LIBS)
+    set("${out_var}" "link_libraries(${CMAKE_DL_LIBS})\n" PARENT_SCOPE)
+  endif()
 endfunction()

--- a/cmake/therock_coverage.cmake
+++ b/cmake/therock_coverage.cmake
@@ -197,28 +197,49 @@ function(therock_coverage_get_init_stanza
   endif()
 
   # Linking -fprofile-instr-generate pulls in the static profile runtime, which
-  # calls dlsym and dladdr. Those moved into libc in glibc 2.34, but the
+  # calls into libdl (dlsym, dladdr) and libpthread (pthread_once,
+  # pthread_getattr_np). Both sets moved into libc in glibc 2.34, but the
   # portable Linux build targets manylinux_2_28, so they still have to come from
-  # libdl. A shared library that does not link it is accepted anyway, because
-  # shared libraries are allowed undefined symbols, and the failure surfaces at
-  # the first executable to link against it, which is where lld applies
-  # --no-allow-shlib-undefined:
+  # the separate libraries. A shared library that does not link them is accepted
+  # anyway, because shared libraries are allowed undefined symbols, and the
+  # failure surfaces at the first executable to link against it, which is where
+  # lld applies --no-allow-shlib-undefined:
   #
-  #   ld.lld: error: undefined reference: dlsym
+  #   ld.lld: error: undefined reference: pthread_once
   #   >>> referenced by library/libhiprand.so.1.1
   #
-  # Components declare the coverage flags but not this dependency of them, so it
-  # is added here for whichever component is being measured.
+  # That executable need not be part of the instrumented component. rocFFT is
+  # not instrumented, but it links libhiprand.so and so is where the missing
+  # pthread dependency stopped the build.
+  #
+  # Components declare the coverage flags but not these dependencies of them, so
+  # they are added here for whichever component is being measured.
   #
   # This cannot go through CMAKE_<TYPE>_LINKER_FLAGS_INIT in the toolchain file,
   # for the same reason the driver build options cannot: the private link dir
   # handling appends to CMAKE_<TYPE>_LINKER_FLAGS before enable_language() has
   # populated it from *_INIT, which shadows the cache value and drops it.
   #
-  # CMAKE_DL_LIBS is resolved here rather than emitted as a reference because
-  # project_init runs before the sub-project has enabled a language, so the
-  # variable is not necessarily set yet on the other side.
+  # The libraries are resolved here rather than emitted as references because
+  # project_init runs before the sub-project has enabled a language: neither
+  # CMAKE_DL_LIBS nor FindThreads is usable on the other side. FindThreads is
+  # what decides whether a separate thread library is needed at all, so it also
+  # gives the right answer on a glibc 2.34 or newer host, where it is not.
+  set(_link_libs)
   if(CMAKE_DL_LIBS)
-    set("${out_var}" "link_libraries(${CMAKE_DL_LIBS})\n" PARENT_SCOPE)
+    list(APPEND _link_libs "${CMAKE_DL_LIBS}")
+  endif()
+  # FindThreads is a hard error without C or CXX enabled, which is how the
+  # super-project runs but not how every caller does.
+  if(CMAKE_C_COMPILER_LOADED OR CMAKE_CXX_COMPILER_LOADED)
+    find_package(Threads QUIET)
+    if(CMAKE_THREAD_LIBS_INIT)
+      list(APPEND _link_libs "${CMAKE_THREAD_LIBS_INIT}")
+    endif()
+  endif()
+
+  if(_link_libs)
+    list(JOIN _link_libs " " _link_libs)
+    set("${out_var}" "link_libraries(${_link_libs})\n" PARENT_SCOPE)
   endif()
 endfunction()

--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -928,6 +928,13 @@ function(therock_cmake_subproject_activate target_name)
 
   list(APPEND _cmake_args "${${target_name}_CMAKE_ARGS}")
 
+  # Code coverage options are appended per sub-project rather than set globally:
+  # only the component being measured may be instrumented, or its dependencies
+  # emit profraw files into the same report. See cmake/therock_coverage.cmake.
+  therock_coverage_get_subproject_args(_coverage_args
+    "${_logical_target_name}" "${_external_source_dir}")
+  list(APPEND _cmake_args ${_coverage_args})
+
   # Derive the CMAKE_BUILD_TYPE from either {project}_BUILD_TYPE or the global
   # CMAKE_BUILD_TYPE.
   set(_cmake_build_type "${${target_name}_BUILD_TYPE}")

--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -889,6 +889,12 @@ function(therock_cmake_subproject_activate target_name)
       "add_link_options(\"LINKER:${THEROCK_WINDOWS_DRIVER_BUILD_LINK_FLAGS}\")\n")
   endif()
 
+  # Link half of the coverage options, emitted here for the same reason. See
+  # cmake/therock_coverage.cmake.
+  therock_coverage_get_init_stanza(_coverage_init_stanza
+    "${_logical_target_name}" "${_external_source_dir}")
+  string(APPEND _init_contents "${_coverage_init_stanza}")
+
   if(_dep_provider_file)
     string(APPEND _init_contents "include(${_dep_provider_file})\n")
   endif()

--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -159,8 +159,6 @@ if(THEROCK_ENABLE_COMPILER)
       -DTHEROCK_SANITIZER=${THEROCK_SANITIZER}
       # compiler-rt debug mode
       "-DCOMPILER_RT_DEBUG=${THEROCK_COMPILER_RT_DEBUG}"
-      # Device-side code coverage runtime.
-      "-DCOMPILER_RT_BUILD_PROFILE_ROCM=${THEROCK_COMPILER_RT_BUILD_PROFILE_ROCM}"
 
       ${_extra_llvm_cmake_args}
     BUILD_DEPS

--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -159,6 +159,8 @@ if(THEROCK_ENABLE_COMPILER)
       -DTHEROCK_SANITIZER=${THEROCK_SANITIZER}
       # compiler-rt debug mode
       "-DCOMPILER_RT_DEBUG=${THEROCK_COMPILER_RT_DEBUG}"
+      # Device-side code coverage runtime.
+      "-DCOMPILER_RT_BUILD_PROFILE_ROCM=${THEROCK_COMPILER_RT_BUILD_PROFILE_ROCM}"
 
       ${_extra_llvm_cmake_args}
     BUILD_DEPS

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -20,6 +20,7 @@
 - (root) [TESTING.md](/TESTING.md) - **Start here** for an overview of testing in this project
 - [Adding tests](adding_tests.md)
 - [Code Coverage](code_coverage.md)
+- [Code Coverage Flow](code_coverage_flow.md) - end-to-end trace of the nightly coverage pipeline
 - [Test Debugging](test_debugging.md)
 - [Test Filtering](test_filtering.md)
 - [Test Environment Reproduction](test_environment_reproduction.md)

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -19,6 +19,7 @@
 
 - (root) [TESTING.md](/TESTING.md) - **Start here** for an overview of testing in this project
 - [Adding tests](adding_tests.md)
+- [Code Coverage](code_coverage.md)
 - [Test Debugging](test_debugging.md)
 - [Test Filtering](test_filtering.md)
 - [Test Environment Reproduction](test_environment_reproduction.md)

--- a/docs/development/code_coverage.md
+++ b/docs/development/code_coverage.md
@@ -1,10 +1,11 @@
 # Code Coverage
 
 TheRock can build ROCm components with LLVM source-based coverage
-instrumentation and publish an lcov report per component. This implements
-phase 1 of
-[RFC0014](https://github.com/ROCm/TheRock/pull/6967): full coverage on a single
-default architecture, driven by a standalone nightly workflow.
+instrumentation and publish an lcov report per component. This implements the
+phase 1 proof of concept from
+[RFC0014](https://github.com/ROCm/TheRock/pull/6967): host-side coverage on a
+single default architecture, driven by a standalone nightly workflow that takes
+its baseline run id by hand. hipRAND is the component it is validated against.
 
 This page covers the concepts and how to request coverage.
 [Code Coverage Flow](code_coverage_flow.md) traces a nightly run end to end,
@@ -80,10 +81,9 @@ component moving between monorepos needs no bookkeeping here.
 ### CMake preset
 
 `--preset linux-release-coverage` sets up an instrumented build: it turns on
-`THEROCK_COVERAGE_ROCM_LIBRARIES_ALL` and
-`THEROCK_COMPILER_RT_BUILD_PROFILE_ROCM`, the latter being required for
-device-side counters to be compiled into instrumented device code. Narrow the
-scope by adding a project list on top of the preset:
+`THEROCK_COVERAGE_ROCM_LIBRARIES_ALL` and builds `RelWithDebInfo`, since
+source-based coverage needs debug info to map counters back to lines. Narrow
+the scope by adding a project list on top of the preset:
 
 ```bash
 cmake -B build -GNinja --preset linux-release-coverage \
@@ -170,21 +170,28 @@ workflow artifact containing `coverage.info` (lcov) and `coverage.txt`.
 Forwarding those to a coverage service is deliberately left out; RFC0014 places
 the choice of service and its configuration outside its scope.
 
-## Current limitations
+## Scope
 
-- **Single architecture.** Phase 1 covers common code paths on one default
-  family. Architecture-specific coverage needs arch-specific change detection
-  first.
-- **`baseline_run_id` is manual.** RFC0014 option B1. Phase 2 replaces it with a
-  downstream trigger from the regular nightly, which passes its own run id.
-  Nothing in this workflow assumes a human typed the value.
-- **Host-side coverage only, by default.** The default `prebuilt_stages` reuses
-  the baseline's `compiler-runtime`, which was not built with
-  `THEROCK_COMPILER_RT_BUILD_PROFILE_ROCM`, so the device-side profile runtime
-  is absent. This is what makes a PoC run affordable, and it is sufficient for
-  components whose own code is host code (hipRAND being one). Set
-  `prebuilt_stages` to `none` to build the whole instrumented stack and get
-  device-side counters.
+This is the RFC0014 phase 1 proof of concept and nothing beyond it. The
+following are all deliberate omissions rather than oversights, and each is a
+later phase in the RFC:
+
+- **Host-side coverage only.** Device-side counters need the compiler-rt
+  profile runtime compiled into instrumented device code. That is out of scope
+  here; hipRAND's own code is host code, which is enough to validate the
+  pipeline end to end.
+- **Single architecture.** One default family, `gfx94x`/`gfx942`.
+  Architecture-specific coverage needs arch-specific change detection first.
+- **`baseline_run_id` is manual.** RFC0014 option B1: the run id of a
+  successful regular nightly is typed in at dispatch time. Manual coordination
+  is acceptable for initial validation, and it is what keeps the production
+  nightly unmodified.
+- **No changes to the regular nightly.** The coverage workflow is standalone
+  and nothing triggers it automatically, so it can fail, be retried, or be
+  abandoned without any effect on production CI.
+
+Two implementation details will also change as components adopt the RFC:
+
 - **Components still use the legacy option names.** No component accepts
   `<PROJECT>_ENABLE_COVERAGE` yet, so TheRock passes it alongside
   `BUILD_CODE_COVERAGE` and `CODE_COVERAGE`. Passing those is safe here because

--- a/docs/development/code_coverage.md
+++ b/docs/development/code_coverage.md
@@ -6,6 +6,10 @@ phase 1 of
 [RFC0014](https://github.com/ROCm/TheRock/pull/6967): full coverage on a single
 default architecture, driven by a standalone nightly workflow.
 
+This page covers the concepts and how to request coverage.
+[Code Coverage Flow](code_coverage_flow.md) traces a nightly run end to end,
+naming the file responsible at each step.
+
 ## Why coverage is requested per project
 
 Instrumented code writes `.profraw` counter files whenever it runs. If a

--- a/docs/development/code_coverage.md
+++ b/docs/development/code_coverage.md
@@ -1,0 +1,193 @@
+# Code Coverage
+
+TheRock can build ROCm components with LLVM source-based coverage
+instrumentation and publish an lcov report per component. This implements
+phase 1 of
+[RFC0014](https://github.com/ROCm/TheRock/pull/6967): full coverage on a single
+default architecture, driven by a standalone nightly workflow.
+
+## Why coverage is requested per project
+
+Instrumented code writes `.profraw` counter files whenever it runs. If a
+component's dependencies are instrumented too, they emit counters during the
+component's own test run, and those counters land in the same report. The
+practical consequences are that the report covers code the component does not
+own, and that its denominator moves whenever an unrelated upstream project
+changes.
+
+This is why a single shared option name does not work. rocm-libraries projects
+define `BUILD_CODE_COVERAGE` (hipRAND) or `CODE_COVERAGE` (rocRAND) today, and
+setting either across the super-build would instrument every project that reads
+it. Coverage is therefore requested per project, and TheRock only passes the
+option to the sub-project being measured.
+
+Downstream components are excluded for a different reason: coverage of a
+component is independent of its consumers. rocFFT coverage says nothing about
+hipFFT coverage, and hipFFT is already exercised by the regular CI test suites.
+
+## Requesting coverage
+
+The option name for a project is its logical target name in upper case, so
+`hipDNN` becomes `HIPDNN_ENABLE_COVERAGE`. There are three ways to ask for it.
+
+### Per project
+
+Most useful for local builds of a project you already know the name of:
+
+```bash
+cmake -B build -GNinja \
+  -DTHEROCK_AMDGPU_FAMILIES=gfx942 \
+  -DROCFFT_ENABLE_COVERAGE=ON \
+  -DHIPBLASLT_ENABLE_COVERAGE=ON
+```
+
+An explicit `OFF` also opts a single project out of the group flags below.
+
+### By project list
+
+CI detects changed projects and gets their names in whatever casing the source
+used, so this form accepts any casing and does the conversion internally.
+Separate names with commas or semicolons; `all` and `none` are also accepted:
+
+```bash
+cmake -B build -GNinja \
+  -DTHEROCK_AMDGPU_FAMILIES=gfx942 \
+  -DTHEROCK_COVERAGE_PROJECTS="hiprand,rocFFT,HIPBLASLT"
+```
+
+### By monorepo
+
+For nightly runs that instrument a whole stack at once:
+
+| Flag                                  | Instruments                                                       |
+| ------------------------------------- | ----------------------------------------------------------------- |
+| `THEROCK_COVERAGE_ROCM_LIBRARIES_ALL` | Every rocm-libraries component (math-libs, ml-libs, cv-libs, ...) |
+| `THEROCK_COVERAGE_ROCM_SYSTEMS_ALL`   | Every rocm-systems component (base, core, profiler, ...)          |
+| `THEROCK_COVERAGE_ALL`                | Both of the above                                                 |
+
+The two monorepo flags are independent so a nightly run can instrument the
+libraries without paying to instrument the entire ROCm system stack. Neither
+flag touches in-tree or third-party sub-projects such as `amd-llvm` or
+googletest, which contribute nothing to a component report.
+
+A sub-project's monorepo is determined from its `EXTERNAL_SOURCE_DIR`, so a
+component moving between monorepos needs no bookkeeping here.
+
+### CMake preset
+
+`--preset linux-release-coverage` sets up an instrumented build: it turns on
+`THEROCK_COVERAGE_ROCM_LIBRARIES_ALL` and
+`THEROCK_COMPILER_RT_BUILD_PROFILE_ROCM`, the latter being required for
+device-side counters to be compiled into instrumented device code. Narrow the
+scope by adding a project list on top of the preset:
+
+```bash
+cmake -B build -GNinja --preset linux-release-coverage \
+  -DTHEROCK_AMDGPU_FAMILIES=gfx942 \
+  -DTHEROCK_COVERAGE_ROCM_LIBRARIES_ALL=OFF \
+  -DTHEROCK_COVERAGE_PROJECTS=hiprand
+```
+
+The group flag has to be switched back off explicitly, or it keeps instrumenting
+everything regardless of the project list.
+
+## Nightly coverage workflow
+
+`.github/workflows/coverage_nightly.yml` runs the pipeline end to end. It is a
+separate workflow rather than an extension of the regular nightly because
+instrumented binaries are not what anyone wants to ship or benchmark, and
+because coverage is slow enough (instrumented rocPRIM tests take around 3 hours
+against 20 minutes uninstrumented) that it needs to be able to fail or be
+retried without holding up the regular nightly. A separate workflow also means
+a separate run id, which keeps coverage artifacts in their own S3 namespace.
+
+### Inputs
+
+| Input               | Default                    | Purpose                                                         |
+| ------------------- | -------------------------- | --------------------------------------------------------------- |
+| `baseline_run_id`   | required                   | Regular nightly run to take non-instrumented dependencies from  |
+| `amdgpu_family`     | `gfx94x`                   | Single family to build and test on                              |
+| `coverage_projects` | `hiprand`                  | Projects to instrument; empty instruments all of rocm-libraries |
+| `test_labels`       | `hiprand`                  | Components to run coverage tests for; empty runs all available  |
+| `prebuilt_stages`   | everything but `math-libs` | Stages copied from the baseline instead of built instrumented   |
+
+### How the hybrid artifact set is assembled
+
+Only the projects under test should be instrumented, but the test jobs need a
+complete ROCm stack to run against. Rather than unpacking a full stack and then
+overwriting individual files from a grouped coverage tarball, the workflow makes
+its own run id hold exactly the right mix:
+
+1. `copy_baseline_stages` copies the baseline nightly's stages into this run's
+   artifact namespace, non-instrumented and unmodified.
+1. `build_instrumented_stack` builds the remaining stage (`math-libs` by
+   default) with the coverage preset and pushes it to the same namespace.
+1. `test_coverage` fetches everything from this run id, so it gets a stack in
+   which only the projects under test are instrumented.
+
+The test jobs therefore need no special artifact handling, and there is no
+`-coverage` artifact suffix to maintain: the separate run id already isolates
+these artifacts from the regular nightly's.
+
+### Collecting and merging profraw
+
+`test_component.yml` gains a `coverage_enabled` input. When set, each test shard
+points `LLVM_PROFILE_FILE` at a per-shard, per-process path and uploads its
+`.profraw` files unmerged. A `coverage_report` job then runs once per component,
+after the whole shard matrix, and calls
+`build_tools/github_actions/coverage_report.py` to merge them and export lcov.
+
+Merging across shards is what makes the number meaningful. Each shard runs only
+its slice of the suite, so a per-shard report would claim roughly
+100/*shard count* percent coverage no matter how complete the suite is.
+
+The report job needs no GPU. It reads profraw files and the instrumented
+binaries, using `llvm-profdata` and `llvm-cov` from the same build's artifacts,
+since a coverage profile is only readable by a tool at least as new as the
+compiler that produced it.
+
+Objects are discovered rather than configured:
+
+- A component that installs `lib/lib<component>.so` is reported against that
+  library, which keeps test binaries out of the numbers automatically.
+- A header-only component (rocPRIM, hipCUB) has no library to point at because
+  its code is compiled into the test binaries, so those binaries become the
+  objects. `llvm-cov`'s `-object` flag takes one path and does not expand globs,
+  so each binary is passed separately. Test sources are then filtered out with
+  `--ignore-filename-regex` so that testing code does not count as covered
+  product code.
+
+Missing profraw files fail the job. Instrumentation that produced no counters,
+or an `LLVM_PROFILE_FILE` pointing somewhere else, would otherwise be published
+as 0% rather than reported as a problem.
+
+Each component's report is uploaded as a `coverage-report-<component>-<family>`
+workflow artifact containing `coverage.info` (lcov) and `coverage.txt`.
+Forwarding those to a coverage service is deliberately left out; RFC0014 places
+the choice of service and its configuration outside its scope.
+
+## Current limitations
+
+- **Single architecture.** Phase 1 covers common code paths on one default
+  family. Architecture-specific coverage needs arch-specific change detection
+  first.
+- **`baseline_run_id` is manual.** RFC0014 option B1. Phase 2 replaces it with a
+  downstream trigger from the regular nightly, which passes its own run id.
+  Nothing in this workflow assumes a human typed the value.
+- **Host-side coverage only, by default.** The default `prebuilt_stages` reuses
+  the baseline's `compiler-runtime`, which was not built with
+  `THEROCK_COMPILER_RT_BUILD_PROFILE_ROCM`, so the device-side profile runtime
+  is absent. This is what makes a PoC run affordable, and it is sufficient for
+  components whose own code is host code (hipRAND being one). Set
+  `prebuilt_stages` to `none` to build the whole instrumented stack and get
+  device-side counters.
+- **Components still use the legacy option names.** No component accepts
+  `<PROJECT>_ENABLE_COVERAGE` yet, so TheRock passes it alongside
+  `BUILD_CODE_COVERAGE` and `CODE_COVERAGE`. Passing those is safe here because
+  they only reach the configure command of the sub-project being measured, which
+  is exactly the scoping a super-build-wide `-DBUILD_CODE_COVERAGE` would lose.
+  They can be dropped once components take the project-specific option.
+- **Hyphenated target names produce awkward option names.** `rocprofiler-sdk`
+  maps to `ROCPROFILER-SDK_ENABLE_COVERAGE`, following the RFC's naming rule.
+  It is harmless (an unused CMake variable) and only reachable via
+  `THEROCK_COVERAGE_ROCM_SYSTEMS_ALL`, which is not part of phase 1.

--- a/docs/development/code_coverage.md
+++ b/docs/development/code_coverage.md
@@ -81,9 +81,8 @@ component moving between monorepos needs no bookkeeping here.
 ### CMake preset
 
 `--preset linux-release-coverage` sets up an instrumented build: it turns on
-`THEROCK_COVERAGE_ROCM_LIBRARIES_ALL` and builds `RelWithDebInfo`, since
-source-based coverage needs debug info to map counters back to lines. Narrow
-the scope by adding a project list on top of the preset:
+`THEROCK_COVERAGE_ROCM_LIBRARIES_ALL` and builds `Release`. Narrow the scope by
+adding a project list on top of the preset:
 
 ```bash
 cmake -B build -GNinja --preset linux-release-coverage \
@@ -165,9 +164,35 @@ path. A `ROCm/rockrel` baseline was built in `/__w/rockrel/rockrel`, so
 unpacking it into a `ROCm/TheRock` run at `/__w/TheRock/TheRock` leaves those
 configs pointing at a directory that does not exist. Nothing detects this: the
 copy succeeds, most components never look, and the first one that does resolves
-its dependency to `NOTFOUND`. rocFFT is the one that surfaces it, failing its
-configure with `fftw3_libs-NOTFOUND` even though the `fftw3` artifact was copied
-and unpacked correctly.
+its dependency to a path that is not there. rocFFT surfaces it as an
+`FFTW_INCLUDE_DIRS` under `/__w/rockrel/rockrel`, even though the `fftw3`
+artifact was copied and unpacked correctly.
+
+The coverage build also has to use the same `CMAKE_BUILD_TYPE` as the baseline,
+which is why the preset builds `Release` rather than `RelWithDebInfo`. An
+exported package config only defines imported locations for the configuration it
+was built in: the baseline's `fftw3` ships `FFTW3LibraryDepends-release.cmake`
+with `IMPORTED_CONFIGURATIONS RELEASE` and nothing else. Consumers that read
+those properties directly get nothing back under a different build type. rocFFT
+does exactly that:
+
+```cmake
+string(TOUPPER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_UPPER)
+get_target_property(fftw3_libs FFTW3::fftw3 IMPORTED_LOCATION_${CMAKE_BUILD_TYPE_UPPER})
+```
+
+Under `RelWithDebInfo` that asks for `IMPORTED_LOCATION_RELWITHDEBINFO` and
+configure fails with `fftw3_libs-NOTFOUND`, while `libfftw3_threads.so` in the
+same directory still resolves because it is located with `find_library`, which
+does not depend on the configuration. Setting
+`CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO` does not help here, since that
+mapping is applied when CMake resolves a use of the imported target, not when a
+specific property is read with `get_target_property`.
+
+Building `Release` costs nothing in coverage fidelity. `llvm-cov` reads the
+coverage mapping that `-fcoverage-mapping` emits into the binary rather than
+DWARF, and the instrumented components add their own `-g -O0` for the targets
+being measured.
 
 ### Collecting and merging profraw
 

--- a/docs/development/code_coverage.md
+++ b/docs/development/code_coverage.md
@@ -236,9 +236,26 @@ or an `LLVM_PROFILE_FILE` pointing somewhere else, would otherwise be published
 as 0% rather than reported as a problem.
 
 Each component's report is uploaded as a `coverage-report-<component>-<family>`
-workflow artifact containing `coverage.info` (lcov) and `coverage.txt`.
-Forwarding those to a coverage service is deliberately left out; RFC0014 places
-the choice of service and its configuration outside its scope.
+workflow artifact containing `coverage.info` (lcov), `coverage.txt` (the summary
+table) and `coverage.html` (the source annotated line by line). Forwarding these
+to a coverage service is deliberately left out; RFC0014 places the choice of
+service and its configuration outside its scope.
+
+The HTML report is written as one self-contained file rather than the directory
+tree `llvm-cov show --output-dir` produces, so that it opens straight from an
+artifact download. It is the only output that needs the component's sources:
+`export` and `report` read the coverage mapping embedded in the binaries, but
+`show` opens each source file at the absolute path recorded there, which is the
+build machine's path.
+
+The report job therefore checks those sources out, but cannot do it the obvious
+way. `rocm-libraries` is around 7GB, which is an absurd download for annotating
+one component, so the job takes a partial clone with `--filter=blob:none` and a
+sparse checkout limited to `projects/<component>`, fetching only the files it
+will actually annotate. This is allowed to fail: the other two reports do not
+need source, and `coverage_report.py` warns rather than failing when the
+recorded paths hold nothing, so a wrong or missing checkout degrades the HTML
+instead of losing the run's results.
 
 ## Scope
 

--- a/docs/development/code_coverage.md
+++ b/docs/development/code_coverage.md
@@ -95,6 +95,31 @@ cmake -B build -GNinja --preset linux-release-coverage \
 The group flag has to be switched back off explicitly, or it keeps instrumenting
 everything regardless of the project list.
 
+### What the super-project adds to an instrumented sub-project
+
+Components own the coverage flags themselves, through whichever option they
+define (`BUILD_CODE_COVERAGE` in hipRAND, `CODE_COVERAGE` in rocRAND). The
+super-project adds one thing they do not declare: a link against `libdl`.
+
+`-fprofile-instr-generate` links the static profile runtime, which calls `dlsym`
+and `dladdr`. Those moved into libc in glibc 2.34, but the portable Linux build
+targets manylinux_2_28, so they still have to come from `libdl`. A shared
+library that does not link it is accepted anyway, because shared libraries are
+allowed undefined symbols, and the failure surfaces later at the first
+executable to link against that library, which is where lld applies
+`--no-allow-shlib-undefined`:
+
+```
+ld.lld: error: undefined reference: dlsym
+>>> referenced by library/libhiprand.so.1.1 (disallowed by --no-allow-shlib-undefined)
+```
+
+`therock_coverage_get_init_stanza()` adds it to the `project_init.cmake` of
+whichever sub-project is being measured. It has to go there rather than through
+`CMAKE_<TYPE>_LINKER_FLAGS_INIT` in the toolchain file, because the private link
+dir handling appends to `CMAKE_<TYPE>_LINKER_FLAGS` before `enable_language()`
+has populated it from `*_INIT`, which would drop it.
+
 ## Nightly coverage workflow
 
 `.github/workflows/coverage_nightly.yml` runs the pipeline end to end. It is a

--- a/docs/development/code_coverage.md
+++ b/docs/development/code_coverage.md
@@ -158,6 +158,17 @@ The test jobs therefore need no special artifact handling, and there is no
 `-coverage` artifact suffix to maintain: the separate run id already isolates
 these artifacts from the regular nightly's.
 
+The baseline has to come from a run of this repository. Artifacts embed the
+absolute path of the workspace they were built in, which GitHub derives from the
+repository name, and the CMake package configs inside them resolve against that
+path. A `ROCm/rockrel` baseline was built in `/__w/rockrel/rockrel`, so
+unpacking it into a `ROCm/TheRock` run at `/__w/TheRock/TheRock` leaves those
+configs pointing at a directory that does not exist. Nothing detects this: the
+copy succeeds, most components never look, and the first one that does resolves
+its dependency to `NOTFOUND`. rocFFT is the one that surfaces it, failing its
+configure with `fftw3_libs-NOTFOUND` even though the `fftw3` artifact was copied
+and unpacked correctly.
+
 ### Collecting and merging profraw
 
 `test_component.yml` gains a `coverage_enabled` input. When set, each test shard

--- a/docs/development/code_coverage.md
+++ b/docs/development/code_coverage.md
@@ -98,23 +98,32 @@ everything regardless of the project list.
 
 Components own the coverage flags themselves, through whichever option they
 define (`BUILD_CODE_COVERAGE` in hipRAND, `CODE_COVERAGE` in rocRAND). The
-super-project adds one thing they do not declare: a link against `libdl`.
+super-project adds what they do not declare: the profile runtime's own link
+dependencies.
 
-`-fprofile-instr-generate` links the static profile runtime, which calls `dlsym`
-and `dladdr`. Those moved into libc in glibc 2.34, but the portable Linux build
-targets manylinux_2_28, so they still have to come from `libdl`. A shared
-library that does not link it is accepted anyway, because shared libraries are
-allowed undefined symbols, and the failure surfaces later at the first
-executable to link against that library, which is where lld applies
+`-fprofile-instr-generate` links the static profile runtime, which calls into
+`libdl` (`dlsym`, `dladdr`) and `libpthread` (`pthread_once`,
+`pthread_getattr_np`). Both sets moved into libc in glibc 2.34, but the portable
+Linux build targets manylinux_2_28, so they still have to come from the separate
+libraries. A shared library that does not link them is accepted anyway, because
+shared libraries are allowed undefined symbols, and the failure surfaces later
+at the first executable to link against that library, which is where lld applies
 `--no-allow-shlib-undefined`:
 
 ```
-ld.lld: error: undefined reference: dlsym
+ld.lld: error: undefined reference: pthread_once
 >>> referenced by library/libhiprand.so.1.1 (disallowed by --no-allow-shlib-undefined)
 ```
 
-`therock_coverage_get_init_stanza()` adds it to the `project_init.cmake` of
-whichever sub-project is being measured. It has to go there rather than through
+That executable does not have to belong to the instrumented component, which
+makes this confusing to read in a build log: rocFFT is not instrumented, but it
+links `libhiprand.so`, so an incomplete link line on hipRAND fails the build in
+rocFFT.
+
+`therock_coverage_get_init_stanza()` adds them to the `project_init.cmake` of
+whichever sub-project is being measured, asking `FindThreads` whether a separate
+thread library is needed so that a glibc 2.34 or newer host correctly gets
+nothing. It has to go there rather than through
 `CMAKE_<TYPE>_LINKER_FLAGS_INIT` in the toolchain file, because the private link
 dir handling appends to `CMAKE_<TYPE>_LINKER_FLAGS` before `enable_language()`
 has populated it from `*_INIT`, which would drop it.

--- a/docs/development/code_coverage_flow.md
+++ b/docs/development/code_coverage_flow.md
@@ -42,7 +42,7 @@ flowchart TB
 
     subgraph COV["coverage_nightly.yml — run_id 99999 · artifact_group multi-arch-coverage"]
         direction TB
-        T["1 · trigger<br/>workflow_dispatch / workflow_call"]
+        T["1 · trigger<br/>workflow_dispatch, manual baseline_run_id"]
         S["2 · setup<br/>setup_multi_arch.yml"]
         CP["3 · copy_baseline_stages<br/>artifact_manager.py copy"]
         BI["4 · build_instrumented_stack<br/>multi_arch_build_portable_linux.yml"]
@@ -66,14 +66,14 @@ flowchart TB
 
 **File:** `.github/workflows/coverage_nightly.yml`
 
-Two entry points, no presubmit path:
+`workflow_dispatch` is the only entry point, which is what RFC0014 option B1
+asks for: nothing triggers this automatically, so the production nightly is
+untouched and a coverage run can fail or be abandoned without consequence.
 
-- `workflow_dispatch` — phase 1. `baseline_run_id` is `required: true`; there is
-  no default because silently picking the latest nightly would mix an
-  unknown dependency set into the report.
-- `workflow_call` — the phase 2 entry point, so the regular nightly can invoke
-  this and pass its own `run_id`. Nothing downstream assumes a human typed the
-  value.
+`baseline_run_id` is `required: true` and has no default. Silently picking the
+latest nightly would mix an unknown dependency set into the report, and the
+operator supplying a known-good run id by hand is the "manual coordination"
+the PoC explicitly accepts.
 
 A `concurrency` group keyed on ref and family prevents two instrumented builds
 of the same family competing for nodes for hours to produce the same report.
@@ -171,11 +171,10 @@ alongside the copied ones. The hybrid stack now exists.
 
 | File                             | Role                                                                    |
 | -------------------------------- | ----------------------------------------------------------------------- |
-| `CMakePresets.json`              | `linux-release-coverage`: group flag, profile runtime, `RelWithDebInfo` |
+| `CMakePresets.json`              | `linux-release-coverage`: group flag plus `RelWithDebInfo`              |
 | `CMakeLists.txt`                 | `include(therock_coverage)` and the `therock_coverage_init()` call site |
 | `cmake/therock_coverage.cmake`   | Normalizes requests; decides per sub-project                            |
 | `cmake/therock_subproject.cmake` | Appends the resulting options to one sub-project's configure line       |
-| `compiler/CMakeLists.txt`        | Forwards `COMPILER_RT_BUILD_PROFILE_ROCM` to `amd-llvm`                 |
 
 `therock_coverage_init()` is called from `CMakeLists.txt` after the monorepo
 source directories are known and before any sub-project is declared, because
@@ -312,24 +311,23 @@ coverage service is out of scope; RFC0014 leaves the choice of service open.
 
 ## File index
 
-| File                                                              | Change                                                      |
-| ----------------------------------------------------------------- | ----------------------------------------------------------- |
-| `.github/workflows/coverage_nightly.yml`                          | new                                                         |
-| `.github/workflows/multi_arch_build_portable_linux.yml`           | `extra_cmake_options` input, forwarded to stage jobs        |
-| `.github/workflows/multi_arch_build_portable_linux_artifacts.yml` | `extra_cmake_options` appended to configure                 |
-| `.github/workflows/test_artifacts.yml`                            | `coverage_enabled` input, threaded to components            |
-| `.github/workflows/test_component.yml`                            | profraw capture and upload, `coverage_report` job           |
-| `CMakeLists.txt`                                                  | include + `therock_coverage_init()`, profile runtime option |
-| `CMakePresets.json`                                               | `linux-release-coverage` preset                             |
-| `cmake/therock_coverage.cmake`                                    | new: request normalization and per-project decision         |
-| `cmake/therock_subproject.cmake`                                  | passthrough into the measured sub-project                   |
-| `compiler/CMakeLists.txt`                                         | `COMPILER_RT_BUILD_PROFILE_ROCM` to `amd-llvm`              |
-| `build_tools/github_actions/amdgpu_family_matrix.py`              | `coverage` variant, enabled for `gfx94x` and `gfx950`       |
-| `build_tools/github_actions/configure_multi_arch_ci.py`           | disables packaging for coverage builds                      |
-| `build_tools/github_actions/coverage_report.py`                   | new: merge and export                                       |
-| `build_tools/github_actions/tests/coverage_report_test.py`        | new: 14 tests                                               |
-| `docs/development/code_coverage.md`                               | new: concepts and usage                                     |
-| `docs/development/code_coverage_flow.md`                          | new: this page                                              |
+| File                                                              | Change                                               |
+| ----------------------------------------------------------------- | ---------------------------------------------------- |
+| `.github/workflows/coverage_nightly.yml`                          | new                                                  |
+| `.github/workflows/multi_arch_build_portable_linux.yml`           | `extra_cmake_options` input, forwarded to stage jobs |
+| `.github/workflows/multi_arch_build_portable_linux_artifacts.yml` | `extra_cmake_options` appended to configure          |
+| `.github/workflows/test_artifacts.yml`                            | `coverage_enabled` input, threaded to components     |
+| `.github/workflows/test_component.yml`                            | profraw capture and upload, `coverage_report` job    |
+| `CMakeLists.txt`                                                  | include + `therock_coverage_init()` call site        |
+| `CMakePresets.json`                                               | `linux-release-coverage` preset                      |
+| `cmake/therock_coverage.cmake`                                    | new: request normalization and per-project decision  |
+| `cmake/therock_subproject.cmake`                                  | passthrough into the measured sub-project            |
+| `build_tools/github_actions/amdgpu_family_matrix.py`              | `coverage` variant, enabled for `gfx94x`             |
+| `build_tools/github_actions/configure_multi_arch_ci.py`           | disables packaging for coverage builds               |
+| `build_tools/github_actions/coverage_report.py`                   | new: merge and export                                |
+| `build_tools/github_actions/tests/coverage_report_test.py`        | new: 14 tests                                        |
+| `docs/development/code_coverage.md`                               | new: concepts and usage                              |
+| `docs/development/code_coverage_flow.md`                          | new: this page                                       |
 
 ## Debugging a failed run
 
@@ -341,4 +339,4 @@ coverage service is out of scope; RFC0014 leaves the choice of service open.
 | `Could not find llvm-profdata`               | Whether `amd-llvm_run` was fetched; see `install_rocm_from_artifacts.py`                                                                          |
 | Test job cannot find a library at runtime    | A stage missing from both `prebuilt_stages` and the built stage, so it is in neither half of the hybrid stack                                     |
 | `llvm-cov` reports a profile format mismatch | Tools and binaries came from different builds; the report job must fetch the same run id the tests did                                            |
-| Device code shows no coverage                | Expected with the default `prebuilt_stages`; see the limitations in [Code Coverage](code_coverage.md)                                             |
+| Device code shows no coverage                | Expected. Phase 1 is host-side only; see the scope section in [Code Coverage](code_coverage.md)                                                   |

--- a/docs/development/code_coverage_flow.md
+++ b/docs/development/code_coverage_flow.md
@@ -1,0 +1,344 @@
+# Nightly Code Coverage: End-to-End Flow
+
+This page traces a nightly coverage run from the dispatch button to the
+published lcov report, naming the file responsible at every step. It is a
+control-flow reference for people modifying or debugging the pipeline.
+
+For *why* coverage is scoped per project and *how* to request it, see
+[Code Coverage](code_coverage.md). For the CI machinery this pipeline reuses,
+see [CI Overview](ci_overview.md) and [Artifacts](artifacts.md).
+
+## The one idea to hold on to
+
+A coverage run does not build a full instrumented ROCm stack. It takes an
+already-completed regular nightly, copies that nightly's **non-instrumented**
+stage artifacts into its own run id, and builds only the stage containing the
+projects under test on top of them. The run then owns a complete stack in which
+only those projects are instrumented, and every downstream job can fetch it
+from a single run id without knowing coverage exists.
+
+Everything below is in service of that assembly.
+
+## Worked example
+
+The walkthrough uses the workflow's defaults, with two invented run ids:
+
+| Thing                | Value                                                |
+| -------------------- | ---------------------------------------------------- |
+| Baseline nightly     | run id `12345`, artifact group `multi-arch`          |
+| Coverage run         | run id `99999`, artifact group `multi-arch-coverage` |
+| Family / target      | `gfx94X-dcgpu` / `gfx942`                            |
+| Instrumented project | `hipRAND`                                            |
+| Stage built          | `math-libs`                                          |
+| Stages copied        | all eleven others                                    |
+
+## Overview
+
+```mermaid
+flowchart TB
+    subgraph BASE["Regular nightly — ran earlier, NOT instrumented"]
+        RN["run_id 12345 · artifact_group multi-arch"]
+    end
+
+    subgraph COV["coverage_nightly.yml — run_id 99999 · artifact_group multi-arch-coverage"]
+        direction TB
+        T["1 · trigger<br/>workflow_dispatch / workflow_call"]
+        S["2 · setup<br/>setup_multi_arch.yml"]
+        CP["3 · copy_baseline_stages<br/>artifact_manager.py copy"]
+        BI["4 · build_instrumented_stack<br/>multi_arch_build_portable_linux.yml"]
+        CMK["5 · CMake flag resolution<br/>therock_coverage.cmake"]
+        HYB["hybrid stack in run 99999<br/>libhiprand.so instrumented,<br/>everything else clean"]
+        TC["6 · test_coverage<br/>test_artifacts.yml"]
+        SH["7 · shards<br/>test_component.yml"]
+        RP["8 · coverage_report<br/>coverage_report.py"]
+        OUT["coverage.info · coverage.txt"]
+    end
+
+    RN -.->|"run id typed by hand"| T
+    RN ==>|"stage artifacts copied"| CP
+    T --> S --> CP --> BI --> CMK --> HYB --> TC --> SH --> RP --> OUT
+
+    style HYB fill:#fff4e5,stroke:#f9a825
+    style OUT fill:#e6f4ea,stroke:#34a853
+```
+
+## 1. Trigger
+
+**File:** `.github/workflows/coverage_nightly.yml`
+
+Two entry points, no presubmit path:
+
+- `workflow_dispatch` — phase 1. `baseline_run_id` is `required: true`; there is
+  no default because silently picking the latest nightly would mix an
+  unknown dependency set into the report.
+- `workflow_call` — the phase 2 entry point, so the regular nightly can invoke
+  this and pass its own `run_id`. Nothing downstream assumes a human typed the
+  value.
+
+A `concurrency` group keyed on ref and family prevents two instrumented builds
+of the same family competing for nodes for hours to produce the same report.
+
+## 2. Setup: resolving the coverage build variant
+
+| File                                                    | Role                                                       |
+| ------------------------------------------------------- | ---------------------------------------------------------- |
+| `.github/workflows/setup_multi_arch.yml`                | Called with `build_variant: coverage`                      |
+| `build_tools/github_actions/configure_multi_arch_ci.py` | Expands that variant into a build config                   |
+| `build_tools/github_actions/amdgpu_family_matrix.py`    | Defines the `coverage` variant and which families offer it |
+
+`amdgpu_family_matrix.py` supplies the three facts that make the variant real:
+
+```python
+all_build_variants["linux"]["coverage"] = {
+    "build_variant_label": "coverage",
+    "build_variant_suffix": "coverage",
+    "build_variant_cmake_preset": "linux-release-coverage",
+}
+```
+
+The suffix is what yields artifact group `multi-arch-coverage`, and that
+separate S3 namespace is what makes it impossible for a coverage build to be
+consumed as though it were shippable. `coverage` also has to appear in a
+family's `build_variants` list to be selectable for that family; it is listed
+for `gfx94x` and `gfx950`.
+
+In `configure_multi_arch_ci.py`, `_expand_build_config_for_platform` turns off
+Python wheels, PyTorch, JAX, and native Linux packages when the suffix is
+`coverage`. All four are consumers of a stack you would ship, which this is not.
+
+The job's `linux_build_config` output carries `baseline_run_id`,
+`prebuilt_stages`, `artifact_group`, and the preset name forward. Every later
+job reads its inputs out of that JSON rather than from the workflow inputs, so
+there is one source of truth.
+
+`stage_reuse_mode` is `dry-run` on purpose. It honors the explicit
+`prebuilt_stages` list while only *reporting* what automatic reuse could
+additionally do. Applying automatic reuse would be unsafe here: reusing a stage
+that holds a project under test would substitute non-instrumented binaries and
+produce an empty report rather than an error.
+
+## 3. Copying the baseline stages
+
+**Files:** `.github/workflows/coverage_nightly.yml` (job `copy_baseline_stages`)
+→ `build_tools/artifact_manager.py`, plus
+`.github/actions/configure_aws_artifacts_credentials`
+
+This job builds nothing. It runs, on a CPU node:
+
+```bash
+python build_tools/artifact_manager.py copy \
+  --source-run-id=12345 \
+  --source-repository=ROCm/TheRock \
+  --stage="compiler-runtime,emulation,runtime-tests,..." \
+  --amdgpu-families="gfx94X-dcgpu" \
+  --expand-family-to-targets
+```
+
+The alternative to copying would be to point the test jobs at two run ids, one
+for instrumented artifacts and one for dependencies. That would mean teaching
+the artifact fetch path about coverage. Copying keeps `setup_test_environment`,
+`install_rocm_from_artifacts.py`, and every test job coverage-agnostic, at the
+cost of some S3 traffic.
+
+## 4. Building the instrumented stage
+
+| File                                                              | Role                                              |
+| ----------------------------------------------------------------- | ------------------------------------------------- |
+| `.github/workflows/multi_arch_build_portable_linux.yml`           | One job per stage; forwards `extra_cmake_options` |
+| `.github/workflows/multi_arch_build_portable_linux_artifacts.yml` | Runs the configure, build, and artifact upload    |
+
+`prebuilt_stages` causes every stage job except `math-libs` to skip its build,
+so only that stage's `multi_arch_build_portable_linux_artifacts.yml` invocation
+does real work. It configures with the preset and appends
+`extra_cmake_options`, an input added by this PR for build variants that need
+per-run settings a preset cannot express:
+
+```bash
+cmake ... --preset=linux-release-coverage <stage args> \
+  -DTHEROCK_COVERAGE_ROCM_LIBRARIES_ALL=OFF -DTHEROCK_COVERAGE_PROJECTS=hiprand
+```
+
+The group flag has to be switched back **off**. The preset instruments all of
+rocm-libraries, which is what a full nightly wants, so a run narrowing to one
+project must undo it or it will instrument everything and only test hipRAND.
+`coverage_nightly.yml` composes that pair of options whenever
+`coverage_projects` is non-empty.
+
+Artifacts upload into artifact group `multi-arch-coverage` under run id `99999`,
+alongside the copied ones. The hybrid stack now exists.
+
+## 5. How CMake decides what gets instrumented
+
+| File                             | Role                                                                    |
+| -------------------------------- | ----------------------------------------------------------------------- |
+| `CMakePresets.json`              | `linux-release-coverage`: group flag, profile runtime, `RelWithDebInfo` |
+| `CMakeLists.txt`                 | `include(therock_coverage)` and the `therock_coverage_init()` call site |
+| `cmake/therock_coverage.cmake`   | Normalizes requests; decides per sub-project                            |
+| `cmake/therock_subproject.cmake` | Appends the resulting options to one sub-project's configure line       |
+| `compiler/CMakeLists.txt`        | Forwards `COMPILER_RT_BUILD_PROFILE_ROCM` to `amd-llvm`                 |
+
+`therock_coverage_init()` is called from `CMakeLists.txt` after the monorepo
+source directories are known and before any sub-project is declared, because
+the group flags are resolved against those directories. It folds
+`THEROCK_COVERAGE_PROJECTS` entries to upper case — CI forwards project names
+in whatever casing its change detection produced — and sets
+`HIPRAND_ENABLE_COVERAGE=ON` in the parent scope.
+
+Then, as each sub-project is activated,
+`therock_cmake_subproject_activate()` in `cmake/therock_subproject.cmake` calls
+`therock_coverage_get_subproject_args()`:
+
+```mermaid
+flowchart LR
+    A["sub-project activates"] --> B{"PROJECT_ENABLE_COVERAGE<br/>explicitly defined?"}
+    B -->|yes| C["use verbatim<br/>an explicit OFF opts one<br/>component out of a group flag"]
+    B -->|no| D{"EXTERNAL_SOURCE_DIR<br/>under which monorepo?"}
+    D -->|rocm-libraries| E{"ROCM_LIBRARIES_ALL?"}
+    D -->|rocm-systems| F{"ROCM_SYSTEMS_ALL?"}
+    D -->|"in-tree / third-party"| G["never instrumented"]
+    E -->|ON| H
+    F -->|ON| H
+    E -->|OFF| G
+    F -->|OFF| G
+    C -->|ON| H["append ON to THIS sub-project only:<br/>HIPRAND_ENABLE_COVERAGE<br/>BUILD_CODE_COVERAGE<br/>CODE_COVERAGE"]
+    C -->|OFF| G
+
+    style H fill:#fff4e5,stroke:#f9a825
+    style G fill:#eeeeee,stroke:#999999
+```
+
+Monorepo membership comes from the sub-project's `EXTERNAL_SOURCE_DIR` rather
+than a declared list, so components moving between monorepos need no
+bookkeeping. `amd-llvm` and third-party sources fall through to "never
+instrumented": they cost build time and contribute nothing to a component
+report.
+
+The two legacy option names are what hipRAND and rocRAND read today. Passing
+them is safe **only** because these arguments reach one sub-project's configure
+command; a super-build-wide `-DBUILD_CODE_COVERAGE=ON` would be read by every
+project that defines it, which is the cross-contamination the design exists to
+prevent.
+
+## 6. Selecting what to test
+
+| File                                                      | Role                                             |
+| --------------------------------------------------------- | ------------------------------------------------ |
+| `.github/workflows/test_artifacts.yml`                    | Threads `coverage_enabled` to the component jobs |
+| `build_tools/github_actions/fetch_test_configurations.py` | Resolves `test_labels` into component jobs       |
+
+`coverage_nightly.yml` passes `coverage_enabled: true` and pins
+`test_type: full`, since coverage measured against a partial suite understates
+a component. With `test_labels: hiprand`, `fetch_test_configurations.py`
+resolves to a single component job named `hiprand` with fetch arguments
+`--rand --tests`.
+
+The sanity check job also runs but is not given `coverage_enabled`: it only
+proves the artifacts are usable, so there is nothing worth reporting.
+
+## 7. Running tests and capturing profraw
+
+**File:** `.github/workflows/test_component.yml` (job `test_component`), via
+`.github/actions/setup_test_environment` → `build_tools/install_rocm_from_artifacts.py`
+
+Each shard, on a `gfx942` runner:
+
+1. Fetches artifacts for run `99999` — instrumented hipRAND plus the copied
+   clean dependencies, one coherent stack.
+
+1. Sets `LLVM_PROFILE_FILE` **before any test runs**, since that variable is
+   the only thing telling the profile runtime where to write:
+
+   ```
+   $GITHUB_WORKSPACE/coverage-report/profraw/hiprand-shard1-%p-%m.profraw
+   ```
+
+   `%p` (pid) and `%m` (binary signature) are expanded by the profile runtime
+   and keep concurrent test processes from overwriting each other. The shard
+   index keeps this shard's files distinct once every shard's files are
+   downloaded into one directory.
+
+1. Runs the component's test script. Instrumented code writes a `.profraw` per
+   process on exit.
+
+1. Uploads the directory **unmerged** as
+   `coverage-profraw-hiprand-gfx94X-dcgpu-shard1`, with
+   `if-no-files-found: error`.
+
+Merging on the shard would produce a report reflecting only that shard's slice
+of the suite: for a five-shard component, roughly 20% no matter how thorough
+the tests are. The upload step uses `if: !cancelled()` so counters from a
+failing test run are still collected.
+
+## 8. Merging and reporting
+
+**Files:** `.github/workflows/test_component.yml` (job `coverage_report`) →
+`build_tools/github_actions/coverage_report.py` →
+`build_tools/github_actions/github_actions_api.py`
+
+The job depends on the whole shard matrix, because a component's coverage is
+only complete once every shard has reported, and it needs no GPU — it only
+reads files. It runs `setup_test_environment` again for two reasons: the
+instrumented binaries are the objects the report is generated against, and that
+build's `llvm-profdata` / `llvm-cov` are the only tools guaranteed to
+understand the profile format those binaries emitted. Both tools arrive with
+`amd-llvm_run`, which is in the always-fetched base artifact set in
+`install_rocm_from_artifacts.py` and includes `lib/llvm/bin/**`.
+
+Shard artifacts are downloaded with `pattern: ...-shard*` and
+`merge-multiple: true`, landing in one directory. Then `coverage_report.py`:
+
+| Step                      | Detail                                                                          |
+| ------------------------- | ------------------------------------------------------------------------------- |
+| `find_llvm_tool`          | Prefers `build/lib/llvm/bin`, falls back to `PATH` for local runs               |
+| `collect_profraw_files`   | Non-empty `*.profraw` recursively; **raises if none found**                     |
+| `merge_profraw`           | `llvm-profdata merge -sparse` → `coverage.profdata`                             |
+| `discover_objects`        | Prefers `lib/libhiprand.so`; falls back to `bin/hipRAND/test_*` for header-only |
+| `run_llvm_cov`            | `export --format=lcov` → `coverage.info`, then `report` → `coverage.txt`        |
+| `gha_append_step_summary` | Posts the `TOTAL` line to the job summary                                       |
+
+Two behaviors are deliberate. Missing profraw **fails** the job, because
+instrumentation that produced no counters would otherwise be published as 0%
+rather than reported as a problem. And `--ignore-filename-regex` drops
+`/test/`, `/tests/`, `/googletest/`, `/benchmark/`, and `/_deps/`, so a
+component cannot raise its coverage by adding test code.
+
+`COMPONENT_TEST_DIR_OVERRIDES` in the script maps job names to install
+directories where they differ, which is why `hiprand` finds its binaries under
+`bin/hipRAND`. Only mismatches need an entry.
+
+The result uploads as `coverage-report-hiprand-gfx94X-dcgpu`, holding
+`coverage.info` (lcov) and `coverage.txt`, retained 14 days. Forwarding to a
+coverage service is out of scope; RFC0014 leaves the choice of service open.
+
+## File index
+
+| File                                                              | Change                                                      |
+| ----------------------------------------------------------------- | ----------------------------------------------------------- |
+| `.github/workflows/coverage_nightly.yml`                          | new                                                         |
+| `.github/workflows/multi_arch_build_portable_linux.yml`           | `extra_cmake_options` input, forwarded to stage jobs        |
+| `.github/workflows/multi_arch_build_portable_linux_artifacts.yml` | `extra_cmake_options` appended to configure                 |
+| `.github/workflows/test_artifacts.yml`                            | `coverage_enabled` input, threaded to components            |
+| `.github/workflows/test_component.yml`                            | profraw capture and upload, `coverage_report` job           |
+| `CMakeLists.txt`                                                  | include + `therock_coverage_init()`, profile runtime option |
+| `CMakePresets.json`                                               | `linux-release-coverage` preset                             |
+| `cmake/therock_coverage.cmake`                                    | new: request normalization and per-project decision         |
+| `cmake/therock_subproject.cmake`                                  | passthrough into the measured sub-project                   |
+| `compiler/CMakeLists.txt`                                         | `COMPILER_RT_BUILD_PROFILE_ROCM` to `amd-llvm`              |
+| `build_tools/github_actions/amdgpu_family_matrix.py`              | `coverage` variant, enabled for `gfx94x` and `gfx950`       |
+| `build_tools/github_actions/configure_multi_arch_ci.py`           | disables packaging for coverage builds                      |
+| `build_tools/github_actions/coverage_report.py`                   | new: merge and export                                       |
+| `build_tools/github_actions/tests/coverage_report_test.py`        | new: 14 tests                                               |
+| `docs/development/code_coverage.md`                               | new: concepts and usage                                     |
+| `docs/development/code_coverage_flow.md`                          | new: this page                                              |
+
+## Debugging a failed run
+
+| Symptom                                      | Look at                                                                                                                                           |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Report is 0% or nearly empty                 | Was the component instrumented? `therock_coverage.cmake` logs `ENABLE CODE COVERAGE: <target>` per instrumented sub-project in the configure log. |
+| `No non-empty .profraw files found`          | `LLVM_PROFILE_FILE` versus the upload path in `test_component.yml`, or the binaries were never instrumented                                       |
+| `Found neither lib<c>.so nor test binaries`  | `COMPONENT_TEST_DIR_OVERRIDES` in `coverage_report.py`, or the fetch arguments from `fetch_test_configurations.py`                                |
+| `Could not find llvm-profdata`               | Whether `amd-llvm_run` was fetched; see `install_rocm_from_artifacts.py`                                                                          |
+| Test job cannot find a library at runtime    | A stage missing from both `prebuilt_stages` and the built stage, so it is in neither half of the hybrid stack                                     |
+| `llvm-cov` reports a profile format mismatch | Tools and binaries came from different builds; the report job must fetch the same run id the tests did                                            |
+| Device code shows no coverage                | Expected with the default `prebuilt_stages`; see the limitations in [Code Coverage](code_coverage.md)                                             |


### PR DESCRIPTION
## Motivation

Implements the **phase 1 proof of concept** from [RFC0014](https://github.com/ROCm/TheRock/pull/6967), and only that:

> Phase 1 (PoC): Option B1 — Separate workflow, manual `baseline_run_id` input

The goal is to prove the instrumented build and coverage reporting work end to end in isolation, using hipRAND as the component. Scope is deliberately held to:

- **Host-side coverage.** Device-side counters need the compiler-rt profile runtime, which is a later phase. hipRAND's own code is host code.
- **One default architecture**, `gfx94x` / `gfx942`.
- **`baseline_run_id` supplied by hand** at dispatch time, from a successful regular nightly. Manual coordination is acceptable for initial validation.
- **No changes to the production nightly.** `coverage_nightly.yml` is `workflow_dispatch` only and nothing triggers it automatically, so it can fail, be retried, or be abandoned with no effect on production CI. Nothing runs on presubmit.

## Technical Details

**Coverage is requested per project, never through one shared option.** Instrumented code emits `.profraw` counters whenever it runs, so instrumenting a dependency of the component under test folds that dependency's counters into the report and lets an unrelated upstream change move the component's denominator. A single shared option name cannot express that scoping, which is why the existing rocm-libraries `BUILD_CODE_COVERAGE` / `CODE_COVERAGE` options are not simply set globally.

`cmake/therock_coverage.cmake` resolves the RFC's three request forms into per-project options that `therock_subproject.cmake` appends to only the sub-project being measured:

| Request | Intended caller |
| --- | --- |
| `-DHIPRAND_ENABLE_COVERAGE=ON` | local builds |
| `-DTHEROCK_COVERAGE_PROJECTS=hiprand,rocFFT` | CI, matched case-insensitively |
| `-DTHEROCK_COVERAGE_ROCM_LIBRARIES_ALL=ON`, `..._ROCM_SYSTEMS_ALL`, `THEROCK_COVERAGE_ALL` | nightly runs |

The case-insensitive list exists because CI forwards detected project names in whatever casing the source used (`hiprand`, `rocFFT`, `hipBLASLt`). The two monorepo flags are independent so a nightly can instrument the libraries without paying to instrument the ROCm system stack, and neither touches in-tree or third-party sub-projects. A sub-project's monorepo comes from its `EXTERNAL_SOURCE_DIR`, so components moving between monorepos need no bookkeeping. An explicit `-DHIPRAND_ENABLE_COVERAGE=OFF` overrides a monorepo flag, so one misbehaving component can be excluded without abandoning the group flag.

**Workflow.** `coverage_nightly.yml` is separate from the regular nightly: instrumented binaries are not what gets shipped or benchmarked, coverage is slow enough that it should fail independently, and a separate run id puts its artifacts in their own S3 namespace (`multi-arch-coverage`). It assembles a hybrid stack by copying the baseline nightly's non-instrumented stages into its own run id and building only the instrumented stage on top, so test jobs fetch a complete stack from one run id and need no coverage-specific artifact logic.

**Aggregation.** `test_component.yml` gains a `coverage_enabled` input. Each shard writes profraw to a per-shard, per-process path and uploads it unmerged; one report job per component then merges across every shard, since a per-shard report would only reflect that shard's slice of the suite. `coverage_report.py` prefers a component's shared library as the reporting object and falls back to test binaries for header-only components, where `llvm-cov`'s `-object` flag requires each binary listed separately. Missing profraw fails the job rather than publishing a misleading 0%.

Coverage builds skip Python wheels, PyTorch, JAX, and distro packages, since only the coverage test and report jobs consume these artifacts.

### One deviation from the RFC

The RFC's coverage preset sets `THEROCK_FLAG_KPACK_SPLIT_ARTIFACTS=OFF`. I left it at the default `ON`: the hybrid stack copies the baseline nightly's stages, which are split, so disabling splitting in the coverage run would have the test jobs look for non-split artifacts that do not exist. Documented in `docs/development/code_coverage.md`.

## Test Plan

No GPU was available, so this covers the build-independent logic only; the first dispatched run is what validates the instrumented build itself.

- CMake request resolution across 6 flag combinations: direct per-project, case-insensitive list (`hiprand` and `hipRAND`), each monorepo flag, `THEROCK_COVERAGE_ALL`, explicit per-project opt-out overriding a group flag, and no flags at all.
- `coverage_report_test.py`, 14 new tests: shared-library and header-only object discovery, discovery overrides, and the missing-profraw and missing-binary failure paths, using stub LLVM tools.
- Full `build_tools/github_actions/tests` suite.
- `configure_multi_arch_ci.py` with `BUILD_VARIANT=coverage`, then `fetch_test_configurations.py` on its output, to confirm the generated config end to end.
- `actionlint` (with the repo's own ignore arguments) on all changed workflows, plus `mdformat` and `black`.

## Test Result

CMake resolution is correct in all 6 combinations: `hiprand` and `hipRAND` both yield `-DHIPRAND_ENABLE_COVERAGE=ON`, the group flag instruments hipRAND and rocRAND but not `rocprofiler-sdk` or `amd-llvm`, `THEROCK_COVERAGE_ALL` adds `rocprofiler-sdk`, and the explicit opt-out suppresses hipRAND while leaving rocRAND instrumented. All 14 coverage report tests pass. The `build_tools` suite passes 912 tests with 1 pre-existing failure in an unrelated ccache test, confirmed to fail identically with these changes stashed.

The generated coverage config resolves to: `artifact_group=multi-arch-coverage`, preset `linux-release-coverage`, a single family (`gfx94X-dcgpu` / `gfx942`), a real GPU test runner, `build_python_packages`/`build_pytorch`/`build_jax`/`build_native_linux` all disabled, `baseline_run_id` preserved, and every stage prebuilt except math-libs. Test selection from that config narrows to `hiprand` alone, fetching `--rand --tests`.

Unvalidated until a real dispatch, hence draft: that the instrumented build links and completes, and that profraw files appear where the report job expects them.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
