### PR TITLE
feat(ci): add Windows driver build variant to nightly releases

### DIFF
--- a/.github/workflows/multi_arch_release.yml
+++ b/.github/workflows/multi_arch_release.yml
@@ -206,9 +206,7 @@ jobs:
       actions: write  # Added permission to trigger workflows
       id-token: write  # Added permission for AWS S3 upload
 
-  # Driver-variant setup. Windows only; families opt in via "driver" in their
-  # build_variants list, so this produces an empty build config (and the build
-  # below is skipped) until a family declares it.
+  # Windows only. Emits an empty build config until a family opts in, skipping both jobs.
   setup_driver:
     uses: ./.github/workflows/setup_multi_arch.yml
     with:

--- a/.github/workflows/multi_arch_release.yml
+++ b/.github/workflows/multi_arch_release.yml
@@ -206,9 +206,49 @@ jobs:
       actions: write  # Added permission to trigger workflows
       id-token: write  # Added permission for AWS S3 upload
 
+  # Driver-variant setup. Windows only; families opt in via "driver" in their
+  # build_variants list, so this produces an empty build config (and the build
+  # below is skipped) until a family declares it.
+  setup_driver:
+    uses: ./.github/workflows/setup_multi_arch.yml
+    with:
+      build_variant: "driver"
+      release_type: ${{ inputs.release_type }}
+      prerelease_version: ${{ inputs.prerelease_version }}
+      build_pytorch: false
+      build_jax: false
+      python_version: ${{ inputs.python_version }}
+      linux_amdgpu_families: "none"
+      windows_amdgpu_families: ${{ inputs.windows_amdgpu_families }}
+      repository: ${{ inputs.repository || github.repository }}
+      ref: ${{ inputs.ref }}
+      quartz_tracking_id: ${{ inputs.enable_quartz_tracking && format('{0};{1}', github.run_id, inputs.release_type) || '' }}
+    secrets: inherit
+
+  windows_driver_release:
+    name: Windows::${{ fromJSON(needs.setup_driver.outputs.windows_build_config || '{}').build_variant_label || 'skip' }}
+    needs: setup_driver
+    if: ${{ needs.setup_driver.outputs.windows_build_config != '' }}
+    uses: ./.github/workflows/multi_arch_release_windows.yml
+    secrets: inherit
+    with:
+      build_config: ${{ needs.setup_driver.outputs.windows_build_config }}
+      rocm_package_version: ${{ needs.setup_driver.outputs.rocm_package_version }}
+      test_type: ${{ needs.setup_driver.outputs.test_type }}
+      release_type: ${{ inputs.release_type }}
+      repository: ${{ inputs.repository || github.repository }}
+      ref: ${{ needs.setup_driver.outputs.ref }}
+      build_pytorch: false
+      python_version: ${{ inputs.python_version }}
+      quartz_tracking_id: ${{ inputs.enable_quartz_tracking && format('{0};{1}', github.run_id, inputs.release_type) || '' }}
+    permissions:
+      contents: read
+      actions: write  # Added permission to trigger workflows
+      id-token: write  # Added permission for AWS S3 upload
+
   notify_quartz_completed:
     if: ${{ always() && vars.NOTIFY_QUARTZ_ENABLED == 'true' }}
-    needs: [setup, linux_release, windows_release]
+    needs: [setup, linux_release, windows_release, windows_driver_release]
     name: "Quartz - completed - release"
     runs-on: ubuntu-24.04
     timeout-minutes: 10

--- a/.github/workflows/multi_arch_release_windows.yml
+++ b/.github/workflows/multi_arch_release_windows.yml
@@ -99,8 +99,7 @@ jobs:
 
   build_python_packages:
     needs: [build_artifacts]
-    # Driver builds are a reduced component set consumed by driver packaging;
-    # they are not a ROCm distribution, so no wheels and no release publishing.
+    # Driver builds are a partial tree, not a ROCm distribution.
     if: ${{ fromJSON(inputs.build_config).build_variant_suffix != 'driver' }}
     name: Build Python Packages
     uses: ./.github/workflows/build_windows_python_packages.yml
@@ -160,8 +159,7 @@ jobs:
   trigger_test_artifacts_per_family:
     needs: [build_artifacts]
     name: Trigger Test Artifacts (${{ matrix.family_info.amdgpu_family }})
