### PR TITLE
fix(ci): make ASAN sanity findings reachable and readable

### DIFF
--- a/build_tools/print_driver_gpu_info.py
+++ b/build_tools/print_driver_gpu_info.py
@@ -78,6 +78,12 @@ def run_command(args: List[str | Path], cwd: Optional[Path] = None) -> None:
             stdin=subprocess.DEVNULL,
         )
         log(proc.stdout.rstrip())
+    except subprocess.CalledProcessError as e:
+        # Print the captured output before propagating, otherwise the command's
+        # own diagnostics are lost and only the traceback survives.
+        if e.stdout:
+            log(e.stdout.rstrip())
+        raise
     except FileNotFoundError:
         log(f"{args[0]}: command not found")
 

--- a/tests/test_rocm_sanity.py
+++ b/tests/test_rocm_sanity.py
@@ -29,10 +29,10 @@ def is_windows():
     return "windows" == platform.system().lower()
 
 
-def run_command(command: list[str], cwd=None):
+def run_command(command: list[str], cwd=None, env=None):
     logger.info(f"++ Run [{cwd}]$ {shlex.join(command)}")
     process = subprocess.run(
-        command, capture_output=True, cwd=cwd, shell=is_windows(), text=True
+        command, capture_output=True, cwd=cwd, env=env, shell=is_windows(), text=True
     )
     if process.returncode != 0:
         logger.error(f"Command failed!")
@@ -154,7 +154,20 @@ class TestROCmSanity:
         # Running and checking the executable
         platform_executable_prefix = "./" if not is_windows() else ""
         hip_check_executable = f"{platform_executable_prefix}hip_check"
-        process = run_command([hip_check_executable], cwd=str(THEROCK_BIN_DIR))
+        # hip_check is deliberately compiled without -fsanitize=address, so it
+        # needs the runtime preloaded to link against instrumented ROCm
+        # libraries. Instrumenting it instead would pull in device-side
+        # instrumentation that the host-asan variant exists to avoid. CI does
+        # not export LD_PRELOAD globally, to keep third-party libraries from
+        # producing spurious leak reports.
+        env = None
+        asan_runtime_path = os.getenv("ASAN_RUNTIME_PATH", "")
+        if asan_runtime_path and os.getenv("BUILD_VARIANT", "") in (
+            "asan",
+            "host-asan",
+        ):
+            env = {**os.environ, "LD_PRELOAD": asan_runtime_path}
+        process = run_command([hip_check_executable], cwd=str(THEROCK_BIN_DIR), env=env)
         check.equal(process.returncode, 0)
         check.greater(
             os.path.getsize(str(THEROCK_BIN_DIR / hip_check_executable_file)), 0


### PR DESCRIPTION
Depends on #8123, which sets up the ASAN environment for test jobs:
`configure_asan_env.py` resolves `ASAN_RUNTIME_PATH` and `ASAN_SYMBOLIZER_PATH`
from the artifact tree, and the workflow scopes `LD_PRELOAD` and the leak
suppression to the sanity step.

This PR is the remainder: the two script-side changes needed to get past the
sanity check and read what ASAN reports once it runs. It touches no workflow
files.

Earlier revisions of this PR also carried the workflow reorder, a
`BUILD_VARIANT` branch inside `print_driver_gpu_info.py`, and the
`ASAN_SYMBOLIZER_PATH` fix. All three now live in #8123 — the first two after
review feedback on #7311 asking that generic utilities not learn about CI build
variants, the third as part of moving that logic out of inline bash.

## Commits

1. **print a failing command's output in the driver sanity script** —
   `run_command` pipes stdout and stderr but only logs them on success, so a
   failing probe produced a bare `CalledProcessError` traceback. Nightly ASAN
   runs failed this way for days with no indication of why `amd-smi` returned
   non-zero. No CI or sanitizer coupling: it applies to any failing probe on
   any system.

2. **preload the ASAN runtime for hip_check in the sanity test** — `hip_check`
   is deliberately built without `-fsanitize=address`, so it aborts with "ASan
   runtime does not come first" when it loads instrumented ROCm libraries.
   Instrumenting it instead would pull in the device-side instrumentation that
   the host-asan variant exists to avoid, so the runtime is preloaded for that
   one subprocess, reusing the `ASAN_RUNTIME_PATH` that #8123 exports.

   Kept in the project test rather than exported job-wide. A job-wide
   `LD_PRELOAD` puts the non-instrumented Python driving pytest under
   LeakSanitizer, which then reports CPython's own end-of-process allocations
   and fails test steps: measured at 531244 bytes in 499 allocations, all
   `_PyMem_RawMalloc` / `_PyBytes_Resize` / `rpds`, in run
   [34492719442](https://github.com/ROCm/rocm-systems/actions/runs/34492719442).

## Validation

Exercised against ROCm/rocm-systems#10088 on a branch carrying #7780 and #8123
plus these changes, added progressively:

| Run | State | Result |
|---|---|---|
| [34385342239](https://github.com/ROCm/rocm-systems/actions/runs/34385342239) | baseline | `amd-smi static` exit 1 after 0.19s, reason not logged |
| [34395575767](https://github.com/ROCm/rocm-systems/actions/runs/34395575767) | + preload (#8123) | survives 2.11s then exit 1, reason still not logged |
| [34401743892](https://github.com/ROCm/rocm-systems/actions/runs/34401743892) | + commit 1, leak suppression | sanity passes; `hip_check` aborts, now visible |
| [34408883136](https://github.com/ROCm/rocm-systems/actions/runs/34408883136) | + commit 2 | real ASAN `bad-free` in `libamdhip64.so.7`, unsymbolized |
| [34513780373](https://github.com/ROCm/rocm-systems/actions/runs/34513780373) | + symbolizer fix (now #8123) | same finding, symbolized, no spurious leak report |

The sanity check passes and the remaining failure is a genuine defect:

```
ERROR: AddressSanitizer: attempting free on address which was not malloc()-ed
    #0 hsa_amd_memory_pool_free   compiler-rt/lib/asan/asan_interceptors.cpp:916
allocated by thread T0 here:
    #0 hsa_amd_memory_pool_allocate compiler-rt/lib/asan/asan_interceptors.cpp:908
SUMMARY: AddressSanitizer: bad-free (build/bin/../lib/libamdhip64.so.7+0x5febae)
```

A 4 MiB region allocated through the HSA pool allocator is released through a
path the allocator does not recognise, during static destructor teardown. That
is tracked separately; it is not addressed here.

ISSUE ID: https://github.com/ROCm/TheRock/issues/7202
