### PR TITLE
fix(ci): add missing trailing comma in skip_tests dict

### DIFF
--- a/external-builds/pytorch/skip_tests/generic.py
+++ b/external-builds/pytorch/skip_tests/generic.py
@@ -299,7 +299,7 @@ skip_tests = {
             # The callstack for this one points to _fill_mem_eff_dropout_mask, so it may be related to aotriton?
             "test_cublas_config_nondeterministic_alert_cuda",
             # Large test that isn't very CI-friendly (takes ~2 seconds, possibly hanging)
-            "test_memory_format_operators_cuda"
+            "test_memory_format_operators_cuda",
             # Flaky tests hanging on some gfx1151 machines...
             # Maybe memory pressure? Tests use some large tensors:
             #   v = torch.FloatTensor([64000., 32., 64000.])


### PR DESCRIPTION
 ## Summary
 Add a missing trailing comma after `"test_memory_format_operators_cuda"` in  `external-builds/pytorch/skip_tests/generic.py`.

Without the trailing comma, the string literal silently concatenated with the  comment on the next line is avoided, but more practically this fixes a syntax inconsistency that could cause a Python parse error or incorrect dict entries if  lines are reordered or new entries are added adjacent to this one.
  
## Changes  

- `external-builds/pytorch/skip_tests/generic.py`: add trailing comma after `"test_memory_format_operators_cuda"` entry in `skip_tests` dict.

GitHub issue: https://github.com/ROCm/TheRock/issues/7997


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
