### PR TITLE
fix(test-selection): promote TensileLite to a synthetic consumer-graph node

### DIFF
--- a/test_tools/determine_rocm_test_dependencies.py
+++ b/test_tools/determine_rocm_test_dependencies.py
@@ -11,7 +11,11 @@ that directly depend on it.
 
 Algorithm
 ---------
-1. Load the consumer graph.
+1. Load the consumer graph, merging in any synthetic subprojects declared in
+   test_policies.toml's `[synthetic.<name>]` tables -- projects with no CMake
+   target (e.g. TensileLite) but real test couplings the graph cannot express.
+   Once merged, a synthetic subproject is an ordinary node: same BFS walk, same
+   validation, no special-casing elsewhere in this module.
 2. For each changed subproject, walk its `consumers` edges to a depth set by the
    component's policy level (see the level ladder below).
 3. UNION the per-subproject walk results across all changed subprojects.
@@ -82,8 +86,12 @@ _EXTERNAL_SUBTREE_ALIASES = {
         "rocroller",
         "tensilelite",
     ],
-    "shared/origami": ["hipblas", "hipblaslt", "origami", "rocblas", "tensilelite"],
-    "shared/stinkytofu": ["hipblas", "hipblaslt", "rocblas", "tensilelite"],
+    # hipblaslt/rocblas/hipblas are reachable transitively from "tensilelite"
+    # itself now that TensileLite is a synthetic consumer-graph node (see
+    # _load_synthetic_subprojects below) with level 3 (unbounded) in
+    # test_policies.toml -- no need to hand-list them here too.
+    "shared/origami": ["origami", "tensilelite"],
+    "shared/stinkytofu": ["tensilelite"],
     "shared/tensile": ["hipblas", "rocblas"],
     "dnn-providers/cmake": ["hipdnn_integration_tests"],
     "dnn-providers/hipblaslt-provider": ["hipblasltprovider"],
@@ -107,10 +115,6 @@ _CI_TEST_SELECTOR_ALIASES = {
     "hipdnn_samples": ["hipdnn-samples"],
 }
 
-_TEST_ONLY_SELECTORS = {
-    "tensilelite",
-}
-
 
 def _test_tools_file(name: str, therock_dir: Path | None) -> Path:
     """Resolve a committed file under test_tools/.
@@ -130,10 +134,19 @@ def _consumer_graph_path(therock_dir: Path | None) -> Path:
 
 
 def _load_consumer_graph(therock_dir: Path | None = None) -> dict:
-    """Load the committed consumer graph JSON.
+    """Load the committed consumer graph JSON, plus synthetic subprojects.
 
     Read directly from test_tools/ — no configure, no source fetch. Freshness is
     enforced by the test_consumer_graph_drift.yml CI job.
+
+    Synthetic subprojects declared in test_policies.toml's `[synthetic.<name>]`
+    tables (see `_load_synthetic_subprojects`) are merged in here as ordinary
+    nodes, so every caller of this function -- the BFS walk, the "unrecognized
+    project" check, `validate_policies()`, `list_subprojects()` -- sees them
+    exactly like any CMake-derived project, with no special-casing elsewhere in
+    this module. The merge is additive (union of consumers) so it cannot
+    silently drop a real edge if a synthetic name ever collides with one added
+    to the real graph later.
     """
     graph_path = _consumer_graph_path(therock_dir)
     if not graph_path.exists():
@@ -144,7 +157,14 @@ def _load_consumer_graph(therock_dir: Path | None = None) -> dict:
             "...`) and copy build/therock_consumer_graph.json to "
             "test_tools/therock_consumer_graph.json."
         )
-    return json.loads(graph_path.read_text())
+    graph = json.loads(graph_path.read_text())
+
+    for name, consumers in _load_synthetic_subprojects(therock_dir).items():
+        node = graph.setdefault(name, {})
+        existing = node.get("consumers", [])
+        node["consumers"] = existing + [c for c in consumers if c not in existing]
+
+    return graph
 
 
 def _test_policies_path(therock_dir: Path | None) -> Path:
@@ -192,6 +212,40 @@ def _load_policies(therock_dir: Path | None = None) -> dict[str, dict]:
             "test_exclude": [c.lower() for c in body.get("test_exclude", [])],
         }
     return policies
