### PR TITLE
fix(ci): longest-prefix-match for external-repo subtree change detection

### DIFF
--- a/build_tools/github_actions/configure_external_repo_ci.py
+++ b/build_tools/github_actions/configure_external_repo_ci.py
@@ -203,13 +203,32 @@ def get_valid_prefixes(config: List[RepoEntry]) -> Set[str]:
 def find_matched_subtrees(
     changed_files: Iterable[str], valid_prefixes: Set[str]
 ) -> List[str]:
-    """Find subtrees matching changed files."""
-    changed_subtrees = {
-        "/".join(path.split("/", 2)[:2])
-        for path in changed_files
-        if len(path.split("/")) >= 2
-    }
-    return sorted(changed_subtrees & valid_prefixes)
+    """Find subtrees matching changed files via longest-prefix match.
+
+    A changed file's subtree is the LONGEST registered prefix (`category/name`,
+    or a nested `category/name/subname`) that matches its path -- checked from
+    most to least specific -- not a fixed 2-segment truncation. A fixed
+    2-segment truncation would make a nested subtree registered in
+    repos-config.json (e.g. `hipblaslt/tensilelite`, nested inside `hipblaslt`)
+    indistinguishable from a change to its parent: both collapse to
+    `projects/hipblaslt`, silently losing the more specific match. Matching
+    longest-prefix-first, and attributing each changed file to exactly one
+    subtree, keeps a tensilelite-only change from also firing hipblaslt-proper's
+    (potentially different) test selection.
+    """
+    # Longest prefixes first, so a nested subtree wins over its parent.
+    prefixes_by_specificity = sorted(
+        valid_prefixes, key=lambda p: p.count("/"), reverse=True
+    )
+    matched: Set[str] = set()
+    for path in changed_files:
+        segments = path.split("/")
+        for prefix in prefixes_by_specificity:
+            prefix_segments = prefix.split("/")
+            if segments[: len(prefix_segments)] == prefix_segments:
+                matched.add(prefix)
+                break
+    return sorted(matched)
 
 
 def set_github_output(outputs: Mapping[str, str]) -> None:

--- a/build_tools/tests/configure_external_repo_ci_test.py
+++ b/build_tools/tests/configure_external_repo_ci_test.py
@@ -99,6 +99,37 @@ class FindMatchedSubtreesTest(unittest.TestCase):
         result = find_matched_subtrees(files, prefixes)
         self.assertEqual(result, [])
 
+    def test_nested_subtree_wins_over_parent(self):
+        # A file inside a registered nested subtree (e.g. hipblaslt/tensilelite)
+        # must match the longer, more specific prefix, not collapse to its
+        # 2-segment parent -- a fixed-length truncation would make the two
+        # indistinguishable and silently lose the more specific match.
+        files = ["projects/hipblaslt/tensilelite/Tensile/KernelWriter.py"]
+        prefixes = {"projects/hipblaslt", "projects/hipblaslt/tensilelite"}
+        result = find_matched_subtrees(files, prefixes)
+        self.assertEqual(result, ["projects/hipblaslt/tensilelite"])
+
+    def test_parent_only_change_does_not_match_nested_subtree(self):
+        # A change outside the nested subtree still matches the parent, not the
+        # (unrelated) nested prefix.
+        files = ["projects/hipblaslt/library/src/Handle.cpp"]
+        prefixes = {"projects/hipblaslt", "projects/hipblaslt/tensilelite"}
+        result = find_matched_subtrees(files, prefixes)
+        self.assertEqual(result, ["projects/hipblaslt"])
+
+    def test_mixed_nested_and_parent_changes_match_both(self):
+        # Changes to both areas in the same PR attribute independently: one
+        # file matches the nested subtree, the other matches the parent.
+        files = [
+            "projects/hipblaslt/tensilelite/Tensile/KernelWriter.py",
+            "projects/hipblaslt/library/src/Handle.cpp",
+        ]
+        prefixes = {"projects/hipblaslt", "projects/hipblaslt/tensilelite"}
+        result = find_matched_subtrees(files, prefixes)
+        self.assertEqual(
+            result, ["projects/hipblaslt", "projects/hipblaslt/tensilelite"]
+        )
+
 
 class GetValidPrefixesTest(unittest.TestCase):
     """Tests for get_valid_prefixes()."""


### PR DESCRIPTION
ISSUE ID: https://github.com/ROCm/rocm-libraries/issues/11784

## Problem

`find_matched_subtrees()` in `configure_external_repo_ci.py` truncates every changed file path to exactly 2 segments (`category/name`) before matching against registered subtree prefixes. This makes a nested subtree registered in `repos-config.json` (e.g. `projects/hipblaslt/tensilelite`, nested inside `projects/hipblaslt`) indistinguishable from a change to its parent: both collapse to `projects/hipblaslt`, silently losing the more specific match.

This blocks the companion synthetic-subprojects PR (#7998): even once TensileLite has its own consumer-graph node, change detection needs to be able to tell a TensileLite-only change apart from a hipblaslt-proper change in the first place.

## Fix

Switch to longest-prefix-match: check registered prefixes from most to least specific, and attribute each changed file to exactly one (the longest matching) subtree.

```python
def find_matched_subtrees(changed_files, valid_prefixes):
    prefixes_by_specificity = sorted(valid_prefixes, key=lambda p: p.count("/"), reverse=True)
    matched = set()
    for path in changed_files:
        segments = path.split("/")
        for prefix in prefixes_by_specificity:
            prefix_segments = prefix.split("/")
            if segments[: len(prefix_segments)] == prefix_segments:
                matched.add(prefix)
                break
    return sorted(matched)
```

A file nested in `projects/hipblaslt/tensilelite/...` now resolves to `projects/hipblaslt/tensilelite` (when that prefix is registered); a file elsewhere under `projects/hipblaslt/...` still resolves to `projects/hipblaslt` as before.

## Testing

Added `test_nested_subtree_wins_over_parent`, `test_parent_only_change_does_not_match_nested_subtree`, and `test_mixed_nested_and_parent_changes_match_both` to `build_tools/tests/configure_external_repo_ci_test.py`, alongside the existing suite.

- `python -m pytest build_tools/tests/configure_external_repo_ci_test.py` -- 27 passed
- `pre-commit run --files build_tools/github_actions/configure_external_repo_ci.py build_tools/tests/configure_external_repo_ci_test.py` (black)

Tracked in ROCm/rocm-libraries#11784, alongside the companion synthetic-subprojects PR (#7998) and the rocm-libraries repos-config.json PR, which applies the identical fix to its own independently-duplicated copy of this function.

