### PR TITLE
feat(ci): add compact workflow result summaries

### DIFF
--- a/build_tools/github_actions/tests/workflow_summary_test.py
+++ b/build_tools/github_actions/tests/workflow_summary_test.py
@@ -14,11 +14,25 @@ sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 
 from workflow_summary import (
     FailedJobInfo,
+    JobResult,
+    LogicalFailure,
     evaluate_results,
     fetch_failed_jobs,
+    group_failed_jobs,
     main,
+    normalize_failed_job,
     parse_needs_json,
+    render_step_summary,
 )
+
+
+@pytest.fixture(autouse=True)
+def clear_github_environment(monkeypatch):
+    """Keep main() tests from using or modifying the enclosing Actions run."""
+    monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+    monkeypatch.delenv("GITHUB_RUN_ID", raising=False)
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+
 
 # ---------------------------------------------------------------------------
 # Fixtures: realistic needs JSON blobs
@@ -193,6 +207,26 @@ class TestFetchFailedJobs:
 
         assert len(failed) == 0
 
+    def test_includes_root_problem_conclusions_but_not_cascade_cancellation(self):
+        api_response = {
+            "jobs": [
+                {"name": "Timed out", "conclusion": "timed_out", "html_url": ""},
+                {
+                    "name": "Could not start",
+                    "conclusion": "startup_failure",
+                    "html_url": "",
+                },
+                {"name": "Cancelled", "conclusion": "cancelled", "html_url": ""},
+            ]
+        }
+        with patch("workflow_summary.gha_send_request", return_value=api_response):
+            failed = fetch_failed_jobs("owner/repo", "12345")
+
+        assert [(job.name, job.conclusion) for job in failed] == [
+            ("Timed out", "timed_out"),
+            ("Could not start", "startup_failure"),
+        ]
+
     def test_empty_jobs_list(self):
         with patch("workflow_summary.gha_send_request", return_value={"jobs": []}):
             failed = fetch_failed_jobs("owner/repo", "12345")
@@ -219,13 +253,259 @@ class TestFetchFailedJobs:
                 },
             ]
         }
-        with patch("workflow_summary.gha_send_request", side_effect=[page1, page2]):
+        with patch(
+            "workflow_summary.gha_send_request", side_effect=[page1, page2]
+        ) as request:
             failed = fetch_failed_jobs("owner/repo", "12345")
 
         assert len(failed) == 1
         assert failed[0] == FailedJobInfo(
             name="Job 101", html_url="https://github.com/test/run/101"
         )
