### PR TITLE
fix(ci): preload ASAN runtime for GPU sanity check in host-asan builds

### DIFF
--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -158,9 +158,40 @@ jobs:
         run: |
           python ./build_tools/health_status.py
 
+        # TODO(#3755): Clean this up after final sanitizer environment variable flags are determined
+        # Must run before sanity check so ASAN_RUNTIME_PATH is available for LD_PRELOAD
+      - name: Enable sanitizer-specific test flags
+        if: ${{ contains(inputs.artifact_group, 'asan') }}
+        run: |
+          echo "ASAN_OPTIONS=detect_odr_violation=0:quarantine_size_mb=600" >> $GITHUB_ENV
+          echo "HSA_XNACK=1" >> $GITHUB_ENV
+          echo "ASAN_SYMBOLIZER_PATH=${{ env.OUTPUT_ARTIFACTS_DIR }}/llvm/bin/llvm-symbolizer" >> $GITHUB_ENV
+          # Resolve ASAN runtime path for steps that need LD_PRELOAD (e.g., sanity check).
+          # Non-instrumented executables like Python need LD_PRELOAD to load ASAN-instrumented
+          # libraries (e.g., libamdhip64). We don't set LD_PRELOAD globally to avoid false
+          # leak reports from third-party libraries.
+          CLANG_BIN="${{ env.OUTPUT_ARTIFACTS_DIR }}/llvm/bin/clang"
+          if [[ -x "${CLANG_BIN}" ]]; then
+            ASAN_RT_PATH=$("${CLANG_BIN}" -print-file-name=libclang_rt.asan.so)
+            if [[ -f "${ASAN_RT_PATH}" ]]; then
+              echo "ASAN_RUNTIME_PATH=${ASAN_RT_PATH}" >> $GITHUB_ENV
+              echo "Resolved ASAN runtime: ${ASAN_RT_PATH}"
+            else
+              echo "Warning: ASAN runtime not found at ${ASAN_RT_PATH}"
+            fi
+          else
+            echo "Warning: clang not found at ${CLANG_BIN}, ASAN runtime path not resolved"
+          fi
+
       - name: Driver / GPU sanity check
         if: ${{ !fromJSON(inputs.component).linux_cpu_runner }}
         timeout-minutes: 3
+        env:
+          # Preload ASAN runtime so Python can load ASAN-instrumented libraries
+          LD_PRELOAD: ${{ env.ASAN_RUNTIME_PATH }}
+          # Disable leak detection for sanity check only - Python itself is not
+          # ASAN-instrumented and reports false positive leaks
+          ASAN_OPTIONS: detect_leaks=0
         run: |
           python ./build_tools/print_driver_gpu_info.py
 
@@ -169,14 +200,6 @@ jobs:
         run: |
           python ./build_tools/install_additional_requirements.py \
             --requirements-files ${{ join(fromJSON(inputs.component).additional_requirements_files, ',') }}
-
-        # TODO(#3755): Clean this up after final sanitizer environment variable flags are determined
-      - name: Enable sanitizer-specific test flags
-        if: ${{ contains(inputs.artifact_group, 'asan') }}
-        run: |
-          echo "ASAN_OPTIONS=detect_odr_violation=0:quarantine_size_mb=600" >> $GITHUB_ENV
-          echo "HSA_XNACK=1" >> $GITHUB_ENV
-          echo "ASAN_SYMBOLIZER_PATH=${{ env.OUTPUT_ARTIFACTS_DIR }}/llvm/bin/llvm-symbolizer" >> $GITHUB_ENV
 
       # Set thread limits from KUBE_CPU_REQUEST (Kubernetes-injected) to avoid oversubscription.
       # Must be done at runtime since container env vars aren't in GitHub's env context.

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -163,25 +163,8 @@ jobs:
       - name: Enable sanitizer-specific test flags
         if: ${{ contains(inputs.artifact_group, 'asan') }}
         run: |
