### PR TITLE
fix(ci): let CPU-only test components bypass GPU-scarcity family gates

### DIFF
--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -180,6 +180,11 @@ jobs:
         env:
           ARTIFACT_GROUP: ${{ inputs.artifact_group }}
           AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
+          # Passed through so the script can detect the CPU_ONLY_TEST_RUNS_ON
+          # sentinel (see configure_multi_arch_ci.py) and filter to
+          # linux_cpu_runner components only when the family's GPU test
+          # runner has been disabled by a GPU-scarcity gate.
+          TEST_RUNS_ON: ${{ inputs.test_runs_on }}
           TEST_TYPE: ${{ inputs.test_type }}
           TEST_LABELS: ${{ inputs.test_labels }}
           RUN_EXTENDED_TESTS: ${{ inputs.run_extended_tests }}

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -86,6 +86,14 @@ from stage_reuse_decision import (
 
 _NULL_GIT_SHA = "0" * 40
 
+# Sentinel written to a family's "test-runs-on" when submodule_bump_tests_only
+# disables its GPU test runner. Kept non-empty (instead of "") so downstream
+# workflow gates that check `test_runs_on != ''` still fire, letting
+# fetch_test_configurations.py's linux_cpu_runner-only components (which never
+# touch the gated GPU hardware this flag protects) continue to run. Read by
+# fetch_test_configurations.py to filter its component selection accordingly.
+CPU_ONLY_TEST_RUNS_ON = "cpu-only"
+
 # ---------------------------------------------------------------------------
 # Input parsing helpers
 # ---------------------------------------------------------------------------
@@ -1349,17 +1357,21 @@ def _expand_build_config_for_platform(
                 f"disabling test runner for non-scheduled/non-dispatch runs"
             )
 
-        # If submodule_bump_tests_only is set, only run tests when submodule changes
-        # are detected or on workflow_dispatch (manual triggers).
+        # If submodule_bump_tests_only is set, only run GPU tests when submodule
+        # changes are detected or on workflow_dispatch (manual triggers). Use the
+        # CPU_ONLY_TEST_RUNS_ON sentinel rather than "": this flag exists to
+        # protect scarce GPU hardware, not to block CPU-only (linux_cpu_runner)
+        # test components, which never touch it.
         if (
             platform_info.get("submodule_bump_tests_only", False)
             and not ci_inputs.is_workflow_dispatch
             and git_context.has_submodule_changes is not True
         ):
-            test_runs_on = ""
+            test_runs_on = CPU_ONLY_TEST_RUNS_ON
             print(
                 f"  {family_name}: submodule_bump_tests_only flag set, "
-                f"disabling tests (no submodule changes detected)"
+                f"disabling GPU tests (no submodule changes detected); "
+                f"linux_cpu_runner components still run"
             )
 
         # If skip_tests_on_submodule_bump is set, skip tests when submodule changes

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -36,6 +36,7 @@ from amdgpu_family_matrix import (
     get_all_families_for_trigger_types,
     select_weighted_label,
 )
+from configure_multi_arch_ci import CPU_ONLY_TEST_RUNS_ON
 
 logging.basicConfig(level=logging.INFO)
 
@@ -945,6 +946,10 @@ def run():
     test_labels = ast.literal_eval(os.getenv("TEST_LABELS") or "[]")
     run_extended_tests = str2bool(os.getenv("RUN_EXTENDED_TESTS", "false"))
     build_variant = os.getenv("BUILD_VARIANT", "release")
+    # Set by configure_multi_arch_ci.py (CPU_ONLY_TEST_RUNS_ON) when a
+    # GPU-scarcity gate (e.g. submodule_bump_tests_only) disabled this family's
+    # GPU test runner. Only linux_cpu_runner components may run in that case.
+    cpu_only_mode = os.getenv("TEST_RUNS_ON") == CPU_ONLY_TEST_RUNS_ON
 
     # Get runner config for per-component runner selection
     # This enables better load distribution across runner pools
@@ -1034,6 +1039,19 @@ def run():
         ):
             logging.info(
                 f"Excluding job {job_name} for platform {platform} and family {amdgpu_families}"
+            )
+            continue
+
+        # When the family's GPU test runner is disabled (cpu_only_mode -- see
+        # CPU_ONLY_TEST_RUNS_ON), only linux_cpu_runner components may run:
+        # they never touch the GPU hardware the gate protects. Sanity requires
+        # a real GPU runner, so it's excluded too in this mode.
+        if cpu_only_mode and (
+            key == "sanity" or not selected_matrix[key].get("linux_cpu_runner", False)
+        ):
+            logging.info(
+                f"Excluding job {job_name} for platform {platform}: GPU tests "
+                f"disabled for family {amdgpu_families} (not linux_cpu_runner)"
             )
             continue
 