+        assert "filter=latest&per_page=100&page=1" in request.call_args_list[0].args[0]
+        assert "filter=latest&per_page=100&page=2" in request.call_args_list[1].args[0]
+
+
+# ---------------------------------------------------------------------------
+# compact summary rendering
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeFailedJob:
+    def test_normalizes_standalone_shard_name(self):
+        assert normalize_failed_job("Test hip-tests (shard 1/1)") == LogicalFailure(
+            normalized_name="Test hip-tests",
+            total_shards=1,
+            display_name="Test hip-tests",
+        )
+
+    @pytest.mark.parametrize("component", ["hip-tests (PAL)", "hip-tests (ROCR)"])
+    def test_friendly_name_preserves_component_parentheses(self, component):
+        name = (
+            "Linux::release / Test gfx94X-dcgpu / "
+            f"Test {component} / Test {component} (shard 2/4) (gfx94X-dcgpu)"
+        )
+
+        failure = normalize_failed_job(name)
+
+        assert failure.normalized_name == (
+            "Linux::release / Test gfx94X-dcgpu / "
+            f"Test {component} / Test {component} (gfx94X-dcgpu)"
+        )
+        assert failure.total_shards == 4
+        assert failure.display_name == f"Linux · gfx94X-dcgpu · {component}"
+
+    def test_friendly_name_supports_legacy_platform_segment(self):
+        name = (
+            "Windows::gfx110X-all::release / Test Artifacts / Test rocthrust / "
+            "Test rocthrust (shard 1/1) (gfx110X-all)"
+        )
+
+        failure = normalize_failed_job(name)
+
+        assert failure.display_name == "Windows · gfx110X-all · rocthrust"
+
+    def test_friendly_name_keeps_xfail_as_a_suffix(self):
+        name = (
+            "Linux::asan / Test gfx94X / Test hip-tests (PAL) / "
+            "Test hip-tests (PAL) (shard 1/4) (gfx94X) (xfail)"
+        )
+
+        failure = normalize_failed_job(name)
+
+        assert failure.display_name == "Linux · gfx94X · hip-tests (PAL) (xfail)"
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "Build Multi-Arch Stages",
+            "Test hipblaslt (shard 2/1) (gfx94X-dcgpu)",
+            "Test hipblaslt (shard 0/4) (gfx94X-dcgpu)",
+            "Test hipblaslt (shard 1/4)unexpected (gfx94X-dcgpu)",
+            "Test hipblaslt (shard 1/4) then (shard 2/4) (gfx94X-dcgpu)",
+        ],
+    )
+    def test_unknown_or_invalid_shapes_are_lossless(self, name):
+        assert normalize_failed_job(name) == LogicalFailure(name, None, name)
+
+
+class TestGroupFailedJobs:
+    def test_collapses_shards_by_normalized_full_name_and_total(self):
+        prefix = "Linux::release / Test gfx94X-dcgpu / Test hipblaslt / Test hipblaslt"
+        jobs = [
+            FailedJobInfo(f"{prefix} (shard 1/6) (gfx94X-dcgpu)", "shard-1"),
+            FailedJobInfo(f"{prefix} (shard 5/6) (gfx94X-dcgpu)", "shard-5"),
+        ]
+
+        assert group_failed_jobs(jobs) == [
+            LogicalFailure(
+                normalized_name=f"{prefix} (gfx94X-dcgpu)",
+                total_shards=6,
+                display_name="Linux · gfx94X-dcgpu · hipblaslt",
+            )
+        ]
+
+    def test_different_totals_and_full_paths_remain_distinct(self):
+        jobs = [
+            FailedJobInfo(
+                "Linux::release / Path A / Test hipblaslt (shard 1/4) (gfx94X)",
+                "",
+            ),
+            FailedJobInfo(
+                "Linux::release / Path A / Test hipblaslt (shard 1/6) (gfx94X)",
+                "",
+            ),
+            FailedJobInfo(
+                "Linux::release / Path B / Test hipblaslt (shard 1/4) (gfx94X)",
+                "",
+            ),
+        ]
+
+        failures = group_failed_jobs(jobs)
+
+        assert len(failures) == 3
+        assert all(
+            failure.display_name == failure.normalized_name for failure in failures
+        )
+
+    def test_does_not_collapse_same_named_non_sharded_jobs(self):
+        jobs = [
+            FailedJobInfo("Build", "first"),
+            FailedJobInfo("Build", "second"),
+        ]
+
+        assert len(group_failed_jobs(jobs)) == 2
+
+    def test_omits_aggregate_summary_job(self):
+        jobs = [
+            FailedJobInfo("Linux test", ""),
+            FailedJobInfo("Multi-Arch CI Summary", ""),
+        ]
+
+        assert group_failed_jobs(jobs) == [
+            LogicalFailure("Linux test", None, "Linux test")
+        ]
+
+
+class TestRenderStepSummary:
+    def test_success_is_terse(self):
+        summary = render_step_summary(parse_needs_json(json.dumps(ALL_SUCCESS)), None)
+
+        assert summary == (
+            "## Workflow result\n\n" "✅ Workflow jobs completed: 3 succeeded."
+        )
+
+    def test_success_distinguishes_skips_and_allowed_failures(self):
+        jobs = parse_needs_json(
+            json.dumps(
+                {
+                    "build": {"result": "success"},
+                    "optional": {
+                        "result": "failure",
+                        "outputs": {"continue_on_error": "true"},
+                    },
+                    "not_selected": {"result": "skipped"},
+                }
+            )
+        )
+
+        summary = render_step_summary(jobs, None)
+
+        assert "1 succeeded · 1 skipped · 1 allowed failure" in summary
+        assert "All required jobs succeeded" not in summary
+
+    def test_groups_shards_and_links_only_to_overall_run(self):
+        jobs = parse_needs_json(json.dumps(ONE_FAILURE))
+        failed_jobs = [
+            FailedJobInfo(
+                "Linux::release / Test gfx94X / Test hipblaslt / "
+                "Test hipblaslt (shard 1/6) (gfx94X)",
+                "https://github.com/test/shard/1",
+            ),
+            FailedJobInfo(
+                "Linux::release / Test gfx94X / Test hipblaslt / "
+                "Test hipblaslt (shard 4/6) (gfx94X)",
+                "https://github.com/test/shard/4",
+            ),
+        ]
+
+        summary = render_step_summary(jobs, failed_jobs, "ROCm/TheRock", "123")
+
+        assert summary.count("Linux · gfx94X · hipblaslt") == 1
+        assert "shard" not in summary
+        assert "https://github.com/test/shard" not in summary
+        assert summary.count("[View workflow run]") == 1
+        assert "https://github.com/ROCm/TheRock/actions/runs/123" in summary
+
+    def test_retains_cancelled_job_with_granular_failures(self):
+        jobs = [
+            JobResult("linux", "failure", False),
+            JobResult("windows", "cancelled", False),
+        ]
+        failed_jobs = [FailedJobInfo("Linux build", "")]
+
+        summary = render_step_summary(jobs, failed_jobs)
+
+        assert "Linux build" in summary
+        assert "windows — cancelled" in summary
+        assert "1 cancelled · 1 failure" in summary
+
+    def test_surfaces_timed_out_logical_failure(self):
+        jobs = [JobResult("linux", "failure", False)]
+        failed_jobs = [
+            FailedJobInfo(
+                "Linux::release / Test gfx94X / Test hipblaslt / "
+                "Test hipblaslt (shard 1/6) (gfx94X)",
+                "",
+                conclusion="timed_out",
+            )
+        ]
+
+        summary = render_step_summary(jobs, failed_jobs)
+
+        assert "Linux · gfx94X · hipblaslt — timed out" in summary
+
+    def test_falls_back_to_top_level_jobs_when_details_unavailable(self):
+        jobs = [JobResult("linux_build_and_test", "failure", False)]
+
+        summary = render_step_summary(jobs, None)
+
+        assert "linux\\_build\\_and\\_test — failure" in summary
+
+    def test_escapes_untrusted_job_names(self):
+        jobs = [JobResult("top", "failure", False)]
+        failed_jobs = [
+            FailedJobInfo("<b>@team [x](url) | *boom*\n# heading", "ignored")
+        ]
+
+        summary = render_step_summary(jobs, failed_jobs)
+
+        assert "<b>" not in summary
+        assert "@team" not in summary
+        assert "&lt;b&gt;&#64;team" in summary
+        assert r"\[x\]\(url\) \| \*boom\*" in summary
+        assert "&#10;\\# heading" in summary
+
+    def test_caps_logical_failures(self):
+        jobs = [JobResult("top", "failure", False)]
+        failed_jobs = [
+            FailedJobInfo(f"Failed job {index:02}", "") for index in range(22)
+        ]
+
+        summary = render_step_summary(jobs, failed_jobs)
+
+        assert "Failed job 19" in summary
+        assert "Failed job 20" not in summary
+        assert "and 2 more failure(s) not shown" in summary
+
+    def test_caps_untrusted_job_name_length(self):
+        jobs = [JobResult("top", "failure", False)]
+        failed_jobs = [FailedJobInfo("x" * 500, "")]
+
+        summary = render_step_summary(jobs, failed_jobs)
+
+        assert "x" * 200 not in summary
+        assert "…" in summary
 
 
 # ---------------------------------------------------------------------------