-          echo "ASAN_OPTIONS=detect_odr_violation=0:quarantine_size_mb=600" >> $GITHUB_ENV
-          echo "HSA_XNACK=1" >> $GITHUB_ENV
-          echo "ASAN_SYMBOLIZER_PATH=${{ env.OUTPUT_ARTIFACTS_DIR }}/llvm/bin/llvm-symbolizer" >> $GITHUB_ENV
-          # Resolve ASAN runtime path for steps that need LD_PRELOAD (e.g., sanity check).
-          # Non-instrumented executables like Python need LD_PRELOAD to load ASAN-instrumented
-          # libraries (e.g., libamdhip64). We don't set LD_PRELOAD globally to avoid false
-          # leak reports from third-party libraries.
-          CLANG_BIN="${{ env.OUTPUT_ARTIFACTS_DIR }}/llvm/bin/clang"
-          if [[ -x "${CLANG_BIN}" ]]; then
-            ASAN_RT_PATH=$("${CLANG_BIN}" -print-file-name=libclang_rt.asan.so)
-            if [[ -f "${ASAN_RT_PATH}" ]]; then
-              echo "ASAN_RUNTIME_PATH=${ASAN_RT_PATH}" >> $GITHUB_ENV
-              echo "Resolved ASAN runtime: ${ASAN_RT_PATH}"
-            else
-              echo "Warning: ASAN runtime not found at ${ASAN_RT_PATH}"
-            fi
-          else
-            echo "Warning: clang not found at ${CLANG_BIN}, ASAN runtime path not resolved"
-          fi
+          python ./build_tools/github_actions/configure_asan_env.py \
+            --artifacts-dir "${{ env.OUTPUT_ARTIFACTS_DIR }}"
 
       - name: Driver / GPU sanity check
         if: ${{ !fromJSON(inputs.component).linux_cpu_runner }}
@@ -189,9 +172,13 @@ jobs:
         env:
           # Preload ASAN runtime so Python can load ASAN-instrumented libraries
           LD_PRELOAD: ${{ env.ASAN_RUNTIME_PATH }}
-          # Disable leak detection for sanity check only - Python itself is not
-          # ASAN-instrumented and reports false positive leaks
-          ASAN_OPTIONS: detect_leaks=0
+          # The probes load instrumented ROCm libraries, so LeakSanitizer reports
+          # whatever those leak at exit and the probe returns non-zero. This step
+          # answers "is the driver and GPU functional", not "is the runtime
+          # leak-free". Extends rather than replaces, to keep the options set by
+          # configure_asan_env.py; scoped here so component tests still run with
+          # leak detection enabled.
+          ASAN_OPTIONS: ${{ env.ASAN_OPTIONS }}:detect_leaks=0
         run: |
           python ./build_tools/print_driver_gpu_info.py
 

