### PR TITLE
fix(ci): fix TheRock submodule bump pin-PR automation for rocm-libraries and rocm-systems

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux.yml
+++ b/.github/workflows/multi_arch_build_portable_linux.yml
@@ -412,6 +412,43 @@ jobs:
       contents: read
       id-token: write
 
+  # ==========================================================================
+  # GATE: libraries_baseline_ready
+  # rocm-libraries reuses exactly these stages from this run via
+  # `baseline_run_id` when a submodule bump PR is opened (see
+  # ROCm/rocm-libraries' therock-multi-arch-ci.yml `prebuilt_stages` input;
+  # math-libs and compiler-runtime are rebuilt by rocm-libraries itself and
+  # deliberately excluded here). TheRock's bump automation
+  # (build_tools/github_actions/bump_automation.py) checks this job's
+  # conclusion instead of the whole run's, so an unrelated math-libs failure
+  # elsewhere in the matrix does not block a baseline that is otherwise fine
+  # to reuse. If rocm-libraries' reused-stage list changes, update `needs:`
+  # below (and the matching job in multi_arch_build_windows.yml) to match.
+  # ==========================================================================
+  libraries_baseline_ready:
+    name: "Libraries Baseline Ready"
+    if: always()
+    needs:
+      [
+        runtime-tests,
+        comm-libs,
+        storage-libs,
+        debug-tools,
+        dctools-core,
+        profiler-apps,
+        cv-libs,
+        media-libs,
+        wsl-rocdxg,
+      ]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Require reused stages to have succeeded
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
+        run: |
+          echo "One or more stages rocm-libraries reuses via baseline_run_id did not succeed:"
+          echo '${{ toJSON(needs) }}'
+          exit 1
+
   notify_quartz_completed:
     if: ${{ always() && vars.NOTIFY_QUARTZ_ENABLED == 'true' }}
     needs: [compiler-runtime, emulation, runtime-tests, wsl-rocdxg, math-libs, comm-libs, storage-libs, debug-tools, dctools-core, profiler-apps, media-libs]

--- a/.github/workflows/multi_arch_build_windows.yml
+++ b/.github/workflows/multi_arch_build_windows.yml
@@ -234,6 +234,25 @@ jobs:
       contents: read
       id-token: write
 
+  # ==========================================================================
+  # GATE: libraries_baseline_ready
+  # See multi_arch_build_portable_linux.yml for why this job exists. Windows
+  # only builds a subset of the stages rocm-libraries reuses (the rest are
+  # Linux-only), so `needs:` here is narrower than the Linux copy.
+  # ==========================================================================
+  libraries_baseline_ready:
+    name: "Libraries Baseline Ready"
+    if: always()
+    needs: [runtime-tests, debug-tools, media-libs]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Require reused stages to have succeeded
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
+        run: |
+          echo "One or more stages rocm-libraries reuses via baseline_run_id did not succeed:"
+          echo '${{ toJSON(needs) }}'
+          exit 1
+
   notify_quartz_completed:
     if: ${{ always() && vars.NOTIFY_QUARTZ_ENABLED == 'true' }}
     needs: [compiler-runtime, runtime-tests, math-libs, debug-tools, media-libs]

