### PR TITLE
ci: Windows MSI build workflow + dev-bucket upload (Milestone 2)

### DIFF
--- a/.github/workflows/multi_arch_build_native_windows_packages.yml
+++ b/.github/workflows/multi_arch_build_native_windows_packages.yml
@@ -1,0 +1,116 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# Builds Windows MSI installer packages from TheRock artifact tarballs.
+#
+# This is a standalone build workflow (Milestone 2 of ROCm/TheRock#1987): it is
+# decoupled from CI and release workflows so that its MSI outputs can be
+# consumed by an arbitrary run of a downstream test workflow, and so that the
+# `ci` and `release` workflows can call it as they wish. It does not build ROCm
+# from source; it packages already-published artifacts.
+#
+# The `packages` input defaults to only `runtime`. Additional packages (e.g.
+# `core`) can be requested by passing a JSON list once their Windows artifacts
+# are published in nightly runs.
+
+name: Build Multi-Arch Native Windows Packages
+
+on:
+  workflow_dispatch:
+    inputs:
+      artifacts_url:
+        description: "Base URL of the artifact storage directory containing {name}_{component}_generic.tar.zst files."
+        type: string
+        required: true
+      packages:
+        description: 'JSON list of packages to build (e.g. ["runtime","core"]).'
+        type: string
+        default: '["runtime"]'
+      rocm_version:
+        description: "ROCm version to stamp on the MSI (e.g. '7.15.0'). Defaults to the repo's version.json."
+        type: string
+        default: ""
+      repository:
+        description: "Repository to checkout. Defaults to github.repository."
+        type: string
+        default: ""
+      ref:
+        description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
+        type: string
+        default: ""
+  workflow_call:
+    inputs:
+      artifacts_url:
+        type: string
+        required: true
+      packages:
+        type: string
+        default: '["runtime"]'
+      rocm_version:
+        type: string
+        default: ""
+      repository:
+        type: string
+        default: ""
+      ref:
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+run-name: Build Windows MSI packages (${{ inputs.artifacts_url }})
+
+jobs:
+  build:
+    name: Build MSI | ${{ matrix.package }}
+    runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-windows-scale-rocm' || 'windows-2022' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ${{ fromJSON(inputs.packages) }}
+    defaults:
+      run:
+        shell: bash
+    env:
+      ARTIFACTS_URL: ${{ inputs.artifacts_url }}
+      PACKAGE_VERSION: ${{ inputs.rocm_version }}
+      MSI_DIR: ${{ github.workspace }}/msi-output
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Install Python requirements
+        run: pip install -r requirements.txt
+
+      # Pin to WiX v4: v5+ compiles the same schema but v7 gates every command
+      # behind the OSMF EULA (error WIX7015), which would fail unattended CI.
+      - name: Install WiX Toolset v4
+        run: dotnet tool install --global wix --version "4.*"
+
+      - name: Generate WiX source and build MSI
+        run: |
+          python build_tools/packaging/windows/generate_msi_wxs.py \
+            --package "${{ matrix.package }}" \
+            --artifacts-url "${ARTIFACTS_URL}" \
+            ${PACKAGE_VERSION:+--package-version "${PACKAGE_VERSION}"} \
+            --output "${MSI_DIR}/${{ matrix.package }}.wxs"
+
+          wix build "${MSI_DIR}/${{ matrix.package }}.wxs" \
+            -arch x64 \
+            -o "${MSI_DIR}/${{ matrix.package }}.msi"
+
+      - name: Upload MSI artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: windows-msi-${{ matrix.package }}
+          path: ${{ env.MSI_DIR }}/${{ matrix.package }}.msi
+          if-no-files-found: error

--- a/.github/workflows/multi_arch_build_native_windows_packages.yml
+++ b/.github/workflows/multi_arch_build_native_windows_packages.yml
@@ -125,7 +125,12 @@ jobs:
           path: ${{ env.MSI_DIR }}/${{ matrix.package }}.msi
           if-no-files-found: error
 
+      # The S3 upload requires OIDC credentials whose IAM role trust is scoped
+      # to ROCm/TheRock, so it is skipped on forks (where it would fail). Forks
+      # still exercise the full generate + wix build path above and keep the
+      # GHA artifact from the previous step.
       - name: Configure AWS Credentials
+        if: ${{ github.repository_owner == 'ROCm' }}
         uses: ./.github/actions/configure_aws_artifacts_credentials
         with:
           release_type: ${{ inputs.release_type }}