+
+
+def _load_synthetic_subprojects(
+    therock_dir: Path | None = None,
+) -> dict[str, list[str]]:
+    """Return { name: [consumers] } for `[synthetic.<name>]` tables.
+
+    Synthetic subprojects have no CMake target (no consumer-graph node) but have
+    real test couplings the graph cannot express -- e.g. TensileLite, a kernel
+    generator + YAML corpus bundled inside hipblaslt (and a variant inside
+    hipsparselt) with no build target of its own. Declaring one here promotes it
+    into a normal graph node (merged in by `_load_consumer_graph`), so it
+    participates in the same BFS walk as every CMake-derived project. `consumers`
+    values are validated by `validate_policies()` against the merged graph, same
+    as any other cross-reference in this file.
+    """
+    policies_path = _test_policies_path(therock_dir)
+    if not policies_path.exists():
+        raise FileNotFoundError(
+            f"Test policy file not found at {policies_path}.\n"
+            "It is a committed file expected to be present in every checkout."
+        )
+    raw = tomllib.loads(policies_path.read_text())
+    synthetic = raw.get("synthetic", {})
+    if not isinstance(synthetic, dict):
+        raise ValueError(
+            "test_policies.toml: [synthetic] must be a table of "
+            "[synthetic.<name>] entries, not "
+            f"{type(synthetic).__name__}"
+        )
+    result: dict[str, list[str]] = {}
+    for name, body in synthetic.items():
+        result[name.lower()] = [c.lower() for c in body.get("consumers", [])]
+    return result
 
 
 def _level_for(policies: dict[str, dict], proj: str) -> int:
