### PR TITLE
fix(packaging): stop distributing amdrocm-fft-test (links GPL fftw3)

### DIFF
--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -431,49 +431,6 @@
     "Disable_DWZ": "True"
   },
   {
-    "Package": "amdrocm-fft-test",
-    "Version": "",
-    "Architecture": "amd64",
-    "BuildArch": "x86_64",
-    "DEBDepends": [
-      "amdrocm-fft-devel",
-      "amdrocm-rand"
-    ],
-    "RPMRequires": [
-      "amdrocm-fft-devel",
-      "amdrocm-rand"
-    ],
-    "Maintainer": "ROCm Dev Support <rocm-dev.support@amd.com>",
-    "Description_Short": "ROCm FFT library test suite and validation binaries",
-    "Description_Long": "Comprehensive test suite for rocFFT and hipFFT libraries. Includes unit tests, performance benchmarks, and correctness validation tools for Fast Fourier Transform operations on AMD GPUs. Provides test binaries and verification utilities for FFT algorithm implementation.",
-    "Section": "devel",
-    "Priority": "optional",
-    "Group": "unknown",
-    "License": "MIT",
-    "Vendor": "Advanced Micro Devices, Inc",
-    "Homepage": "https://github.com/ROCm/rocm-libraries",
-    "Artifactory": [
-      {
-        "Artifact": "fft",
-        "Artifact_Subdir": [
-          {
-            "Name": "rocFFT",
-            "Components": [
-              "test"
-            ]
-          },
-          {
-            "Name": "hipFFT",
-            "Components": [
-              "test"
-            ]
-          }
-        ]
-      }
-    ],
-    "Gfxarch": "True"
-  },
-  {
     "Package": "amdrocm-fft",
     "Version": "",
     "Architecture": "amd64",

--- a/tests/test_artifact_structure.py
+++ b/tests/test_artifact_structure.py
@@ -66,6 +66,7 @@ IGNORED_COMPONENTS = {"dbg"}
 
 KNOWN_UNCOVERED_COMPONENTS: set[tuple[str, str]] = {
     ("base", "test"),
+    ("fft", "test"),  # amdrocm-fft-test removed: links GPL fftw3, not distributed.
     ("fftw3", "dev"),  # fftw3 is currently test-only; may be distributed later.
     ("fftw3", "doc"),
     ("fftw3", "run"),


### PR DESCRIPTION
# fix(packaging): stop distributing amdrocm-fft-test (links GPL fftw3)

## Motivation

`amdrocm-fft-test` packages rocFFT and hipFFT test binaries, both linked
against GPL-licensed fftw3. Even without bundling fftw3's own binary
(removed in #8073), distributing a binary linked against a GPL library can
itself carry GPL obligations onto that binary — bundling and linking are
separate exposures, and removing only the bundled artifact doesn't
resolve the linking one. Rather than resolve that licensing question,
this removes the package entirely so it's not built or distributed.

Related to https://amd-hub.atlassian.net/browse/ROCM-30822.

## Technical Details

- Removed the `amdrocm-fft-test` package definition from `package.json`.
  No other package depended on it.
- Added `("fft", "test")` to `KNOWN_UNCOVERED_COMPONENTS` in
  `tests/test_artifact_structure.py`, same pattern as the `("fftw3",
  "lib")` entry added in #8073.

## Test Plan / Result

- Successful CI run