@@ -135,6 +140,7 @@ jobs:
       # workflow can consume this run's MSIs. Each matrix leg uploads its own
       # package into the shared prefix.
       - name: Upload MSI to artifacts bucket
+        if: ${{ github.repository_owner == 'ROCm' }}
         run: |
           python build_tools/packaging/windows/upload_msi_packages.py \
             --run-id "${{ github.run_id }}" \

--- a/.github/workflows/multi_arch_build_native_windows_packages.yml
+++ b/.github/workflows/multi_arch_build_native_windows_packages.yml
@@ -106,6 +106,38 @@ jobs:
       - name: Install WiX Toolset v4
         run: dotnet tool install --global wix --version "4.*"
 
+      # The legacy System32 DLLs (amdhip64_6.dll, amd_comgr_2.dll) are tracked
+      # by DVC under rocm-systems/shared/amdgpu-windows-interop/legacy/. The
+      # outer checkout uses submodules: false for speed, so sparse-fetch only
+      # that directory — the generator then pulls the actual DLLs over
+      # anonymous HTTPS from the DVC remote. A full submodule init would clone
+      # the multi-GB rocm-systems repo needlessly.
+      #
+      # CRITICAL: the rocm-systems SHA must match the commit the *artifacts*
+      # were built from (or the legacy DLLs would be version-skewed against the
+      # rest of the MSI), so read pin_sha from the artifact set's own manifest
+      # rather than from this checkout's submodule gitlink.
+      #
+      # TODO(#1987): this belongs in generate_msi_wxs.py — in --artifacts-url
+      # mode the generator already fetches the manifest and should self-pin the
+      # legacy DVC fetch. Wiring it here keeps this PR scoped to the workflow;
+      # a follow-up will move the logic into the generator and drop this step.
+      - name: Sparse-checkout rocm-systems legacy DVC pointers
+        run: |
+          manifest_url="${ARTIFACTS_URL%/}/manifests/therock_manifest.json"
+          echo "Reading rocm-systems pin from ${manifest_url}"
+          rocm_systems_sha="$(
+            curl -fsSL "${manifest_url}" \
+              | python -c "import json,sys; m=json.load(sys.stdin); print(next(s['pin_sha'] for s in m['submodules'] if s['submodule_name']=='rocm-systems'))"
+          )"
+          echo "rocm-systems pin_sha=${rocm_systems_sha}"
+          git clone --no-checkout --filter=blob:none --depth=1 \
+            https://github.com/ROCm/rocm-systems.git rocm-systems
+          git -C rocm-systems sparse-checkout set --no-cone \
+            shared/amdgpu-windows-interop/legacy
+          git -C rocm-systems fetch --depth=1 origin "${rocm_systems_sha}"
+          git -C rocm-systems checkout "${rocm_systems_sha}"
+
       - name: Generate WiX source and build MSI
         run: |
           python build_tools/packaging/windows/generate_msi_wxs.py \

--- a/.github/workflows/multi_arch_build_native_windows_packages.yml
+++ b/.github/workflows/multi_arch_build_native_windows_packages.yml
@@ -140,21 +140,31 @@ jobs:
 
       - name: Generate WiX source and build MSI
         run: |
+          # The distributable filename is the package's output_stem
+          # (e.g. amdrocm-runtime), not the --package selector (runtime). Read
+          # it from the generator's PACKAGES table so there is a single source
+          # of truth for the name.
+          # TODO(#1987): follow-up PR to add a --output-dir flag to
+          # generate_msi_wxs.py so it writes <dir>/<output_stem>.wxs itself and
+          # the workflow no longer needs to know the filename.
+          stem="$(python -c "import sys; sys.path.insert(0, 'build_tools/packaging/windows'); from generate_msi_wxs import PACKAGES; print(PACKAGES['${{ matrix.package }}'].output_stem)")"
+          echo "MSI_STEM=${stem}" >> "${GITHUB_ENV}"
+
           python build_tools/packaging/windows/generate_msi_wxs.py \
             --package "${{ matrix.package }}" \
             --artifacts-url "${ARTIFACTS_URL}" \
             ${PACKAGE_VERSION:+--package-version "${PACKAGE_VERSION}"} \
-            --output "${MSI_DIR}/${{ matrix.package }}.wxs"
+            --output "${MSI_DIR}/${stem}.wxs"
 
-          wix build "${MSI_DIR}/${{ matrix.package }}.wxs" \
+          wix build "${MSI_DIR}/${stem}.wxs" \
             -arch x64 \
