### PR TITLE
Add multiarch tarball index filter

### DIFF
--- a/build_tools/index_generation_s3_tar.py
+++ b/build_tools/index_generation_s3_tar.py
@@ -184,6 +184,7 @@ def generate_index_s3(
             <label for="filter">Filter by:</label>
             <select id="filter">
                 <option value="all">All</option>
+                <option value="multiarch">Multiarch</option>
                 {gpu_families_options}
             </select>
         </div>

--- a/build_tools/tests/index_generation_s3_tar_test.py
+++ b/build_tools/tests/index_generation_s3_tar_test.py
@@ -51,6 +51,31 @@ class IndexGenerationS3TarTest(unittest.TestCase):
         )
         self.s3_client.put_object.assert_not_called()
 
+    def test_index_offers_multiarch_filter(self) -> None:
+        """Combined archives must be selectable separately from GPU archives."""
+        self._set_contents(
+            [
+                {
+                    "Key": f"{self.prefix}/therock-dist-linux-{target}-10.1.0.tar.gz",
+                    "LastModified": datetime(2026, 8, 7, tzinfo=timezone.utc),
+                }
+                for target in ("multiarch", "gfx90a", "gfx1100")
+            ]
+        )
+
+        index_generation_s3_tar.generate_index_s3(
+            s3_client=self.s3_client,
+            bucket_name=self.bucket_name,
+            prefix=self.prefix,
+            upload=True,
+        )
+
+        html = self._uploaded_html()
+        self.assertIn('<option value="all">All</option>', html)
+        self.assertIn('<option value="multiarch">Multiarch</option>', html)
+        self.assertIn('<option value="gfx90a">gfx90a</option>', html)
+        self.assertIn('<option value="gfx1100">gfx1100</option>', html)
+
     def test_deleting_last_tarball_uploads_empty_index_when_allowed(self) -> None:
         """Removing the last tarball must replace the stale index."""
         tarball_key = f"{self.prefix}/test-rvs.tar.gz"


### PR DESCRIPTION
## Motivation

The tarball index offers All and GPU-specific filters, but users cannot select only the combined `multiarch` archives.

Fixes #7190.

## Technical Details

Add a Multiarch option with value `multiarch` to the filter dropdown. The existing filename filter already handles this value, so no filtering or sorting logic changes are needed. When no combined archives exist, selecting Multiarch uses the existing empty-results message.

Add a regression test using a mixed S3 listing to verify that Multiarch is available alongside All and the GPU-specific options.

## Test Plan

```text
python -m pytest build_tools/tests/index_generation_s3_tar_test.py build_tools/tests/generate_s3_index_test.py -q
python -m pre_commit run --files build_tools/index_generation_s3_tar.py build_tools/tests/index_generation_s3_tar_test.py
git diff --check
```

Browser validation used generated HTML from fake S3 listings containing combined and GPU-specific archives, GPU-only archives, and an empty listing.

## Test Result

- Before the fix: the new regression test failed because the Multiarch option was absent; the two existing tarball-index tests passed.
- After the fix: all 21 targeted and adjacent index tests passed on Windows with Python 3.13.
- Browser checks passed for All, Multiarch, GPU-specific filtering, both sort directions, and empty results.
- All applicable pre-commit checks and `git diff --check` passed.
- No live S3 uploads or GPU builds were required.
