### PR TITLE
Fix directory escaping in native package indexes

### DIFF
--- a/build_tools/packaging/linux/generate_package_indexes.py
+++ b/build_tools/packaging/linux/generate_package_indexes.py
@@ -67,11 +67,6 @@ def generate_index_html(directory: str) -> None:
         for entry in os.scandir(directory):
             if entry.name.startswith("."):
                 continue
-            if entry.is_dir():
-                rows.append(
-                    f'<tr><td><a href="{entry.name}">{entry.name}</a></td></tr>'
-                )
-                continue
             # Escape only at render: quote() percent-encodes '+' (and any
             # other unsafe char) in the href, while html.escape() guards the
             # display text.
@@ -118,7 +113,7 @@ def generate_top_index_from_s3(
         for cp in page.get("CommonPrefixes", []):
             folder = cp["Prefix"][len(prefix) + 1 :].rstrip("/")
             rows.append(
-                f'<tr><td><a href="{folder}/index.html">{folder}/</a></td></tr>'
+                f'<tr><td><a href="{quote(folder)}/index.html">{html.escape(folder)}/</a></td></tr>'
             )
 
         # Add files at this level only (no nested files)
@@ -270,7 +265,7 @@ def generate_index_from_s3(
 
         for subdir in sorted(subdirs):
             rows.append(
-                f'<tr><td><a href="{subdir}/index.html">{subdir}/</a></td></tr>'
+                f'<tr><td><a href="{quote(subdir)}/index.html">{html.escape(subdir)}/</a></td></tr>'
             )
 
         # Add files. Escape only at render: quote() percent-encodes '+'

--- a/build_tools/packaging/tests/generate_package_indexes_test.py
+++ b/build_tools/packaging/tests/generate_package_indexes_test.py
@@ -243,26 +243,20 @@ class GeneratePackageIndexesTest(unittest.TestCase):
             self.assertIn('href="pkg%2Bcu124-1.0.whl"', html_out)
             self.assertIn(">pkg+cu124-1.0.whl<", html_out)
 
-    def test_generate_index_html_does_not_escape_directory_names(self) -> None:
-        """Ensure local filesystem index generation leaves subdirectory names raw.
-
-        Verifies:
-        - A subdirectory entry (even one with a '+' in its name) is
-          rendered unescaped, since directory names are repo-layout
-          segments, not package names.
-        - A sibling file with a '+' in its name is still percent-encoded.
-        """
+    def test_generate_index_html_escapes_directory_names(self) -> None:
+        """Directory links must preserve URL characters and escape display text."""
         with tempfile.TemporaryDirectory() as td:
             d = Path(td) / "repo"
             d.mkdir(parents=True, exist_ok=True)
 
-            (d / "x86_64+avx").mkdir()
+            (d / "x86_64+avx #1&100%").mkdir()
             (d / "pkg+cu124-1.0.whl").write_text("x", encoding="utf-8")
 
             generate_package.generate_index_html(str(d))
 
             html_out = (d / "index.html").read_text(encoding="utf-8")
-            self.assertIn('href="x86_64+avx"', html_out)
+            self.assertIn('href="x86_64%2Bavx%20%231%26100%25"', html_out)
+            self.assertIn(">x86_64+avx #1&amp;100%<", html_out)
             self.assertIn('href="pkg%2Bcu124-1.0.whl"', html_out)
 
     def test_generate_index_from_s3_escapes_special_characters(self) -> None:
@@ -271,8 +265,7 @@ class GeneratePackageIndexesTest(unittest.TestCase):
         Verifies:
         - '+' in a filename is percent-encoded in the href, with the
           display text kept literal (HTML-escaped).
-        - Directory names are repo-layout segments (not package-derived)
-          and are rendered unescaped, unaffected by this change.
+        - Directory links encode URL characters and escape HTML metacharacters.
         """
         bucket = "b"
         prefix = "rpm/20260224-123"
@@ -280,7 +273,7 @@ class GeneratePackageIndexesTest(unittest.TestCase):
         pages: list[dict[str, Any]] = [
             {
                 "Contents": [
-                    {"Key": f"{prefix}/x86_64+avx/a+b.rpm"},
+                    {"Key": f"{prefix}/x86_64+avx #&<>\"'/a+b.rpm"},
                 ]
             }
         ]
@@ -294,10 +287,10 @@ class GeneratePackageIndexesTest(unittest.TestCase):
         generate_package.generate_index_from_s3(s3, bucket, prefix)
 
         root_html = s3.put_body_for(f"{prefix}/index.html")
-        self.assertIn('href="x86_64+avx/index.html"', root_html)
-        self.assertIn(">x86_64+avx/<", root_html)
+        self.assertIn('href="x86_64%2Bavx%20%23%26%3C%3E%22%27/index.html"', root_html)
+        self.assertIn(">x86_64+avx #&amp;&lt;&gt;&quot;&#x27;/<", root_html)
 
-        subdir_html = s3.put_body_for(f"{prefix}/x86_64+avx/index.html")
+        subdir_html = s3.put_body_for(f"{prefix}/x86_64+avx #&<>\"'/index.html")
         self.assertIn('href="a%2Bb.rpm"', subdir_html)
         self.assertIn(">a+b.rpm<", subdir_html)
 
@@ -307,9 +300,7 @@ class GeneratePackageIndexesTest(unittest.TestCase):
         Verifies:
         - '+' in a top-level filename is percent-encoded in the href, with
           the display text kept literal (HTML-escaped).
-        - '+' in a subfolder prefix is rendered unescaped, since directory
-          names are repo-layout segments (not package-derived) and are
-          unaffected by this change.
+        - Subfolder links encode URL characters and escape HTML metacharacters.
         """
         bucket = "b"
         top_prefix = "rpm"
@@ -317,7 +308,7 @@ class GeneratePackageIndexesTest(unittest.TestCase):
         pages: list[dict[str, Any]] = [
             {
                 "CommonPrefixes": [
-                    {"Prefix": "rpm/20260224+111/"},
+                    {"Prefix": "rpm/20260224+111 #&<>\"'/"},
                 ],
                 "Contents": [
                     {"Key": "rpm/some+file.txt"},
@@ -334,8 +325,8 @@ class GeneratePackageIndexesTest(unittest.TestCase):
         generate_package.generate_top_index_from_s3(s3, bucket, top_prefix)
 
         html_out = s3.put_body_for(f"{top_prefix}/index.html")
-        self.assertIn('href="20260224+111/index.html"', html_out)
-        self.assertIn(">20260224+111/<", html_out)
+        self.assertIn('href="20260224%2B111%20%23%26%3C%3E%22%27/index.html"', html_out)
+        self.assertIn(">20260224+111 #&amp;&lt;&gt;&quot;&#x27;/<", html_out)
         self.assertIn('href="some%2Bfile.txt"', html_out)
         self.assertIn(">some+file.txt<", html_out)
 


### PR DESCRIPTION
## Motivation

Directory names containing spaces, `#`, quotes, or HTML metacharacters still produce incorrect links or markup in native package indexes. PR #7708 added filename escaping but left directory names unescaped.

Fixes #7709. Follow-up to #7708.

## Technical Details

Apply the existing `urllib.parse.quote()` and `html.escape()` rendering to local directories, top-level S3 folders, and recursive S3 subdirectories. For example, a directory named `x86_64+avx #1&100%` links to `x86_64%2Bavx%20%231%26100%25`, with the ampersand escaped in its HTML label. S3 object keys and directory layout remain unchanged.

Update the existing regression tests to cover directory escaping, retaining filename checks. Local fixtures use Windows-compatible names; fake S3 listings additionally cover angle brackets and both quote characters.

Risk is low: this changes HTML rendering only, with no GPU, build configuration, or package-content changes.

## Test Plan

Run on Windows with Python 3.13:

```text
python -m pytest build_tools/packaging/tests -q
python -m pre_commit run --files build_tools/packaging/linux/generate_package_indexes.py build_tools/packaging/tests/generate_package_indexes_test.py
git diff --check
```

The existing `packaging/tests` directory is not included in `build_tools/pyproject.toml` default test discovery, so the explicit test command above is necessary.

## Test Result

Before changing production code, the updated regression suite produced 3 failures and 5 passes, reproducing the directory bug in all three entry points. With the fix, all 8 generator tests pass. The complete local packaging suite passes 89 tests and 12 subtests, including the adjacent local-index tests.

No live S3 uploads or GPU builds are needed for this rendering change. Hosted PR CI has not yet run.