-            -o "${MSI_DIR}/${{ matrix.package }}.msi"
+            -o "${MSI_DIR}/${stem}.msi"
 
       - name: Upload MSI artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: windows-msi-${{ matrix.package }}
-          path: ${{ env.MSI_DIR }}/${{ matrix.package }}.msi
+          path: ${{ env.MSI_DIR }}/${{ env.MSI_STEM }}.msi
           if-no-files-found: error
 
       # The S3 upload requires OIDC credentials whose IAM role trust is scoped

--- a/.github/workflows/multi_arch_build_native_windows_packages.yml
+++ b/.github/workflows/multi_arch_build_native_windows_packages.yml
@@ -31,9 +31,9 @@ on:
         type: string
         default: ""
       release_type:
-        description: "Release type for the destination artifacts bucket (dev, nightly, ...)."
+        description: "Release type for the destination artifacts bucket. Developer-triggered runs should use the default."
         type: string
-        default: dev
+        default: ci
       repository:
         description: "Repository to checkout. Defaults to github.repository."
         type: string
@@ -55,7 +55,7 @@ on:
         default: ""
       release_type:
         type: string
-        default: dev
+        default: ci
       repository:
         type: string
         default: ""

--- a/.github/workflows/multi_arch_build_native_windows_packages.yml
+++ b/.github/workflows/multi_arch_build_native_windows_packages.yml
@@ -160,11 +160,16 @@ jobs:
             -arch x64 \
             -o "${MSI_DIR}/${stem}.msi"
 
-      - name: Upload MSI artifact
+      # Publish both the compiled MSI and the generated WiX source (.wxs) so the
+      # exact source that produced the installer is available for inspection and
+      # reproducible rebuilds.
+      - name: Upload MSI and WiX source artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: windows-msi-${{ matrix.package }}
-          path: ${{ env.MSI_DIR }}/${{ env.MSI_STEM }}.msi
+          path: |
+            ${{ env.MSI_DIR }}/${{ env.MSI_STEM }}.msi
+            ${{ env.MSI_DIR }}/${{ env.MSI_STEM }}.wxs
           if-no-files-found: error
 
       # The S3 upload requires OIDC credentials whose IAM role trust is scoped

--- a/.github/workflows/multi_arch_build_native_windows_packages.yml
+++ b/.github/workflows/multi_arch_build_native_windows_packages.yml
@@ -88,6 +88,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        timeout-minutes: 15
         with:
           repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref }}

--- a/.github/workflows/multi_arch_build_native_windows_packages.yml
+++ b/.github/workflows/multi_arch_build_native_windows_packages.yml
@@ -30,6 +30,10 @@ on:
         description: "ROCm version to stamp on the MSI (e.g. '7.15.0'). Defaults to the repo's version.json."
         type: string
         default: ""
+      release_type:
+        description: "Release type for the destination artifacts bucket (dev, nightly, ...)."
+        type: string
+        default: dev
       repository:
         description: "Repository to checkout. Defaults to github.repository."
         type: string
@@ -49,6 +53,9 @@ on:
       rocm_version:
         type: string
         default: ""
+      release_type:
+        type: string
+        default: dev
       repository:
         type: string
         default: ""
@@ -58,6 +65,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 run-name: Build Windows MSI packages (${{ inputs.artifacts_url }})
 
@@ -76,6 +84,7 @@ jobs:
       ARTIFACTS_URL: ${{ inputs.artifacts_url }}
       PACKAGE_VERSION: ${{ inputs.rocm_version }}
       MSI_DIR: ${{ github.workspace }}/msi-output
