### PR TITLE
feat(profiler): Wire hipFile as a rocprofiler-systems dependency

### DIFF
--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -831,7 +831,7 @@ disable_platforms = ["windows"]
 [artifacts.rocprofiler-systems]
 artifact_group = "profiler-apps"
 type = "target-neutral"
-artifact_deps = ["amd-llvm", "core-hip", "rocprofiler-sdk", "core-amdsmi", "spdlog", "openmpi"]
+artifact_deps = ["amd-llvm", "core-hip", "rocprofiler-sdk", "core-amdsmi", "hipfile", "spdlog", "openmpi"]
 feature_name = "ROCPROFSYS"
 feature_group = "PROFILER"
 disable_platforms = ["windows"]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -506,8 +506,9 @@ add_subdirectory(debug-tools)
 # performs optional find_package(rocdecode)/find_package(rocjpeg) for trace
 # feature detection.
 add_subdirectory(media-libs)
-# storage-libs (hipfile) must be added before profiler: rocprofiler-sdk performs
-# optional find_package(hipfile) for hipFILE trace feature detection.
+# storage-libs (hipfile) must be added before profiler: rocprofiler-sdk and
+# rocprofiler-systems both find_package(hipfile) (SDK for API tracing; systems
+# for optional GPU-direct storage I/O telemetry when the package is usable).
 add_subdirectory(storage-libs)
 # Note that rocprofiler-register is in base and is what higher level clients
 # depend on. The profiler itself is independent.

--- a/build_tools/install_rocm_from_artifacts.py
+++ b/build_tools/install_rocm_from_artifacts.py
@@ -550,6 +550,11 @@ def retrieve_artifacts_by_run_id(args):
             if args.tests:
                 # Tests need version.h for rocprofiler-sdk version detection.
                 argv.append("rocprofiler-sdk_dev")
+            # librocprof-sys.so DT_NEEDED libhipfile.so.0 once hipFile telemetry
+            # is compiled in. Not implied by --rocprofiler-systems-examples:
+            # those samples skip at configure when hipFile is missing.
+            extra_artifacts.append("hipfile")
+            extra_artifacts.append("sysdeps-util-linux")
         if args.rocprofiler_systems_examples:
             # Only a _test artifact is produced
             argv.append("rocprofiler-systems-examples_test")

--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -1624,12 +1624,14 @@
       "amdrocm-runtime",
       "amdrocm-sysdeps",
       "amdrocm-amdsmi",
+      "amdrocm-hipfile",
       "amdrocm-profiler-base"
     ],
     "RPMRequires": [
       "amdrocm-runtime",
       "amdrocm-sysdeps",
       "amdrocm-amdsmi",
+      "amdrocm-hipfile",
       "amdrocm-profiler-base"
     ],
     "Maintainer": "ROCm Dev Support <rocm-dev.support@amd.com>",
@@ -1700,12 +1702,14 @@
       "amdrocm-runtime",
       "amdrocm-sysdeps",
       "amdrocm-amdsmi",
+      "amdrocm-hipfile",
       "amdrocm-profiler-base"
     ],
     "RPMRequires": [
       "amdrocm-runtime",
       "amdrocm-sysdeps",
       "amdrocm-amdsmi",
+      "amdrocm-hipfile",
       "amdrocm-profiler-base"
     ],
     "Maintainer": "ROCm Dev Support <rocm-dev.support@amd.com>",

--- a/build_tools/tests/install_rocm_from_artifacts_test.py
+++ b/build_tools/tests/install_rocm_from_artifacts_test.py
@@ -429,5 +429,20 @@ class TestDebugToolsAmdLlvmDev(unittest.TestCase):
         self.assertIn("amd-llvm_dev", argv)
 
 
+class TestRocprofilerSystemsHipfile(unittest.TestCase):
+    """librocprof-sys.so DT_NEEDED libhipfile.so.0."""
+
+    def test_rocprofiler_systems_includes_hipfile(self) -> None:
+        argv = _captured_fetch_argv(_make_run_id_args(rocprofiler_systems=True))
+        self.assertIn("hipfile_lib", argv)
+        self.assertIn("sysdeps-util-linux_lib", argv)
+
+    def test_rocprofiler_systems_examples_does_not_imply_hipfile(self) -> None:
+        argv = _captured_fetch_argv(
+            _make_run_id_args(rocprofiler_systems_examples=True)
+        )
+        self.assertNotIn("hipfile_lib", argv)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -323,6 +323,17 @@ if(THEROCK_ENABLE_ROCPROFSYS)
     set(_rocprofsys_build_libiberty ON)
   endif()
 
