### PR TITLE
[bkc] Set base-date to 20260908

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "rocm-version": "10.1.0",
   "release-metadata": {
-    "base-date": ""
+    "base-date": "20260908"
   }
 }


### PR DESCRIPTION
## Motivation

The next BKC release branch is cut and this sets the `base-date` accordingly to create the correct version.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
