### PR TITLE
fix(ci): add missing rocm-systems workflow files to bump automation

### DIFF
--- a/build_tools/github_actions/bump_automation.py
+++ b/build_tools/github_actions/bump_automation.py
@@ -19,11 +19,17 @@ BOT_EMAIL = "therockbot@amd.com"
 COMMON_CI_LABELS = ["ci:run-all-archs"]
 
 ROCM_SYSTEMS_FILES = [
+    ".github/workflows/therock-build-linux.yml",
     ".github/workflows/therock-ci-linux.yml",
     ".github/workflows/therock-ci-windows.yml",
+    ".github/workflows/therock-ci.yml",
     ".github/workflows/therock-rccl-ci-linux.yml",
+    ".github/workflows/therock-rccl-test-jax-collective.yml",
+    ".github/workflows/therock-rccl-test-madengine.yml",
     ".github/workflows/therock-rccl-test-packages-multi-node.yml",
     ".github/workflows/therock-rccl-test-packages-single-node.yml",
+    ".github/workflows/therock-rccl-test-pytorch-distributed.yml",
+    ".github/workflows/therock-rccl-test-rocprof.yml",
     ".github/workflows/therock-test-component.yml",
     ".github/workflows/therock-test-packages.yml",
 ]


### PR DESCRIPTION
Add 6 missing workflow files that were not being updated in rocm-systems bump PRs: therock-build-linux.yml, therock-ci.yml, and 4 RCCL test workflows.