### PR TITLE
test: restage GPU-free MIOpen dbsync (rocjitsu) test component, gfx942 (ALMIOPEN-1779)

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -586,6 +586,33 @@ test_matrix = {
             "windows": 4,
         },
     },
+    # MIOpen dbsync (StaticFDBSync) -- GPU-free under the rocjitsu KMD interposer on a CPU runner.
+    # The runner ships in the MIOpen dist (share/miopen/bin/run_dbsync_rocjitsu.py, pulled via
+    # --miopen; defined in rocm-libraries projects/miopen/test/gtest/dbsync/): it resolves arch + CU
+    # list from AMDGPU_FAMILIES, sparse-builds the pinned rocjitsu KMD, and runs StaticFDBSync once
+    # per CU with a CU-corrected config. include_family restricts it to gfx942, whose FAMILY_MAP
+    # entry covers both CU variants -- MI300X (304 CU) and MI300A (228 CU) -- in a single job.
+    # linux_cpu_runner: no scarce GPU test runner needed; uses the default no_rocm Ubuntu container
+    # (the runner sudo-apt-installs cmake/build-essential/libdrm-dev to build rocjitsu).
+    "miopen-dbsync": {
+        "job_name": "miopen-dbsync",
+        "fetch_artifact_args": "--blas --miopen --rand --tests",
+        # Skipped on the `quick` tier by the runner script (TEST_TYPE guard); this
+        # governs standard/comprehensive/full only. Runs serially
+        # (MIOPEN_DBSYNC_MAX_THREADS=1) under rocjitsu; full set (gfx942 304+228) +
+        # artifact fetch + rocjitsu build measures ~15 min, so 30 gives margin and
+        # fails a hung interposer faster.
+        "timeout_minutes": 30,
+        "test_script": "python ./build/share/miopen/bin/run_dbsync_rocjitsu.py",
+        "platform": ["linux"],
+        "linux_cpu_runner": True,
+        "include_family": {
+            "linux": ["gfx942"],
+        },
+        "total_shards_dict": {
+            "linux": 1,
+        },
+    },
     # RCCL tests
     "rccl": {
         "job_name": "rccl",


### PR DESCRIPTION
### What

Re-adds the `miopen-dbsync` test component (one entry in
build_tools/github_actions/fetch_test_configurations.py) that runs MIOpen's StaticFDBSync gate
GPU-free on a CPU runner under the rocjitsu KMD interposer.

- linux_cpu_runner: True -> aws-linux-scale-rocm-prod (no GPU runner).
- test_script: python ./build/share/miopen/bin/run_dbsync_rocjitsu.py (ships in the MIOpen dist,
  pulled via --miopen).
- include_family: {"linux": ["gfx942"]} -- gfx942-only; one job covers both CU variants,
  MI300X (304 CU) and MI300A (228 CU), via FAMILY_MAP["gfx94X-dcgpu"].
- fetch_artifact_args: --blas --miopen --rand --tests; timeout_minutes: 30; total_shards: 1.

Skips on the quick tier; executes at standard/comprehensive/full, running StaticFDBSync once per
CU with MIOPEN_DBSYNC_MAX_THREADS=1.

### Dependencies -- resolved

rocm-libraries#11831 (MERGED) -- the `sudo apt-get` fix in run_dbsync_rocjitsu.py, required
because aws-linux-scale-rocm-prod runs as an unprivileged `tester` user with passwordless sudo
(bare apt-get failed there -- the root cause of the earlier revert, #7965). This branch's
rocm-libraries submodule is bumped past it.

### Scope

- gfx950 is DROPPED (not deferred): gfx942-only. The gfx950-only gate-bypass PR (#8085) was closed.

### Validation

- **Functional:** three multi_arch_ci `workflow_dispatch` runs executed StaticFDBSync per CU
  (304 + 228), gtest PASSED, zero FAILED. (workflow_dispatch routes linux_cpu_runner components to
  the family GPU runner, so those did not exercise the CPU pool.)
- **CPU-pool (#7965) proof -- DONE:** the labeled `pull_request` CI of this PR ran the
  `miopen-dbsync` job on the unprivileged **aws-linux-scale-rocm-prod** pool and passed --
  run 35009374940, job 104542951034: CU-corrected 304 + 228, StaticFDBSync `[ PASSED ]` x2,
  0 FAILED, `sudo apt-get` succeeded, zero Permission-denied / lock errors. The #7965 failure mode
  is confirmed fixed on the pool that originally broke.

ALMIOPEN-1779
