### PR TITLE
fix(ci): filter rebuild_artifacts by stage in configure_stage.py

### DIFF
--- a/build_tools/configure_stage.py
+++ b/build_tools/configure_stage.py
@@ -143,6 +143,31 @@ def get_artifact_features(
     )
 
 
+def filter_artifacts_for_stage(
+    topology: BuildTopology,
+    stage_name: str,
+    artifact_names: List[str],
+    build_dir: Path = None,
+) -> List[str]:
+    """Filter artifacts to only those produced by or dependencies of the stage."""
+    # Get all artifacts that are valid for this stage
+    produced = topology.get_produced_artifacts(stage_name)
+    inbound = topology.get_inbound_artifacts(stage_name)
+    stage_artifacts = produced | inbound
+
+    # Build alias map to resolve artifact names/aliases to canonical names
+    alias_map = topology.get_alias_to_artifact_map(build_dir)
+
+    # Filter: keep only artifacts that resolve to stage artifacts
+    filtered = []
+    for name in artifact_names:
+        canonical = alias_map.get(name.lower())
+        if canonical and canonical in stage_artifacts:
+            filtered.append(name)
+
+    return filtered
+
+
 def generate_cmake_args(
     stage_name: str,
     amdgpu_families: str,
@@ -157,8 +182,17 @@ def generate_cmake_args(
     """Generate CMake arguments for building a specific stage or artifacts."""
     args = []
 
+    # When both stage and artifacts are specified, filter artifacts to only
+    # those relevant to the stage. This prevents enabling features for artifacts
+    # that don't exist in the stage (e.g., enabling RPP in math-libs on Windows).
     if stage_name and artifact_names:
-        desc = f"stage {stage_name} + artifacts: {', '.join(artifact_names)}"
+        artifact_names = filter_artifacts_for_stage(
+            topology, stage_name, artifact_names, build_dir
+        )
+        if artifact_names:
+            desc = f"stage {stage_name} + artifacts: {', '.join(artifact_names)}"
+        else:
+            desc = stage_name
     elif stage_name:
         desc = stage_name
     elif artifact_names:

--- a/build_tools/configure_stage.py
+++ b/build_tools/configure_stage.py
@@ -148,8 +148,15 @@ def filter_artifacts_for_stage(
     stage_name: str,
     artifact_names: List[str],
     build_dir: Path = None,
-) -> List[str]:
-    """Filter artifacts to only those produced by or dependencies of the stage."""
+) -> tuple[List[str], List[str], List[str]]:
+    """Filter artifacts to only those produced by or dependencies of the stage.
+
+    Returns:
+        A tuple of (filtered_artifacts, other_stage_artifacts, unknown_artifacts) where:
+        - filtered_artifacts: artifacts that belong to this stage
+        - other_stage_artifacts: valid artifacts that belong to a different stage
+        - unknown_artifacts: artifact names that don't resolve to any known artifact
+    """
     # Get all artifacts that are valid for this stage
     produced = topology.get_produced_artifacts(stage_name)
     inbound = topology.get_inbound_artifacts(stage_name)
@@ -160,12 +167,21 @@ def filter_artifacts_for_stage(
 
     # Filter: keep only artifacts that resolve to stage artifacts
     filtered = []
+    other_stage = []
+    unknown = []
     for name in artifact_names:
         canonical = alias_map.get(name.lower())
-        if canonical and canonical in stage_artifacts:
-            filtered.append(name)
+        if canonical:
+            if canonical in stage_artifacts:
+                filtered.append(name)
+            else:
+                # Valid artifact but belongs to a different stage
+                other_stage.append(name)
+        else:
+            # Unknown artifact name
+            unknown.append(name)
 
-    return filtered
+    return filtered, other_stage, unknown
 
 
 def generate_cmake_args(
@@ -186,9 +202,19 @@ def generate_cmake_args(
     # those relevant to the stage. This prevents enabling features for artifacts
     # that don't exist in the stage (e.g., enabling RPP in math-libs on Windows).
     if stage_name and artifact_names:
-        artifact_names = filter_artifacts_for_stage(
-            topology, stage_name, artifact_names, build_dir
+        artifact_names, other_stage_artifacts, unknown_artifacts = (
+            filter_artifacts_for_stage(topology, stage_name, artifact_names, build_dir)
         )
+        if other_stage_artifacts:
+            log(
+                f"[{stage_name}] Skipping artifacts from other stages: "
+                f"{', '.join(other_stage_artifacts)}"
+            )
+        if unknown_artifacts:
+            log(
+                f"[{stage_name}] Skipping unknown artifacts: "
+                f"{', '.join(unknown_artifacts)}"
+            )
         if artifact_names:
             desc = f"stage {stage_name} + artifacts: {', '.join(artifact_names)}"
         else:

--- a/build_tools/tests/configure_stage_test.py
+++ b/build_tools/tests/configure_stage_test.py
@@ -100,21 +100,81 @@ class RocmSystemsMappingTest(unittest.TestCase):
 class StageArtifactFilteringTest(unittest.TestCase):
     """Tests for filtering artifacts by stage."""
 
+    def setUp(self):
+        self.topology = get_topology()
+
     def test_artifacts_filtered_to_stage(self):
         """Artifacts not belonging to a stage are filtered out in cmake args."""
-        topology = get_topology()
         # RPP is in cv-libs, blas is in math-libs - passing both to math-libs
         # should only enable blas
         args = generate_cmake_args(
             stage_name="math-libs",
             amdgpu_families="gfx1100",
             dist_amdgpu_families="",
-            topology=topology,
+            topology=self.topology,
             artifact_names=["rpp", "blas"],
             platform_name="linux",
         )
         self.assertIn("-DTHEROCK_ENABLE_BLAS=ON", args)
         self.assertNotIn("-DTHEROCK_ENABLE_RPP=ON", args)
+
+    def test_filter_returns_other_stage_artifacts(self):
+        """filter_artifacts_for_stage returns artifacts from other stages."""
+        filtered, other_stage, unknown = filter_artifacts_for_stage(
+            self.topology, "math-libs", ["rpp", "blas", "miopen"]
+        )
+        # blas is in math-libs, miopen is in ml-libs (built in same stage), rpp is cv-libs
+        self.assertIn("blas", filtered)
+        self.assertIn("miopen", filtered)
+        self.assertIn("rpp", other_stage)
+        self.assertNotIn("blas", other_stage)
+        self.assertEqual(unknown, [])
+
+    def test_filter_returns_unknown_artifacts(self):
+        """filter_artifacts_for_stage returns unknown artifact names."""
+        filtered, other_stage, unknown = filter_artifacts_for_stage(
+            self.topology, "math-libs", ["blas", "not-a-real-artifact", "also-fake"]
+        )
+        self.assertIn("blas", filtered)
+        self.assertEqual(other_stage, [])
+        self.assertIn("not-a-real-artifact", unknown)
+        self.assertIn("also-fake", unknown)
+
+    def test_sparse_subprojects_resolve_to_sparse_feature(self):
+        """hipSPARSE/rocSPARSE resolve to SPARSE, not BLAS."""
+        # These subprojects are in the blas artifact's source paths but should
+        # enable SPARSE feature via project_mappings.json
+        args = generate_cmake_args(
+            stage_name="math-libs",
+            amdgpu_families="gfx1100",
+            dist_amdgpu_families="",
+            topology=self.topology,
+            artifact_names=["hipSPARSE"],
+            platform_name="linux",
+        )
+        self.assertIn("-DTHEROCK_ENABLE_SPARSE=ON", args)
+        self.assertNotIn("-DTHEROCK_ENABLE_BLAS=ON", args)
+
+    def test_hipsparse_and_rocsparse_both_sparse(self):
+        """Both hipSPARSE and rocSPARSE map to SPARSE feature."""
+        for subproject in ["hipSPARSE", "rocSPARSE", "hipSPARSELt"]:
+            features = self.topology.resolve_artifacts_to_features([subproject])
+            self.assertIn("SPARSE", features, f"{subproject} should map to SPARSE")
+            self.assertNotIn("BLAS", features, f"{subproject} should not map to BLAS")
+
+    def test_hipsparselt_resolves_to_sparse(self):
+        """hipSPARSELt is a split_database in sparse and resolves to SPARSE."""
+        # hipsparselt is listed in sparse artifact's split_databases
+        args = generate_cmake_args(
+            stage_name="math-libs",
+            amdgpu_families="gfx1100",
+            dist_amdgpu_families="",
+            topology=self.topology,
+            artifact_names=["hipsparselt"],
+            platform_name="linux",
+        )
+        self.assertIn("-DTHEROCK_ENABLE_SPARSE=ON", args)
+        self.assertNotIn("-DTHEROCK_ENABLE_BLAS=ON", args)
 
 
 class ManifestValidationTest(unittest.TestCase):

--- a/build_tools/tests/configure_stage_test.py
+++ b/build_tools/tests/configure_stage_test.py
@@ -13,6 +13,7 @@ sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 
 from _therock_utils.build_topology import get_topology
 from configure_stage import (
+    filter_artifacts_for_stage,
     generate_cmake_args,
     get_artifact_features,
 )
@@ -94,6 +95,26 @@ class RocmSystemsMappingTest(unittest.TestCase):
         """Canonical artifact names should not be overridden."""
         alias_map = self.topology.get_alias_to_artifact_map()
         self.assertEqual(alias_map.get("rocprofiler-compute"), "rocprofiler-compute")
+
+
+class StageArtifactFilteringTest(unittest.TestCase):
+    """Tests for filtering artifacts by stage."""
+
+    def test_artifacts_filtered_to_stage(self):
+        """Artifacts not belonging to a stage are filtered out in cmake args."""
+        topology = get_topology()
+        # RPP is in cv-libs, blas is in math-libs - passing both to math-libs
+        # should only enable blas
+        args = generate_cmake_args(
+            stage_name="math-libs",
+            amdgpu_families="gfx1100",
+            dist_amdgpu_families="",
+            topology=topology,
+            artifact_names=["rpp", "blas"],
+            platform_name="linux",
+        )
+        self.assertIn("-DTHEROCK_ENABLE_BLAS=ON", args)
+        self.assertNotIn("-DTHEROCK_ENABLE_RPP=ON", args)
 
 
 class ManifestValidationTest(unittest.TestCase):


### PR DESCRIPTION
When rebuild_artifacts is passed from external repos (e.g., rocm-libraries) to CI workflows, it was being passed to all build stages without filtering. This caused issues when an artifact like RPP (in cv-libs stage) was included in rebuild_artifacts but passed to math-libs stage, which doesn't build RPP.

On Windows, where cv-libs stage doesn't run, this resulted in invalid CMake flags being generated for stages that don't include those artifacts.

Add filter_artifacts_for_stage() to filter the artifact list to only include artifacts that are produced by or are inbound dependencies of the specified stage. When both --stage and --artifacts are provided, the artifacts are now filtered before generating CMake flags.

Error that uncovered: https://github.com/ROCm/rocm-libraries/actions/runs/34266705093/job/102206634317, and resulted in a fix with https://github.com/ROCm/TheRock/commit/8943c0144e06812796c904cef6fc4a59c538d768

ISSUE ID: https://github.com/ROCm/TheRock/issues/3343