### PR TITLE
fix(ci): add disable_platforms for rpp artifact on Windows

### DIFF
--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -755,7 +755,7 @@ type = "target-neutral"
 # half headers come from base; amd-llvm arrives transitively via core-hip.
 artifact_deps = ["core-runtime", "core-hip", "base", "sysdeps"]
 feature_group = "CV_LIBS"
-# No disable_platforms: Windows is opt-in via -DTHEROCK_ENABLE_RPP=ON.
+disable_platforms = ["windows"]
 
 # --- Media Integration ---
 


### PR DESCRIPTION
RPP is documented as experimental and disabled by default on Windows, but the BUILD_TOPOLOGY.toml was missing the disable_platforms entry. 

This caused issues when RPP changes triggered CI - the RPP flag would be passed to Windows stages even though cv-libs doesn't build there.