-    # Skipped for driver builds: the standard test matrix assumes the full
-    # component set. See the PR discussion for what coverage should replace it.
+    # Driver builds get full validation downstream; this matrix assumes components they don't build.
     if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).build_variant_suffix != 'driver' }}
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/multi_arch_release_windows.yml
+++ b/.github/workflows/multi_arch_release_windows.yml
@@ -99,6 +99,9 @@ jobs:
 
   build_python_packages:
     needs: [build_artifacts]
+    # Driver builds are a reduced component set consumed by driver packaging;
+    # they are not a ROCm distribution, so no wheels and no release publishing.
+    if: ${{ fromJSON(inputs.build_config).build_variant_suffix != 'driver' }}
     name: Build Python Packages
     uses: ./.github/workflows/build_windows_python_packages.yml
     secrets: inherit
@@ -119,6 +122,7 @@ jobs:
 
   publish_to_release_buckets:
     needs: [build_tarballs, build_python_packages]
+    if: ${{ fromJSON(inputs.build_config).build_variant_suffix != 'driver' }}
     name: Publish to Release Buckets
     runs-on: ubuntu-24.04
     permissions:
@@ -156,7 +160,9 @@ jobs:
   trigger_test_artifacts_per_family:
     needs: [build_artifacts]
     name: Trigger Test Artifacts (${{ matrix.family_info.amdgpu_family }})
-    if: ${{ !failure() && !cancelled() }}
+    # Skipped for driver builds: the standard test matrix assumes the full
+    # component set. See the PR discussion for what coverage should replace it.
+    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).build_variant_suffix != 'driver' }}
     runs-on: ubuntu-24.04
     permissions:
       actions: write

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -168,6 +168,17 @@
       "inherits": [
         "windows-base"
       ]