+      RELEASE_TYPE: ${{ inputs.release_type }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -114,3 +123,18 @@ jobs:
           name: windows-msi-${{ matrix.package }}
           path: ${{ env.MSI_DIR }}/${{ matrix.package }}.msi
           if-no-files-found: error
+
+      - name: Configure AWS Credentials
+        uses: ./.github/actions/configure_aws_artifacts_credentials
+        with:
+          release_type: ${{ inputs.release_type }}
+
+      # Upload to the current run's artifacts-bucket prefix
+      # ({run_id}-windows/packages/msi/) so a downstream publish or test
+      # workflow can consume this run's MSIs. Each matrix leg uploads its own
+      # package into the shared prefix.
+      - name: Upload MSI to artifacts bucket
+        run: |
+          python build_tools/packaging/windows/upload_msi_packages.py \
+            --run-id "${{ github.run_id }}" \
+            --package-dir "${MSI_DIR}"

--- a/build_tools/_therock_utils/workflow_outputs.py
+++ b/build_tools/_therock_utils/workflow_outputs.py
@@ -229,6 +229,21 @@ class WorkflowOutputRoot:
         """
         return StorageLocation(self.bucket, f"{self.prefix}/packages/{pkg_type}")
 
+    def native_windows_packages(self, pkg_type: str = "msi") -> StorageLocation:
+        """Location for the native Windows package directory.
+
+        Returns ``StorageLocation`` at ``{run_id}-windows/packages/{pkg_type}``
+        (e.g. ``12345678901-windows/packages/msi``).
+
+        Unlike the Linux deb/rpm repositories, the contents are loose installer
+        files (one ``.msi`` per package). See ``upload_msi_packages.py`` for the
+        upload side.
+
+        Args:
+            pkg_type: Package type (currently only 'msi').
+        """
+        return StorageLocation(self.bucket, f"{self.prefix}/packages/{pkg_type}")
+
     def native_linux_packages_log_dir(self, pkg_type: str) -> StorageLocation:
         """Location for native Linux packaging logs directory.
 

--- a/build_tools/github_actions/publish_rocm_to_release_buckets.py
+++ b/build_tools/github_actions/publish_rocm_to_release_buckets.py
@@ -9,7 +9,7 @@ These release file types are supported:
 - [x] tarballs
 - [x] python packages
 - [x] native linux packages
-- [ ] native windows packages
+- [x] native windows packages
 
 Example with ``--run-id 12345 --platform linux --release-type dev``:
 
@@ -42,6 +42,11 @@ Example with ``--run-id 12345 --platform linux --release-type dev``:
       -> s3://therock-repo-amd-rc-core/v5/rocm/core/packages/deb/
     s3://therock-prerelease-artifacts/12345-linux/packages/rpm/
       -> s3://therock-repo-amd-rc-core/v5/rocm/core/packages/rpm/
+
+    native windows packages (dev/nightly), with ``--platform windows``:
+
+    s3://therock-dev-artifacts/12345-windows/packages/msi/
+      -> s3://therock-repo-amd-dev-core/v5/rocm/core/packages/msi/20250101-12345/
 
 ASAN build variant:
 
@@ -278,6 +283,43 @@ def publish_native_linux_packages(
             raise FileNotFoundError(f"No {pkg_type} packages found at {source.s3_uri}")
 
 
+def publish_native_windows_packages(
+    artifacts_root: WorkflowOutputRoot,
+    release_type: str,
+    backend: StorageBackend,
+) -> None:
+    """Copy native Windows MSI packages from the artifacts bucket to the release bucket.
+
+    The source MSIs were uploaded by upload_msi_packages.py (called from
+    multi_arch_build_native_windows_packages.yml) as loose .msi files.
+
+    dev/nightly example:
+        s3://therock-dev-artifacts/12345-windows/packages/msi/
+          -> s3://therock-repo-amd-dev-core/v5/rocm/core/packages/msi/20250101-12345/
+
+    prerelease example:
+        s3://therock-prerelease-artifacts/12345-windows/packages/msi/
+          -> s3://therock-repo-amd-rc-core/v5/rocm/core/packages/msi/
+    """
+    dest_bucket = get_product_release_bucket_config(release_type, "core")
+    today = datetime.date.today().strftime("%Y%m%d")
+
+    source = artifacts_root.native_windows_packages("msi")
+
+    base_path = "v5/rocm/core/packages"
+    if release_type == "prerelease":
+        dest_prefix = f"{base_path}/msi"
+    else:
+        dest_prefix = f"{base_path}/msi/{today}-{artifacts_root.run_id}"
+
+    dest = StorageLocation(dest_bucket.name, dest_prefix)
+    logger.info("Native msi packages: %s -> %s", source.s3_uri, dest.s3_uri)
+    count = backend.copy_directory(source, dest)
+    logger.info("Copied %d files for msi packages", count)
+    if count == 0:
+        raise FileNotFoundError(f"No msi packages found at {source.s3_uri}")
+
+
 def main(argv: list[str]) -> None:
     parser = argparse.ArgumentParser(
         description="Publish ROCm release files to release buckets"
@@ -360,6 +402,8 @@ def main(argv: list[str]) -> None:
         publish_native_linux_packages(
             artifacts_root, args.release_type, backend, args.build_variant
         )
+    if artifacts_root.platform == "windows" and not args.skip_native_packages:
+        publish_native_windows_packages(artifacts_root, args.release_type, backend)
 
 
 if __name__ == "__main__":

--- a/build_tools/github_actions/tests/publish_rocm_to_release_buckets_test.py
+++ b/build_tools/github_actions/tests/publish_rocm_to_release_buckets_test.py
@@ -133,7 +133,7 @@ class TestPublishRocmToReleaseBuckets(unittest.TestCase):
         )
 
     @mock.patch("_therock_utils.storage_backend.S3StorageBackend.copy_directory")
-    def test_windows_skips_native_packages(self, mock_copy):
+    def test_windows_copies_native_msi_packages(self, mock_copy):
         mock_copy.return_value = 1
         main(
             [
@@ -146,8 +146,16 @@ class TestPublishRocmToReleaseBuckets(unittest.TestCase):
                 "--dry-run",
             ]
         )
-        # Only tarballs + python x2 (3 calls) — native packages skipped for windows
-        self.assertEqual(mock_copy.call_count, 3)
+        # Calls: tarballs, python x2, msi (4 calls)
+        self.assertEqual(mock_copy.call_count, 4)
+        # msi packages are the last call
+        msi_source, msi_dest = mock_copy.call_args_list[3].args
+        self.assertEqual(msi_source.bucket, "therock-nightly-artifacts")
+        self.assertEqual(msi_source.relative_path, "99-windows/packages/msi")
+        self.assertEqual(msi_dest.bucket, "therock-repo-amd-nightly-core")
+        self.assertRegex(
+            msi_dest.relative_path, r"^v5/rocm/core/packages/msi/\d{8}-99$"
+        )
 
     @mock.patch("_therock_utils.storage_backend.S3StorageBackend.copy_directory")
     def test_raises_when_no_tarballs_found(self, mock_copy):

--- a/build_tools/packaging/windows/upload_msi_packages.py
+++ b/build_tools/packaging/windows/upload_msi_packages.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Upload built Windows MSI installer packages to the artifacts S3 bucket.
+
+The destination bucket is auto-selected from the RELEASE_TYPE environment
+variable (e.g. RELEASE_TYPE=dev -> therock-dev-artifacts), matching how the
+Linux native packages and Python packages are uploaded.
+
+Usage:
+  upload_msi_packages.py --run-id RUN_ID --package-dir DIR [--dry-run]
+
+Output layout:
+  {bucket}/{external_repo}{run_id}-windows/packages/msi/
+    *.msi
+
+The published MSIs are later copied into a release bucket by
+build_tools/github_actions/publish_rocm_to_release_buckets.py.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+_BUILD_TOOLS_DIR = Path(__file__).resolve().parent.parent.parent
+if str(_BUILD_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_BUILD_TOOLS_DIR))
+
+from _therock_utils.storage_backend import create_storage_backend
+from _therock_utils.workflow_outputs import WorkflowOutputRoot
+
+# MSIs are Windows installers regardless of the runner this script executes on,
+# so the artifact prefix is always the "-windows" one.
+PLATFORM = "windows"
+
+
+def upload_msi_packages(run_id: str, package_dir: Path, dry_run: bool) -> None:
+    if not package_dir.is_dir():
+        sys.exit(f"Error: package dir not found: {package_dir}")
+
+    output_root = WorkflowOutputRoot.from_workflow_run(run_id=run_id, platform=PLATFORM)
+    dest = output_root.native_windows_packages("msi")
+
+    backend = create_storage_backend(dry_run=dry_run)
+    print(f"Uploading *.msi from {package_dir} to {dest.s3_uri}")
+    count = backend.upload_directory(package_dir, dest, include=["*.msi"])
+    print(f"Uploaded {count} MSI file(s)")
+    if count == 0:
+        raise FileNotFoundError(f"No .msi files found in {package_dir}")
+
+
+def main(argv: list[str]) -> None:
+    parser = argparse.ArgumentParser(
+        description="Upload Windows MSI packages to the artifacts bucket."
+    )
+    parser.add_argument("--run-id", required=True, help="GitHub Actions run ID")
+    parser.add_argument(
+        "--package-dir",
+        required=True,
+        type=Path,
+        help="Local directory containing the built .msi files",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Print plan without uploading"
+    )
+    args = parser.parse_args(argv)
+    upload_msi_packages(args.run_id, args.package_dir, args.dry_run)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])


