### PR TITLE
fix(ci): map rocm-systems shared/* components for test selection

### DIFF
--- a/test_tools/determine_rocm_test_dependencies.py
+++ b/test_tools/determine_rocm_test_dependencies.py
@@ -75,6 +75,11 @@ _EXTERNAL_SUBTREE_ALIASES = {
     "emulation/rocjitsu": ["rocjitsu"],
     "shared/rocroller": ["rocroller"],
     "shared/amdgpu-windows-interop": ["hip-clr"],
+    # rocm-systems shared/* components that are not subtree-synced repos.
+    # machine-readable-isa ships the ISA data consumed by the rocjitsu
+    # emulation stack; kpack is the ROCm packaging tool (rocm-kpack).
+    "shared/kpack": ["rocm-kpack"],
+    "shared/machine-readable-isa": ["rocjitsu"],
     "shared/mxdatagenerator": [
         "hipblas",
         "hipblaslt",

--- a/test_tools/tests/determine_rocm_test_dependencies_test.py
+++ b/test_tools/tests/determine_rocm_test_dependencies_test.py
@@ -496,6 +496,7 @@ class TestCliInputParsing(_FixtureTestCase):
             "mirage": {"consumers": []},
             "rdc": {"consumers": []},
             "rocjitsu": {"consumers": []},
+            "rocm-kpack": {"consumers": []},
             "rocm_smi_lib": {"consumers": []},
             "rocprofiler-sdk": {"consumers": []},
         }
@@ -512,6 +513,8 @@ class TestCliInputParsing(_FixtureTestCase):
                 "projects/rocm-smi-lib": "rocm_smi_lib",
                 "projects/rocprofiler": "rocprofiler-sdk",
                 "shared/amdgpu-windows-interop": "hip-clr",
+                "shared/kpack": "rocm-kpack",
+                "shared/machine-readable-isa": "rocjitsu",
             }
             for changed_project, expected in cases.items():
                 with self.subTest(changed_project=changed_project):


### PR DESCRIPTION
## Motivation

rocm-systems multi-arch CI selects per-PR tests by mapping changed subtree
paths through TheRock's test dependency selector
(`test_tools/determine_rocm_test_dependencies.py`). #7921 added external-repo
path mappings and made the selector fail loudly on any unmapped
`shared//dnn-providers//emulation/` namespace.

Two rocm-systems `shared/*` directories that are *not* subtree-synced repos
still have no alias: `shared/kpack` and `shared/machine-readable-isa`. Once
rocm-systems surfaces these paths as changed projects (companion rocm-systems
change), a PR touching only them raises
`no entry in _EXTERNAL_SUBTREE_ALIASES`. This adds the missing mappings so
those PRs select runnable tests.

ISSUE ID : https://github.com/ROCm/TheRock/issues/3343

## Technical Details

- `_EXTERNAL_SUBTREE_ALIASES`:
  - `shared/kpack -> ["rocm-kpack"]`
  - `shared/machine-readable-isa -> ["rocjitsu"]` (the ISA data consumed by
    the rocjitsu emulation stack)
- `shared/ctest` is intentionally left unmapped: it is test-selection
  infrastructure and is routed to a full test run on the rocm-systems side
  rather than treated as a component.
- Follow-up to #7921; the build-topology side already resolves these
  directories via `source_paths`, so no `BUILD_TOPOLOGY.toml` change is
  needed.

## Test Plan

- Extended `test_rocm_systems_prefixes_mapped` with the two new subtree->key
  cases and added `rocm-kpack` to the fixture consumer graph.
- `python -m pytest test_tools/tests/determine_rocm_test_dependencies_test.py`
- 
## Test Result

- 58 passed (19 subtests).
- Manual check against the live consumer graph:
  `--changed-projects shared/kpack` -> `rocm-kpack` (+ consumers);
  `--changed-projects shared/machine-readable-isa` -> `rocjitsu` (+ consumers).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.