### PR TITLE
fix: Set timeout for hipTensor test shards to be sized to the largest tier

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -906,7 +906,13 @@ test_matrix = {
     "hiptensor": {
         "job_name": "hiptensor",
         "fetch_artifact_args": "--hiptensor --tests",
-        "timeout_minutes": 15,
+        # Github Actions step timeout, applied to every tier (it does not vary by test_type).
+        # Must be sized for the largest tier the nightly runs (comprehensive),
+        # not quick/standard -- otherwise the step is killed mid-suite well
+        # before ctest's own per-test --timeout 7200 can take effect. See
+        # rocm-libraries/projects/hiptensor/test_categories.yaml
+        # execution_settings.category_timeouts (full: 7200s = 2h).
+        "timeout_minutes": 120,
         "test_script": f"python {_get_script_path('test_runner.py')}",
         "platform": ["linux", "windows"],
         "total_shards_dict": {


### PR DESCRIPTION
## Motivation

The nightly hipTensor comprehensive test job was being killed at exactly 15 minutes (e.g. https://github.com/ROCm/rocm-libraries/actions/runs/34018454849/job/101480308495), mid-suite, even though the run was invoked with a 2-hour ctest budget (ctest --timeout 7200).

  The 15-minute limit was a GitHub Actions step timeout, hardcoded for the hipTensor component and unrelated to ctest's --timeout (which only bounds individual tests). The Test step in test_component.yml derives its timeout-minutes from
  fromJSON(inputs.component).timeout_minutes, and hipTensor's entry in fetch_test_configurations.py set that to a static 15.

  Because timeout_minutes is applied to every tier (it does not vary by test_type), the value fit quick/standard but killed the comprehensive nightly run long before completion.
  
  ISSUE ID : AIHIPTENS-564

## Technical Details

Raised hipTensor's timeout_minutes from 15 to 120, sizing the step timeout for the largest tier the nightly runs. This mirrors the existing convention for other heavy components (miopen: 120, rpp) and matches hipTensor's own 2-hour
  budget (test_categories.yaml → execution_settings.category_timeouts.full: 7200). A comment was added documenting why the value must track the largest tier.

## Test Plan and Results

- fetch_test_configurations_test.py: 49 passed, 4 subtests passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