--- a/build_tools/github_actions/configure_asan_env.py
+++ b/build_tools/github_actions/configure_asan_env.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Exports the environment that ASAN-instrumented test jobs need to GITHUB_ENV.
+
+Test jobs for `asan` and `host-asan` artifact groups run binaries that link
+against instrumented ROCm libraries. Two paths have to be discovered from the
+downloaded artifacts rather than hardcoded:
+
+* The ASAN runtime, so that executables built without `-fsanitize=address`
+  (Python, hip_check) can preload it. Without the preload they abort with
+  "ASan runtime does not come first in initial library list".
+* The symbolizer, so that ASAN reports resolve to function names instead of
+  raw hex offsets. This must be absolute: it is read by processes whose working
+  directory is not the workspace root (hip_check runs from build/bin), where a
+  relative path resolves to nothing.
+
+Which steps consume these values is left to the workflow; this script only
+exports them. Leak suppression in particular is deliberately not set here: a
+job-wide `detect_leaks=0` would disable leak detection for the component tests
+as well, so the workflow scopes that to the sanity step's own `env`.
+
+Missing binaries warn rather than fail, preserving the behavior of the inline
+shell this replaced.
+
+Used by `test_component.yml`.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from github_actions_api import gha_set_env
+
+# Applied to every ASAN test job.
+#   detect_odr_violation=0 : instrumented ROCm libraries trip ODR checks that
+#                            are not actionable from a test job.
+#   quarantine_size_mb=600 : bounds ASAN's quarantine for freed memory.
+STATIC_ASAN_ENV = {
+    "ASAN_OPTIONS": "detect_odr_violation=0:quarantine_size_mb=600",
+    "HSA_XNACK": "1",
+}
+
+ASAN_RUNTIME_LIB = "libclang_rt.asan.so"
+
+
+def _resolve_asan_runtime(
+    artifacts_dir: Path,
+) -> tuple[Optional[Path], Optional[str]]:
+    """Asks the artifact tree's clang where its ASAN runtime lives.
+
+    Returns (path, warning); exactly one is set.
+    """
+    clang = artifacts_dir / "llvm" / "bin" / "clang"
+    if not os.access(clang, os.X_OK):
+        return None, f"clang not found at {clang}, ASAN runtime path not resolved"
+
+    try:
+        result = subprocess.run(
+            [str(clang), f"-print-file-name={ASAN_RUNTIME_LIB}"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, OSError) as e:
+        return None, f"could not query {clang} for the ASAN runtime: {e}"
+
+    runtime = Path(result.stdout.strip())
+    if not runtime.is_file():
+        return None, f"ASAN runtime not found at {runtime}"
+    return runtime.resolve(), None
+
+
+def _resolve_symbolizer(artifacts_dir: Path) -> tuple[Optional[Path], Optional[str]]:
+    """Locates llvm-symbolizer in the artifact tree.
+
+    Returns (path, warning); exactly one is set.
+    """
+    symbolizer = artifacts_dir / "llvm" / "bin" / "llvm-symbolizer"
+    if not os.access(symbolizer, os.X_OK):
+        return (
+            None,
+            f"llvm-symbolizer not found at {symbolizer}, "
+            "ASAN reports will be unsymbolized",
+        )
+    return symbolizer.resolve(), None
+
+
+def resolve_asan_env(artifacts_dir: Path) -> tuple[dict[str, str], list[str]]:
+    """Returns (environment variables to export, warnings to surface)."""
+    env = dict(STATIC_ASAN_ENV)
+    warnings: list[str] = []
+
+    runtime, warning = _resolve_asan_runtime(artifacts_dir)
+    if runtime:
+        env["ASAN_RUNTIME_PATH"] = str(runtime)
+    if warning:
+        warnings.append(warning)
+
+    symbolizer, warning = _resolve_symbolizer(artifacts_dir)
+    if symbolizer:
+        env["ASAN_SYMBOLIZER_PATH"] = str(symbolizer)
+    if warning:
+        warnings.append(warning)
+
+    return env, warnings
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifacts-dir",
+        type=Path,
+        required=True,
+        help="Directory ROCm artifacts were extracted into (OUTPUT_ARTIFACTS_DIR).",
+    )
+    args = parser.parse_args(argv)
+
+    env, warnings = resolve_asan_env(args.artifacts_dir)
+
+    for warning in warnings:
+        print(f"::warning::{warning}")
+    if "ASAN_RUNTIME_PATH" in env:
+        print(f"Resolved ASAN runtime: {env['ASAN_RUNTIME_PATH']}")
+    if "ASAN_SYMBOLIZER_PATH" in env:
+        print(f"Resolved ASAN symbolizer: {env['ASAN_SYMBOLIZER_PATH']}")
+
+    gha_set_env(env)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build_tools/github_actions/configure_asan_env.py
+++ b/build_tools/github_actions/configure_asan_env.py
@@ -39,11 +39,22 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from github_actions_api import gha_set_env
 
 # Applied to every ASAN test job.