--- a/build_tools/github_actions/bump_automation.py
+++ b/build_tools/github_actions/bump_automation.py
@@ -35,8 +35,10 @@ ROCM_SYSTEMS_FILES = [
 ROCM_LIBRARIES_CI_ENV_FILE = ".github/actions/ci-env/action.yml"
 
 FULL_COMMIT_SHA_PATTERN = re.compile(r"\b[0-9a-f]{40}\b")
+# Title convention we generate below; not tied to any one downstream repo, so
+# it stays a shared constant even though the PR author does not (see
+# SUBMODULE_CONFIG["bot_author"]).
 THEROCK_REF_PR_TITLE_PREFIX = "Update TheRock reference to ("
-THEROCK_REF_PR_AUTHOR = "assistant-librarian[bot]"
 GITHUB_SEARCH_PAGE_SIZE = 100
 # The GitHub search API refuses to serve matches past the first 1000.
 GITHUB_SEARCH_RESULT_LIMIT = 1000
@@ -49,6 +51,8 @@ SUBMODULE_CONFIG = {
         "files": ROCM_SYSTEMS_FILES,
         "updater": "ref",
         "token_key": "systems",
+        # See the "rocm-libraries" entry below for why this is per-repo.
+        "bot_author": "systems-assistant[bot]",
         # Changes to rocm-systems should run the full matrix of CI jobs:
         #   * Build for all gfx archs
         #   * Build for all variants (asan)
@@ -60,6 +64,12 @@ SUBMODULE_CONFIG = {
         "files": [ROCM_LIBRARIES_CI_ENV_FILE],
         "updater": "ci-env",
         "token_key": "libraries",
+        # GitHub App bot identity that opens "Update TheRock reference to
+        # (...)" PRs on this repo; only used by the "ci-env" updater's stale
+        # pin-PR cleanup. Each downstream repo has its own GitHub App (see
+        # ROCM_LIBRARIES_APP_ID / ROCM_SYSTEMS_APP_ID in bump_submodules.yml),
+        # so this must not be hardcoded as a single module-wide constant.
+        "bot_author": "assistant-librarian[bot]",
         # Changes to rocm-libraries should run the full matrix of CI jobs:
         #   * Build for all gfx archs
         #   * Build for all variants (asan)
@@ -465,10 +475,17 @@ def close_stale_therock_ref_prs(
     repo: str,
     current_pr_number: int,
     token: str,
+    bot_author: str,
     *,
     now: datetime | None = None,
 ) -> None:
     """Close older automated TheRock reference PRs in an upstream repository.
+
+    `bot_author` is the GitHub App bot identity that opens these PRs on
+    `repo` (SUBMODULE_CONFIG["bot_author"] for the relevant entry); it is not
+    a single global value because each downstream repo has its own GitHub
+    App, and matching the wrong one would silently close nothing (or, if
+    reused carelessly, PRs that were never ours to close).
 
     PRs younger than STALE_THEROCK_REF_PR_AGE are left open so their CI can
     finish before they are superseded.
@@ -483,7 +500,7 @@ def close_stale_therock_ref_prs(
         number = item["number"]
         if number == current_pr_number:
             continue
-        if item["user"]["login"] != THEROCK_REF_PR_AUTHOR:
+        if item["user"]["login"] != bot_author:
             continue
         if not item["title"].startswith(THEROCK_REF_PR_TITLE_PREFIX):
             continue
@@ -738,7 +755,9 @@ def handle_push(before: str, after: str, tokens: dict[str, str]) -> None:
                 "body": pr_body,
             },
         )
-        close_stale_therock_ref_prs(repo_name, pr["number"], token)
+        close_stale_therock_ref_prs(
+            repo_name, pr["number"], token, config["bot_author"]
+        )
 
     os.chdir(original_cwd)
 

--- a/build_tools/github_actions/bump_automation.py
+++ b/build_tools/github_actions/bump_automation.py
@@ -139,7 +139,18 @@ def gh_api(
 def get_baseline_run_id_from_merged_pr(
     repo: str, token: str, merge_commit_sha: str, workflow_name: str = "Multi-Arch CI"
 ) -> str | None:
-    """Get the baseline run ID from the PR that was just merged."""
+    """Get the baseline run ID from the PR that was just merged.
+
+    Downstream repos reuse this run's build-stage artifacts directly (via
+    `baseline_run_id`), so only a run that actually finished successfully is
+    safe to hand out. `status=completed` alone is not enough: a completed run
+    can still have `conclusion` of "failure" or "cancelled", and picking one
+    of those would silently point rocm-libraries at broken or missing
+    artifacts. If the newest matching run did not succeed, we deliberately do
+    not fall back to an older one on a different commit; the caller treats a
+    `None` return as "no baseline", which forces a full rebuild instead of a
+    plausible-looking but wrong artifact reuse.
+    """
     # Find the PR that produced this merge commit
     prs = gh_api(token, f"repos/{repo}/commits/{merge_commit_sha}/pulls")
     pr = next(
@@ -159,14 +170,28 @@ def get_baseline_run_id_from_merged_pr(
     runs = gh_api(
         token, f"repos/{repo}/actions/runs?head_sha={pr_head_sha}&status=completed"
     )
-    for run in runs.get("workflow_runs", []):
-        if run["name"] == workflow_name:
+    matching_runs = [
+        run for run in runs.get("workflow_runs", []) if run["name"] == workflow_name
+    ]
+
+    for run in matching_runs:
+        if run.get("conclusion") == "success":
             print(
-                f"[INFO] Found {workflow_name} run {run['id']} for PR #{pr['number']}"
+                f"[INFO] Found successful {workflow_name} run {run['id']} "
+                f"for PR #{pr['number']}"
             )
             return str(run["id"])
 
-    print(f"[WARN] No {workflow_name} run found for PR #{pr['number']}")
+    if matching_runs:
+        found = ", ".join(
+            f"#{run['id']} ({run.get('conclusion')})" for run in matching_runs
+        )
+        print(
+            f"[WARN] No successful {workflow_name} run found for PR #{pr['number']} "
+            f"(found: {found})"
+        )
+    else:
+        print(f"[WARN] No {workflow_name} run found for PR #{pr['number']}")
     return None
 
 

--- a/build_tools/github_actions/bump_automation.py
+++ b/build_tools/github_actions/bump_automation.py
@@ -146,20 +146,68 @@ def gh_api(
     return response.json()
 
 
+LIBRARIES_BASELINE_GATE_JOB_NAME = "Libraries Baseline Ready"
+
+
+def _list_run_jobs(repo: str, token: str, run_id: str | int) -> list[dict[str, Any]]:
+    """Return every job in a workflow run, following pagination."""
+    jobs: list[dict[str, Any]] = []
+    page = 1
+
+    while True:
+        result = gh_api(
+            token,
+            f"repos/{repo}/actions/runs/{run_id}/jobs?per_page=100&page={page}",
+        )
+        page_jobs = result.get("jobs", [])
+        jobs.extend(page_jobs)
+
+        if len(page_jobs) < 100 or len(jobs) >= result.get("total_count", 0):
+            return jobs
+
+        page += 1
+
+
+def _baseline_gate_jobs_succeeded(repo: str, token: str, run_id: str | int) -> bool:
+    """Return whether every "Libraries Baseline Ready" job in this run succeeded.
+
+    That job (defined in multi_arch_build_portable_linux.yml and
+    multi_arch_build_windows.yml) depends on exactly the stages rocm-libraries
+    reuses via `baseline_run_id`. Checking it instead of the whole run's
+    `conclusion` means an unrelated math-libs/compiler-runtime failure
+    elsewhere in the matrix does not block a baseline that is otherwise fine
+    to reuse. If no such job is found at all, treat the run as unsafe to use;
+    that should only happen for a run that predates this gate.
+    """
+    gate_jobs = [
+        job
+        for job in _list_run_jobs(repo, token, run_id)
+        if job["name"].endswith(LIBRARIES_BASELINE_GATE_JOB_NAME)
+    ]
+    if not gate_jobs:
+        print(f"[WARN] Run {run_id} has no '{LIBRARIES_BASELINE_GATE_JOB_NAME}' job")
+        return False
+    return all(job.get("conclusion") == "success" for job in gate_jobs)
+
+
 def get_baseline_run_id_from_merged_pr(
     repo: str, token: str, merge_commit_sha: str, workflow_name: str = "Multi-Arch CI"
 ) -> str | None:
     """Get the baseline run ID from the PR that was just merged.
 
     Downstream repos reuse this run's build-stage artifacts directly (via
-    `baseline_run_id`), so only a run that actually finished successfully is
-    safe to hand out. `status=completed` alone is not enough: a completed run
-    can still have `conclusion` of "failure" or "cancelled", and picking one
-    of those would silently point rocm-libraries at broken or missing
-    artifacts. If the newest matching run did not succeed, we deliberately do
-    not fall back to an older one on a different commit; the caller treats a
-    `None` return as "no baseline", which forces a full rebuild instead of a
-    plausible-looking but wrong artifact reuse.
+    `baseline_run_id`), so only a run where those specific stages actually
+    succeeded is safe to hand out. We check the "Libraries Baseline Ready"
+    gate job rather than the whole run's `conclusion`: an unrelated
+    math-libs/compiler-runtime failure elsewhere in the matrix makes the
+    overall run "failure" even when every stage rocm-libraries needs
+    succeeded, and rejecting on that basis would throw away perfectly good
+    baselines. `status=completed` still filters candidate runs to ones that
+    have finished; their overall `conclusion` no longer decides usability. If
+    the newest matching run's gate job did not succeed (or does not exist),
+    we deliberately do not fall back to an older run on a different commit;
+    the caller treats a `None` return as "no baseline", which forces a full
+    rebuild instead of a plausible-looking but wrong artifact reuse.
     """
     # Find the PR that produced this merge commit
     prs = gh_api(token, f"repos/{repo}/commits/{merge_commit_sha}/pulls")
@@ -185,20 +233,21 @@ def get_baseline_run_id_from_merged_pr(
     ]
 
     for run in matching_runs:
-        if run.get("conclusion") == "success":
+        if _baseline_gate_jobs_succeeded(repo, token, run["id"]):
             print(
-                f"[INFO] Found successful {workflow_name} run {run['id']} "
-                f"for PR #{pr['number']}"
+                f"[INFO] Found {workflow_name} run {run['id']} with all reused "
+                f"stages succeeded for PR #{pr['number']}"
             )
             return str(run["id"])
+        print(
+            f"[WARN] Run {run['id']} (conclusion={run.get('conclusion')}) does not "
+            f"have all reused stages succeeded; skipping"
+        )
 
     if matching_runs:
-        found = ", ".join(
-            f"#{run['id']} ({run.get('conclusion')})" for run in matching_runs
-        )
         print(
-            f"[WARN] No successful {workflow_name} run found for PR #{pr['number']} "
-            f"(found: {found})"
+            f"[WARN] No {workflow_name} run with all reused stages succeeded "
+            f"found for PR #{pr['number']}"
         )
     else:
         print(f"[WARN] No {workflow_name} run found for PR #{pr['number']}")

--- a/build_tools/github_actions/bump_automation.py
+++ b/build_tools/github_actions/bump_automation.py
@@ -3,11 +3,15 @@
 # SPDX-License-Identifier: MIT
 
 import argparse
+import os
+import re
 import subprocess
 import tempfile
-import os
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Any
+from urllib.parse import quote
+
 import requests
 
 THEROCK_REPO = "ROCm/TheRock"
@@ -28,9 +32,13 @@ ROCM_SYSTEMS_FILES = [
     ".github/workflows/therock-test-packages.yml",
 ]
 
-ROCM_LIBRARIES_FILES = [
-    ".github/actions/ci-env/action.yml",
-]
+ROCM_LIBRARIES_CI_ENV_FILE = ".github/actions/ci-env/action.yml"
+
+FULL_COMMIT_SHA_PATTERN = re.compile(r"\b[0-9a-f]{40}\b")
+THEROCK_REF_PR_TITLE_PREFIX = "Update TheRock reference to ("
+THEROCK_REF_PR_AUTHOR = "assistant-librarian[bot]"
+# Leave recent bot pin PRs open so their CI can finish before they are closed.
+STALE_THEROCK_REF_PR_AGE = timedelta(days=2)
 
 SUBMODULE_CONFIG = {
     "rocm-systems": {
@@ -46,7 +54,7 @@ SUBMODULE_CONFIG = {
     },
     "rocm-libraries": {
         "repo": "ROCm/rocm-libraries",
-        "files": ROCM_LIBRARIES_FILES,
+        "files": [ROCM_LIBRARIES_CI_ENV_FILE],
         "updater": "ci-env",
         "token_key": "libraries",
         # Changes to rocm-libraries should run the full matrix of CI jobs:
@@ -298,6 +306,73 @@ def update_ci_env_file(
         print(f"[INFO] Set baseline-run-id to {baseline_run_id}")
 
 
+def _find_therock_workflow_refs(content: str) -> set[str]:
+    """Find pinned TheRock SHAs in a rocm-libraries workflow."""
+    refs = set()
+    therock_checkout_indent = None
+
+    for line in content.splitlines():
+        stripped = line.strip()
+        indent = len(line) - len(line.lstrip())
+
+        if therock_checkout_indent is not None:
+            if stripped and indent < therock_checkout_indent:
+                therock_checkout_indent = None
+            elif stripped.startswith("ref:"):
+                refs.update(FULL_COMMIT_SHA_PATTERN.findall(line))
+                therock_checkout_indent = None
+
+        if re.fullmatch(r"""repository:\s*["']?ROCm/TheRock["']?""", stripped):
+            therock_checkout_indent = indent
+
+        if "ROCm/TheRock" in line or "therock_ref_override" in line:
+            refs.update(FULL_COMMIT_SHA_PATTERN.findall(line))
+
+    return refs
+
+
+def update_therock_workflow_file(file_path: str, new_sha: str) -> None:
+    """Update every pinned TheRock workflow/source SHA in one workflow file."""
+    path = Path(file_path)
+    content = path.read_text(encoding="utf-8")
+    old_refs = _find_therock_workflow_refs(content)
+    if not old_refs:
+        raise RuntimeError(f"No pinned TheRock refs found in {file_path}")
+
+    updated_content = content
+    for old_ref in old_refs:
+        updated_content = updated_content.replace(old_ref, new_sha)
+
+    date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    updated_content = re.sub(
+        rf"({re.escape(new_sha)}\s+#\s+)\d{{4}}-\d{{2}}-\d{{2}}",
+        rf"\g<1>{date}",
+        updated_content,
+    )
+
+    remaining_refs = _find_therock_workflow_refs(updated_content) - {new_sha}
+    if remaining_refs:
+        raise RuntimeError(
+            f"Stale TheRock refs remain in {file_path}: {sorted(remaining_refs)}"
+        )
+
+    path.write_text(updated_content, encoding="utf-8")
+    print(f"[INFO] Updated {file_path}")
+
+
+def find_therock_workflow_files(root: Path = Path(".github")) -> list[str]:
+    """Find YAML files under root that contain pinned TheRock refs."""
+    candidates = sorted([*root.rglob("*.yml"), *root.rglob("*.yaml")])
+    files = [
+        path.as_posix()
+        for path in candidates
+        if _find_therock_workflow_refs(path.read_text(encoding="utf-8"))
+    ]
+    if not files:
+        raise RuntimeError(f"No pinned TheRock workflow files found under {root}")
+    return files
+
+
 def close_stale_prs(submodule: str, old_sha: str, token: str) -> None:
     """Close all open PRs on TheRock that originated from old submodule SHA."""
     old_short = old_sha[:7]
@@ -323,6 +398,69 @@ def close_stale_prs(submodule: str, old_sha: str, token: str) -> None:
                 method="PATCH",
                 data={"state": "closed"},
             )