@@ -1205,8 +1223,13 @@ def run():
     ]
 
     # Separate sanity (always a prerequisite) from the regular component matrix.
+    # Falls back to an explicit empty test_runner (rather than a bare `None` ->
+    # JSON `null`) so `fromJSON(...).test_runner != ''` in test_artifacts.yml
+    # evaluates cleanly when sanity was excluded (e.g. cpu_only_mode, where
+    # sanity has no GPU runner to run on).
     sanity_component = next(
-        (c for c in all_components if c.get("job_name") == "sanity"), None
+        (c for c in all_components if c.get("job_name") == "sanity"),
+        {"test_runner": ""},
     )
     output_matrix = [c for c in all_components if c.get("job_name") != "sanity"]
 

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -2028,7 +2028,13 @@ class TestFamilyTestFilters(unittest.TestCase):
         self.assertNotEqual(gfx90a_info["test-runs-on"], "")
 
     def test_submodule_bump_tests_only_disables_tests_without_submodule_changes(self):
-        """gfx950 tests should be disabled on push without submodule changes."""
+        """gfx950 GPU tests should be disabled on push without submodule changes.
+
+        The family's GPU runner is disabled via the CPU_ONLY_TEST_RUNS_ON
+        sentinel rather than "", so linux_cpu_runner-only test components
+        (which never touch gfx950 GPU hardware) can still run -- see
+        fetch_test_configurations.py's cpu_only_mode filtering.
+        """
         ci_inputs = cm.CIInputs(
             run_id="12345",
             event_name="push",
@@ -2052,8 +2058,10 @@ class TestFamilyTestFilters(unittest.TestCase):
                     break
 
         self.assertIsNotNone(gfx950_info)
-        # Tests should be disabled (empty runner)
-        self.assertEqual(gfx950_info["test-runs-on"], "")
+        # GPU tests should be disabled via the CPU-only sentinel, not a real
+        # GPU runner label, but still non-empty so downstream `!= ''` gates
+        # still invoke the test stage (for CPU-only components).
+        self.assertEqual(gfx950_info["test-runs-on"], cm.CPU_ONLY_TEST_RUNS_ON)
 
     def test_submodule_bump_tests_only_enables_tests_on_workflow_dispatch(self):
         """gfx950 tests should be enabled on workflow_dispatch regardless of submodule changes."""

--- a/build_tools/github_actions/tests/fetch_test_configurations_test.py
+++ b/build_tools/github_actions/tests/fetch_test_configurations_test.py
@@ -35,6 +35,9 @@ class FetchTestConfigurationsTest(unittest.TestCase):
         os.environ["TEST_TYPE"] = "full"
         os.environ["TEST_LABELS"] = "[]"
         os.environ["PROJECTS_TO_TEST"] = "*"
+        # Explicitly unset (rather than relying on the ambient shell): most
+        # tests exercise today's default (no GPU-scarcity gate active).
+        os.environ.pop("TEST_RUNS_ON", None)
 
         # Default to linux platform
         sys.argv = ["fetch_test_configurations.py", "--platform=linux"]
@@ -308,6 +311,59 @@ class FetchTestConfigurationsTest(unittest.TestCase):
         os.environ["PROJECTS_TO_TEST"] = "rocgdb-corefile"
         os.environ["AMDGPU_FAMILIES"] = "gfx1150"
         self.assertNotIn("rocgdb-corefile", self._selected_names())
+
+    # -----------------------
+    # cpu_only_mode (CPU_ONLY_TEST_RUNS_ON sentinel): when a family's GPU test
+    # runner is disabled (e.g. submodule_bump_tests_only), only
+    # linux_cpu_runner components may still run.
+    # -----------------------
+
+    def test_gated_family_without_cpu_only_mode_selects_everything(self):
+        # Regression check: today's behavior (TEST_RUNS_ON unset) must be
+        # completely unaffected -- both GPU and CPU-only jobs are selected.
+        os.environ["PROJECTS_TO_TEST"] = "*"
+        self._inject_job("gpu-job")
+        self._inject_job("cpu-job", linux_cpu_runner=True)
+        # _inject_job overwrites PROJECTS_TO_TEST to isolate a single job;
+        # widen back out so both injected jobs are candidates.
+        os.environ["PROJECTS_TO_TEST"] = "*"
+        names = self._selected_names()
+        self.assertIn("gpu-job", names)
+        self.assertIn("cpu-job", names)
+
+    def test_cpu_only_mode_excludes_gpu_components(self):
+        os.environ["TEST_RUNS_ON"] = fetch_test_configurations.CPU_ONLY_TEST_RUNS_ON
+        os.environ["PROJECTS_TO_TEST"] = "*"
+        self._inject_job("gpu-job")
+        self._inject_job("cpu-job", linux_cpu_runner=True)
+        # _inject_job overwrites PROJECTS_TO_TEST to isolate a single job;
+        # widen back out so both injected jobs are candidates.
+        os.environ["PROJECTS_TO_TEST"] = "*"
+        names = self._selected_names()
+        self.assertNotIn("gpu-job", names)
+        self.assertIn("cpu-job", names)
+
+    def test_cpu_only_mode_excludes_sanity(self):
+        os.environ["TEST_RUNS_ON"] = fetch_test_configurations.CPU_ONLY_TEST_RUNS_ON
+
+        fetch_test_configurations.run()
+
+        sanity_component = json.loads(self.gha_output["sanity_component"])
+        self.assertEqual(sanity_component["test_runner"], "")
+
+    def test_non_sentinel_test_runs_on_does_not_trigger_cpu_only_mode(self):
+        # A real GPU runner label (not the sentinel) must not be mistaken for
+        # cpu_only_mode.
+        os.environ["TEST_RUNS_ON"] = "linux-gfx942-1gpu-ccs-ossci-rocm"
+        os.environ["PROJECTS_TO_TEST"] = "*"
+        self._inject_job("gpu-job")
+        self._inject_job("cpu-job", linux_cpu_runner=True)
+        # _inject_job overwrites PROJECTS_TO_TEST to isolate a single job;
+        # widen back out so both injected jobs are candidates.
+        os.environ["PROJECTS_TO_TEST"] = "*"
+        names = self._selected_names()
+        self.assertIn("gpu-job", names)
+        self.assertIn("cpu-job", names)
 
     # -----------------------
     # Functional test merging via run_extended_tests


### PR DESCRIPTION
`submodule_bump_tests_only` (and its siblings) exists to protect scarce GPU hardware from being
exercised on every PR/push. Its implementation zeroed a family's `test-runs-on` to `""` wholesale,
which also skipped the whole `test_artifacts.yml` invocation for that family — including any
`linux_cpu_runner` test component, which never touches the gated GPU hardware in the first place.

Use a `CPU_ONLY_TEST_RUNS_ON` sentinel (`"cpu-only"`) instead of `""` when the gate fires, so
`configure_test_matrix`'s `!= ''` check still runs, and teach `fetch_test_configurations.py` to
filter to `linux_cpu_runner`-only components (excluding sanity, which needs a real GPU) when that
sentinel is set. GPU-requiring components remain excluded exactly as before — this only adds
coverage for components that were incorrectly swept into the gate, it doesn't change what already
runs.

### Why

Restaging the GPU-free MIOpen dbsync component (reverted in #7967 after #7965) needs this: it's
`linux_cpu_runner: true` but gfx950's presubmit entry has `submodule_bump_tests_only: true`, so under
today's implementation it would never run per-PR even after the underlying apt-get permission bug
(#7965) is fixed. Rather than bolt a second, hand-rolled CPU test job into rocm-libraries, this fixes
the shared gate so gfx942 and gfx950 both flow through the exact same `test_component.yml` path.

### Scope

Deliberately narrow: only `submodule_bump_tests_only` is touched. `skip_tests_on_submodule_bump` and
`nightly_check_only_for_family` are left as-is — their exact intent is less clearly GPU-scarcity-
specific, so no need to touch them for this.

### Safety

This is additive, not risky: it only changes behavior for *newly-CPU-eligible* components under a
gate that previously blocked everything for that family. Every component that was already excluded
by a gated family stays excluded (still gets no real GPU runner label); the only new behavior is
`linux_cpu_runner` components starting to run where they previously didn't.

### Testing

- Extended `configure_multi_arch_ci_test.py`'s existing
  `test_submodule_bump_tests_only_disables_tests_without_submodule_changes` to assert the sentinel
  value instead of `""`.
- Added 4 new cases to `fetch_test_configurations_test.py` covering: unaffected default behavior,
  GPU-component exclusion + CPU-component inclusion under the sentinel, sanity exclusion under the
  sentinel, and that a real (non-sentinel) runner label doesn't falsely trigger cpu-only filtering.
- `python3 -m pytest tests/configure_multi_arch_ci_test.py tests/fetch_test_configurations_test.py
  tests/stage_reuse_decision_test.py` — all green (161 passed, 1 pre-existing unrelated skip).

Companion PRs (land in this order): rocm-libraries#11831 (sudo fix for the dbsync runner script),
this PR, then a restage of `miopen-dbsync` in `fetch_test_configurations.py` (unscoped
`include_family`, as originally in #7651), then the rocm-libraries `therock_matrix.py` token.

ALMIOPEN-1779

🤖 Generated with [Claude Code](https://claude.com/claude-code)