-#   detect_odr_violation=0 : instrumented ROCm libraries trip ODR checks that
-#                            are not actionable from a test job.
-#   quarantine_size_mb=600 : bounds ASAN's quarantine for freed memory.
+#   detect_odr_violation=0      : instrumented ROCm libraries trip ODR checks
+#                                 that are not actionable from a test job.
+#   quarantine_size_mb=600      : bounds ASAN's quarantine for freed memory.
+#   verify_asan_link_order=0    : uninstrumented binaries that load instrumented
+#                                 ROCm libraries abort unless the runtime is
+#                                 first in the library list. ASAN_RUNTIME_PATH
+#                                 below lets callers preload it where they
+#                                 control the process, but tests also invoke
+#                                 tools they do not spawn directly (amdclang++,
+#                                 for example). Disabling the check keeps those
+#                                 running; it suppresses the guard rather than
+#                                 fixing the ordering, so preload where you can.
 STATIC_ASAN_ENV = {
-    "ASAN_OPTIONS": "detect_odr_violation=0:quarantine_size_mb=600",
+    "ASAN_OPTIONS": (
+        "detect_odr_violation=0:quarantine_size_mb=600:verify_asan_link_order=0"
+    ),
     "HSA_XNACK": "1",
 }
 

--- a/build_tools/github_actions/tests/configure_asan_env_test.py
+++ b/build_tools/github_actions/tests/configure_asan_env_test.py
@@ -62,6 +62,10 @@ class TestResolveAsanEnv(unittest.TestCase):
             for key, value in STATIC_ASAN_ENV.items():
                 self.assertEqual(env[key], value)
 
+    def test_link_order_check_is_disabled(self):
+        """Uninstrumented tools (amdclang++) abort without this."""
+        self.assertIn("verify_asan_link_order=0", STATIC_ASAN_ENV["ASAN_OPTIONS"])
+
     @requires_posix
     def test_symbolizer_path_is_absolute_for_a_relative_artifacts_dir(self):
         """hip_check runs from build/bin, so a relative path resolves to nothing."""

