### PR TITLE
fix(thirparty): patch swapped VERSION/SOVERSION on fftw3 shared libraries

### DIFF
--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -437,9 +437,7 @@
     "BuildArch": "x86_64",
     "DEBDepends": [
       "amdrocm-fft-devel",
-      "amdrocm-rand",
-      "libfftw3-double3",
-      "libfftw3-single3"
+      "amdrocm-rand"
     ],
     "RPMRequires": [
       "amdrocm-fft-devel",

--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -437,7 +437,9 @@
     "BuildArch": "x86_64",
     "DEBDepends": [
       "amdrocm-fft-devel",
-      "amdrocm-rand"
+      "amdrocm-rand",
+      "libfftw3-double3",
+      "libfftw3-single3"
     ],
     "RPMRequires": [
       "amdrocm-fft-devel",

--- a/patches/third-party/fftw3/0001-Fix-swapped-VERSION-SOVERSION-on-shared-libraries.patch
+++ b/patches/third-party/fftw3/0001-Fix-swapped-VERSION-SOVERSION-on-shared-libraries.patch
@@ -1,0 +1,44 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nirmal Unnikrishnan <nunnikri@amd.com>
+Date: Wed, 9 Sep 2026 00:00:00 +0000
+Subject: [PATCH] Fix swapped VERSION/SOVERSION on shared libraries
+
+FFTW's CMakeLists.txt sets:
+
+  set_target_properties (${subtarget} PROPERTIES SOVERSION 3.6.9 VERSION 3)
+
+CMake ties the real installed filename to VERSION and the SONAME
+(embedded in the library, plus the symlink consumers link against) to
+SOVERSION. With these swapped, the real file is named libfftw3.so.3
+while the embedded SONAME/symlink is libfftw3.so.3.6.9 - backwards
+from the standard Unix shared-library layout, and from what FFTW's
+own autotools/libtool build produces for this exact release: libtool
+version-info "9:9:6" translates to SONAME major 3 and real file
+version 3.6.9, per configure.ac.
+
+Every consumer that links against this build records the wrong,
+overly-specific libfftw3.so.3.6.9 as its runtime dependency instead
+of the stable libfftw3.so.3 SONAME that distro fftw3 packages
+actually provide, breaking installs/execution wherever TheRock's own
+build of fftw3 isn't also bundled alongside it (ROCM-30822).
+
+Swap the two properties so VERSION carries the full version (real
+filename) and SOVERSION carries the major-only ABI version (SONAME),
+matching the conventional layout and what distro packages provide.
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -356,7 +356,7 @@
+ endif ()
+ 
+ foreach(subtarget ${subtargets})
+-  set_target_properties (${subtarget} PROPERTIES SOVERSION 3.6.9 VERSION 3)
++  set_target_properties (${subtarget} PROPERTIES VERSION 3.6.9 SOVERSION 3)
+   install (TARGETS ${subtarget}
+ 	  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+ 	  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+--
+2.43.0

--- a/third-party/fftw3/CMakeLists.txt
+++ b/third-party/fftw3/CMakeLists.txt
@@ -6,6 +6,7 @@ therock_subproject_fetch(therock-fftw3-sources
   # Originally mirrored from: https://fftw.org/fftw-3.3.10.tar.gz
   URL https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/fftw-3.3.10.tar.gz
   URL_HASH SHA256=56c932549852cddcfafdab3820b0200c7742675be92179e59e6215b340e26467
+  PATCH_COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/build_tools/patch_third_party_source.py ${CMAKE_SOURCE_DIR}/patches/third-party/fftw3
 )
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")


### PR DESCRIPTION
Fixing VERSION/SOVERSION of fftw3 libraries.

## Motivation

ISSUE ID : https://amd-hub.atlassian.net/browse/ROCM-30822 
native RPM installs fail on RHEL 10 and SLES 16 because `amdrocm-fft-test-host`
requires the exact `libfftw3.so.3.6.9()(64bit)`, which no distro package
provides (distros ship `libfftw3.so.3.6.10` under the generic SONAME
`libfftw3.so.3`). The same build also fails at **runtime** on Ubuntu DEB
(`rocFFT_bitwiseRepro`: `error while loading shared libraries:
libfftw3.so.3.6.9: cannot open shared object file`).

This regressed after #8073 ("remove fftw3 from amdrocm-fft-test", merged
for licensing concerns) stopped bundling TheRock's own compiled fftw3
alongside the fft-test packages. Bundling had been the workaround for the
same defect class previously (ROCM-19867, fixed via #4170 — "Add fftw3
artifact to amdrocm-fft-test package"). Removing the bundle was the right
call for licensing, but it exposed the underlying defect that bundling had
only been papering over.

## Technical Details

Root cause traced to FFTW 3.3.10's own upstream `CMakeLists.txt`:

```
foreach(subtarget ${subtargets})
  set_target_properties (${subtarget} PROPERTIES SOVERSION 3.6.9 VERSION 3)
```

CMake ties the **real installed filename** to `VERSION` and the
**embedded SONAME** (plus the symlink consumers actually link against) to
`SOVERSION`. With these two properties swapped, every consumer that links
against TheRock's build of fftw3 records the overly-specific
`libfftw3.so.3.6.9` as its runtime dependency, instead of the stable
`libfftw3.so.3` SONAME that every distro's fftw3 package actually
provides.

This is a genuine upstream bug, not a version mismatch: FFTW's
`configure.ac` documents the intended libtool version-info for this exact
release —
https://github.com/FFTW/fftw3/blob/fftw-3.3.10/configure.ac#L15-L29
https://github.com/FFTW/fftw3/blob/fftw-3.3.10/CMakeLists.txt#L359
```
dnl fftw-3.3.10 was 9:x:6
SHARED_VERSION_INFO="9:FFTW_MINOR_VERSION:6" # CURRENT:REVISION:AGE
```

Applying the standard libtool translation (`SONAME major = CURRENT − AGE`,
`file version = (CURRENT−AGE).AGE.REVISION`) gives `SONAME major = 3` and
`file version = 3.6.9` — i.e. FFTW's own autotools/libtool build already
produces the correct layout for this release; only the CMake build path
has the two properties transposed.

**Before vs. after this patch:**

| Library | Real file (before) | Embedded SONAME (before) | Real file (after) | Embedded SONAME (after) |
|---|---|---|---|---|
| `fftw3` | `libfftw3.so.3` | `libfftw3.so.3.6.9` | `libfftw3.so.3.6.9` | `libfftw3.so.3` |
| `fftw3_threads` | `libfftw3_threads.so.3` | `libfftw3_threads.so.3.6.9` | `libfftw3_threads.so.3.6.9` | `libfftw3_threads.so.3` |
| `fftw3f` | `libfftw3f.so.3` | `libfftw3f.so.3.6.9` | `libfftw3f.so.3.6.9` | `libfftw3f.so.3` |
| `fftw3f_threads` | `libfftw3f_threads.so.3` | `libfftw3f_threads.so.3.6.9` | `libfftw3f_threads.so.3.6.9` | `libfftw3f_threads.so.3` |

The "after" layout matches the standard Unix shared-library convention
(real file carries the full version, SONAME carries the stable major
version) — the same layout every distro's fftw3 package ships, so
consumers built against it will correctly depend on `libfftw3.so.3` and
resolve against whatever exact patch version the target system provides.

**Fix**: added `patches/third-party/fftw3/0001-Fix-swapped-VERSION-SOVERSION-on-shared-libraries.patch`,
applied via the existing `patch_third_party_source.py` `PATCH_COMMAND`
mechanism (same pattern already used for `elfio`, `host-blas`, `gmp`,
`numactl`, `util-linux`, `yaml-cpp`) — no new patching infrastructure
needed. Wired into `third-party/fftw3/CMakeLists.txt`'s existing
`therock_subproject_fetch(therock-fftw3-sources ...)` call.

Also checked `third-party/fftw3/artifact_fftw3.toml` — it uses
directory-level component definitions with no filename-specific globs, so
it's unaffected by the corrected real-filename layout.

## Test Plan

- Verify the patch applies cleanly against the actual FFTW 3.3.10 source
  (`fftw-3.3.10` tag) via a local dry run of
  `patch -p1 -i patches/third-party/fftw3/0001-...patch`.
- Run pre-commit hooks against both changed files.
- Rely on CI to rebuild `fftw3`/`fftw3f` and their consumers
  (`hipfft-test`, `rocfft-test`) and confirm the resulting binaries record
  `libfftw3.so.3`/`libfftw3_threads.so.3`/`libfftw3f.so.3`/
  `libfftw3f_threads.so.3` as `DT_NEEDED` entries (via `readelf -d`),
  and that native RPM/DEB installs and `rocFFT_bitwiseRepro` pass on
  RHEL 10, SLES 16, and Ubuntu 24.04.

## Test Result

- Downloaded the real FFTW 3.3.10 `CMakeLists.txt` (tag `fftw-3.3.10`) and
  confirmed the patch applies cleanly with `patch -p1`, producing exactly
  `set_target_properties (${subtarget} PROPERTIES VERSION 3.6.9 SOVERSION 3)`.
