### PR TITLE
fix(build): forward THEROCK_COMGR_DLL_NAME to ocl-clr

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -12,6 +12,15 @@ if(WIN32)
   set(_system_toolchain "")
 endif()
 
+# Optionally override the comgr DLL name that CLR dynamically loads (Windows).
+# Kept in sync with the comgr build side via the same THEROCK_COMGR_DLL_NAME
+# option, so the name CLR loads matches the name comgr is built as. Applies to
+# both CLR builds: hip-clr and ocl-clr each compile their own rocclr.
+set(_clr_comgr_dll_name_cmake_args)
+if(THEROCK_COMGR_DLL_NAME)
+  list(APPEND _clr_comgr_dll_name_cmake_args "-DCOMGR_DLL_NAME=${THEROCK_COMGR_DLL_NAME}")
+endif()
+
 ################################################################################
 # rocm-kpack
 ################################################################################
@@ -276,16 +285,6 @@ if(THEROCK_ENABLE_HIP_RUNTIME)
     )
   endif()
 
-  # Optionally override the comgr DLL name that CLR dynamically loads (Windows).
-  # Kept in sync with the comgr build side via the same THEROCK_COMGR_DLL_NAME
-  # option, so the name CLR loads matches the name comgr is built as.
-  set(_clr_comgr_dll_name_cmake_args)
-  if(THEROCK_COMGR_DLL_NAME)
-    list(APPEND _clr_comgr_dll_name_cmake_args "-DCOMGR_DLL_NAME=${THEROCK_COMGR_DLL_NAME}")
-  endif()
-
-
-
   therock_cmake_subproject_declare(hip-clr
     USE_DIST_AMDGPU_TARGETS
     EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/clr"
@@ -509,6 +508,7 @@ if(THEROCK_ENABLE_OCL_RUNTIME)
       "${_system_toolchain}"
     CMAKE_ARGS
       "-DCLR_BUILD_OCL=ON"
+      ${_clr_comgr_dll_name_cmake_args}
       ${OCL_CLR_CMAKE_ARGS}
     BUILD_DEPS
       rocm-cmake


### PR DESCRIPTION
`THEROCK_COMGR_DLL_NAME` (#6971) forwards `-DCOMGR_DLL_NAME` to `amd-comgr` and `hip-clr`, but not `ocl-clr`. Since `ocl-clr` is a separate configure of clr and compiles its own rocclr, it kept the default `amd_comgr.dll` while comgr was built under the overridden name — so the OpenCL runtime loads a DLL that is never produced. That is the mismatch the option exists to prevent.

- Hoist the `_clr_comgr_dll_name_cmake_args` block to file scope; it sat inside the `THEROCK_ENABLE_HIP_RUNTIME` guard, so an OpenCL-only build never saw it.
- Pass it to `ocl-clr` as well.

Windows-only in effect, inert when the option is empty.

ISSUE ID: #6970
