### PR TITLE
fix(test): skip duplicate rocprofiler-sdk fixture in standalone library load checks

### DIFF
--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/core_test.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/core_test.py
@@ -102,11 +102,13 @@ class ROCmCoreTest(unittest.TestCase):
             if (
                 "lib/rocprofiler-sdk/" in str(so_path)
                 or "libexec/rocprofiler-sdk/" in str(so_path)
+                or "share/rocprofiler-sdk/tests/duplicate-sdk/" in str(so_path)
                 or "libpyrocpd" in str(so_path)
                 or "libpyroctx" in str(so_path)
             ):
-                # Internal rocprofiler-sdk libraries are meant to be pre-loaded
-                # explicitly and cannot necessarily be loaded standalone.
+                # Internal rocprofiler-sdk libraries cannot necessarily be loaded
+                # standalone. The duplicate SDK is a test fixture that requires the
+                # primary SDK to be preloaded by its test harness.
                 continue
             if "libtest_linking_lib" in str(so_path):
                 # rocprim unit tests, not actual library files

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/devel_test.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/devel_test.py
@@ -153,11 +153,13 @@ class ROCmDevelTest(unittest.TestCase):
             if (
                 "lib/rocprofiler-sdk/" in str(so_path)
                 or "libexec/rocprofiler-sdk/" in str(so_path)
+                or "share/rocprofiler-sdk/tests/duplicate-sdk/" in str(so_path)
                 or "libpyrocpd" in str(so_path)
                 or "libpyroctx" in str(so_path)
             ):
-                # Internal rocprofiler-sdk libraries are meant to be pre-loaded
-                # explicitly and cannot necessarily be loaded standalone.
+                # Internal rocprofiler-sdk libraries cannot necessarily be loaded
+                # standalone. The duplicate SDK is a test fixture that requires the
+                # primary SDK to be preloaded by its test harness.
                 continue
             if "libtest_linking_lib" in str(so_path):
                 # rocprim unit tests, not actual library files


### PR DESCRIPTION

## Motivation & Technical Details

ISSUE ID: https://github.com/ROCm/rocm-systems/issues/11439
Fixes Issue: https://github.com/ROCm/rocm-systems/issues/11439

Exclude the rocprofiler-sdk duplicate-library test fixture from `ROCmCoreTest.testSharedLibrariesLoad`.

The fixture is installed at:

`share/rocprofiler-sdk/tests/duplicate-sdk/librocprofiler-sdk.so`

It is intended to be loaded by the rocprofiler-sdk regression test after the primary SDK has been preloaded. It is not a standalone runtime library.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
