### PR TITLE
[ON HOLD] feat(windows): enable Control Flow Guard for all binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,12 +25,22 @@ include(therock_detect_python_versions)
 include(therock_amdgpu_targets)
 include(therock_artifacts)
 include(therock_compiler_config)
+include(therock_control_flow_guard)
 include(therock_external_source)
 include(therock_features)
 include(therock_sanitizers)
 include(therock_subproject)
 include(therock_job_pools)
 include(therock_testing)
+
+################################################################################
+# Exploit mitigations.
+# Declares THEROCK_ENABLE_CONTROL_FLOW_GUARD and sets the effective
+# THEROCK_CONTROL_FLOW_GUARD_ACTIVE. Must run before any sub-project is
+# declared, since sub-projects capture it when their toolchain is generated.
+################################################################################
+
+therock_configure_control_flow_guard()
 
 ################################################################################
 # Python is used throughout the build. Ensure it is initialized early.

--- a/FLAGS.cmake
+++ b/FLAGS.cmake
@@ -144,7 +144,9 @@ therock_declare_flag(
 therock_declare_flag(
   NAME WINDOWS_DRIVER_BUILD
   DEFAULT_VALUE OFF
-  DESCRIPTION "Windows: build for the AMD driver package (Control Flow Guard, driver comgr DLL name)"
+  # Control Flow Guard used to live here. It is now on by default for every
+  # Windows build; see THEROCK_ENABLE_CONTROL_FLOW_GUARD.
+  DESCRIPTION "Windows: build for the AMD driver package (driver comgr DLL name)"
   GLOBAL_PROPAGATE_FLAG
   CMAKE_VARS
     COMGR_DLL_NAME=amd_comgr_drivers.dll

--- a/cmake/therock_compiler_flag_probe.cpp
+++ b/cmake/therock_compiler_flag_probe.cpp
@@ -1,0 +1,8 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// Trivial translation unit used by therock_probe_control_flow_guard() to ask a
+// compiler whether it accepts a flag. It is only ever syntax-checked, never
+// linked, so it deliberately has no includes and no main().
+
+int therock_compiler_flag_probe() { return 0; }

--- a/cmake/therock_control_flow_guard.cmake
+++ b/cmake/therock_control_flow_guard.cmake
@@ -1,0 +1,206 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# Windows Control Flow Guard (CFG).
+#
+# CFG is a Windows exploit mitigation that checks the target of every indirect
+# call against a table of legal targets embedded in the image:
+# https://learn.microsoft.com/en-us/windows/win32/secbp/control-flow-guard
+#
+# It needs both a compile flag (the compiler records the legal targets and
+# emits the check) and a link flag (the linker writes the guard tables into the
+# PE load config), so it has to be applied to every sub-project rather than to
+# a single final link. TheRock compiles sub-projects with two different
+# compilers, which spell the compile flag differently:
+#   * the host MSVC toolchain    -> /guard:cf
+#   * the in-tree amd-llvm clang -> -Xclang -cfguard
+#
+# Support is probed rather than assumed. A toolchain that does not implement
+# the flags gets a warning and a build without the mitigation: CFG is defense
+# in depth, and losing it is not worth failing an otherwise good build over.
+#
+# This module is included both by the super-project and by every generated
+# sub-project toolchain file, so it must not do anything at include time.
+# Toolchain files are re-read by every try_compile, which rules out
+# check_<lang>_compiler_flag() there; therock_probe_control_flow_guard() runs
+# the compiler directly instead.
+
+# Deliberately no include_guard(): generated toolchain files include this file,
+# and CMake re-reads a toolchain file in several different scopes per configure.
+# A global guard would leave the variables below set in whichever scope happened
+# to include it first. Re-running the set()s and re-defining the functions is
+# cheap.
+
+# Compile flag spellings, by compiler. Each is a list, since clang needs two
+# arguments.
+set(THEROCK_CONTROL_FLOW_GUARD_MSVC_COMPILE_FLAGS "/guard:cf")
+# clang exposes CFG as clang-cl's /guard:cf and as the cc1 flag -cfguard.
+# TheRock drives the amd-llvm clang through the GNU-style driver, which accepts
+# neither directly, so the cc1 flag is passed explicitly. Note that -mguard=cf
+# is *not* a substitute: it is only implemented for the ARM and PowerPC
+# targets and clang rejects it outright for x86_64-pc-windows-msvc.
+set(THEROCK_CONTROL_FLOW_GUARD_CLANG_COMPILE_FLAGS -Xclang -cfguard)
+# The link flag goes through CMake's LINKER: prefix, which handles the compiler
+# driver difference. /machine and /DYNAMICBASE are omitted: CMake emits the
+# former and the linker defaults to the latter.
+set(THEROCK_CONTROL_FLOW_GUARD_LINK_FLAGS "/guard:cf")
+
+# therock_control_flow_guard_compile_flags(out_var compiler_id)
+# Sets `out_var` to the CFG compile flags for `compiler_id` as a list, or to
+# the empty string if we do not know how to spell them for that compiler.
+function(therock_control_flow_guard_compile_flags out_var compiler_id)
+  if(compiler_id STREQUAL "MSVC")
+    set("${out_var}" "${THEROCK_CONTROL_FLOW_GUARD_MSVC_COMPILE_FLAGS}" PARENT_SCOPE)
+  elseif(compiler_id MATCHES "Clang")
+    set("${out_var}" "${THEROCK_CONTROL_FLOW_GUARD_CLANG_COMPILE_FLAGS}" PARENT_SCOPE)
+  else()
+    set("${out_var}" "" PARENT_SCOPE)
+  endif()
+endfunction()
+
+# therock_probe_control_flow_guard(out_var compiler compile_flags)
+# Syntax-checks a trivial translation unit with `compile_flags` (a list) and
+# sets `out_var` to whether `compiler` accepted them. The result is memoized in
+# the cache, keyed on the compiler and the flags.
+#
+# This exists instead of check_cxx_compiler_flag() because it is called from
+# generated toolchain files, which CMake re-includes inside try_compile: the
+# check_* modules would recurse.
+function(therock_probe_control_flow_guard out_var compiler compile_flags)
+  string(JOIN " " _flags_pretty ${compile_flags})
+  string(MAKE_C_IDENTIFIER "THEROCK_FLAG_PROBE_${compiler}_${_flags_pretty}" _cache_var)
+  if(DEFINED CACHE{${_cache_var}})
+    set("${out_var}" "${${_cache_var}}" PARENT_SCOPE)
+    return()
+  endif()
+
+  if(_flags_pretty MATCHES "^/")
+    # MSVC: /Zs is a syntax-only check and /TP forces C++ for a .cpp-agnostic
+    # invocation. cl.exe reports an unknown option as warning D9002 and still
+    # exits 0, so the output has to be inspected as well.
+    set(_probe_args /nologo /Zs /TP)
+  else()
+    set(_probe_args -fsyntax-only -x c++)
+  endif()
+
+  # Resolved from the defining file rather than a module-scope variable, since
+  # this may be called from a toolchain file scope that never saw the include.
+  set(_probe_source
+    "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/therock_compiler_flag_probe.cpp")
+
+  execute_process(
+    COMMAND "${compiler}" ${_probe_args} ${compile_flags} "${_probe_source}"
+    RESULT_VARIABLE _probe_rc
+    OUTPUT_VARIABLE _probe_stdout
+    ERROR_VARIABLE _probe_stderr
+  )
+
+  set(_supported TRUE)
+  if(NOT _probe_rc EQUAL 0)
+    set(_supported FALSE)
+  elseif("${_probe_stdout}${_probe_stderr}" MATCHES
+      "D9002|unknown argument|unsupported option|unrecognized|is not supported")
+    set(_supported FALSE)
+  endif()
+
+  set("${_cache_var}" "${_supported}" CACHE INTERNAL
+    "Whether ${compiler} accepts ${_flags_pretty}")
+  set("${out_var}" "${_supported}" PARENT_SCOPE)
+endfunction()
+
+# therock_configure_control_flow_guard()
+# Super-project entry point. Declares the THEROCK_ENABLE_CONTROL_FLOW_GUARD
+# user option and sets THEROCK_CONTROL_FLOW_GUARD_ACTIVE in the caller's scope
+# to the effective state after probing the host toolchain. Must be called after
+# the C/CXX compilers have been detected.
+#
+# The rest of the build keys off THEROCK_CONTROL_FLOW_GUARD_ACTIVE, so that a
+# failed probe does not permanently clear the user's option in the cache.
+function(therock_configure_control_flow_guard)
+  if(WIN32)
+    set(_default ON)
+  else()
+    set(_default OFF)
+  endif()
+  option(THEROCK_ENABLE_CONTROL_FLOW_GUARD
+    "Build Windows binaries with the Control Flow Guard exploit mitigation"
+    "${_default}")
+  set(THEROCK_CONTROL_FLOW_GUARD_ACTIVE OFF PARENT_SCOPE)
+
+  if(NOT THEROCK_ENABLE_CONTROL_FLOW_GUARD)
+    return()
+  endif()
+  if(NOT WIN32)
+    message(WARNING
+      "THEROCK_ENABLE_CONTROL_FLOW_GUARD is a Windows-only mitigation and is "
+      "ignored on this platform (CMAKE_SYSTEM_NAME=${CMAKE_SYSTEM_NAME}).")
+    return()
+  endif()
+
+  therock_control_flow_guard_compile_flags(_compile_flags "${CMAKE_CXX_COMPILER_ID}")
+  string(JOIN " " _compile_flags_pretty ${_compile_flags})
+  set(_unavailable_reason)
+  if(NOT _compile_flags)
+    set(_unavailable_reason
+      "no Control Flow Guard compile flag is known for compiler id '${CMAKE_CXX_COMPILER_ID}'")
+  else()
+    include(CheckCXXCompilerFlag)
+    include(CheckLinkerFlag)
+    check_cxx_compiler_flag("${_compile_flags_pretty}"
+      THEROCK_HAVE_CONTROL_FLOW_GUARD_COMPILE_FLAG)
+    check_linker_flag(CXX "LINKER:${THEROCK_CONTROL_FLOW_GUARD_LINK_FLAGS}"
+      THEROCK_HAVE_CONTROL_FLOW_GUARD_LINK_FLAG)
+    if(NOT THEROCK_HAVE_CONTROL_FLOW_GUARD_COMPILE_FLAG)
+      set(_unavailable_reason "the compiler rejected ${_compile_flags_pretty}")
+    elseif(NOT THEROCK_HAVE_CONTROL_FLOW_GUARD_LINK_FLAG)
+      set(_unavailable_reason
+        "the linker rejected ${THEROCK_CONTROL_FLOW_GUARD_LINK_FLAGS}")
+    endif()
+  endif()
+
+  if(_unavailable_reason)
+    message(WARNING
+      "Control Flow Guard was requested but is not available: "
+      "${_unavailable_reason}.\n"
+      "  CMAKE_CXX_COMPILER: ${CMAKE_CXX_COMPILER}\n"
+      "  CMAKE_CXX_COMPILER_ID: ${CMAKE_CXX_COMPILER_ID}\n"
+      "  CMAKE_CXX_COMPILER_VERSION: ${CMAKE_CXX_COMPILER_VERSION}\n"
+      "Continuing without the mitigation. Set "
+      "-DTHEROCK_ENABLE_CONTROL_FLOW_GUARD=OFF to silence this warning.")
+    return()
+  endif()
+
+  message(STATUS "Control Flow Guard: enabled (${_compile_flags_pretty})")
+  set(THEROCK_CONTROL_FLOW_GUARD_ACTIVE ON PARENT_SCOPE)
+endfunction()
+
+# therock_toolchain_enable_control_flow_guard(compile_flags subproject)
+# Called from a generated sub-project toolchain file, after that file has
+# selected the compiler. Probes the compiler and, if it accepts the flags,
+# appends them to CMAKE_{C,CXX}_FLAGS_INIT. Either way it sets the
+# THEROCK_CONTROL_FLOW_GUARD_SUPPORTED cache entry, which the generated
+# project_init.cmake reads to decide whether to add the matching link flags.
+#
+# This is a macro so that the CMAKE_*_FLAGS_INIT appends land directly in the
+# toolchain file's scope, where CMake reads them.
+macro(therock_toolchain_enable_control_flow_guard compile_flags subproject)
+  therock_probe_control_flow_guard(_therock_cfg_supported
+    "${CMAKE_CXX_COMPILER}" "${compile_flags}")
+  string(JOIN " " _therock_cfg_flags ${compile_flags})
+  if(_therock_cfg_supported)
+    string(APPEND CMAKE_C_FLAGS_INIT " ${_therock_cfg_flags}")
+    string(APPEND CMAKE_CXX_FLAGS_INIT " ${_therock_cfg_flags}")
+  else()
+    message(WARNING
+      "Control Flow Guard is not supported by the compiler used for "
+      "sub-project '${subproject}' and will not be enabled for it:\n"
+      "  Compiler: ${CMAKE_CXX_COMPILER}\n"
+      "  Rejected flags: ${_therock_cfg_flags}\n"
+      "Continuing without the mitigation. Set "
+      "-DTHEROCK_ENABLE_CONTROL_FLOW_GUARD=OFF to silence this warning.")
+  endif()
+  set(THEROCK_CONTROL_FLOW_GUARD_SUPPORTED "${_therock_cfg_supported}"
+    CACHE INTERNAL "Whether Control Flow Guard is active for this sub-project")
+  unset(_therock_cfg_supported)
+  unset(_therock_cfg_flags)
+endmacro()

--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -9,6 +9,7 @@
 # development flow.
 
 include(ExternalProject)
+include(therock_control_flow_guard)
 
 # Global properties.
 # THEROCK_DEFAULT_CMAKE_VARS:
@@ -36,6 +37,10 @@ set_property(GLOBAL PROPERTY THEROCK_DEFAULT_CMAKE_VARS
 
   # Debug info handling.
   THEROCK_SPLIT_DEBUG_INFO
+
+  # Exploit mitigations. Sub-projects that drive a nested configure need this
+  # to decide whether to forward the mitigation flags along.
+  THEROCK_CONTROL_FLOW_GUARD_ACTIVE
 )
 
 # Whenever a new package is advertised by the super-project, it is added here.
@@ -86,15 +91,6 @@ if(WIN32)
   #     duplicate 'static' declaration specifier
   list(APPEND THEROCK_AMD_LLVM_DEFAULT_CXX_FLAGS -Wno-duplicate-decl-specifier)
 endif()
-
-# Options added to every subproject when THEROCK_FLAG_WINDOWS_DRIVER_BUILD is set.
-# The compile flag is spelled per compiler; the link flag goes through CMake's
-# LINKER: prefix, which handles the driver difference.
-# /machine and /DYNAMICBASE are omitted: CMake emits the former and the linker
-# defaults to the latter.
-set(THEROCK_WINDOWS_DRIVER_BUILD_MSVC_COMPILE_FLAGS "/guard:cf")
-set(THEROCK_WINDOWS_DRIVER_BUILD_CLANG_COMPILE_FLAGS "-mguard=cf")
-set(THEROCK_WINDOWS_DRIVER_BUILD_LINK_FLAGS "/guard:cf")
 
 # Generates a command prefix that can be prepended to any custom command line
 # to perform log/console redirection and pretty printing.
@@ -879,14 +875,20 @@ function(therock_cmake_subproject_activate target_name)
     string(APPEND _init_contents "add_link_options(\"LINKER:/Brepro\")\n")
   endif()
 
-  # Link half of the driver build options. This cannot go through
+  # Link half of Control Flow Guard. This cannot go through
   # CMAKE_<TYPE>_LINKER_FLAGS_INIT in the toolchain file: the private link dir
   # handling above appends to CMAKE_<TYPE>_LINKER_FLAGS before enable_language()
   # has populated it from *_INIT, which shadows the cache value and drops
   # whatever the toolchain set.
-  if(MSVC AND THEROCK_FLAG_WINDOWS_DRIVER_BUILD)
+  # THEROCK_CONTROL_FLOW_GUARD_SUPPORTED is set by the toolchain file, which
+  # probes the sub-project's actual compiler. Skipping the link flag when the
+  # compile flag was rejected keeps the image from advertising guard tables
+  # that were never emitted.
+  if(THEROCK_CONTROL_FLOW_GUARD_ACTIVE)
+    string(APPEND _init_contents "if(THEROCK_CONTROL_FLOW_GUARD_SUPPORTED)\n")
     string(APPEND _init_contents
-      "add_link_options(\"LINKER:${THEROCK_WINDOWS_DRIVER_BUILD_LINK_FLAGS}\")\n")
+      "  add_link_options(\"LINKER:${THEROCK_CONTROL_FLOW_GUARD_LINK_FLAGS}\")\n")
+    string(APPEND _init_contents "endif()\n")
   endif()
 
   if(_dep_provider_file)
@@ -1762,18 +1764,6 @@ function(_therock_cmake_subproject_setup_toolchain
     string(APPEND _toolchain_contents "set(CMAKE_SHARED_LINKER_FLAGS_INIT \"@CMAKE_SHARED_LINKER_FLAGS@\")\n")
   endif()
 
-  # Compile half of the driver build options. The link half is emitted as
-  # add_link_options() in the project_init file.
-  if(MSVC AND THEROCK_FLAG_WINDOWS_DRIVER_BUILD)
-    if(compiler_toolchain)
-      set(_driver_build_compile_flags "${THEROCK_WINDOWS_DRIVER_BUILD_CLANG_COMPILE_FLAGS}")
-    else()
-      set(_driver_build_compile_flags "${THEROCK_WINDOWS_DRIVER_BUILD_MSVC_COMPILE_FLAGS}")
-    endif()
-    string(APPEND _toolchain_contents "string(APPEND CMAKE_C_FLAGS_INIT \" ${_driver_build_compile_flags}\")\n")
-    string(APPEND _toolchain_contents "string(APPEND CMAKE_CXX_FLAGS_INIT \" ${_driver_build_compile_flags}\")\n")
-  endif()
-
   # Customize debug info generation.
   if(THEROCK_MINIMAL_DEBUG_INFO)
     # System toolchain can be either MSVC or another system compiler.
@@ -1884,6 +1874,31 @@ function(_therock_cmake_subproject_setup_toolchain
   endif()
 
   string(APPEND _toolchain_contents "${_sanitizer_stanza}")
+
+  # Compile half of Control Flow Guard. The link half is emitted as
+  # add_link_options() in the project_init file.
+  #
+  # This has to come last: the emitted code probes CMAKE_CXX_COMPILER, so the
+  # compiler-toolchain handling above must already have selected it. The probe
+  # runs in the sub-project rather than here because a COMPILER_TOOLCHAIN
+  # sub-project uses the amd-llvm clang we build, which does not exist yet at
+  # super-project configure time.
+  if(THEROCK_CONTROL_FLOW_GUARD_ACTIVE)
+    set(_control_flow_guard_module
+      "${THEROCK_SOURCE_DIR}/cmake/therock_control_flow_guard.cmake")
+    if(compiler_toolchain)
+      set(_control_flow_guard_compile_flags
+        "${THEROCK_CONTROL_FLOW_GUARD_CLANG_COMPILE_FLAGS}")
+    else()
+      set(_control_flow_guard_compile_flags
+        "${THEROCK_CONTROL_FLOW_GUARD_MSVC_COMPILE_FLAGS}")
+    endif()
+    string(APPEND _toolchain_contents "include(\"@_control_flow_guard_module@\")\n")
+    string(APPEND _toolchain_contents
+      "therock_toolchain_enable_control_flow_guard("
+      "\"${_control_flow_guard_compile_flags}\" \"${target_name}\")\n")
+  endif()
+
   set(_compiler_toolchain_addl_depends "${_compiler_toolchain_addl_depends}" PARENT_SCOPE)
   set(_compiler_toolchain_init_contents "${_compiler_toolchain_init_contents}" PARENT_SCOPE)
   set(_build_env_pairs "${_build_env_pairs}" PARENT_SCOPE)

--- a/docs/development/windows_support.md
+++ b/docs/development/windows_support.md
@@ -320,6 +320,33 @@ If iterating and wishes to use ccache, see [CCache usage on Windows](../../READM
 > If you see some other compiler there, refer to the MSVC setup instructions up
 > in [Important tool settings](#important-tool-settings).
 
+#### Control Flow Guard
+
+Windows builds enable [Control Flow Guard][cfg] (CFG) for every binary by
+default. CFG is a compiler/linker pair of flags, so it is applied to every
+subproject rather than to a single final link:
+
+| Compiler                       | Compile flag       | Link flag   |
+| ------------------------------ | ------------------ | ----------- |
+| Host MSVC (`cl.exe`)           | `/guard:cf`        | `/guard:cf` |
+| In-tree amd-llvm `clang++.exe` | `-Xclang -cfguard` | `/guard:cf` |
+
+The amd-llvm toolchain drives clang through its GNU-style driver, which accepts
+neither clang-cl's `/guard:cf` nor `-mguard=cf` (the latter is only implemented
+for the ARM and PowerPC targets), so the `cc1` flag is passed explicitly.
+
+Both compilers are probed before the flags are used, since the amd-llvm clang
+is built by TheRock and cannot be checked at super-project configure time. If a
+compiler rejects the flags, the build prints a warning and continues without
+the mitigation; it does not fail. Set `-DTHEROCK_ENABLE_CONTROL_FLOW_GUARD=OFF`
+to turn CFG off and silence the warning.
+
+To confirm the mitigation landed in a binary:
+
+```bat
+dumpbin /loadconfig build\dist\rocm\bin\some_tool.exe | findstr "Guard CF function count"
+```
+
 ### CMake build usage
 
 ```bash
@@ -572,3 +599,5 @@ features should be turned off:
 -DTHEROCK_ENABLE_MATH_LIBS=OFF \
 -DTHEROCK_ENABLE_ML_LIBS=OFF \
 ```
+
+[cfg]: https://learn.microsoft.com/en-us/windows/win32/secbp/control-flow-guard

--- a/third-party/sysdeps/common/zlib/CMakeLists.txt
+++ b/third-party/sysdeps/common/zlib/CMakeLists.txt
@@ -68,10 +68,11 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 endif()
 
 # The nested configure below does not otherwise inherit compile flags, and zlib
-# links statically into shipped binaries.
-set(driver_build_flag_args)
-if(WIN32 AND THEROCK_FLAG_WINDOWS_DRIVER_BUILD)
-  list(APPEND driver_build_flag_args
+# links statically into shipped binaries, so it has to be built with the same
+# Control Flow Guard flags as its consumers.
+set(mitigation_flag_args)
+if(WIN32 AND THEROCK_CONTROL_FLOW_GUARD_ACTIVE)
+  list(APPEND mitigation_flag_args
     "-DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}"
     "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}"
     "-DCMAKE_EXE_LINKER_FLAGS=${CMAKE_EXE_LINKER_FLAGS}"
@@ -106,7 +107,7 @@ add_custom_target(
       "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
       "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
       "-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}"
-      ${driver_build_flag_args}
+      ${mitigation_flag_args}
       # Force lib/ to match the hardcoded paths throughout this file.
       -DCMAKE_INSTALL_LIBDIR=lib
       # On Windows we only use the static library; skip the shared build

--- a/third-party/sysdeps/common/zstd/CMakeLists.txt
+++ b/third-party/sysdeps/common/zstd/CMakeLists.txt
@@ -98,10 +98,11 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 endif()
 
 # The nested configure below does not otherwise inherit compile flags, and zstd
-# links statically into shipped binaries.
-set(driver_build_flag_args)
-if(WIN32 AND THEROCK_FLAG_WINDOWS_DRIVER_BUILD)
-  list(APPEND driver_build_flag_args
+# links statically into shipped binaries, so it has to be built with the same
+# Control Flow Guard flags as its consumers.
+set(mitigation_flag_args)
+if(WIN32 AND THEROCK_CONTROL_FLOW_GUARD_ACTIVE)
+  list(APPEND mitigation_flag_args
     "-DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}"
     "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}"
     "-DCMAKE_EXE_LINKER_FLAGS=${CMAKE_EXE_LINKER_FLAGS}"
@@ -126,7 +127,7 @@ add_custom_target(
       "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
       "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
       "-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}"
-      ${driver_build_flag_args}
+      ${mitigation_flag_args}
       -DZSTD_BUILD_TESTS=OFF
       -DZSTD_LEGACY_SUPPORT=OFF
       -DZSTD_BUILD_PROGRAMS=OFF

--- a/third-party/sysdeps/windows/amd-mesa/CMakeLists.txt
+++ b/third-party/sysdeps/windows/amd-mesa/CMakeLists.txt
@@ -59,30 +59,62 @@ else()
   set(_meson_path_env "PATH=$ENV{PATH}")
 endif()
 
+# Formats its arguments as a meson array literal, e.g. ['a', 'b'].
+function(_therock_meson_string_array out_var)
+  set(_elems "")
+  foreach(_arg ${ARGN})
+    list(APPEND _elems "'${_arg}'")
+  endforeach()
+  list(JOIN _elems ", " _joined)
+  set(${out_var} "[${_joined}]" PARENT_SCOPE)
+endfunction()
+
 # Pass the compiler (and any launcher such as ccache) to meson via a native
 # file rather than CC/CXX env strings. Meson whitespace-splits the CC/CXX env
 # value, which breaks the MSVC compiler path ("C:/Program Files/.../cl.exe");
 # quoting it instead breaks `cmake -E env` batch parsing. A native file lists
 # the command as an array, so the space-containing path is never re-split.
 function(_therock_meson_binary_array out_var compiler)
-  set(_elems "")
-  foreach(_launcher ${ARGN})
-    list(APPEND _elems "'${_launcher}'")
-  endforeach()
-  list(APPEND _elems "'${compiler}'")
-  list(JOIN _elems ", " _joined)
-  set(${out_var} "[${_joined}]" PARENT_SCOPE)
+  # Launchers come first, so that e.g. ccache wraps the compiler.
+  _therock_meson_string_array(_array ${ARGN} "${compiler}")
+  set(${out_var} "${_array}" PARENT_SCOPE)
 endfunction()
 
 _therock_meson_binary_array(_meson_c_bin "${CMAKE_C_COMPILER}" ${CMAKE_C_COMPILER_LAUNCHER})
 _therock_meson_binary_array(_meson_cpp_bin "${CMAKE_CXX_COMPILER}" ${CMAKE_CXX_COMPILER_LAUNCHER})
+
+# The meson build does not inherit CMAKE_<LANG>_FLAGS, so the mitigations the
+# rest of the build gets from the generated toolchain file have to be restated
+# here as meson built-in options.
+set(_meson_builtin_options)
+if(THEROCK_CONTROL_FLOW_GUARD_ACTIVE)
+  include("${THEROCK_SOURCE_DIR}/cmake/therock_control_flow_guard.cmake")
+  therock_control_flow_guard_compile_flags(_cfg_compile_flags "${CMAKE_C_COMPILER_ID}")
+  therock_probe_control_flow_guard(_cfg_supported
+    "${CMAKE_C_COMPILER}" "${_cfg_compile_flags}")
+  if(NOT _cfg_supported)
+    message(WARNING
+      "Control Flow Guard is not supported by ${CMAKE_C_COMPILER}; building "
+      "amd-mesa without it.")
+  else()
+    _therock_meson_string_array(_cfg_compile_array ${_cfg_compile_flags})
+    _therock_meson_string_array(_cfg_link_array ${THEROCK_CONTROL_FLOW_GUARD_LINK_FLAGS})
+    set(_meson_builtin_options
+"[built-in options]
+c_args = ${_cfg_compile_array}
+cpp_args = ${_cfg_compile_array}
+c_link_args = ${_cfg_link_array}
+cpp_link_args = ${_cfg_link_array}
+")
+  endif()
+endif()
 
 set(_meson_native_file "${CMAKE_CURRENT_BINARY_DIR}/therock-native.ini")
 file(WRITE "${_meson_native_file}"
 "[binaries]
 c = ${_meson_c_bin}
 cpp = ${_meson_cpp_bin}
-")
+${_meson_builtin_options}")
 
 set(PATCH_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/../patch_source")
 


### PR DESCRIPTION
Control Flow Guard was previously gated behind
THEROCK_FLAG_WINDOWS_DRIVER_BUILD. Turn it on by default for every Windows build instead, via a new THEROCK_ENABLE_CONTROL_FLOW_GUARD option. WINDOWS_DRIVER_BUILD keeps only the driver comgr DLL name.

CFG needs a compile flag and a link flag, so it is applied per sub-project rather than at a single final link. Neither compiler is assumed to support it: if a probe fails, the build warns and continues without the mitigation rather than failing.

  * Host MSVC is probed at super-project configure with check_cxx_compiler_flag/check_linker_flag, giving one visible warning on the console.
  * The amd-llvm clang does not exist at super-project configure time, so its probe is emitted into the generated toolchain file. That rules out check_<lang>_compiler_flag (CMake re-reads toolchain files inside try_compile, so the check modules recurse), hence the execute_process based therock_probe_control_flow_guard().

The clang spelling in the old code, -mguard=cf, does not work: it is only implemented for the ARM and PowerPC targets and clang rejects it for x86_64-pc-windows-msvc. TheRock drives the amd-llvm clang through the GNU-style driver, which accepts neither that nor clang-cl's /guard:cf, so the cc1 flag is passed as -Xclang -cfguard. Verified to emit .gfids$y, to leave HIP device compilation alone, and to produce a populated guard table under dumpbin /loadconfig.

Also covers the builds that do not inherit CMAKE_<LANG>_FLAGS: the zlib and zstd nested configures, and the amd-mesa meson native file.

Resolves : https://github.com/ROCm/TheRock/issues/1293

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