+  # hipFile telemetry: ROCPROFSYS_USE_HIPFILE is ON/OFF/AUTO. TheRock uses ON
+  # when hipFile is enabled so a missing or too-old package fails configure
+  # instead of silently dropping support. Only declare the subproject dep when
+  # hipFile is enabled; otherwise CMake would fail looking up a missing target.
+  set(_rocprofiler_systems_hipfile_dep)
+  set(_rocprofsys_use_hipfile OFF)
+  if(THEROCK_ENABLE_HIPFILE)
+    set(_rocprofiler_systems_hipfile_dep hipfile)
+    set(_rocprofsys_use_hipfile ON)
+  endif()
+
   therock_cmake_subproject_declare(rocprofiler-systems
     USE_DIST_AMDGPU_TARGETS
     EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rocprofiler-systems"
@@ -340,7 +351,7 @@ if(THEROCK_ENABLE_ROCPROFSYS)
       -DROCPROFSYS_BUILD_FMT=OFF
       -DROCPROFSYS_BUILD_SPDLOG=OFF
       -DROCPROFSYS_BUILD_SQLITE3=OFF
-      -DROCPROFSYS_BUILD_HIPFILE=AUTO
+      -DROCPROFSYS_USE_HIPFILE="${_rocprofsys_use_hipfile}"
       -DROCPROFSYS_USE_PYTHON="${_ROCPROFSYS_USE_PYTHON}"
       -DROCPROFSYS_PYTHON_VERSIONS:STRING="${_ROCPROFSYS_PYTHON_VERSIONS_STR}"
       -DROCPROFSYS_PYTHON_ROOT_DIRS:STRING="${_ROCPROFSYS_PYTHON_ROOT_DIRS_STR}"
@@ -361,7 +372,6 @@ if(THEROCK_ENABLE_ROCPROFSYS)
       amdsmi
       aqlprofile
       hip-clr
-      hipfile
       rocprofiler-register
       rocprofiler-sdk
       ${THEROCK_BUNDLED_LIBIBERTY}
@@ -369,6 +379,7 @@ if(THEROCK_ENABLE_ROCPROFSYS)
       ${THEROCK_BUNDLED_LIBDRM}
       ${THEROCK_BUNDLED_SQLITE3}
       ${_openmpi_optional_dep}
+      ${_rocprofiler_systems_hipfile_dep}
   )
   therock_cmake_subproject_glob_c_sources(rocprofiler-systems
     SUBDIRS .
@@ -389,9 +400,9 @@ if(THEROCK_ENABLE_ROCPROFSYS)
       test
     SUBPROJECT_DEPS
       amdsmi
-      hipfile
       rocprofiler-sdk
       rocprofiler-systems
+      ${_rocprofiler_systems_hipfile_dep}
     )
 
 
@@ -421,15 +432,13 @@ if(THEROCK_ENABLE_ROCPROFSYS)
         "lib"
         "lib/rocprofiler-systems"
         "lib/llvm/lib"
-      # hipfile is already provide_package'd (storage-libs is added before profiler).
-      # Without IGNORE_PACKAGES, find_package(hipfile) in examples/hipfile is a
-      # strict-provider fatal instead of the same skip-if-missing path used for
-      # rocdecode, rocJPEG, RCCL, etc. Do not declare hipfile as a RUNTIME_DEP.
-      IGNORE_PACKAGES
-        hipfile
-        HIPFILE
+      # When hipFile is enabled, declare it so find_package(hipfile) in
+      # examples/hipfile resolves from the super-project and the sample is
+      # built. Leaving it undeclared would either fatal (strict provider) or
+      # skip the sample; pytest then skips hipfile-io / hipfile-trace.
       RUNTIME_DEPS
         rocprofiler-systems
+        ${_rocprofiler_systems_hipfile_dep}
     )
     therock_cmake_subproject_glob_c_sources(rocprofiler-systems-examples
       SUBDIRS .

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -340,6 +340,7 @@ if(THEROCK_ENABLE_ROCPROFSYS)
       -DROCPROFSYS_BUILD_FMT=OFF
       -DROCPROFSYS_BUILD_SPDLOG=OFF
       -DROCPROFSYS_BUILD_SQLITE3=OFF
+      -DROCPROFSYS_BUILD_HIPFILE=AUTO
       -DROCPROFSYS_USE_PYTHON="${_ROCPROFSYS_USE_PYTHON}"
       -DROCPROFSYS_PYTHON_VERSIONS:STRING="${_ROCPROFSYS_PYTHON_VERSIONS_STR}"
       -DROCPROFSYS_PYTHON_ROOT_DIRS:STRING="${_ROCPROFSYS_PYTHON_ROOT_DIRS_STR}"
@@ -360,6 +361,7 @@ if(THEROCK_ENABLE_ROCPROFSYS)
       amdsmi
       aqlprofile
       hip-clr
+      hipfile
       rocprofiler-register
       rocprofiler-sdk
       ${THEROCK_BUNDLED_LIBIBERTY}
@@ -387,6 +389,7 @@ if(THEROCK_ENABLE_ROCPROFSYS)
       test
     SUBPROJECT_DEPS
       amdsmi
+      hipfile
       rocprofiler-sdk
       rocprofiler-systems
     )
