### PR TITLE
fix(ci): parallelize rocjitsu build tests in Linux CI

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
@@ -187,8 +187,13 @@ jobs:
 
       - name: Configure
         run: |
+          SUBPROJECT_TEST_JOBS="$(( $(nproc) / 2 ))"
+          if ((SUBPROJECT_TEST_JOBS > 16)); then
+            SUBPROJECT_TEST_JOBS=16
+          fi
           cmake -B "${BUILD_DIR}" -S . -GNinja \
             -DTHEROCK_PACKAGE_VERSION=${{ inputs.rocm_package_version }} \
+            -DTHEROCK_ROCJITSU_TEST_JOBS="${SUBPROJECT_TEST_JOBS}" \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             ${{ inputs.build_variant_cmake_preset && format('--preset={0}', inputs.build_variant_cmake_preset) }} \

--- a/emulation/CMakeLists.txt
+++ b/emulation/CMakeLists.txt
@@ -3,6 +3,9 @@
 
 # ROCm Emulation Tools
 
+set(THEROCK_ROCJITSU_TEST_JOBS "1" CACHE STRING
+  "Number of parallel jobs for rocJITsu tests")
+
 if(THEROCK_ENABLE_ROCJITSU)
   ##############################################################################
   # rocjitsu
@@ -36,6 +39,7 @@ if(THEROCK_ENABLE_ROCJITSU)
 
   therock_cmake_subproject_build_test(rocjitsu
     COMMAND "${CMAKE_CTEST_COMMAND}" --output-on-failure --no-tests=error
+      -j "${THEROCK_ROCJITSU_TEST_JOBS}"
   )
 
   therock_test_validate_shared_lib(PATH rocjitsu/dist/lib


### PR DESCRIPTION
## Motivation

The rocjitsu build tests are the dominant portion of the multi-arch ci workflow's emulation test step.

## Issue ID
https://github.com/ROCm/TheRock/issues/7784
https://github.com/ROCm/rocm-systems/issues/11195
## Technical Details

- Added cmake cache variable `THEROCK_ROCJITSU_TEST_JOBS` specific for rocjitsu, allow the yml file to control the -j count for rocjitsu's ctest invocation.
- Job count set default to 1, capped to 16 in the ci.

## Test Plan

Run same CI jobs for main and the branch with changes.

## Test Result

The `Run build tests (emulation , non-blocking)` step changed from `3m59s` -> `37s`
[Main - logs](https://github.com/ROCm/TheRock/actions/runs/34296510688/job/102295151360)
[Change - logs](https://github.com/ROCm/TheRock/actions/runs/34296513167/job/102295193596)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