--- a/build_tools/github_actions/tests/configure_asan_env_test.py
+++ b/build_tools/github_actions/tests/configure_asan_env_test.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for configure_asan_env.py"""
+
+import os
+import stat
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from configure_asan_env import STATIC_ASAN_ENV, main, resolve_asan_env
+
+# The runtime is located by executing the artifact tree's clang, which the tests
+# stub with a shell script. Windows has no equivalent shebang mechanism.
+requires_posix = unittest.skipIf(
+    os.name != "posix", "stub executables require a POSIX shell"
+)
+
+
+def _make_executable(path: Path, contents: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(contents)
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _make_artifacts(root: Path, *, clang=True, symbolizer=True, runtime=True) -> Path:
+    """Builds a fake artifact tree; returns the artifacts dir."""
+    artifacts = root / "build"
+    runtime_path = artifacts / "lib" / "llvm" / "lib" / "clang" / "24" / "asan.so"
+    if runtime:
+        runtime_path.parent.mkdir(parents=True, exist_ok=True)
+        runtime_path.write_text("")
+    if clang:
+        _make_executable(
+            artifacts / "llvm" / "bin" / "clang",
+            f'#!/bin/sh\necho "{runtime_path}"\n',
+        )
+    if symbolizer:
+        _make_executable(artifacts / "llvm" / "bin" / "llvm-symbolizer", "#!/bin/sh\n")
+    return artifacts
+
+
+class TestResolveAsanEnv(unittest.TestCase):
+    @requires_posix
+    def test_resolves_runtime_and_symbolizer(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            artifacts = _make_artifacts(Path(tmp))
+            env, warnings = resolve_asan_env(artifacts)
+
+            self.assertEqual(warnings, [])
+            self.assertTrue(env["ASAN_RUNTIME_PATH"].endswith("asan.so"))
+            self.assertTrue(env["ASAN_SYMBOLIZER_PATH"].endswith("llvm-symbolizer"))
+
+    def test_static_values_are_always_exported(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            env, _ = resolve_asan_env(Path(tmp) / "missing")
+            for key, value in STATIC_ASAN_ENV.items():
+                self.assertEqual(env[key], value)
+
+    @requires_posix
+    def test_symbolizer_path_is_absolute_for_a_relative_artifacts_dir(self):
+        """hip_check runs from build/bin, so a relative path resolves to nothing."""
+        with tempfile.TemporaryDirectory() as tmp:
+            _make_artifacts(Path(tmp))
+            cwd = os.getcwd()
+            os.chdir(tmp)
+            try:
+                env, _ = resolve_asan_env(Path("./build"))
+            finally:
+                os.chdir(cwd)
+
+            self.assertTrue(Path(env["ASAN_SYMBOLIZER_PATH"]).is_absolute())
+            self.assertTrue(Path(env["ASAN_RUNTIME_PATH"]).is_absolute())
+
+    def test_missing_clang_warns_without_exporting_runtime(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            artifacts = _make_artifacts(Path(tmp), clang=False)
+            env, warnings = resolve_asan_env(artifacts)
+
+            self.assertNotIn("ASAN_RUNTIME_PATH", env)
+            self.assertTrue(any("clang not found" in w for w in warnings))
+
+    @requires_posix
+    def test_missing_runtime_file_warns(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            artifacts = _make_artifacts(Path(tmp), runtime=False)
+            env, warnings = resolve_asan_env(artifacts)
+
+            self.assertNotIn("ASAN_RUNTIME_PATH", env)
+            self.assertTrue(any("ASAN runtime not found" in w for w in warnings))
+
+    @requires_posix
+    def test_missing_symbolizer_warns_but_keeps_runtime(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            artifacts = _make_artifacts(Path(tmp), symbolizer=False)
+            env, warnings = resolve_asan_env(artifacts)
+
+            self.assertIn("ASAN_RUNTIME_PATH", env)
+            self.assertNotIn("ASAN_SYMBOLIZER_PATH", env)
+            self.assertTrue(any("unsymbolized" in w for w in warnings))
+
+
+class TestMain(unittest.TestCase):
+    @requires_posix
+    def test_writes_key_value_lines_to_github_env(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            artifacts = _make_artifacts(Path(tmp))
+            env_file = Path(tmp) / "github_env"
+            env_file.touch()
+
+            previous = os.environ.get("GITHUB_ENV")
+            os.environ["GITHUB_ENV"] = str(env_file)
+            try:
+                self.assertEqual(main(["--artifacts-dir", str(artifacts)]), 0)
+            finally:
+                if previous is None:
+                    del os.environ["GITHUB_ENV"]
+                else:
+                    os.environ["GITHUB_ENV"] = previous
+
+            written = dict(
+                line.split("=", 1) for line in env_file.read_text().splitlines() if line
+            )
+            self.assertEqual(written["ASAN_OPTIONS"], STATIC_ASAN_ENV["ASAN_OPTIONS"])
+            self.assertIn("ASAN_RUNTIME_PATH", written)
+            self.assertIn("ASAN_SYMBOLIZER_PATH", written)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
  Move the sanitizer-specific test flags setup before the GPU sanity check
  and resolve the ASAN runtime library path. Set LD_PRELOAD only for the
  sanity check step so that non-instrumented Python can load ASAN-instrumented
  libraries (e.g., libamdhip64).

  LD_PRELOAD is not set globally to avoid false leak reports from third-party
  libraries during tests.
Leak detection is also disabled for the sanity check
  since Python itself is not ASAN-instrumented and triggers false positives.

ISSUE ID:  https://github.com/ROCm/TheRock/issues/7202

