### PR TITLE
CI: skip multi-arch tests for StinkyTofu changes

### DIFF
--- a/test_tools/determine_rocm_test_dependencies.py
+++ b/test_tools/determine_rocm_test_dependencies.py
@@ -96,7 +96,9 @@ _EXTERNAL_SUBTREE_ALIASES = {
     # _load_synthetic_subprojects below) with level 3 (unbounded) in
     # test_policies.toml, so they don't need to be hand-listed here too.
     "shared/origami": ["origami", "tensilelite"],
-    "shared/stinkytofu": ["tensilelite"],
+    # StinkyTofu only affects gfx1250. Multi-arch CI currently has no gfx1250
+    # test runners, so preserve its build selection while selecting no tests.
+    "shared/stinkytofu": [],
     "shared/tensile": ["hipblas", "rocblas"],
     "dnn-providers/cmake": ["hipdnn_integration_tests"],
     "dnn-providers/hipblaslt-provider": ["hipblasltprovider"],
@@ -626,13 +628,18 @@ def main():
         print(json.dumps(result, indent=2))
         return
 
-    # Parse and normalize changed_projects
+    # Parse changed_projects.
     changed = args.changed_projects
     if changed:
         flattened = []
         for item in changed:
             flattened.extend(p.strip() for p in item.split(",") if p.strip())
         changed = flattened
+
+    # Record whether projects were explicitly supplied before alias normalization.
+    # An explicit external project may intentionally map to no tests, while no
+    # supplied projects continues to mean run all tests.
+    projects_were_provided = bool(changed)
 
     if changed:
         normalized = []
@@ -643,8 +650,8 @@ def main():
                 raise SystemExit(str(e)) from e
         changed = normalized
 
-    # No projects specified → all tests
-    if not changed:
+    # No projects supplied → all tests.
+    if not projects_were_provided:
         if args.gha_output:
             gha_set_output({"projects_to_test": "*"})
         else:

--- a/test_tools/tests/determine_rocm_test_dependencies_test.py
+++ b/test_tools/tests/determine_rocm_test_dependencies_test.py
@@ -337,7 +337,7 @@ class TestCliInputParsing(_FixtureTestCase):
                 # only exercises alias expansion, so it sees just the literal
                 # alias contents.
                 "shared/origami": {"origami", "tensilelite"},
-                "shared/stinkytofu": {"tensilelite"},
+                "shared/stinkytofu": set(),
                 "shared/tensile": {"hipblas", "rocblas"},
             }
             for changed_project, expected in cases.items():
@@ -569,6 +569,30 @@ class TestCliInputParsing(_FixtureTestCase):
         lines = proc.stdout.strip().splitlines()
         self.assertIn("amdsmi", lines)
         self.assertIn("rdc", lines)
+
+    def test_stinkytofu_explicitly_selects_no_tests(self) -> None:
+        proc = self._run(
+            "--changed-projects",
+            "shared/stinkytofu",
+        )
+
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(json.loads(proc.stdout), [])
+
+    def test_stinkytofu_does_not_remove_mixed_project_tests(self) -> None:
+        proc = self._run(
+            "--changed-projects",
+            "shared/stinkytofu",
+            "shared/origami",
+            "--level",
+            "5",
+        )
+
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(
+            json.loads(proc.stdout),
+            ["origami", "tensilelite"],
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Issue: https://github.com/ROCm/rocm-libraries/issues/11885

Skip TheRock multi-arch test selection when the only changed external subtree is `shared/stinkytofu`.

StinkyTofu currently affects gfx1250, while the multi-arch CI test runners cover older GPU architectures. Running those tests for StinkyTofu-only changes consumes constrained runners without providing relevant test coverage. Build selection remains unchanged, so the applicable build validation still runs.

## Changes

- Map `shared/stinkytofu` to an empty test dependency list.
- Distinguish between:
  - no changed projects supplied, which continues to select all tests (`*`);
  - an explicitly supplied project that intentionally maps to no tests, which selects an empty test list.
- Preserve tests selected by other projects when StinkyTofu appears in a mixed change.
- Add unit coverage for the empty and mixed-project behaviors.

## Test plan

```text
python -m pytest test_tools/tests/determine_rocm_test_dependencies_test.py
71 passed
```

```text
pre-commit run --files \
  test_tools/determine_rocm_test_dependencies.py \
  test_tools/tests/determine_rocm_test_dependencies_test.py

All checks passed
```

Verified GitHub Actions output for a StinkyTofu-only change:

```text
projects_to_test=
```

Also verified:

- no changed projects still produces `*`;
- `shared/stinkytofu` with `shared/origami` still selects the Origami-related tests.

## Follow-up work

After this PR lands, a follow-up `ROCm/rocm-libraries` PR will:

1. Update `multi_arch_test_projects.py` so `shared/stinkytofu` is forwarded to TheRock unchanged instead of being expanded into BLAS test projects.
2. Update its tests to verify that StinkyTofu is treated as build-only and does not remove tests selected by other changed projects.
3. Update `therock-multi-arch-ci.yml` to pin the TheRock commit containing this change.

A future follow-up can enable appropriate StinkyTofu runtime tests when gfx1250 test runners become available.