@@ -418,6 +421,13 @@ if(THEROCK_ENABLE_ROCPROFSYS)
         "lib"
         "lib/rocprofiler-systems"
         "lib/llvm/lib"
+      # hipfile is already provide_package'd (storage-libs is added before profiler).
+      # Without IGNORE_PACKAGES, find_package(hipfile) in examples/hipfile is a
+      # strict-provider fatal instead of the same skip-if-missing path used for
+      # rocdecode, rocJPEG, RCCL, etc. Do not declare hipfile as a RUNTIME_DEP.
+      IGNORE_PACKAGES
+        hipfile
+        HIPFILE
       RUNTIME_DEPS
         rocprofiler-systems
     )

--- a/storage-libs/CMakeLists.txt
+++ b/storage-libs/CMakeLists.txt
@@ -36,6 +36,9 @@ if(THEROCK_ENABLE_HIPFILE)
     SUBDIRS
       src
   )
+  # Consumers call find_package(hipfile); advertise HIPFILE as well for the same
+  # reason hip-clr advertises both hip and HIP.
+  therock_cmake_subproject_provide_package(hipfile hipfile lib/cmake/hipfile)
   therock_cmake_subproject_provide_package(hipfile HIPFILE lib/cmake/hipfile)
   therock_cmake_subproject_activate(hipfile)
   list(APPEND _hipfile_subproject_names hipfile)

--- a/test_tools/therock_consumer_graph.json
+++ b/test_tools/therock_consumer_graph.json
@@ -181,7 +181,8 @@
   },
   "hipfile": {
     "consumers": [
-      "rocprofiler-sdk"
+      "rocprofiler-sdk",
+      "rocprofiler-systems"
     ]
   },
   "hipify": {


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

<!-- Most pull requests should be associated with at least one GitHub issue -->

<!-- GitHub issue: https://github.com/ROCm/TheRock/issues/1234 -->
rocprofiler-systems compiles in GPU-direct storage I/O telemetry when hipFile is present (`ROCPROFSYS_USE_HIPFILE=ON`). It find_packages hipFile for `<hipfile.h>` and the `≥ 0.5.0` gate; it does not DT_NEEDED libhipfile.so.0. The collector dlopens `libhipfile.so.0` on first sample. The storage telemetry capability is built always and the runtime checks are performed at first sample.

hipFile is its own `storage-libs` artifact, not part of the shared test-prefix base set, so TheRock must declare, fetch, and stage it like other non-base deps.

This PR is the TheRock wiring. Merge it before ([ROCm/rocm-systems#10630](https://github.com/ROCm/rocm-systems/pull/10630)) lands in TheRock via a submodule bump; otherwise find_package(hipfile) hits the strict provider.

JIRA ID: AIPROFSYST-710
Roadmap: ROCM-150
Super epic: ROCM-4010

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

- Advertise `find_package(hipfile)` from the hipFile subproject (`provide_package` for both `hipfile` and `HIPFILE`), matching hip-clr’s `hip` / `HIP`.
- When `THEROCK_ENABLE_HIPFILE` is on, add `hipfile` as a `RUNTIME_DEP` of `rocprofiler-systems` and `rocprofiler-systems-examples`, and as an artifact `SUBPROJECT_DEPS` entry. Pass `-DROCPROFSYS_USE_HIPFILE=ON` so a missing or too-old package fails configure instead of silently dropping telemetry. When hipFile is off, pass `OFF`.
- Topology: `rocprofiler-systems` `artifact_deps` includes `hipfile`; the `profiler-apps` group depends on `storage-libs`. Linux CI `profiler-apps` `needs: storage-libs` so `hipFile` is fetched from that stage instead of rebuilt in parallel.
- `amdrocm-profiler` package does not `Requires: amdrocm-hipfile` and `amdrocm-profiler-test` `Requires: amdrocm-hipfile` so telemetry feature is not missed from the test artifact. 
- Record `hipfile` → `rocprofiler-sdk`, `rocprofiler-systems`, and `rocprofiler-systems-examples` in `therock_consumer_graph.json` (generated from those `RUNTIME_DEPS`).

Note:
- hipFile is not in `base_artifact_pattern` (`storage-libs` / `hipfile_lib`, not `profiler-core`). `--rocprofiler-systems` therefore appends `hipfile` and `sysdeps-util-linux` so tests can dlopen `hipFile` (hipFile itself `DT_NEEDED`s `librocm_sysdeps_mount.so.1`). Examples-only fetch still does not imply hipFile.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