@@ -238,6 +518,17 @@ class TestMain:
         rc = main(["--needs-json", json.dumps(ALL_SUCCESS)])
         assert rc == 0
         assert "succeeded" in capsys.readouterr().out
+
+    def test_all_success_writes_step_summary(self, tmp_path, monkeypatch):
+        summary_path = tmp_path / "summary.md"
+        monkeypatch.setenv("GITHUB_STEP_SUMMARY", os.fspath(summary_path))
+
+        rc = main(["--needs-json", json.dumps(ALL_SUCCESS)])
+
+        assert rc == 0
+        assert summary_path.read_text() == (
+            "## Workflow result\n\n" "✅ Workflow jobs completed: 3 succeeded.\n\n"
+        )
 
     def test_failure_returns_one(self, capsys):
         rc = main(["--needs-json", json.dumps(ONE_FAILURE)])
@@ -259,7 +550,9 @@ class TestMain:
                 },
             ]
         }
-        with patch("workflow_summary.gha_send_request", return_value=api_response):
+        with patch(
+            "workflow_summary.gha_send_request", return_value=api_response
+        ) as request:
             rc = main(
                 [
                     "--needs-json",
@@ -272,6 +565,7 @@ class TestMain:
             )
 
         assert rc == 1
+        request.assert_called_once()
         out = capsys.readouterr().out
         assert "Test hip-tests" in out
         assert "https://github.com/test/run/2" in out
@@ -306,3 +600,21 @@ class TestMain:
         assert rc == 1
         out = capsys.readouterr().out
         assert "Could not fetch job details" in out
+
+    @pytest.mark.parametrize(
+        ("needs", "expected_rc"),
+        [(ALL_SUCCESS, 0), (ONE_FAILURE, 1)],
+    )
+    @pytest.mark.parametrize(
+        "failing_function", ["render_step_summary", "gha_append_step_summary"]
+    )
+    def test_summary_errors_do_not_change_gate_result(
+        self, needs, expected_rc, failing_function, capsys
+    ):
+        with patch(
+            f"workflow_summary.{failing_function}", side_effect=OSError("disk full")
+        ):
+            rc = main(["--needs-json", json.dumps(needs)])
+
+        assert rc == expected_rc
+        assert "Could not write workflow summary: disk full" in capsys.readouterr().out

--- a/build_tools/github_actions/workflow_summary.py
+++ b/build_tools/github_actions/workflow_summary.py
@@ -41,12 +41,20 @@ Notes:
 """
 
 import argparse
+import html
 import json
 import os
+import re
 import sys
 from dataclasses import dataclass
+from urllib.parse import quote
 
-from github_actions_api import GitHubAPIError, gha_send_request, str2bool
+from github_actions_api import (
+    GitHubAPIError,
+    gha_append_step_summary,
+    gha_send_request,
+    str2bool,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -69,6 +77,17 @@ class FailedJobInfo:
 
     name: str
     html_url: str
+    conclusion: str = "failure"
+
+
+@dataclass(frozen=True)
+class LogicalFailure:
+    """A failed job with shard-specific details removed."""
+
+    normalized_name: str
+    total_shards: int | None
+    display_name: str
+    conclusions: tuple[str, ...] = ("failure",)
 
 
 # ---------------------------------------------------------------------------
@@ -77,6 +96,25 @@ class FailedJobInfo:
 
 # Job results that are treated as acceptable (not a failure).
 _ACCEPTABLE_RESULTS = frozenset({"success", "skipped"})
+_PROBLEM_JOB_CONCLUSIONS = frozenset(
+    {"action_required", "failure", "stale", "startup_failure", "timed_out"}
+)
+_MAX_SUMMARY_FAILURES = 20
+_MAX_SUMMARY_NAME_LENGTH = 200
+_SHARD_TOKEN_RE = re.compile(
+    r" \(shard (?P<shard>[1-9][0-9]*)/(?P<total>[1-9][0-9]*)\)(?= |$)"
+)
+_FRIENDLY_TEST_RE = re.compile(r"^Test (?P<component>.+) \((?P<family>[^()\r\n]+)\)$")
+_PLATFORM_RE = re.compile(r"^(?P<platform>Linux|Windows)(?:::[^/\r\n]+)+$")
+_AGGREGATE_SUMMARY_JOB_NAMES = frozenset(
+    {
+        "CI Summary",
+        "Multi-Arch CI ASAN Nightly Summary",
+        "Multi-Arch CI ASAN Summary",
+        "Multi-Arch CI Summary",
+        "Unit Tests Summary",
+    }
+)
 
 
 def parse_needs_json(needs_json: str) -> list[JobResult]:
@@ -172,32 +210,275 @@ def fetch_failed_jobs(
 
     failed: list[FailedJobInfo] = []
     for job in all_jobs:
-        if job.get("conclusion") == "failure":
+        conclusion = job.get("conclusion")
+        if conclusion in _PROBLEM_JOB_CONCLUSIONS:
             failed.append(
                 FailedJobInfo(
                     name=job.get("name", "unknown"),
                     html_url=job.get("html_url", ""),
+                    conclusion=conclusion,
                 )
             )
     return failed
 
 
-def _print_failed_sub_job_urls(github_repository: str, github_run_id: str) -> None:
-    """Best-effort: fetch and print URLs for failed sub-jobs."""
+def _print_failed_sub_job_urls(
+    github_repository: str, github_run_id: str
+) -> list[FailedJobInfo] | None:
+    """Best-effort: fetch and print failed sub-jobs, returning what was found."""
     try:
         failed_jobs = fetch_failed_jobs(github_repository, github_run_id)
     except GitHubAPIError as e:
         print(f"\n  (Could not fetch job details: {e})")
-        return
+        return None
 
     if not failed_jobs:
-        return
+        return []
 
     print(f"\n{_RED}Failed sub-jobs:{_RESET}")
     for job in failed_jobs:
-        print(f"  {_RED}{job.name}{_RESET}")
+        detail = "" if job.conclusion == "failure" else f": {job.conclusion}"
+        print(f"  {_RED}{job.name}{detail}{_RESET}")
         if job.html_url:
             print(f"    {job.html_url}")
+    return failed_jobs
+
+
+def normalize_failed_job(name: str) -> LogicalFailure:
+    """Remove one valid shard token from a failed job name.
+
+    Grouping uses the full normalized name and total shard count. A friendly
+    platform/family/component label is used only when the normalized terminal
+    segment exactly matches the test job convention. Unknown shapes otherwise
+    retain their complete names.
+    """
+    matches = list(_SHARD_TOKEN_RE.finditer(name))
+    if len(matches) != 1:
+        return LogicalFailure(name, None, name)
+
+    match = matches[0]
+    shard = int(match.group("shard"))
+    total = int(match.group("total"))
+    if shard > total:
+        return LogicalFailure(name, None, name)
+
+    normalized_name = name[: match.start()] + name[match.end() :]
+    parts = normalized_name.split(" / ")
+    terminal = parts[-1]
+    xfail = ""
+    if terminal.endswith(" (xfail)"):
+        terminal = terminal.removesuffix(" (xfail)")
+        xfail = " (xfail)"
+    terminal_match = _FRIENDLY_TEST_RE.fullmatch(terminal)
+
+    platform_match = _PLATFORM_RE.fullmatch(parts[0])
+    if platform_match is None or terminal_match is None:
+        display_name = normalized_name
+    else:
+        platform = platform_match.group("platform")
+        family = terminal_match.group("family")
+        component = terminal_match.group("component")
+        display_name = f"{platform} · {family} · {component}{xfail}"
+
+    return LogicalFailure(normalized_name, total, display_name)
+
+
+def group_failed_jobs(failed_jobs: list[FailedJobInfo]) -> list[LogicalFailure]:
+    """Collapse failed shards without conflating distinct job configurations."""
+    shard_groups: dict[tuple[str, int], tuple[LogicalFailure, set[str]]] = {}
+    failures: list[LogicalFailure] = []
+    for job in failed_jobs:
+        # A completed run reports this summary job as failed because the script
+        # exits non-zero. It is the consequence of the failures below, not a
+        # separate failed area.
+        if job.name in _AGGREGATE_SUMMARY_JOB_NAMES:
+            continue
+        logical_failure = normalize_failed_job(job.name)
+        if logical_failure.total_shards is None:
+            # Duplicate names are legal for non-sharded jobs. Preserve each
+            # one; only recognized shard siblings may be collapsed.
+            failures.append(
+                LogicalFailure(
+                    logical_failure.normalized_name,
+                    None,
+                    logical_failure.display_name,
+                    (job.conclusion,),
+                )
+            )
+            continue
+
+        key = (logical_failure.normalized_name, logical_failure.total_shards)
+        if key not in shard_groups:
+            shard_groups[key] = (logical_failure, set())
+        shard_groups[key][1].add(job.conclusion)
+
+    failures.extend(
+        LogicalFailure(
+            failure.normalized_name,
+            failure.total_shards,
+            failure.display_name,
+            tuple(sorted(conclusions)),
+        )
+        for failure, conclusions in shard_groups.values()
+    )
+
+    display_counts: dict[str, int] = {}
+    for failure in failures:
+        display_counts[failure.display_name] = (
+            display_counts.get(failure.display_name, 0) + 1
+        )
+    failures = [
+        LogicalFailure(
+            failure.normalized_name,
+            failure.total_shards,
+            (
+                failure.normalized_name
+                if display_counts[failure.display_name] > 1
+                else failure.display_name
+            ),
+            failure.conclusions,
+        )
+        for failure in failures
+    ]
+
+    return sorted(
+        failures,
+        key=lambda failure: (
+            failure.display_name.casefold(),
+            failure.normalized_name.casefold(),
+            failure.total_shards or 0,
+        ),
+    )
+
+
+def _escape_markdown(value: str) -> str:
+    """Escape untrusted job names for a Markdown/HTML summary."""
+    if len(value) > _MAX_SUMMARY_NAME_LENGTH:
+        value = value[: _MAX_SUMMARY_NAME_LENGTH - 1] + "…"
+    escaped = re.sub(r"([\\`*_[\]{}()#+.!|\-])", r"\\\1", value)
+    escaped = html.escape(escaped, quote=False)
+    escaped = escaped.replace("@", "&#64;")
+    escaped = escaped.replace("\r", "&#13;").replace("\n", "&#10;")
+    return escaped
+
+
+def _workflow_run_url(github_repository: str, github_run_id: str) -> str:
+    """Build a safe URL for the overall workflow run."""
+    repository = quote(github_repository, safe="/")
+    run_id = quote(github_run_id, safe="")
+    return f"https://github.com/{repository}/actions/runs/{run_id}"
+
+
+def _count_phrase(count: int, singular: str, plural: str | None = None) -> str:
+    """Return a compact, grammatically correct result count."""
+    return f"{count} {singular if count == 1 else plural or singular}"
+
+
+def _logical_failure_label(failure: LogicalFailure) -> str:
+    non_failure_conclusions = [
+        conclusion.replace("_", " ")
+        for conclusion in failure.conclusions
+        if conclusion != "failure"
+    ]
+    if not non_failure_conclusions:
+        return failure.display_name
+    return f"{failure.display_name} — {', '.join(non_failure_conclusions)}"
+
+
+def render_step_summary(
+    jobs: list[JobResult],
+    failed_sub_jobs: list[FailedJobInfo] | None,
+    github_repository: str = "",
+    github_run_id: str = "",
+) -> str:
+    """Render a compact Markdown workflow result."""
+    failed, _ = evaluate_results(jobs)
+    if not failed:
+        succeeded = sum(job.result == "success" for job in jobs)
+        skipped = sum(job.result == "skipped" for job in jobs)
+        allowed = sum(
+            job.result not in _ACCEPTABLE_RESULTS and job.continue_on_error
+            for job in jobs
+        )
+        counts = []
+        if succeeded:
+            counts.append(_count_phrase(succeeded, "succeeded"))
+        if skipped:
+            counts.append(_count_phrase(skipped, "skipped"))
+        if allowed:
+            counts.append(_count_phrase(allowed, "allowed failure", "allowed failures"))
+        result_counts = " · ".join(counts) if counts else "no jobs reported"
+        return f"## Workflow result\n\n✅ Workflow jobs completed: {result_counts}."
+
+    result_counts: dict[str, int] = {}
+    for job in failed:
+        result_counts[job.result] = result_counts.get(job.result, 0) + 1
+    result_text = " · ".join(
+        _count_phrase(
+            count,
+            "failure" if result == "failure" else result,
+            "failures" if result == "failure" else result,
+        )
+        for result, count in sorted(result_counts.items())
+    )
+    lines = [
+        "## Workflow result",
+        "",
+        f"❌ Workflow jobs did not succeed: {_escape_markdown(result_text)}.",
+        "",
+    ]
+
+    logical_failures = group_failed_jobs(failed_sub_jobs or [])
+    entries: list[str] = []
+
+    # The jobs API reports only conclusions of "failure". Preserve other
+    # unacceptable top-level results, especially cancellations, alongside any
+    # granular failures returned by the API.
+    for job in failed:
+        if job.result != "failure":
+            entries.append(f"{job.name} — {job.result}")
+
+    entries.extend(_logical_failure_label(job) for job in logical_failures)
+
+    # If granular details were unavailable or empty, retain every failed
+    # top-level job and its result rather than producing an empty report.
+    if not logical_failures:
+        entries = [f"{job.name} — {job.result}" for job in failed]
+
+    visible_entries = entries[:_MAX_SUMMARY_FAILURES]
+    lines.extend(f"- {_escape_markdown(entry)}" for entry in visible_entries)
+    omitted = len(entries) - len(visible_entries)
+    if omitted:
+        lines.append(f"- … and {omitted} more failure(s) not shown")
+
+    if github_repository and github_run_id:
+        lines.extend(
+            [
+                "",
+                f"[View workflow run]({_workflow_run_url(github_repository, github_run_id)})",
+            ]
+        )
+
+    return "\n".join(lines)
+
+
+def _write_step_summary(
+    jobs: list[JobResult],
+    failed_sub_jobs: list[FailedJobInfo] | None,
+    github_repository: str = "",
+    github_run_id: str = "",
+) -> None:
+    """Best-effort: render and publish the compact workflow result."""
+    try:
+        summary = render_step_summary(
+            jobs,
+            failed_sub_jobs,
+            github_repository,
+            github_run_id,
+        )
+        gha_append_step_summary(summary, mirror_to_job_file=False)
+    except Exception as e:
+        print(f"\n  (Could not write workflow summary: {e})")
 
 
 # ---------------------------------------------------------------------------
@@ -257,12 +538,23 @@ def main(argv: list[str]) -> int:
             print(f"  {_RED}{job.name}{_RESET}")
 
         # Try to fetch granular failure info from the API.
+        failed_sub_jobs = None
         if args.github_repository and args.github_run_id:
-            _print_failed_sub_job_urls(args.github_repository, args.github_run_id)
+            failed_sub_jobs = _print_failed_sub_job_urls(
+                args.github_repository, args.github_run_id
+            )
+
+        _write_step_summary(
+            jobs,
+            failed_sub_jobs,
+            args.github_repository,
+            args.github_run_id,
+        )
 
         return 1
 
     print(f"\n{_GREEN}All required jobs succeeded.{_RESET}")
+    _write_step_summary(jobs, None)
     return 0
 
 


### PR DESCRIPTION
Related: ROCm/rocm-libraries#11900

## Motivation

Multi-Arch workflows expose each matrix shard as a separate job. When a component has several failed shards, the final summary log repeats long job names and does not provide a compact workflow-level result that callers can present to pull-request reviewers.

## Technical Details

- Write a concise Markdown result to `GITHUB_STEP_SUMMARY` from the existing workflow-summary helper.
- Collapse only recognized `(shard I/N)` siblings that share the same normalized full job name and shard total.
- Render recognized component tests as `platform · GPU family · component`, while retaining complete names for build, packaging, Python, JAX, and unknown job formats.
- Preserve meaningful component suffixes such as `hip-tests (PAL)`, `hip-tests (ROCR)`, and `(xfail)`.
- Show no successful shard rows and link once to the complete workflow run.
- Keep individual failed job names and links in the console log for debugging.
- Include timeout, startup, action-required, stale, and ordinary failure conclusions while omitting cascade-cancelled leaf jobs.
- Treat summary rendering and GitHub API access as best-effort. The process exit code remains determined exclusively by the existing `needs` evaluation.

## Rendered Examples

The failing Unit Tests summary on this pull request produced:

### Workflow result

❌ Workflow jobs did not succeed: 1 failure.

- Unit Tests :: windows-2022

[View workflow run](https://github.com/ROCm/TheRock/actions/runs/34421410102)

A live Multi-Arch validation with two failed MIOpen shards produced one logical row:

### Workflow result

❌ Workflow jobs did not succeed: 1 failure.

- Linux · gfx94X-dcgpu · miopen

[View workflow run](https://github.com/ROCm/rocm-libraries/actions/runs/34365036396)

The detailed console log retains both shard names and links; the rendered summary does not.

## Test Plan

- Exercise parsing and grouping with current and legacy Multi-Arch job names.
- Verify that shard siblings collapse without merging different platforms, families, totals, paths, PAL/ROCR variants, or non-sharded duplicate names.
- Verify Markdown escaping, bounded output, cancellation fallback, problem conclusions, API pagination, summary-file output, and unchanged gate return codes.
- Exercise the renderer against a completed failing Multi-Arch run from `ROCm/rocm-libraries`.

## Test Result

- `52 passed` in `build_tools/github_actions/tests/workflow_summary_test.py`.
- Ruff formatting, Ruff lint, Python compilation, `git diff --check`, and all configured pre-commit hooks passed for the changed files.
- Live read-only validation against run `34365036396` collapsed two failed MIOpen shards into one `Linux · gfx94X-dcgpu · miopen` row and emitted one workflow-run link.
- The complete `build_tools/github_actions/tests` directory was not collected in the sparse worktree because seven unrelated tests import source trees that were not materialized. The focused module suite and repository hooks completed successfully.
- Automated GitHub checks for this branch are pending.

## Scope

This changes the summary shown after opening a workflow result. GitHub will continue to create one native check row for every Actions matrix job. The companion `rocm-libraries` change provides the pull-request-wide gating versus non-gating overview.