### PR DESCRIPTION
## Summary

Implements **Milestone 2 (steps i–ii)** of the Windows installer effort tracked in #1987, building on the merged `generate_msi_wxs.py` generator from #4803.

- **Step i — build workflow:** `multi_arch_build_native_windows_packages.yml`, a standalone `workflow_dispatch` + `workflow_call` workflow that runs `generate_msi_wxs.py --artifacts-url` and `wix build -arch x64` to produce MSI installers, matrixed over a `packages` input (defaults to `["runtime"]`). Decoupled from CI/release so downstream test/release workflows can consume its output from any run.
- **Step ii — upload to the dev release bucket:** the built MSI is uploaded to the dev artifacts bucket and copied into the dev release bucket, mirroring the existing native-Linux path with `pkg_type = "msi"`.

## What's in each hop

**Upload hop** (MSI → `therock-dev-artifacts`):
- `WorkflowOutputRoot.native_windows_packages("msi")` → `{run_id}-windows/packages/msi`
- new `build_tools/packaging/windows/upload_msi_packages.py` uploads `*.msi` via `backend.upload_directory`; bucket auto-selected from `RELEASE_TYPE`
- the workflow gains a `release_type` input (default `dev`), `id-token: write`, and Configure-AWS + upload steps

**Publish hop** (dev artifacts → `therock-repo-amd-dev-core`):
- `publish_native_windows_packages()` in `publish_rocm_to_release_buckets.py` copies `{run_id}-windows/packages/msi` → `v5/rocm/core/packages/msi/{date}-{run_id}`, wired into the `platform == "windows"` dispatch

