### PR TITLE
build(hipblaslt): skip clients on Windows (no Fortran/LAPACK)

### DIFF
--- a/math-libs/BLAS/CMakeLists.txt
+++ b/math-libs/BLAS/CMakeLists.txt
@@ -164,6 +164,7 @@ therock_cmake_subproject_declare(hipBLASLt
   CMAKE_ARGS
     -DHIP_PLATFORM=amd
     -DHIPBLASLT_ENABLE_BLIS=OFF  # TODO: Evaluate
+    -DHIPBLASLT_ENABLE_CLIENT=$<IF:$<BOOL:${WIN32}>,OFF,ON>
     # TensileLite's C++ gtest suite (tests/) is Linux-only for now (unvalidated
     # on Windows); mirrors the TENSILELITE_ENABLE_CLIENT guard below.
     -DTENSILELITE_BUILD_TESTING=$<IF:$<BOOL:${WIN32}>,OFF,${THEROCK_BUILD_TESTING}>


### PR DESCRIPTION
## Motivation

hipBLASLt client programs (tests, benchmarks, samples) require a Fortran compiler and LAPACK. The Windows build environment has neither (the ROCm Windows SDK ships no usable Fortran compiler), so configuring hipBLASLt with `HIPBLASLT_ENABLE_CLIENT=ON` fails at `find_package(LAPACK REQUIRED)` / `enable_language(Fortran)` and aborts the whole BLAS component build.

Tracked by #52 ("hipblasLT: needs gfortran"). See also #7596 for the state of Fortran on Windows.

## Technical Details

Pass `-DHIPBLASLT_ENABLE_CLIENT=OFF` on Windows and leave it `ON` on Linux, using the same generator-expression pattern already used for the TensileLite guards in this file. This mirrors the rocBLAS/hipBLAS client samples guard. Linux behavior is unchanged; only the Windows configuration stops requesting the clients.

## Test Plan

- Windows (no Fortran/LAPACK): run the TheRock configure step; the hipBLASLt subproject should configure and receive `-DHIPBLASLT_ENABLE_CLIENT=OFF`.
- Linux: unaffected (expression evaluates to `ON`), clients keep building as before.

## Test Result

Windows: `cmake -B build -GNinja . -DTHEROCK_ENABLE_ALL=OFF -DTHEROCK_ENABLE_CORE=ON -DTHEROCK_ENABLE_BLAS=ON -DTHEROCK_AMDGPU_FAMILIES=gfx120X-all` completes with "Configuring done", and `build/build.ninja` shows `-DHIPBLASLT_ENABLE_CLIENT=OFF` in the hipBLASLt configure command.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.

---

AI assistance disclosure: this change and description were prepared with an AI assistant and reviewed by the submitter.