+    },
+    {
+      "name": "windows-release-driver",
+      "displayName": "Windows driver-package release build",
+      "description": "Windows release plus THEROCK_FLAG_WINDOWS_DRIVER_BUILD (Control Flow Guard, driver comgr DLL name).",
+      "cacheVariables": {
+        "THEROCK_FLAG_WINDOWS_DRIVER_BUILD": "ON"
+      },
+      "inherits": [
+        "windows-release"
+      ]
     }
   ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -172,7 +172,7 @@
     {
       "name": "windows-release-driver",
       "displayName": "Windows driver-package release build",
-      "description": "Windows release plus THEROCK_FLAG_WINDOWS_DRIVER_BUILD (Control Flow Guard, driver comgr DLL name), reduced to the components driver packaging consumes.",
+      "description": "Windows release with WINDOWS_DRIVER_BUILD (CFG, driver comgr DLL name), reduced to the components driver packaging consumes.",
       "cacheVariables": {
         "THEROCK_FLAG_WINDOWS_DRIVER_BUILD": "ON",
         "THEROCK_ENABLE_ALL": "OFF",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -172,9 +172,12 @@
     {
       "name": "windows-release-driver",
       "displayName": "Windows driver-package release build",
-      "description": "Windows release plus THEROCK_FLAG_WINDOWS_DRIVER_BUILD (Control Flow Guard, driver comgr DLL name).",
+      "description": "Windows release plus THEROCK_FLAG_WINDOWS_DRIVER_BUILD (Control Flow Guard, driver comgr DLL name), reduced to the components driver packaging consumes.",
       "cacheVariables": {
-        "THEROCK_FLAG_WINDOWS_DRIVER_BUILD": "ON"
+        "THEROCK_FLAG_WINDOWS_DRIVER_BUILD": "ON",
+        "THEROCK_ENABLE_ALL": "OFF",
+        "THEROCK_ENABLE_CORE": "ON",
+        "THEROCK_ENABLE_COMPILER": "ON"
       },
       "inherits": [
         "windows-release"

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -189,9 +189,7 @@ all_build_variants = {
             "build_variant_suffix": "",
             "build_variant_cmake_preset": "windows-release",
         },
-        # Driver-package builds are run on nightly. Same sources as release, but
-        # built with Control Flow Guard and the driver comgr DLL name so the
-        # artifacts can be consumed by downstream driver packaging.
+        # Release sources built with CFG and the driver comgr DLL name.
         "driver": {
             "build_variant_label": "driver",
             "build_variant_suffix": "driver",

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -189,6 +189,14 @@ all_build_variants = {
             "build_variant_suffix": "",
             "build_variant_cmake_preset": "windows-release",
         },
+        # Driver-package builds are run on nightly. Same sources as release, but
+        # built with Control Flow Guard and the driver comgr DLL name so the
+        # artifacts can be consumed by downstream driver packaging.
+        "driver": {
+            "build_variant_label": "driver",
+            "build_variant_suffix": "driver",
+            "build_variant_cmake_preset": "windows-release-driver",
+        },
     },
 }
 
@@ -263,7 +271,7 @@ amdgpu_family_info_matrix_presubmit = {
             "family": "gfx110X-all",
             "fetch-gfx-targets": ["gfx1100", "gfx1101", "gfx1102", "gfx1103"],
             "bypass_tests_for_releases": True,
-            "build_variants": ["release"],
+            "build_variants": ["release", "driver"],
         },
     },
     "gfx1151": {

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -1429,8 +1429,7 @@ def _expand_build_config_for_platform(
 
     # ASAN builds native Linux packages (deb/rpm) but not Python packages.
     # The build_python_packages input allows callers to disable Python packages.
-    # Driver builds feed downstream driver packaging only, so they skip Python
-    # packages too.
+    # Driver builds skip them too: partial tree, not a distribution.
     is_asan = suffix in ("asan", "host-asan")
     is_driver = suffix == "driver"
     build_python_packages = (

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -1429,8 +1429,13 @@ def _expand_build_config_for_platform(
 
     # ASAN builds native Linux packages (deb/rpm) but not Python packages.
     # The build_python_packages input allows callers to disable Python packages.
+    # Driver builds feed downstream driver packaging only, so they skip Python
+    # packages too.
     is_asan = suffix in ("asan", "host-asan")
-    build_python_packages = ci_inputs.build_python_packages and not is_asan
+    is_driver = suffix == "driver"
+    build_python_packages = (
+        ci_inputs.build_python_packages and not is_asan and not is_driver
+    )
     test_python_packages_matrix = (
         build_rocm_python_test_matrix(
             per_family_info=per_family_info,


### PR DESCRIPTION
## Motivation

TheRock's nightly Windows artifacts are built with `THEROCK_FLAG_WINDOWS_DRIVER_BUILD`
off, so they carry neither Control Flow Guard nor the driver comgr DLL name.
Downstream driver packaging needs both. This adds a `driver` Windows build variant
so a nightly run can emit both sets.

ISSUE ID https://github.com/ROCm/TheRock/issues/1293

## Technical Details

Follows the existing ASAN variant pattern.

- **`CMakePresets.json`** — `windows-release-driver`: `windows-release` plus
  `THEROCK_FLAG_WINDOWS_DRIVER_BUILD=ON`, reduced to `ENABLE_ALL=OFF` with `CORE`
  and `COMPILER` on (amd-llvm + KPACK/HIP_RUNTIME/OCL_ICD/OCL_RUNTIME — the
  components driver packaging consumes). `COMPILER` is in the `ALL` group, so it
  needs naming explicitly.
- **`amdgpu_family_matrix.py`** — registers the variant; opt-in is per family via
  `build_variants`, starting with `gfx110x`.
- **`multi_arch_release.yml`** — `setup_driver` + `windows_driver_release`, which
  skip automatically when no family declares the variant.
- **`configure_multi_arch_ci.py`** / **`multi_arch_release_windows.yml`** — driver
  builds skip Python packages, release-bucket publishing and the per-family test
  matrix, since the output is not a ROCm distribution. Conditions key off
  `build_variant_suffix`, empty for release, so that path is unchanged.

CI coverage for this variant is intentionally minimal: these artifacts are handed
off for full downstream validation, so the per-family matrix here would be
redundant as well as inapplicable to a partial component set.

Artifact separation is free from the existing machinery: `artifact_group` becomes
`multi-arch-driver`.

`/guard:cf` is injected per subproject in `_therock_cmake_subproject_setup_toolchain`,
so this is a full second Windows build with no reuse — hence the per-family opt-in
and the reduced component set.

Verified by running `configure_multi_arch_ci.py` for both variants: driver resolves
the right preset and artifact group, disables Python packages, and filters to the
single opted-in family. Matrix and multi-arch CI tests pass; pre-commit clean.

## Open questions

Draft pending these:

1. Which families should opt in? Each addition is one more full Windows build.
2. Is CFG needed across the whole tree, or only for the flag's `SUB_PROJECTS`
   (`amd-comgr`, `hip-clr`, `ocl-clr`)? If the latter, this gets cheaper.
3. Every nightly, or on demand?
