### PR TITLE
fix(asan): include HIP in sanitizer link-flag LINK_LANGUAGE check

### DIFF
--- a/cmake/therock_sanitizers.cmake
+++ b/cmake/therock_sanitizers.cmake
@@ -64,8 +64,15 @@ function(therock_sanitizer_configure
     # Only enable sanitizers for C/C++ for now. Include fortran once the toolchain
     # is available and can be used for portable builds.
     # https://github.com/ROCm/TheRock/issues/1782
-    string(APPEND _stanza "add_link_options($<$<LINK_LANGUAGE:C,CXX>:-fsanitize=${_sanitizer_string}>\n")
-    string(APPEND _stanza "  $<$<AND:$<LINK_LANGUAGE:C,CXX>,$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>>:-shared-libsan>)\n")
+    # LINK_LANGUAGE must include HIP: any target that gains a HIP-language
+    # source (e.g. a .hip test file) has its LINKER_LANGUAGE flipped to HIP by
+    # CMake, even when most of its sources are C/C++. Omitting HIP here would
+    # silently drop the sanitizer link flags for such targets while their C/C++
+    # objects are still compiled with -fsanitize=, producing undefined
+    # __asan_*/__tsan_* symbols at link time.
+    # See https://github.com/ROCm/TheRock/issues/7979
+    string(APPEND _stanza "add_link_options($<$<LINK_LANGUAGE:C,CXX,HIP>:-fsanitize=${_sanitizer_string}>\n")
+    string(APPEND _stanza "  $<$<AND:$<LINK_LANGUAGE:C,CXX,HIP>,$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>>:-shared-libsan>)\n")
     # Fix FindThreads detection under ASAN. The threads probe is a try_compile
     # that inherits CMAKE_C/CXX_FLAGS_INIT (-fsanitize) but NOT the directory
     # add_link_options() above, so it never sees -shared-libsan and links clang's


### PR DESCRIPTION
Include HIP in sanitizer link-flag LINK_LANGUAGE check

## Motivation

ASAN/HOST_ASAN/TSAN builds fail with dozens of `undefined symbol: __asan_*`
link errors for any target that has a mix of C/C++ and HIP sources —
first observed in `hipfile_system_tests` after a `.hip` test file was
added to it (rocm-systems bump 5bdcd35→5ea42aa, #7862).

Confirmed directly against TheRock's own CI: the identical failure occurs
under the plain `asan` variant (not just `asan-debug`) — see
[PR #7930](https://github.com/ROCm/TheRock/pull/7930)'s
`Linux::asan / Build Multi-Arch Stages / storage-libs` job.

ISSUE ID : https://github.com/ROCm/TheRock/issues/7979

## Technical Details

`cmake/therock_sanitizers.cmake` attaches the sanitizer link flags via:

```cmake
add_link_options($<$<LINK_LANGUAGE:C,CXX>:-fsanitize=${_sanitizer_string}>
  $<$<AND:$<LINK_LANGUAGE:C,CXX>,$<OR:$<CXX_COMPILER_ID:Clang>,...>>:-shared-libsan>)
```
CMake sets a target's LINKER_LANGUAGE property based on which language's
linker preference wins among its sources — and per ROCm's own CMake docs,
adding any HIP source to a target flips LINKER_LANGUAGE to HIP,
even when the target is otherwise all .cpp. Since HIP wasn't included
in the $<LINK_LANGUAGE:C,CXX> generator expression, the sanitizer link
flags (-fsanitize=, -shared-libsan) silently stopped applying to any
such target — while its .cpp objects were still compiled with
-fsanitize= (compile flags are set unconditionally via
CMAKE_CXX_FLAGS_INIT, not gated by link language). The result: ASAN-
instrumented objects linked without the ASAN runtime, producing undefined
__asan_* symbols at link time.

**Fix**: 
widen both generator expressions to
`$<LINK_LANGUAGE:C,CXX,HIP>`, so targets whose linker language is HIP
still get the sanitizer link flags.

## Test plan
- Run asan relase job and confirm the storage link error is fixed. https://github.com/ROCm/TheRock/actions/runs/34153675267