### PR TITLE
Validate buckets before publishing

### DIFF
--- a/build_tools/packaging/python/mirror_python_dependencies.py
+++ b/build_tools/packaging/python/mirror_python_dependencies.py
@@ -124,6 +124,8 @@ class PublishSummary:
 class S3Client(Protocol):
     """Subset of the boto3 S3 client used by this tool."""
 
+    def head_bucket(self, **kwargs: object) -> dict[str, object]: ...
+
     def head_object(self, **kwargs: object) -> dict[str, object]: ...
 
     def get_object(self, **kwargs: object) -> dict[str, object]: ...
@@ -698,6 +700,7 @@ def publish_snapshot(
     """Publish one validated local snapshot into one S3 bucket."""
     snapshot = load_snapshot(snapshot_dir)
     client = s3_client if s3_client is not None else boto3.client("s3")
+    client.head_bucket(Bucket=bucket)
     uploaded = 0
     refreshed = 0
     skipped = 0

--- a/build_tools/packaging/python/tests/mirror_python_dependencies_test.py
+++ b/build_tools/packaging/python/tests/mirror_python_dependencies_test.py
@@ -159,10 +159,13 @@ def _mock_s3_client(
 class FakeS3Client:
     def __init__(self) -> None:
         self.objects: dict[str, dict[str, object]] = {}
+        self.head_bucket_calls: list[dict[str, object]] = []
+        self.head_object_calls: list[dict[str, object]] = []
         self.get_calls: list[dict[str, object]] = []
         self.put_calls: list[dict[str, object]] = []
         self.copy_calls: list[dict[str, object]] = []
         self.now = datetime(2026, 8, 25, tzinfo=timezone.utc)
+        self.fail_head_bucket = False
         self.fail_copy_precondition = False
         self.corrupt_copy_checksum = False
         self.corrupt_put_checksum = False
@@ -178,6 +181,15 @@ class FakeS3Client:
         if not include_checksum:
             del self.objects[key]["ChecksumSHA256"]
 
+    def head_bucket(self, **kwargs: object) -> dict[str, object]:
+        self.head_bucket_calls.append(kwargs)
+        if self.fail_head_bucket:
+            raise ClientError(
+                {"Error": {"Code": "404", "Message": "Not Found"}},
+                "HeadBucket",
+            )
+        return {}
+
     def _object(self, body: bytes) -> dict[str, object]:
         return {
             "body": body,
@@ -192,6 +204,7 @@ class FakeS3Client:
         }
 
     def head_object(self, **kwargs: object) -> dict[str, object]:
+        self.head_object_calls.append(kwargs)
         key = str(kwargs["Key"])
         if key not in self.objects:
             raise ClientError(
@@ -631,6 +644,27 @@ def test_publish_dry_run_does_not_write(tmp_path: Path) -> None:
         s3_client=client,
     )
     assert summary.uploaded == 1
+    assert client.head_bucket_calls == [{"Bucket": "test-bucket"}]
+    assert not client.put_calls
+    assert not client.copy_calls
+
+
+def test_publish_dry_run_rejects_inaccessible_bucket(tmp_path: Path) -> None:
+    _write_snapshot(tmp_path)
+    client = FakeS3Client()
+    client.fail_head_bucket = True
+
+    with pytest.raises(ClientError):
+        mirror.publish_snapshot(
+            snapshot_dir=tmp_path,
+            bucket="misspelled-bucket",
+            refresh_existing=False,
+            dry_run=True,
+            s3_client=client,
+        )
+
+    assert client.head_bucket_calls == [{"Bucket": "misspelled-bucket"}]
+    assert not client.head_object_calls
     assert not client.put_calls
     assert not client.copy_calls
 

--- a/docs/packaging/python_packaging.md
+++ b/docs/packaging/python_packaging.md
@@ -202,9 +202,9 @@ python build_tools/packaging/python/mirror_python_dependencies.py resolve \
   --output-dir /tmp/rocm-dependency-snapshot
 ```
 
-After configuring normal boto3/AWS credentials with `HeadObject`, `GetObject`,
-`PutObject`, and same-key `CopyObject` access to one destination bucket,
-publish the same local snapshot:
+After configuring normal boto3/AWS credentials with `HeadBucket` (`ListBucket`),
+`HeadObject`, `GetObject`, `PutObject`, and same-key `CopyObject` access to one
+destination bucket, publish the same local snapshot:
 
 ```bash
 python build_tools/packaging/python/mirror_python_dependencies.py publish \


### PR DESCRIPTION
## Motivation

HeadObject can report the same 404 for a missing object and a nonexistent bucket. This made dry runs treat misspelled bucket names as empty destinations and report every dependency as a pending upload.

With this patch, bucket access is checked once before object reconciliation so invalid or inaccessible destinations fail before any upload plan is reported.

Closes #8128

## Test Plan

- python -m pytest -p no:cacheprovider build_tools/packaging/python/tests/mirror_python_dependencies_test.py -q

## Test Result

- Passed: mirror_python_dependencies_test.py (44 tests)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.

Generated with Codex
