### PR TITLE
docs(windows): bump winget Windows 11 SDK example to 26100

### DIFF
--- a/docs/development/windows_support.md
+++ b/docs/development/windows_support.md
@@ -196,7 +196,7 @@ configuration. It is safe to re-run at any time.
 > ```bash
 > winget install --id Microsoft.VisualStudio.2022.BuildTools --source winget --override "--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add
 > Microsoft.VisualStudio.Component.VC.CMake.Project --add Microsoft.VisualStudio.Component.VC.ATL --add
-> Microsoft.VisualStudio.Component.Windows11SDK.22621"
+> Microsoft.VisualStudio.Component.Windows11SDK.26100"
 > winget install --id Git.Git -e --source winget --custom "/o:PathOption=CmdTools"
 > winget install cmake
 > winget install ninja-build.ninja ccache python strawberryperl


### PR DESCRIPTION
﻿Bumps the winget quick-install example in `docs/development/windows_support.md` from `Windows11SDK.22621` to `Windows11SDK.26100` so a contributor's local toolchain matches the SDK the CI builder image now standardizes on (10.0.26100).

- One-line change; example only.
- The doc's *enforced* toolchain floor is unchanged (MSVC 19.43+ / VS 2022 17.13+); the SDK component version is illustrative, not a hard requirement.
- Context: the CI Windows CPU-builder image was pinned to Windows 11 SDK 26100 (ROCm/TheRock-Infra#841), and a real multiarch-CI `compiler-runtime` build passed on it.

Opening succinct for discussion — happy to also drop the specific version from the example entirely if maintainers prefer not pinning one in docs.

ISSUE ID ROCm/TheRock-Infra#840