+
+
+def _parse_github_datetime(value: str) -> datetime:
+    """Parse a GitHub API timestamp into an aware UTC datetime."""
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def close_stale_therock_ref_prs(
+    repo: str,
+    current_pr_number: int,
+    token: str,
+    *,
+    now: datetime | None = None,
+) -> None:
+    """Close older automated TheRock reference PRs in an upstream repository.
+
+    PRs younger than STALE_THEROCK_REF_PR_AGE are left open so their CI can
+    finish before they are superseded.
+    """
+    query = quote(f'repo:{repo} is:pr is:open in:title "{THEROCK_REF_PR_TITLE_PREFIX}"')
+    result = gh_api(token, f"search/issues?q={query}&per_page=100")
+    now = now or datetime.now(timezone.utc)
+
+    for item in result.get("items", []):
+        number = item["number"]
+        if number == current_pr_number:
+            continue
+        if item["user"]["login"] != THEROCK_REF_PR_AUTHOR:
+            continue
+        if not item["title"].startswith(THEROCK_REF_PR_TITLE_PREFIX):
+            continue
+
+        created_at = item.get("created_at")
+        if not created_at:
+            print(f"[WARN] Skipping PR #{number}: missing created_at")
+            continue
+        age = now - _parse_github_datetime(created_at)
+        if age < STALE_THEROCK_REF_PR_AGE:
+            age_hours = int(age.total_seconds() // 3600)
+            print(
+                f"[INFO] Leaving TheRock reference PR #{number} open "
+                f"({age_hours}h old; close after {STALE_THEROCK_REF_PR_AGE.days}d)"
+            )
+            continue
+
+        print(f"[INFO] Closing stale TheRock reference PR #{number}")
+        gh_api(
+            token,
+            f"repos/{repo}/issues/{number}/comments",
+            method="POST",
+            data={
+                "body": (
+                    f"Closing stale PR superseded by automated update "
+                    f"#{current_pr_number}."
+                )
+            },
+        )
+        gh_api(
+            token,
+            f"repos/{repo}/pulls/{number}",
+            method="PATCH",
+            data={"state": "closed"},
+        )
 
 
 def _git_commit(title: str) -> None:
@@ -504,13 +642,18 @@ def handle_push(before: str, after: str, tokens: dict[str, str]) -> None:
         run(["git", "checkout", "-b", branch])
 
         updater = config.get("updater")
-        for f in config["files"]:
-            if updater == "ci-env":
-                update_ci_env_file(f, after, baseline_run_id)
-            else:
+        files_to_update = list(config["files"])
+        if updater == "ci-env":
+            update_ci_env_file(ROCM_LIBRARIES_CI_ENV_FILE, after, baseline_run_id)
+            workflow_files = find_therock_workflow_files()
+            for f in workflow_files:
+                update_therock_workflow_file(f, after)
+            files_to_update.extend(workflow_files)
+        else:
+            for f in files_to_update:
                 update_ref_in_file(f, after)
 
-        run(["git", "add"] + config["files"])
+        run(["git", "add"] + files_to_update)
 
         commit_msg = f"Update TheRock ref to {after[:7]}"
         if baseline_run_id:
@@ -519,11 +662,14 @@ def handle_push(before: str, after: str, tokens: dict[str, str]) -> None:
 
         run(["git", "push", "origin", branch])
 
-        pr_body = f"Updated TheRock ref to `{after[:7]}` due to submodule bump"
+        pr_body = (
+            f"Updated all pinned TheRock workflow and source refs to "
+            f"`{after[:7]}` due to submodule bump"
+        )
         if baseline_run_id:
             pr_body += f"\n\nBaseline run ID: [{baseline_run_id}](https://github.com/{THEROCK_REPO}/actions/runs/{baseline_run_id})"
 
-        gh_api(
+        pr = gh_api(
             token,
             f"repos/{repo_name}/pulls",
             method="POST",
@@ -534,6 +680,7 @@ def handle_push(before: str, after: str, tokens: dict[str, str]) -> None:
                 "body": pr_body,
             },
         )
+        close_stale_therock_ref_prs(repo_name, pr["number"], token)
 
     os.chdir(original_cwd)
 

--- a/build_tools/github_actions/bump_automation.py
+++ b/build_tools/github_actions/bump_automation.py
@@ -37,6 +37,9 @@ ROCM_LIBRARIES_CI_ENV_FILE = ".github/actions/ci-env/action.yml"
 FULL_COMMIT_SHA_PATTERN = re.compile(r"\b[0-9a-f]{40}\b")
 THEROCK_REF_PR_TITLE_PREFIX = "Update TheRock reference to ("
 THEROCK_REF_PR_AUTHOR = "assistant-librarian[bot]"
+GITHUB_SEARCH_PAGE_SIZE = 100
+# The GitHub search API refuses to serve matches past the first 1000.
+GITHUB_SEARCH_RESULT_LIMIT = 1000
 # Leave recent bot pin PRs open so their CI can finish before they are closed.
 STALE_THEROCK_REF_PR_AGE = timedelta(days=2)
 
@@ -405,6 +408,34 @@ def _parse_github_datetime(value: str) -> datetime:
     return datetime.fromisoformat(value.replace("Z", "+00:00"))
 
 
+def search_issues(token: str, query: str) -> list[dict[str, Any]]:
+    """Return every issue/PR matching a search query, following pagination."""
+    items: list[dict[str, Any]] = []
+    page = 1
+
+    while True:
+        result = gh_api(
+            token,
+            f"search/issues?q={quote(query)}"
+            f"&per_page={GITHUB_SEARCH_PAGE_SIZE}&page={page}",
+        )
+        page_items = result.get("items", [])
+        items.extend(page_items)
+
+        if len(page_items) < GITHUB_SEARCH_PAGE_SIZE:
+            return items
+        if len(items) >= result.get("total_count", 0):
+            return items
+        if len(items) >= GITHUB_SEARCH_RESULT_LIMIT:
+            print(
+                f"[WARN] Search hit the {GITHUB_SEARCH_RESULT_LIMIT}-result API "
+                f"limit; some matches were not retrieved"
+            )
+            return items
+
+        page += 1
+
+
 def close_stale_therock_ref_prs(
     repo: str,
     current_pr_number: int,
@@ -417,11 +448,13 @@ def close_stale_therock_ref_prs(
     PRs younger than STALE_THEROCK_REF_PR_AGE are left open so their CI can
     finish before they are superseded.
     """
-    query = quote(f'repo:{repo} is:pr is:open in:title "{THEROCK_REF_PR_TITLE_PREFIX}"')
-    result = gh_api(token, f"search/issues?q={query}&per_page=100")
+    items = search_issues(
+        token,
+        f'repo:{repo} is:pr is:open in:title "{THEROCK_REF_PR_TITLE_PREFIX}"',
+    )
     now = now or datetime.now(timezone.utc)
 
-    for item in result.get("items", []):
+    for item in items:
         number = item["number"]
         if number == current_pr_number:
             continue

--- a/build_tools/github_actions/tests/bump_automation_test.py
+++ b/build_tools/github_actions/tests/bump_automation_test.py
@@ -18,9 +18,12 @@ from bump_automation import (
     create_therock_bump,
     find_therock_workflow_files,
     generate_pr_body,
+    GITHUB_SEARCH_PAGE_SIZE,
+    GITHUB_SEARCH_RESULT_LIMIT,
     get_submodule_sha,
     handle_push,
     latest_commit,
+    search_issues,
     submodule_changed,
     update_ci_env_file,
     update_ref_in_file,
@@ -395,6 +398,60 @@ class CloseStalePrsTest(unittest.TestCase):
         self.assertTrue(any("comments" in c.args[1] for c in post_calls))
 
 
+def _search_page(numbers: range, total_count: int) -> dict:
+    return {
+        "total_count": total_count,
+        "items": [{"number": n} for n in numbers],
+    }
+
+
+class SearchIssuesTest(unittest.TestCase):
+    def test_returns_single_page_without_further_requests(self):
+        page = _search_page(range(3), total_count=3)
+        with patch("bump_automation.gh_api", return_value=page) as mock_api:
+            items = search_issues("token", "repo:ROCm/rocm-libraries is:pr")
+
+        self.assertEqual(len(items), 3)
+        mock_api.assert_called_once()
+        self.assertIn("page=1", mock_api.call_args.args[1])
+
+    def test_follows_pagination_until_all_matches_are_retrieved(self):
+        total = GITHUB_SEARCH_PAGE_SIZE + 5
+        pages = [
+            _search_page(range(GITHUB_SEARCH_PAGE_SIZE), total_count=total),
+            _search_page(range(GITHUB_SEARCH_PAGE_SIZE, total), total_count=total),
+        ]
+        with patch("bump_automation.gh_api", side_effect=pages) as mock_api:
+            items = search_issues("token", "repo:ROCm/rocm-libraries is:pr")
+
+        self.assertEqual([item["number"] for item in items], list(range(total)))
+        requested_pages = [call.args[1] for call in mock_api.call_args_list]
+        self.assertEqual(len(requested_pages), 2)
+        self.assertIn("page=1", requested_pages[0])
+        self.assertIn("page=2", requested_pages[1])
+
+    def test_stops_at_the_search_api_result_limit(self):
+        full_page = _search_page(range(GITHUB_SEARCH_PAGE_SIZE), total_count=10**6)
+        with patch("bump_automation.gh_api", return_value=full_page) as mock_api:
+            items = search_issues("token", "repo:ROCm/rocm-libraries is:pr")
+
+        self.assertEqual(len(items), GITHUB_SEARCH_RESULT_LIMIT)
+        self.assertEqual(
+            mock_api.call_count, GITHUB_SEARCH_RESULT_LIMIT // GITHUB_SEARCH_PAGE_SIZE
+        )
+
+    def test_quotes_the_query(self):
+        with patch(
+            "bump_automation.gh_api", return_value=_search_page(range(0), 0)
+        ) as mock_api:
+            search_issues("token", 'repo:ROCm/rocm-libraries in:title "Update"')
+
+        endpoint = mock_api.call_args.args[1]
+        self.assertTrue(endpoint.startswith("search/issues?q="))
+        self.assertNotIn(" ", endpoint)
+        self.assertNotIn('"', endpoint)
+
+
 class CloseStaleTheRockRefPrsTest(unittest.TestCase):
     NOW = datetime(2026, 9, 8, 12, 0, tzinfo=timezone.utc)
 
@@ -486,6 +543,50 @@ class CloseStaleTheRockRefPrsTest(unittest.TestCase):
         endpoint = mock_api.call_args.args[1]
         self.assertTrue(endpoint.startswith("search/issues?q="))
         self.assertIn("per_page=100", endpoint)
+
+    def test_closes_stale_prs_found_beyond_the_first_search_page(self):
+        # A full first page of unrelated PRs must not hide stale bot PRs that
+        # only appear on a later page.
+        first_page = {
+            "total_count": GITHUB_SEARCH_PAGE_SIZE + 1,
+            "items": [
+                self._make_pr(
+                    number,
+                    "Update TheRock reference to (1111111)",
+                    "human-author",
+                    age=timedelta(days=3),
+                )
+                for number in range(GITHUB_SEARCH_PAGE_SIZE)
+            ],
+        }
+        second_page = {
+            "total_count": GITHUB_SEARCH_PAGE_SIZE + 1,
+            "items": [
+                self._make_pr(
+                    2000,
+                    "Update TheRock reference to (2222222)",
+                    "assistant-librarian[bot]",
+                    age=timedelta(days=3),
+                )
+            ],
+        }
+        with patch(
+            "bump_automation.gh_api",
+            side_effect=[first_page, second_page, {}, {}],
+        ) as mock_api:
+            close_stale_therock_ref_prs(
+                "ROCm/rocm-libraries",
+                current_pr_number=20,
+                token="token",
+                now=self.NOW,
+            )
+
+        closed_endpoints = [
+            call.args[1]
+            for call in mock_api.call_args_list
+            if call.kwargs.get("method") == "PATCH"
+        ]
+        self.assertEqual(closed_endpoints, ["repos/ROCm/rocm-libraries/pulls/2000"])
 
 
 class HandlePushTest(unittest.TestCase):

--- a/build_tools/github_actions/tests/bump_automation_test.py
+++ b/build_tools/github_actions/tests/bump_automation_test.py
@@ -18,6 +18,7 @@ from bump_automation import (
     create_therock_bump,
     find_therock_workflow_files,
     generate_pr_body,
+    get_baseline_run_id_from_merged_pr,
     GITHUB_SEARCH_PAGE_SIZE,
     GITHUB_SEARCH_RESULT_LIMIT,
     get_submodule_sha,
@@ -84,6 +85,110 @@ class LatestCommitTest(unittest.TestCase):
             mock_api.call_args.args[1],
             "repos/ROCm/rocgdb/commits?sha=amd-staging-rocgdb-16",
         )
+
+
+class GetBaselineRunIdFromMergedPrTest(unittest.TestCase):
+    MERGE_SHA = "df3d451a3c054e14705ddf94e58498e1208df8d5"
+    HEAD_SHA = "23bc501d4b826695062a657d0b582076c354dd77"
+
+    def _pr(self, number: int = 7999) -> dict:
+        return {
+            "number": number,
+            "merged_at": "2026-09-08T20:33:17Z",
+            "merge_commit_sha": self.MERGE_SHA,
+            "head": {"sha": self.HEAD_SHA},
+        }
+
+    def _run(self, run_id: int, conclusion: str | None, name: str = "Multi-Arch CI"):
+        return {"id": run_id, "name": name, "conclusion": conclusion}
+
+    def test_returns_the_successful_run_id(self):
+        with patch(
+            "bump_automation.gh_api",
+            side_effect=[
+                [self._pr()],
+                {"workflow_runs": [self._run(111, "success")]},
+            ],
+        ) as mock_api:
+            run_id = get_baseline_run_id_from_merged_pr(
+                "ROCm/TheRock", "token", self.MERGE_SHA
+            )
+        self.assertEqual(run_id, "111")
+        # The run lookup must key off the PR's pre-merge head SHA, not the
+        # merge commit itself.
+        self.assertIn(self.HEAD_SHA, mock_api.call_args_list[1].args[1])
+
+    def test_skips_failed_and_cancelled_runs(self):
+        with patch(
+            "bump_automation.gh_api",
+            side_effect=[
+                [self._pr()],
+                {
+                    "workflow_runs": [
+                        self._run(111, "failure"),
+                        self._run(112, "success"),
+                    ]
+                },
+            ],
+        ):
+            run_id = get_baseline_run_id_from_merged_pr(
+                "ROCm/TheRock", "token", self.MERGE_SHA
+            )
+        self.assertEqual(run_id, "112")
+
+    def test_returns_none_when_no_run_succeeded(self):
+        with patch(
+            "bump_automation.gh_api",
+            side_effect=[
+                [self._pr()],
+                {
+                    "workflow_runs": [
+                        self._run(111, "failure"),
+                        self._run(112, "cancelled"),
+                    ]
+                },
+            ],
+        ):
+            run_id = get_baseline_run_id_from_merged_pr(
+                "ROCm/TheRock", "token", self.MERGE_SHA
+            )
+        self.assertIsNone(run_id)
+
+    def test_returns_none_when_a_completed_run_has_no_conclusion_yet(self):
+        # Defensive: a "completed" run should always carry a conclusion, but
+        # don't treat a missing/null one as implicitly successful.
+        with patch(
+            "bump_automation.gh_api",
+            side_effect=[
+                [self._pr()],
+                {"workflow_runs": [self._run(111, None)]},
+            ],
+        ):
+            run_id = get_baseline_run_id_from_merged_pr(
+                "ROCm/TheRock", "token", self.MERGE_SHA
+            )
+        self.assertIsNone(run_id)
+
+    def test_returns_none_when_no_matching_workflow_name(self):
+        with patch(
+            "bump_automation.gh_api",
+            side_effect=[
+                [self._pr()],
+                {"workflow_runs": [self._run(111, "success", name="pre-commit")]},
+            ],
+        ):
+            run_id = get_baseline_run_id_from_merged_pr(
+                "ROCm/TheRock", "token", self.MERGE_SHA
+            )
+        self.assertIsNone(run_id)
+
+    def test_returns_none_when_no_merged_pr_found(self):
+        with patch("bump_automation.gh_api", return_value=[]) as mock_api:
+            run_id = get_baseline_run_id_from_merged_pr(
+                "ROCm/TheRock", "token", self.MERGE_SHA
+            )
+        self.assertIsNone(run_id)
+        mock_api.assert_called_once()
 
 
 class SubmoduleChangedTest(unittest.TestCase):

--- a/build_tools/github_actions/tests/bump_automation_test.py
+++ b/build_tools/github_actions/tests/bump_automation_test.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 import os
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 import sys
 import tempfile
@@ -13,7 +14,9 @@ sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 from bump_automation import (
     _clone_url,
     close_stale_prs,
+    close_stale_therock_ref_prs,
     create_therock_bump,
+    find_therock_workflow_files,
     generate_pr_body,
     get_submodule_sha,
     handle_push,
@@ -21,6 +24,7 @@ from bump_automation import (
     submodule_changed,
     update_ci_env_file,
     update_ref_in_file,
+    update_therock_workflow_file,
 )
 
 
@@ -238,6 +242,122 @@ class UpdateCiEnvFileTest(unittest.TestCase):
         self.assertIn("oldsha1234567", result)
 
 
+class UpdateTheRockWorkflowFileTest(unittest.TestCase):
+    OLD_SHA = "1" * 40
+    OTHER_SHA = "2" * 40
+    NEW_SHA = "3" * 40
+    STALE_COMMENT_SHA = "4" * 40
+
+    def _run(self, content: str) -> str:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+            f.write(content)
+            path = f.name
+        try:
+            update_therock_workflow_file(path, self.NEW_SHA)
+            return Path(path).read_text()
+        finally:
+            os.unlink(path)
+
+    def test_updates_reusable_workflow_and_matching_source_refs(self):
+        content = textwrap.dedent(
+            f"""\
+            # TheRock ref: pinned to ROCm/TheRock commit {self.STALE_COMMENT_SHA}.
+            jobs:
+              setup:
+                uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@{self.OLD_SHA} # 2026-01-02
+                with:
+                  repository: ROCm/TheRock
+                  ref: {self.OLD_SHA} # 2026-01-02
+            """
+        )
+        result = self._run(content)
+        self.assertEqual(result.count(self.NEW_SHA), 3)
+        self.assertNotIn(self.OLD_SHA, result)
+        self.assertNotIn(self.STALE_COMMENT_SHA, result)
+        self.assertNotIn("2026-01-02", result)
+
+    def test_updates_therock_checkout_without_reusable_workflow(self):
+        content = textwrap.dedent(
+            f"""\
+            steps:
+              - uses: actions/checkout@{self.OTHER_SHA}
+                with:
+                  repository: "ROCm/TheRock"
+                  ref: {self.OLD_SHA} # 2026-01-02
+            """
+        )
+        result = self._run(content)
+        self.assertIn(f"actions/checkout@{self.OTHER_SHA}", result)
+        self.assertIn(f"ref: {self.NEW_SHA}", result)
+        self.assertNotIn(self.OLD_SHA, result)
+
+    def test_updates_therock_ref_override_default(self):
+        content = textwrap.dedent(
+            f"""\
+            steps:
+              - uses: actions/checkout@{self.OTHER_SHA}
+                with:
+                  repository: "ROCm/TheRock"
+                  ref: ${{{{ inputs.therock_ref_override || '{self.OLD_SHA}' }}}}
+            """
+        )
+        result = self._run(content)
+        self.assertIn(self.NEW_SHA, result)
+        self.assertNotIn(self.OLD_SHA, result)
+
+    def test_fails_when_workflow_has_no_pinned_therock_ref(self):
+        with self.assertRaisesRegex(RuntimeError, "No pinned TheRock refs"):
+            self._run("name: unrelated workflow\n")
+
+
+class FindTheRockWorkflowFilesTest(unittest.TestCase):
+    def test_discovers_all_yaml_extensions_with_pinned_refs(self):
+        old_sha = "1" * 40
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            workflows = root / "workflows"
+            actions = root / "actions"
+            workflows.mkdir()
+            actions.mkdir()
+            (workflows / "reusable.yml").write_text(
+                f"uses: ROCm/TheRock/.github/workflows/ci.yml@{old_sha}\n",
+                encoding="utf-8",
+            )
+            (actions / "checkout.yaml").write_text(
+                textwrap.dedent(
+                    f"""\
+                    repository: ROCm/TheRock
+                    ref: {old_sha}
+                    """
+                ),
+                encoding="utf-8",
+            )
+            (workflows / "unrelated.yml").write_text(
+                "uses: actions/checkout@v4\n", encoding="utf-8"
+            )
+
+            result = find_therock_workflow_files(root)
+
+        self.assertEqual(
+            result,
+            [
+                (actions / "checkout.yaml").as_posix(),
+                (workflows / "reusable.yml").as_posix(),
+            ],
+        )
+
+    def test_fails_when_no_pinned_workflows_are_found(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "unrelated.yml").write_text(
+                "uses: actions/checkout@v4\n", encoding="utf-8"
+            )
+            with self.assertRaisesRegex(
+                RuntimeError, "No pinned TheRock workflow files"
+            ):
+                find_therock_workflow_files(root)
+
+
 class CloseStalePrsTest(unittest.TestCase):
     def _make_pr(self, number: int, title: str) -> dict:
         return {"number": number, "title": title}
@@ -273,6 +393,99 @@ class CloseStalePrsTest(unittest.TestCase):
             c for c in mock_api.call_args_list if c.kwargs.get("method") == "POST"
         ]
         self.assertTrue(any("comments" in c.args[1] for c in post_calls))
+
+
+class CloseStaleTheRockRefPrsTest(unittest.TestCase):
+    NOW = datetime(2026, 9, 8, 12, 0, tzinfo=timezone.utc)
+
+    def _make_pr(self, number: int, title: str, author: str, *, age: timedelta) -> dict:
+        created = self.NOW - age
+        return {
+            "number": number,
+            "title": title,
+            "user": {"login": author},
+            "created_at": created.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        }
+
+    def test_closes_older_bot_reference_prs_only(self):
+        search_result = {
+            "items": [
+                self._make_pr(
+                    10,
+                    "Update TheRock reference to (1111111)",
+                    "assistant-librarian[bot]",
+                    age=timedelta(days=3),
+                ),
+                self._make_pr(
+                    20,
+                    "Update TheRock reference to (2222222)",
+                    "assistant-librarian[bot]",
+                    age=timedelta(days=3),
+                ),
+                self._make_pr(
+                    30,
+                    "Update TheRock reference to (3333333)",
+                    "human-author",
+                    age=timedelta(days=3),
+                ),
+            ]
+        }
+        with patch("bump_automation.gh_api", return_value=search_result) as mock_api:
+            close_stale_therock_ref_prs(
+                "ROCm/rocm-libraries",
+                current_pr_number=20,
+                token="token",
+                now=self.NOW,
+            )
+
+        closed_endpoints = [
+            call.args[1]
+            for call in mock_api.call_args_list
+            if call.kwargs.get("method") == "PATCH"
+        ]
+        self.assertEqual(closed_endpoints, ["repos/ROCm/rocm-libraries/pulls/10"])
+
+    def test_leaves_recent_bot_reference_prs_open(self):
+        search_result = {
+            "items": [
+                self._make_pr(
+                    10,
+                    "Update TheRock reference to (1111111)",
+                    "assistant-librarian[bot]",
+                    age=timedelta(days=1, hours=23),
+                ),
+                self._make_pr(
+                    11,
+                    "Update TheRock reference to (aaaaaaa)",
+                    "assistant-librarian[bot]",
+                    age=timedelta(days=2),
+                ),
+            ]
+        }
+        with patch("bump_automation.gh_api", return_value=search_result) as mock_api:
+            close_stale_therock_ref_prs(
+                "ROCm/rocm-libraries",
+                current_pr_number=20,
+                token="token",
+                now=self.NOW,
+            )
+
+        closed_endpoints = [
+            call.args[1]
+            for call in mock_api.call_args_list
+            if call.kwargs.get("method") == "PATCH"
+        ]
+        self.assertEqual(closed_endpoints, ["repos/ROCm/rocm-libraries/pulls/11"])
+
+    def test_searches_all_open_reference_prs(self):
+        with patch("bump_automation.gh_api", return_value={"items": []}) as mock_api:
+            close_stale_therock_ref_prs(
+                "ROCm/rocm-libraries", current_pr_number=20, token="token"
+            )
+
+        endpoint = mock_api.call_args.args[1]
+        self.assertTrue(endpoint.startswith("search/issues?q="))
+        self.assertIn("per_page=100", endpoint)
 
 
 class HandlePushTest(unittest.TestCase):

--- a/build_tools/github_actions/tests/bump_automation_test.py
+++ b/build_tools/github_actions/tests/bump_automation_test.py
@@ -597,6 +597,7 @@ class CloseStaleTheRockRefPrsTest(unittest.TestCase):
                 "ROCm/rocm-libraries",
                 current_pr_number=20,
                 token="token",
+                bot_author="assistant-librarian[bot]",
                 now=self.NOW,
             )
 
@@ -629,6 +630,7 @@ class CloseStaleTheRockRefPrsTest(unittest.TestCase):
                 "ROCm/rocm-libraries",
                 current_pr_number=20,
                 token="token",
+                bot_author="assistant-librarian[bot]",
                 now=self.NOW,
             )
 
@@ -642,7 +644,10 @@ class CloseStaleTheRockRefPrsTest(unittest.TestCase):
     def test_searches_all_open_reference_prs(self):
         with patch("bump_automation.gh_api", return_value={"items": []}) as mock_api:
             close_stale_therock_ref_prs(
-                "ROCm/rocm-libraries", current_pr_number=20, token="token"
+                "ROCm/rocm-libraries",
+                current_pr_number=20,
+                token="token",
+                bot_author="assistant-librarian[bot]",
             )
 
         endpoint = mock_api.call_args.args[1]
@@ -683,6 +688,7 @@ class CloseStaleTheRockRefPrsTest(unittest.TestCase):
                 "ROCm/rocm-libraries",
                 current_pr_number=20,
                 token="token",
+                bot_author="assistant-librarian[bot]",
                 now=self.NOW,
             )
 
@@ -761,6 +767,99 @@ class HandlePushTest(unittest.TestCase):
         self.assertEqual(mock_close.call_args.args[2], "systems-token")
         # submodule-only: must not clone any upstream repo.
         mock_tmp.assert_not_called()
+
+    def test_ref_updater_closes_stale_prs_with_its_own_bot_author(self):
+        """rocm-systems' bump PRs are opened by "systems-assistant[bot]", a
+        different GitHub App than rocm-libraries' "assistant-librarian[bot]".
+        handle_push must pass each repo's own bot identity through to
+        close_stale_therock_ref_prs rather than a single hardcoded value."""
+
+        def changed(before, after, path):
+            return path == "rocm-systems"
+
+        with patch("bump_automation.submodule_changed", side_effect=changed):
+            with patch(
+                "bump_automation.get_submodule_sha", return_value="oldsha1234567"
+            ):
+                with patch("bump_automation.close_stale_prs"):
+                    with patch("bump_automation.run"):
+                        with patch("bump_automation.os.chdir"):
+                            with patch(
+                                "bump_automation.os.path.exists", return_value=True
+                            ):
+                                with patch("bump_automation.update_ref_in_file"):
+                                    with patch(
+                                        "bump_automation.gh_api",
+                                        return_value={"number": 1},
+                                    ):
+                                        with patch(
+                                            "bump_automation.close_stale_therock_ref_prs"
+                                        ) as mock_close_ref:
+                                            with patch(
+                                                "bump_automation.create_therock_bump"
+                                            ):
+                                                handle_push(
+                                                    "before",
+                                                    "after",
+                                                    {
+                                                        "systems": "systems-token",
+                                                        "libraries": "libraries-token",
+                                                    },
+                                                )
+
+        mock_close_ref.assert_called_once()
+        self.assertEqual(mock_close_ref.call_args.args[0], "ROCm/rocm-systems")
+        self.assertEqual(mock_close_ref.call_args.args[3], "systems-assistant[bot]")
+
+    def test_ci_env_updater_closes_stale_prs_with_its_own_bot_author(self):
+        """rocm-libraries must keep using its own "assistant-librarian[bot]"
+        identity, not rocm-systems'."""
+
+        def changed(before, after, path):
+            return path == "rocm-libraries"
+
+        with patch("bump_automation.submodule_changed", side_effect=changed):
+            with patch(
+                "bump_automation.get_submodule_sha", return_value="oldsha1234567"
+            ):
+                with patch("bump_automation.close_stale_prs"):
+                    with patch(
+                        "bump_automation.get_baseline_run_id_from_merged_pr",
+                        return_value=None,
+                    ):
+                        with patch("bump_automation.run"):
+                            with patch("bump_automation.os.chdir"):
+                                with patch(
+                                    "bump_automation.os.path.exists",
+                                    return_value=True,
+                                ):
+                                    with patch("bump_automation.update_ci_env_file"):
+                                        with patch(
+                                            "bump_automation.find_therock_workflow_files",
+                                            return_value=[],
+                                        ):
+                                            with patch(
+                                                "bump_automation.gh_api",
+                                                return_value={"number": 1},
+                                            ):
+                                                with patch(
+                                                    "bump_automation.close_stale_therock_ref_prs"
+                                                ) as mock_close_ref:
+                                                    with patch(
+                                                        "bump_automation.create_therock_bump"
+                                                    ):
+                                                        handle_push(
+                                                            "before",
+                                                            "after",
+                                                            {
+                                                                "systems": "systems-token",
+                                                                "libraries": "libraries-token",
+                                                            },
+                                                        )
+
+        mock_close_ref.assert_called_once()
+        self.assertEqual(mock_close_ref.call_args.args[0], "ROCm/rocm-libraries")
+        self.assertEqual(mock_close_ref.call_args.args[3], "assistant-librarian[bot]")
 
 
 class CreateTheRockBumpTest(unittest.TestCase):

--- a/build_tools/github_actions/tests/bump_automation_test.py
+++ b/build_tools/github_actions/tests/bump_automation_test.py
@@ -12,7 +12,9 @@ from unittest.mock import patch
 
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 from bump_automation import (
+    _baseline_gate_jobs_succeeded,
     _clone_url,
+    _list_run_jobs,
     close_stale_prs,
     close_stale_therock_ref_prs,
     create_therock_bump,
@@ -24,6 +26,7 @@ from bump_automation import (
     get_submodule_sha,
     handle_push,
     latest_commit,
+    LIBRARIES_BASELINE_GATE_JOB_NAME,
     search_issues,
     submodule_changed,
     update_ci_env_file,
@@ -87,6 +90,82 @@ class LatestCommitTest(unittest.TestCase):
         )
 
 
+def _gate_job(conclusion: str | None, name: str = LIBRARIES_BASELINE_GATE_JOB_NAME):
+    return {
+        "name": f"Linux::release / Build Multi-Arch Stages / {name}",
+        "conclusion": conclusion,
+    }
+
+
+def _jobs_page(jobs: list[dict], total_count: int | None = None) -> dict:
+    return {
+        "jobs": jobs,
+        "total_count": total_count if total_count is not None else len(jobs),
+    }
+
+
+class ListRunJobsTest(unittest.TestCase):
+    def test_returns_single_page_without_further_requests(self):
+        with patch(
+            "bump_automation.gh_api",
+            return_value=_jobs_page([_gate_job("success")]),
+        ) as mock_api:
+            jobs = _list_run_jobs("ROCm/TheRock", "token", 111)
+        self.assertEqual(len(jobs), 1)
+        mock_api.assert_called_once()
+
+    def test_follows_pagination_until_all_jobs_are_retrieved(self):
+        first_page = _jobs_page([_gate_job("success")] * 100, total_count=101)
+        second_page = _jobs_page([_gate_job("success")], total_count=101)
+        with patch(
+            "bump_automation.gh_api", side_effect=[first_page, second_page]
+        ) as mock_api:
+            jobs = _list_run_jobs("ROCm/TheRock", "token", 111)
+        self.assertEqual(len(jobs), 101)
+        self.assertEqual(mock_api.call_count, 2)
+
+
+class BaselineGateJobsSucceededTest(unittest.TestCase):
+    def test_true_when_the_single_gate_job_succeeded(self):
+        with patch(
+            "bump_automation.gh_api", return_value=_jobs_page([_gate_job("success")])
+        ):
+            self.assertTrue(_baseline_gate_jobs_succeeded("ROCm/TheRock", "token", 111))
+
+    def test_true_only_when_every_platform_gate_job_succeeded(self):
+        jobs = [
+            {
+                "name": f"Linux::release / Build Multi-Arch Stages / {LIBRARIES_BASELINE_GATE_JOB_NAME}",
+                "conclusion": "success",
+            },
+            {
+                "name": f"Windows::release / Build Multi-Arch Stages / {LIBRARIES_BASELINE_GATE_JOB_NAME}",
+                "conclusion": "failure",
+            },
+        ]
+        with patch("bump_automation.gh_api", return_value=_jobs_page(jobs)):
+            self.assertFalse(
+                _baseline_gate_jobs_succeeded("ROCm/TheRock", "token", 111)
+            )
+
+    def test_false_when_no_gate_job_is_found(self):
+        with patch(
+            "bump_automation.gh_api",
+            return_value=_jobs_page([{"name": "setup", "conclusion": "success"}]),
+        ):
+            self.assertFalse(
+                _baseline_gate_jobs_succeeded("ROCm/TheRock", "token", 111)
+            )
+
+    def test_false_when_gate_job_conclusion_is_missing(self):
+        with patch(
+            "bump_automation.gh_api", return_value=_jobs_page([_gate_job(None)])
+        ):
+            self.assertFalse(
+                _baseline_gate_jobs_succeeded("ROCm/TheRock", "token", 111)
+            )
+
+
 class GetBaselineRunIdFromMergedPrTest(unittest.TestCase):
     MERGE_SHA = "df3d451a3c054e14705ddf94e58498e1208df8d5"
     HEAD_SHA = "23bc501d4b826695062a657d0b582076c354dd77"
@@ -102,12 +181,13 @@ class GetBaselineRunIdFromMergedPrTest(unittest.TestCase):
     def _run(self, run_id: int, conclusion: str | None, name: str = "Multi-Arch CI"):
         return {"id": run_id, "name": name, "conclusion": conclusion}
 
-    def test_returns_the_successful_run_id(self):
+    def test_returns_the_run_id_when_its_gate_job_succeeded(self):
         with patch(
             "bump_automation.gh_api",
             side_effect=[
                 [self._pr()],
                 {"workflow_runs": [self._run(111, "success")]},
+                _jobs_page([_gate_job("success")]),
             ],
         ) as mock_api:
             run_id = get_baseline_run_id_from_merged_pr(
@@ -118,17 +198,37 @@ class GetBaselineRunIdFromMergedPrTest(unittest.TestCase):
         # merge commit itself.
         self.assertIn(self.HEAD_SHA, mock_api.call_args_list[1].args[1])
 
-    def test_skips_failed_and_cancelled_runs(self):
+    def test_returns_the_run_id_even_when_overall_run_conclusion_is_failure(self):
+        # This is the real scenario that motivated the gate-job check: an
+        # unrelated math-libs/compiler-runtime failure elsewhere in the
+        # matrix makes the whole run "failure" even though every stage
+        # rocm-libraries reuses succeeded.
+        with patch(
+            "bump_automation.gh_api",
+            side_effect=[
+                [self._pr()],
+                {"workflow_runs": [self._run(111, "failure")]},
+                _jobs_page([_gate_job("success")]),
+            ],
+        ):
+            run_id = get_baseline_run_id_from_merged_pr(
+                "ROCm/TheRock", "token", self.MERGE_SHA
+            )
+        self.assertEqual(run_id, "111")
+
+    def test_skips_runs_whose_gate_job_did_not_succeed(self):
         with patch(
             "bump_automation.gh_api",
             side_effect=[
                 [self._pr()],
                 {
                     "workflow_runs": [
-                        self._run(111, "failure"),
+                        self._run(111, "success"),
                         self._run(112, "success"),
                     ]
                 },
+                _jobs_page([_gate_job("failure")]),  # run 111's gate job
+                _jobs_page([_gate_job("success")]),  # run 112's gate job
             ],
         ):
             run_id = get_baseline_run_id_from_merged_pr(
@@ -136,7 +236,7 @@ class GetBaselineRunIdFromMergedPrTest(unittest.TestCase):
             )
         self.assertEqual(run_id, "112")
 
-    def test_returns_none_when_no_run_succeeded(self):
+    def test_returns_none_when_no_run_gate_job_succeeded(self):
         with patch(
             "bump_automation.gh_api",
             side_effect=[
@@ -147,6 +247,8 @@ class GetBaselineRunIdFromMergedPrTest(unittest.TestCase):
                         self._run(112, "cancelled"),
                     ]
                 },
+                _jobs_page([_gate_job("failure")]),
+                _jobs_page([_gate_job("cancelled")]),
             ],
         ):
             run_id = get_baseline_run_id_from_merged_pr(
@@ -154,14 +256,15 @@ class GetBaselineRunIdFromMergedPrTest(unittest.TestCase):
             )
         self.assertIsNone(run_id)
 
-    def test_returns_none_when_a_completed_run_has_no_conclusion_yet(self):
-        # Defensive: a "completed" run should always carry a conclusion, but
-        # don't treat a missing/null one as implicitly successful.
+    def test_returns_none_when_gate_job_is_missing(self):
+        # A run that predates the gate job (or is otherwise structurally
+        # different) must not be treated as a usable baseline.
         with patch(
             "bump_automation.gh_api",
             side_effect=[
                 [self._pr()],
-                {"workflow_runs": [self._run(111, None)]},
+                {"workflow_runs": [self._run(111, "success")]},
+                _jobs_page([{"name": "setup", "conclusion": "success"}]),
             ],
         ):
             run_id = get_baseline_run_id_from_merged_pr(


### PR DESCRIPTION
## Motivation

GitHub issue: https://github.com/ROCm/TheRock/issues/8068

The submodule bump bot is supposed to open a rocm-libraries pin PR whenever a `rocm-libraries` bump lands on TheRock `main`. Those PRs only rewrite `ci-env` (`therock-ref` and `baseline-run-id`). Multi-Arch CI, which is now the libraries per-PR gate, is defined by literal `uses: ROCm/TheRock/...@<sha>` pins that GitHub will not take from an expression. Complete pins such as ROCm/rocm-libraries#11699 update both surfaces; bot PRs such as ROCm/rocm-libraries#11767 do not, then conflict and pile up.

A third gap surfaced while manually validating a pin bump against ROCm/rocm-libraries#11818: the bot's `baseline_run_id` lookup only checked that the upstream Multi-Arch CI run had `status=completed`, not that it actually succeeded, so a failed or cancelled run could still be handed to rocm-libraries as a baseline.

Review also caught a fourth, pre-existing bug: the stale-PR closer hardcoded rocm-libraries' bot identity (`assistant-librarian[bot]`), but `handle_push()` already runs it for every repo in `SUBMODULE_CONFIG`, including rocm-systems, whose PRs are opened by a different GitHub App (`systems-assistant[bot]`). The author check never matched there, so rocm-systems' stale `Update TheRock reference` PRs were never being closed; 10+ are open on that repo right now as a result.

A fifth issue turned up once the fix for the third gap was checked against a real run: requiring the whole Multi-Arch CI run to have `conclusion == "success"` was too strict. rocm-libraries only reuses 9 specific stages (`runtime-tests`, `comm-libs`, `cv-libs`, `storage-libs`, `debug-tools`, `dctools-core`, `profiler-apps`, `media-libs`, `wsl-rocdxg`) via `baseline_run_id`; an unrelated `math-libs` or `compiler-runtime` failure anywhere else in the matrix flips the whole run's conclusion to failure and would have thrown away an otherwise-good baseline. Confirmed live on run https://github.com/ROCm/TheRock/actions/runs/34275481546, where a Windows `math-libs` failure would have discarded a run whose reused stages all succeeded.

Scope: the pin-PR completeness, baseline-run-success, and baseline-gate-job fixes are libraries-specific (only the `ci-env` updater path hits them); the search pagination and per-repo bot-author fixes apply to the stale-PR closer shared by both rocm-libraries and rocm-systems.

## Technical Details

On the libraries `ci-env` updater path, discover YAML under `.github` that already contains a pinned TheRock SHA and rewrite those pins in lockstep with `ci-env`. Fail if a targeted file has no pin or still has a stale SHA after the rewrite. After opening the new pin PR, close older bot-authored `Update TheRock reference` PRs that are at least two days old so recent ones can finish CI.

`bot_author` moved from a single module-level constant into a per-repo field in `SUBMODULE_CONFIG`, and `close_stale_therock_ref_prs()` now takes it as a required parameter instead of assuming one global bot identity.

Added a `libraries_baseline_ready` job to `multi_arch_build_portable_linux.yml` and `multi_arch_build_windows.yml` that `needs:` exactly the stages rocm-libraries reuses (a narrower subset on Windows, since several of those stages are Linux-only) and fails if any of them didn't succeed. This puts the reused-stage list in one visible place in the CI graph instead of duplicating it as a name-matching list in Python. `get_baseline_run_id_from_merged_pr()` now checks that job's conclusion via the Actions jobs API instead of the run's overall conclusion. A run with no such job is treated as no baseline. If more than one gate job is present (Linux and Windows in the same run), every one of them must have succeeded. A run that only produced one platform's gate job is still accepted if that job succeeded; that is the partial-rerun / one-OS-completion case, and throwing the baseline away there would force a full libraries rebuild even when the artifacts we reuse are fine.

Does not change TheRock-side `Bump rocm-*` stale handling (#7764 / #7585) or token passing (#7725).

## Test Plan

- `python -m pytest build_tools/github_actions/tests/bump_automation_test.py -q`
- `pre-commit run --files build_tools/github_actions/bump_automation.py build_tools/github_actions/tests/bump_automation_test.py`

## Test Result

62 passed. Targeted pre-commit hooks passed (Black reformatted the new tests on first commit attempt each time; final commit is clean). `actionlint` (via pre-commit) passed on both edited workflow files.

## Risk Assessment

Risk 3. This is reusable-CI / bump-bot wiring used on every libraries and systems submodule merge. A bad rewrite could open a pin PR with the wrong SHA or close a human pin PR. Discovery is limited to files that already contain a TheRock pin; close is limited to the repo's own bot author and title prefix, and only after two days. The new `libraries_baseline_ready` job is additive: nothing else in Multi-Arch CI depends on it, so a bug in it can make its own status wrong but cannot block or skip any other job in the run.

## Related

- Work tracking: https://github.com/ROCm/TheRock/issues/8068
- Related PRs: ROCm/rocm-libraries#11699, ROCm/rocm-libraries#11767, #7764, #7725, #6183

## Device / Architecture Coverage

No device code. Passing PR CI (unit tests for bump automation) is sufficient.

## Testing Summary

- Unit tests cover workflow SHA rewrite (including `uses:`, checkout `ref:`, `therock_ref_override` defaults, and comment SHAs), discovery of pinned YAML, stale-bot close with a two-day age floor, and leaving human PRs alone.
- Unit tests cover `handle_push` passing the correct per-repo `bot_author` to the stale-PR closer for both the `ci-env` (rocm-libraries) and `ref` (rocm-systems) updater paths.
- Unit tests cover the baseline gate-job lookup: returns the run whose gate job succeeded even when the run's own overall `conclusion` is "failure" (the real scenario found on run 34275481546), skips runs whose gate job failed/was cancelled, treats a missing gate job as not a usable baseline, and if both Linux and Windows gate jobs are present, requires both to succeed. A single-platform gate job that succeeded is still accepted. Also covers jobs-list pagination.

## Testing Checklist

- [x] Bump automation unit tests - `python -m pytest build_tools/github_actions/tests/bump_automation_test.py -q` - Status: Passed
- [x] Targeted pre-commit - `pre-commit run --files build_tools/github_actions/bump_automation.py build_tools/github_actions/tests/bump_automation_test.py .github/workflows/multi_arch_build_portable_linux.yml .github/workflows/multi_arch_build_windows.yml` - Status: Passed (includes actionlint on the workflow files)
- [ ] PR CI - GitHub PR checks - Status: Pending

## Flags / Guardrails

None.

## Adjacent Tests Considered

`CloseStalePrsTest` still covers TheRock-side `Bump rocm-*` closing and is unchanged. End-to-end live bump is not exercised here; that needs a real submodule merge after this lands.

## Risk Acceptance / Waivers

None. `W-BUILD` would fit a CI-only change, but the new unit tests cover the behavior so no waiver is claimed.

## Technical Changes

- Discover and rewrite all pinned TheRock workflow SHAs when opening a libraries pin PR, not only `ci-env`.
- Close superseded bot pin PRs after two days.
- Fix the stale-PR closer to use each downstream repo's own bot identity instead of one hardcoded to rocm-libraries, which had left rocm-systems' stale pin PRs uncleaned.
- Add a `libraries_baseline_ready` gate job (Linux and Windows) that depends on exactly the stages rocm-libraries reuses, and require every found instance of that job to succeed before handing out `baseline_run_id`, instead of requiring the whole Multi-Arch CI run to succeed. A run with only one platform's gate job is still usable if that job succeeded.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.