@@ -267,11 +321,10 @@ def get_subprojects_to_test(
 
     changed_lower = [p.lower() for p in changed_subprojects]
 
-    # Warn on unrecognized projects (typo guard).
+    # Warn on unrecognized projects (typo guard). `known` includes synthetic
+    # subprojects (e.g. tensilelite) since _load_consumer_graph merges them in.
     known = set(graph.keys())
-    unknown = [
-        p for p in changed_lower if p not in known and p not in _TEST_ONLY_SELECTORS
-    ]
+    unknown = [p for p in changed_lower if p not in known]
     if unknown:
         print(
             f"Warning: unrecognized project(s) {unknown}; "
@@ -353,10 +406,16 @@ def validate_policies(therock_dir: Path | None = None) -> tuple[bool, list[str]]
     FAILS (ok is False) if:
       * any `[component.<name>]` KEY is not a consumer-graph key — a stale /
         renamed / removed component that could never fire the selection. Each
-        offending key is listed.
+        offending key is listed. (`graph_keys` includes synthetic subprojects,
+        since `_load_consumer_graph` merges them in, so `[component.tensilelite]`
+        validates like any real component.)
       * any `level` is not an implemented level (a key of `_LEVEL_TO_DEPTH`).
         The range is derived from the engine, so validation can never bless a
         level the walk would silently coerce to the default.
+      * any `[synthetic.<name>]`'s `consumers` value is not itself a
+        consumer-graph key (real or another synthetic name) — almost always a
+        typo, since a synthetic edge to a nonexistent project silently walks
+        nowhere.
 
     Does NOT fail on `test_include` / `test_exclude` VALUES absent from the graph:
     those are legitimately test-only targets (ctest suites / tool targets like
@@ -365,6 +424,7 @@ def validate_policies(therock_dir: Path | None = None) -> tuple[bool, list[str]]
     """
     graph = _load_consumer_graph(therock_dir)
     policies = _load_policies(therock_dir)
+    synthetic = _load_synthetic_subprojects(therock_dir)
     graph_keys = set(graph.keys())
 
     errors: list[str] = []
@@ -374,6 +434,14 @@ def validate_policies(therock_dir: Path | None = None) -> tuple[bool, list[str]]
             f"stale component key '{key}': not a consumer-graph key "
             "(renamed/removed component? it can never trigger selection)"
         )
+
+    for name, consumers in sorted(synthetic.items()):
+        for consumer in consumers:
+            if consumer not in graph_keys:
+                errors.append(
+                    f"synthetic subproject '{name}': consumer '{consumer}' is not "
+                    "a consumer-graph key (real or synthetic) -- typo?"
+                )
 
     valid_levels = sorted(_LEVEL_TO_DEPTH)
     lo, hi = valid_levels[0], valid_levels[-1]
@@ -402,9 +470,15 @@ def validate_policies(therock_dir: Path | None = None) -> tuple[bool, list[str]]
             f"; {len(test_only_values)} test-only value(s) noted (not graph keys): "
             + ", ".join(sorted(test_only_values))
         )
+    synthetic_note = ""
+    if synthetic:
+        synthetic_note = (
+            f"; {len(synthetic)} synthetic subproject(s) merged in: "
+            + ", ".join(sorted(synthetic))
+        )
     messages.append(
         f"OK: {len(policies)} component key(s) validated against "
-        f"{len(graph_keys)} graph node(s){note}"
+        f"{len(graph_keys)} graph node(s){note}{synthetic_note}"
     )
     return True, messages
 

--- a/test_tools/determine_rocm_test_dependencies.py
+++ b/test_tools/determine_rocm_test_dependencies.py
@@ -162,6 +162,11 @@ def _load_consumer_graph(therock_dir: Path | None = None) -> dict:
     for name, consumers in _load_synthetic_subprojects(therock_dir).items():
         node = graph.setdefault(name, {})
         existing = node.get("consumers", [])
+        if not isinstance(existing, list):
+            raise ValueError(
+                f"{graph_path}: node '{name}' has non-list 'consumers' "
+                f"({existing!r}); cannot merge synthetic edges into it."
+            )
         node["consumers"] = existing + [c for c in consumers if c not in existing]
 
     return graph
@@ -244,7 +249,20 @@ def _load_synthetic_subprojects(
         )
     result: dict[str, list[str]] = {}
     for name, body in synthetic.items():
-        result[name.lower()] = [c.lower() for c in body.get("consumers", [])]
+        if not isinstance(body, dict):
+            raise ValueError(
+                f"test_policies.toml: [synthetic.{name}] must be a table, not "
+                f"{type(body).__name__}"
+            )
+        consumers = body.get("consumers", [])
+        if not isinstance(consumers, list) or not all(
+            isinstance(c, str) for c in consumers
+        ):
+            raise ValueError(
+                f"test_policies.toml: [synthetic.{name}] consumers must be a "
+                f"list of strings, not {consumers!r}"
+            )
+        result[name.lower()] = [c.lower() for c in consumers]
     return result
 
 

--- a/test_tools/determine_rocm_test_dependencies.py
+++ b/test_tools/determine_rocm_test_dependencies.py
@@ -87,9 +87,9 @@ _EXTERNAL_SUBTREE_ALIASES = {
         "tensilelite",
     ],
     # hipblaslt/rocblas/hipblas are reachable transitively from "tensilelite"
-    # itself now that TensileLite is a synthetic consumer-graph node (see
+    # itself: TensileLite is a synthetic consumer-graph node (see
     # _load_synthetic_subprojects below) with level 3 (unbounded) in
-    # test_policies.toml -- no need to hand-list them here too.
+    # test_policies.toml, so they don't need to be hand-listed here too.
     "shared/origami": ["origami", "tensilelite"],
     "shared/stinkytofu": ["tensilelite"],
     "shared/tensile": ["hipblas", "rocblas"],

--- a/test_tools/test_policies.toml
+++ b/test_tools/test_policies.toml
@@ -5,11 +5,34 @@
 # docs/rfcs/RFC0013-Consumer-Based-Test-Selection.md.
 #
 # Each table:
-#   [component.<name>]  <name> must be a graph key (validated).
+#   [component.<name>]  <name> must be a graph key, real or synthetic (validated).
 #   level = <1-5>       Walk depth. Default 4 (self + direct consumers). 5 = self
 #                       only; 3 = self + all transitive consumers.
 #   test_include        Extra targets to test; values need not be graph keys.
 #   test_exclude        Targets to drop after the walk and includes.
+#
+#   [synthetic.<name>]  <name> need not be (and typically is not) a graph key --
+#                       that's the point. Promotes <name> into the in-memory
+#                       consumer graph as an ordinary node so it walks like any
+#                       CMake-derived project. Use this instead of test_include
+#                       when the changed project itself has no graph node but
+#                       DOES have real downstream consumers worth walking
+#                       transitively (test_include alone cannot do that: it
+#                       unions in the listed names but does not continue the
+#                       walk past them).
+#     consumers          Projects that consume <name>; must be real graph keys
+#                        or other synthetic keys (validated).
+
+# --- Synthetic subprojects -----------------------------------------------------
+# Projects with no CMake target (no consumer-graph node) but with real test
+# couplings the graph cannot express.
+
+[synthetic.tensilelite]
+# TensileLite is a kernel-generator tool + YAML corpus bundled inside hipblaslt
+# (and a variant inside hipsparselt), not tracked as an independent build
+# target in the consumer graph. hipblaslt and hipsparselt are its real
+# consumers; see [component.tensilelite] below for the walk depth.
+consumers = ["hipblaslt", "hipsparselt"]
 
 # --- Foundational runtimes ----------------------------------------------------
 # Used by most of the tree, so they test their full transitive downstream.
@@ -62,6 +85,18 @@ test_include = ["rocgdb-cpu", "rocgdb-gpu", "rocgdb-corefile"]
 
 [component.hipblas]
 test_include = ["hipsolver"]
+
+[component.hipblaslt]
+# The generated graph does not yet declare hipblas as a hipblaslt consumer,
+# even though a hipblaslt change can break hipblas. test_include patches the
+# one missing edge (hipblaslt is a real graph node otherwise).
+test_include = ["hipblas"]
+
+[component.tensilelite]
+# Unbounded: a TensileLite-only change should retest hipblaslt/hipsparselt
+# (its synthetic consumers, declared above), then ripple transitively through
+# their own real consumers (rocblas, hipblas, ...) via the normal graph walk.
+level = 3
 
 [component.hiprand]
 test_include = ["miopen", "rocprim"]

--- a/test_tools/tests/determine_rocm_test_dependencies_test.py
+++ b/test_tools/tests/determine_rocm_test_dependencies_test.py
@@ -307,6 +307,10 @@ class TestCliInputParsing(_FixtureTestCase):
         self.assertIn("hipblaslt", projects)
 
     def test_shared_blas_prefixes_mapped(self) -> None:
+        # tensilelite has no node in `graph` itself -- it is declared as a
+        # synthetic subproject below (empty consumers here; the real transitive
+        # reach through hipblaslt/rocblas/hipblas is covered by
+        # TestSyntheticSubprojects, not by this alias-expansion test).
         graph = {
             "hipblas": {"consumers": []},
             "hipblaslt": {"consumers": []},
@@ -314,7 +318,8 @@ class TestCliInputParsing(_FixtureTestCase):
             "rocblas": {"consumers": []},
             "rocroller": {"consumers": []},
         }
-        root = _make_fixture(graph=graph, policies="")
+        policies = "[synthetic.tensilelite]\nconsumers = []\n"
+        root = _make_fixture(graph=graph, policies=policies)
         try:
             cases = {
                 "shared/mxdatagenerator": {
@@ -324,19 +329,14 @@ class TestCliInputParsing(_FixtureTestCase):
                     "rocroller",
                     "tensilelite",
                 },
-                "shared/origami": {
-                    "hipblas",
-                    "hipblaslt",
-                    "origami",
-                    "rocblas",
-                    "tensilelite",
-                },
-                "shared/stinkytofu": {
-                    "hipblas",
-                    "hipblaslt",
-                    "rocblas",
-                    "tensilelite",
-                },
+                # origami/stinkytofu are intentionally short now: tensilelite is
+                # a synthetic node with level=3 in the REAL test_policies.toml,
+                # so its own walk reaches hipblaslt/rocblas/hipblas transitively
+                # without hand-duplicating them here. This --level 5 (self-only)
+                # check only exercises alias expansion, so it sees just the
+                # literal alias contents.
+                "shared/origami": {"origami", "tensilelite"},
+                "shared/stinkytofu": {"tensilelite"},
                 "shared/tensile": {"hipblas", "rocblas"},
             }
             for changed_project, expected in cases.items():
@@ -565,6 +565,106 @@ class TestCliInputParsing(_FixtureTestCase):
         lines = proc.stdout.strip().splitlines()
         self.assertIn("amdsmi", lines)
         self.assertIn("rdc", lines)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic subprojects: [synthetic.<name>] promotes a project with no CMake
+# target (e.g. TensileLite) into an ordinary consumer-graph node, merged in by
+# _load_consumer_graph. Once merged it walks, validates, and lists exactly like
+# a real graph node -- these tests exercise that mechanism directly, using a
+# small graph modeling tensilelite -> hipblaslt -> rocblas -> hipblas so the
+# transitive reach can be checked end to end (mirrors the real repo's shape
+# without depending on its size or drifting with it).
+# ---------------------------------------------------------------------------
+_SYNTHETIC_GRAPH = {
+    "hipblaslt": {"consumers": ["rocblas"]},
+    "rocblas": {"consumers": ["hipblas"]},
+    "hipblas": {"consumers": []},
+    "hipsparselt": {"consumers": []},
+}
+_SYNTHETIC_POLICIES = """\
+[synthetic.tensilelite]
+consumers = ["hipblaslt", "hipsparselt"]
+
+[component.tensilelite]
+level = 3
+
+[component.hipblaslt]
+test_include = ["hipblas"]
+"""
+
+
+class TestSyntheticSubprojects(unittest.TestCase):
+    def setUp(self) -> None:
+        self.root = _make_fixture(graph=_SYNTHETIC_GRAPH, policies=_SYNTHETIC_POLICIES)
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.root, ignore_errors=True)
+
+    def test_synthetic_node_appears_in_list_subprojects(self) -> None:
+        # Merged in by _load_consumer_graph, so it is a known subproject just
+        # like any CMake-derived one.
+        self.assertIn("tensilelite", list_subprojects(self.root))
+
+    def test_tensilelite_change_ripples_transitively(self) -> None:
+        # tensilelite (level=3, unbounded) -> synthetic edge to
+        # {hipblaslt, hipsparselt} -> continues into the REAL graph edges
+        # transitively: hipblaslt -> rocblas -> hipblas.
+        result = get_subprojects_to_test(["tensilelite"], self.root)
+        self.assertEqual(
+            result,
+            {"tensilelite", "hipblaslt", "hipsparselt", "rocblas", "hipblas"},
+        )
+
+    def test_tensilelite_change_does_not_warn_unrecognized(self) -> None:
+        # A synthetic node is a known graph key -- no "unrecognized project"
+        # warning, unlike a bare test-only string with no declaration.
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            get_subprojects_to_test(["tensilelite"], self.root)
+        self.assertEqual(buf.getvalue(), "")
+
+    def test_hipblaslt_change_does_not_retest_tensilelite(self) -> None:
+        # The asymmetric coupling this mechanism exists for: hipblaslt-proper
+        # changes must NOT force a tensilelite retest (only the reverse).
+        result = get_subprojects_to_test(["hipblaslt"], self.root, level=4)
+        self.assertNotIn("tensilelite", result)
+        # The real missing edge (hipblaslt -> hipblas) is still patched via
+        # test_include, independent of the synthetic mechanism.
+        self.assertIn("hipblas", result)
+
+    def test_validate_policies_passes_with_synthetic_table(self) -> None:
+        ok, messages = validate_policies(self.root)
+        self.assertTrue(ok, "\n".join(messages))
+        self.assertTrue(any("synthetic subproject" in m for m in messages))
+
+    def test_validate_policies_catches_bad_synthetic_consumer(self) -> None:
+        # A synthetic consumer naming a nonexistent project is almost always a
+        # typo: it would silently select nothing beyond itself.
+        bad = _SYNTHETIC_POLICIES.replace(
+            'consumers = ["hipblaslt", "hipsparselt"]',
+            'consumers = ["hipblaslt", "not-a-real-project"]',
+        )
+        root = _make_fixture(graph=_SYNTHETIC_GRAPH, policies=bad)
+        try:
+            ok, messages = validate_policies(root)
+            self.assertFalse(ok)
+            self.assertIn("not-a-real-project", "\n".join(messages))
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+    def test_synthetic_merge_is_additive_not_overwriting(self) -> None:
+        # If a synthetic name ever collides with a real graph node, the merge
+        # must union consumers rather than silently drop the real edge.
+        graph = {**_SYNTHETIC_GRAPH, "hipblaslt": {"consumers": ["rocblas"]}}
+        policies = '[synthetic.hipblaslt]\nconsumers = ["hipsparselt"]\n'
+        root = _make_fixture(graph=graph, policies=policies)
+        try:
+            result = get_subprojects_to_test(["hipblaslt"], root, level=4)
+            self.assertIn("rocblas", result)  # the pre-existing real edge
+            self.assertIn("hipsparselt", result)  # the added synthetic edge
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
 
 
 # ---------------------------------------------------------------------------

--- a/test_tools/tests/determine_rocm_test_dependencies_test.py
+++ b/test_tools/tests/determine_rocm_test_dependencies_test.py
@@ -329,12 +329,13 @@ class TestCliInputParsing(_FixtureTestCase):
                     "rocroller",
                     "tensilelite",
                 },
-                # origami/stinkytofu are intentionally short now: tensilelite is
-                # a synthetic node with level=3 in the REAL test_policies.toml,
-                # so its own walk reaches hipblaslt/rocblas/hipblas transitively
-                # without hand-duplicating them here. This --level 5 (self-only)
-                # check only exercises alias expansion, so it sees just the
-                # literal alias contents.
+                # origami/stinkytofu intentionally list only the literal
+                # alias-seed names: tensilelite is a synthetic node with
+                # level=3 in the REAL test_policies.toml, so its own walk
+                # reaches hipblaslt/rocblas/hipblas transitively without
+                # hand-duplicating them here. This --level 5 (self-only) check
+                # only exercises alias expansion, so it sees just the literal
+                # alias contents.
                 "shared/origami": {"origami", "tensilelite"},
                 "shared/stinkytofu": {"tensilelite"},
                 "shared/tensile": {"hipblas", "rocblas"},

--- a/test_tools/tests/determine_rocm_test_dependencies_test.py
+++ b/test_tools/tests/determine_rocm_test_dependencies_test.py
@@ -666,6 +666,49 @@ class TestSyntheticSubprojects(unittest.TestCase):
         finally:
             shutil.rmtree(root, ignore_errors=True)
 
+    def test_synthetic_consumers_must_be_a_list(self) -> None:
+        # consumers = "hipblaslt" (a bare string, not a list) would otherwise
+        # silently iterate characters instead of failing loudly.
+        bad = '[synthetic.tensilelite]\nconsumers = "hipblaslt"\n'
+        root = _make_fixture(graph=_SYNTHETIC_GRAPH, policies=bad)
+        try:
+            with self.assertRaisesRegex(ValueError, "must be a list of strings"):
+                get_subprojects_to_test(["tensilelite"], root)
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+    def test_synthetic_consumers_must_be_strings(self) -> None:
+        bad = "[synthetic.tensilelite]\nconsumers = [1, 2]\n"
+        root = _make_fixture(graph=_SYNTHETIC_GRAPH, policies=bad)
+        try:
+            with self.assertRaisesRegex(ValueError, "must be a list of strings"):
+                get_subprojects_to_test(["tensilelite"], root)
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+    def test_synthetic_entry_must_be_a_table(self) -> None:
+        bad = '[synthetic]\ntensilelite = "not-a-table"\n'
+        root = _make_fixture(graph=_SYNTHETIC_GRAPH, policies=bad)
+        try:
+            with self.assertRaisesRegex(ValueError, "must be a table"):
+                get_subprojects_to_test(["tensilelite"], root)
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+    def test_graph_node_with_non_list_consumers_raises_on_merge(self) -> None:
+        # A corrupt/future-schema graph node ("consumers": null or similar)
+        # must fail loudly at merge time, not with a confusing TypeError --
+        # exercised via a synthetic name colliding with that corrupt node
+        # (the merge only ever touches the node named by the synthetic table).
+        graph = {**_SYNTHETIC_GRAPH, "hipblaslt": {"consumers": None}}
+        policies = '[synthetic.hipblaslt]\nconsumers = ["hipsparselt"]\n'
+        root = _make_fixture(graph=graph, policies=policies)
+        try:
+            with self.assertRaisesRegex(ValueError, "non-list 'consumers'"):
+                get_subprojects_to_test(["hipblaslt"], root)
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
 
 # ---------------------------------------------------------------------------
 # Unknown changed project warns and selects only itself.


### PR DESCRIPTION
ISSUE ID: https://github.com/ROCm/rocm-libraries/issues/11784

## Problem

TensileLite has no CMake target, so it has no node in the committed consumer graph (`test_tools/therock_consumer_graph.json`). A change confined to TensileLite (bundled inside hipblaslt/hipsparselt, no build target of its own) previously resolved to `{tensilelite}` only, never retesting hipblaslt itself. This was the gap found via [rocm-libraries#11447](https://github.com/ROCm/rocm-libraries/pull/11447)'s CI run.

The reverse direction was also incomplete: hipblaslt is a real graph node, but the generated graph doesn't declare hipblas as one of its consumers even though a hipblaslt change can break hipblas.

## Design: synthetic subprojects

Adds a `[synthetic.<name>]` table shape to `test_policies.toml`: a hand-maintained declaration that promotes a project with no CMake target into the in-memory consumer graph as an ordinary node, merged in by `_load_consumer_graph()`. Once merged, a synthetic node is indistinguishable from a real graph key to every downstream consumer of the graph -- the BFS walk, the "unrecognized project" warning check, and `validate_policies()` all treat it identically, with no special-casing anywhere else in `determine_rocm_test_dependencies.py`.

```toml
[synthetic.tensilelite]
consumers = ["hipblaslt", "hipsparselt"]

[component.tensilelite]
level = 3   # unbounded: ripple through hipblaslt -> rocblas -> hipblas -> ...

[component.hipblaslt]
test_include = ["hipblas"]   # the one known-missing real edge
```

This replaces a narrower `test_include`-only approach: `test_include` values are unioned in *after* the walk, so they can't continue the walk past themselves. A bare `test_include = ["hipblaslt", "hipsparselt"]` on `tensilelite` would stop right there and never reach `rocblas`/`hipblas`.

It also lets `_TEST_ONLY_SELECTORS = {"tensilelite"}` be deleted entirely -- that carve-out existed only because TensileLite had no graph key to be "known" by; now it does.

## Simplified aliases

`shared/stinkytofu` and `shared/origami` previously hand-duplicated `hipblas`/`hipblaslt`/`rocblas` to compensate for TensileLite's isolation from the graph. That reach is now covered by TensileLite's own transitive walk, so those lists shrink to just the seeds that still need independent representation:

```python
# Before
"shared/origami": ["hipblas", "hipblaslt", "origami", "rocblas", "tensilelite"],
"shared/stinkytofu": ["hipblas", "hipblaslt", "rocblas", "tensilelite"],

# After
"shared/origami": ["origami", "tensilelite"],
"shared/stinkytofu": ["tensilelite"],
```

## Verification

```
$ python test_tools/determine_rocm_test_dependencies.py --explain tensilelite
	level:	3 (walk depth unbounded: self + transitive consumers)
	final:	hipblas, hipblaslt, hipblasltprovider, hipdnn_samples, hipsolver, hipsparse,
	        hipsparselt, miopen, miopenprovider, rocalution, rocblas, rocsolver, rocsparse,
	        rocwmma, tensilelite

$ python test_tools/determine_rocm_test_dependencies.py --explain hipblaslt
	level:	4 (walk depth 1: self + direct consumers)
	final:	hipblas, hipblaslt, hipblasltprovider, hipsparselt, miopen, rocblas
```

A TensileLite change now ripples all the way to hipblas; a hipblaslt-proper change does **not** pull in TensileLite -- the asymmetric coupling this PR exists to fix.

- `python -m pytest test_tools/tests/determine_rocm_test_dependencies_test.py` -- 65 passed
- `python test_tools/determine_rocm_test_dependencies.py --validate-policies` -- OK
- `pre-commit run --files test_tools/determine_rocm_test_dependencies.py test_tools/test_policies.toml test_tools/tests/determine_rocm_test_dependencies_test.py` (black)

## Notes

This introduces a new "synthetic subprojects" concept not yet reflected in [RFC0013-Consumer-Based-Test-Selection.md](docs/rfcs/RFC0013-Consumer-Based-Test-Selection.md) (currently a draft by @endurthiabhilash). I deliberately didn't edit that doc myself since it's someone else's active design doc -- flagging here for their review; happy to fold in an RFC update if wanted.

Tracked in ROCm/rocm-libraries#11784, alongside the companion longest-prefix-match PR and the rocm-libraries repos-config.json PR.