## Scope

Dev flow only (`--release-type dev`). Nightly / prerelease / public destinations are intentionally out of scope for now.

> Note: WiX is pinned to v4. WiX v7 gates every command behind the OSMF EULA (error `WIX7015`), which would fail unattended CI.

## Remaining milestones (follow-ups, per #1987)

- iv. call this workflow from `multi_arch_ci_windows.yml` / `multi_arch_release_windows.yml`
- v. MSI install tests (à la `test_native_linux_packages_install.yml`)
- vi. MSI/DLL signing
- vii. GUI installer on top of the MSIs

## Test plan

- [ ] Merge, then `workflow_dispatch` with a real `artifacts_url` from a Windows nightly run
- [ ] Confirm MSI lands at `s3://therock-dev-artifacts/<run-id>-windows/packages/msi/`
- [ ] `publish_rocm_to_release_buckets.py --platform windows --release-type dev` copies it to `s3://therock-repo-amd-dev-core/v5/rocm/core/packages/msi/<date>-<run-id>/`
- [x] Local: `generate_msi_wxs.py` + `wix build -arch x64` produces a valid MSI
- [x] `pre-commit` (black + actionlint) passes on all changed files

Tracking: #1987


## Conventions

Audited against `docs/development/style_guides/github_actions_style_guide.md`,
`python_style_guide.md`, and `docs/development/github_actions_debugging.md`.
Compliant on: SHA-pinned actions, pinned runner, `timeout-minutes`, OIDC
`id-token: write`, `configure_aws_artifacts_credentials` + `release_type`,
Python-over-bash, and the Python script's pathlib/type-hints/argparse style.
`release_type` now defaults to `ci` (safe default) to match the sibling build
helpers.


## Pre-merge testing (fork dispatch)

Per `TESTING.md` (link workflow_dispatch test runs when a workflow has no
`pull_request` trigger), validated end-to-end from a personal fork
(`idass1990/TheRock`), which exercises the full generate + `wix build` path on a
clean `windows-2022` runner. The two S3 steps skip on forks (`if:
github.repository_owner == 'ROCm'`); the S3 upload/publish hops are covered by
the `publish_rocm_to_release_buckets_test` unit test and run for real via
`workflow_dispatch` on `main` post-merge.

- Run: https://github.com/idass1990/TheRock/actions/runs/34398151295 — ✅ green
- Built the `runtime` MSI from nightly artifacts (`34293167034-windows`)
- Confirmed all five legacy System32 DLLs are included: `amdhip64_7`,
  `amd_comgr`, `rocm_kpack` (from artifacts) plus `amdhip64_6`, `amd_comgr_2`
  (fetched from DVC at the artifact-matched `rocm-systems` `pin_sha`)
- Output named after the package `output_stem` (`amdrocm-runtime.msi`)

