### PR TITLE
[Quartz] Adjust reporting_workflow for rename of jax test workflow 

### DIFF
--- a/.github/workflows/test_multi_arch_linux_jax_wheels.yml
+++ b/.github/workflows/test_multi_arch_linux_jax_wheels.yml
@@ -235,7 +235,7 @@ jobs:
         shell: bash
 
     env:
-      QUARTZ_REPORTING_WORKFLOW: test_linux_jax_wheels_partial.yml
+      QUARTZ_REPORTING_WORKFLOW: test_multi_arch_linux_jax_wheels.yml
       QUARTZ_WORKFLOW_POSTFIX: "- test JAX wheels (partial)"
       VIRTUAL_ENV: ${{ github.workspace }}/.venv
       PYTHON_VERSION: ${{ inputs.python_version }}


### PR DESCRIPTION
Jax testing workflow was renamed in #6558 from `test_linux_jax_wheels_partial.yml` to `test_multi_arch_linux_jax_wheels.yml`. However this change was never propagated to the quartz notify step. 