### PR TITLE
fix(asan): set CMAKE_HIP_FLAGS_INIT for native HIP-language projects

### DIFF
--- a/cmake/therock_sanitizers.cmake
+++ b/cmake/therock_sanitizers.cmake
@@ -47,13 +47,20 @@ function(therock_sanitizer_configure
       # Avoids: (1) -Woption-ignored on gfx942 without :xnack+ (MIOpen failure due to -Werror)
       #         (2) handleSanitizeOption dropping all device -I/-D with -fno-gpu-sanitize (Bug in Driver)
       # TODO: If this is indeed a Driver bug, then this can be replaced with -fno-gpu-sanitize when that is fixed.
+      # CMAKE_HIP_FLAGS_INIT is set alongside CMAKE_CXX_FLAGS_INIT/CMAKE_C_FLAGS_INIT:
+      # projects that call project(... LANGUAGES ... HIP) compile .hip sources
+      # via CMake's native HIP language support, which reads CMAKE_HIP_FLAGS
+      # (seeded from CMAKE_HIP_FLAGS_INIT), not CMAKE_CXX_FLAGS. Without this,
+      # such .hip sources silently get zero sanitizer instrumentation.
       string(APPEND _stanza "string(APPEND CMAKE_CXX_FLAGS_INIT \" -Xarch_host -fsanitize=address -Xarch_host -fno-omit-frame-pointer\")\n")
       string(APPEND _stanza "string(APPEND CMAKE_C_FLAGS_INIT \" -Xarch_host -fsanitize=address -Xarch_host -fno-omit-frame-pointer\")\n")
+      string(APPEND _stanza "string(APPEND CMAKE_HIP_FLAGS_INIT \" -Xarch_host -fsanitize=address -Xarch_host -fno-omit-frame-pointer\")\n")
     else()
       # TODO: Support ASAN_STATIC/TSAN_STATIC to use static sanitizer linkage. Shared is almost always the right thing,
       # so make the sanitizer imply shared linkage.
       string(APPEND _stanza "string(APPEND CMAKE_CXX_FLAGS_INIT \" -fsanitize=${_sanitizer_string} -fno-omit-frame-pointer\")\n")
       string(APPEND _stanza "string(APPEND CMAKE_C_FLAGS_INIT \" -fsanitize=${_sanitizer_string} -fno-omit-frame-pointer\")\n")
+      string(APPEND _stanza "string(APPEND CMAKE_HIP_FLAGS_INIT \" -fsanitize=${_sanitizer_string} -fno-omit-frame-pointer\")\n")
     endif()
 
     # Sharp edge: The -shared-libsan flag is compiler frontend specific:


### PR DESCRIPTION
## Motivation

While investigating https://github.com/ROCm/rocm-systems/issues/11283 (hipfile ASAN
build failing with undefined `__asan_*` symbols at link time), found projects 
that enable CMake's native `HIP` language (`project(... LANGUAGES ... HIP)`, 
as `hipfile` does) compile `.hip` sources  through `CMAKE_HIP_FLAGS` — 
a completely independent variable from `CMAKE_CXX_FLAGS`. 
`therock_sanitizer_configure()` only ever set `CMAKE_CXX_FLAGS_INIT`/`CMAKE_C_FLAGS_INIT`, 
so any `.hip` source in a native-HIP-language target was silently compiled with **zero sanitizer
instrumentation**, in every sanitizer mode (`ASAN`, `HOST_ASAN`, `TSAN`).

This didn't cause the link failure in https://github.com/ROCm/rocm-systems/issues/11283 (that came from `.cpp` objects, confirmed via the undefined-symbol backtraces never pointing at the `.hip`
object), but it's a under-instrumentation bug: the device-side
ASAN coverage the `GPU_TARGETS` xnack+ munging exists to enable never
actually reaches `.hip` kernel code in native-HIP-language targets, because
`-fsanitize=address` never reaches that compilation at all.

Kept as a **separate PR** from the `LINK_LANGUAGE` fix (https://github.com/ROCm/TheRock/pull/7980) since this adds new compile-time instrumentation that may increase ASAN build times — reviewable
and revertable independently.

## Technical Details

CMake handles `HIP` as a fully independent first-class
language from `CXX`/`C` when native language support is used —
`CMAKE_HIP_FLAGS` is its own cache variable seeded from its own `HIPFLAGS`
env var, entirely separate from `CMAKE_CXX_FLAGS`/`CXXFLAGS`. Confirmed
directly that `hipfile`'s top-level `CMakeLists.txt` uses this path:
`project("hipfile" ... LANGUAGES C CXX HIP ...)`.

Added `CMAKE_HIP_FLAGS_INIT` handling mirroring the existing
`CMAKE_CXX_FLAGS_INIT`/`CMAKE_C_FLAGS_INIT` lines, in **both** branches:

- **`HOST_ASAN`**: `-Xarch_host -fsanitize=address -Xarch_host -fno-omit-frame-pointer`,
  same `-Xarch_host` scoping already used for CXX/C — a `.hip` compile is a
  single clang driver invocation handling host + device sub-compiles
  internally, so the same reasoning (avoiding `-Woption-ignored`
  MIOpen-`-Werror` failures and the `handleSanitizeOption`/`-fno-gpu-sanitize`
  driver bug) applies identically here.
- **Full `ASAN`/`TSAN`**: plain `-fsanitize=${_sanitizer_string} -fno-omit-frame-pointer`,
  unscoped, so device-side HIP kernel code in native-HIP-language targets
  gets instrumented too — matching the intent of the existing
  `GPU_TARGETS` xnack+ device-instrumentation logic just below it, which
  otherwise has nothing to instrument for `.hip` sources in this project
  shape.

`-Xarch_host` scoping was confirmed to be arch-agnostic (a host-vs-device
toolchain-scoping directive, not gated on which GPU archs are present in
`--offload-arch=`), so it behaves the same for newer default-xnack-on
targets like gfx1250 as it does for gfx942/gfx950.

## Test Plan

- Run ci-asan build and confirms build is success and build time is not heavily regressed
- Run ci-host-asan build and confirms build is success and build time is not regressed
- Run asan release build and confirms build is success and build time is not regressed

## Test Result
https://github.com/ROCm/TheRock/actions/runs/34273551469
