### PR TITLE
debug-tools: Add GoogleTest dependency for rocr-debug-agent-tests

### DIFF
--- a/debug-tools/CMakeLists.txt
+++ b/debug-tools/CMakeLists.txt
@@ -213,6 +213,8 @@ if(THEROCK_ENABLE_ROCR_DEBUG_AGENT_TESTS)
         "-DHIP_PLATFORM=amd"
       COMPILER_TOOLCHAIN
         amd-hip
+      BUILD_DEPS
+        therock-googletest
       RUNTIME_DEPS
         amd-dbgapi
         hip-clr

--- a/test_tools/therock_consumer_graph.json
+++ b/test_tools/therock_consumer_graph.json
@@ -658,6 +658,7 @@
       "rocblas",
       "rocfft",
       "rocprim_tests",
+      "rocr-debug-agent-tests",
       "rocrand",
       "rocroller",
       "rocshmem",


### PR DESCRIPTION
The rocr-debug-agent unit tests use GoogleTest for testing. Add therock-googletest to RUNTIME_DEPS so the dependency provider can resolve find_package(GTest) calls.

Related PR: https://github.com/ROCm/rocm-systems/pull/9721

JIRA ID : AIROCGDB-635
