### PR TITLE
fix(ci): pull DVC artifacts for external rocm-libraries checkout

### DIFF
--- a/build_tools/github_actions/detect_external_repo_config.py
+++ b/build_tools/github_actions/detect_external_repo_config.py
@@ -46,6 +46,7 @@ REPO_CONFIGS: Dict[str, Dict[str, Any]] = {
         "cmake_source_var": "THEROCK_ROCM_LIBRARIES_SOURCE_DIR",
         "submodule_path": "rocm-libraries",
         "skip_submodules": ["rocm-libraries"],
+        "dvc_projects": ["external-rocm-libraries"],
     },
     "rocm-systems": {
         "cmake_source_var": "THEROCK_ROCM_SYSTEMS_SOURCE_DIR",

--- a/build_tools/github_actions/tests/dvc_external_repo_test.py
+++ b/build_tools/github_actions/tests/dvc_external_repo_test.py
@@ -59,13 +59,22 @@ class TestDVCProjectsConfiguration(unittest.TestCase):
             f"rocm-systems config missing required keys: {required_keys - config.keys()}",
         )
 
-    def test_rocm_libraries_no_dvc_projects(self):
-        """Test that rocm-libraries doesn't have dvc_projects (not needed)."""
+    def test_rocm_libraries_has_dvc_projects(self):
+        """Test that rocm-libraries config includes dvc_projects."""
         config = get_repo_config("rocm-libraries")
 
-        # rocm-libraries doesn't use DVC for external builds
-        self.assertNotIn(
-            "dvc_projects", config, "rocm-libraries doesn't need dvc_projects"
+        # Verify dvc_projects key exists
+        self.assertIn(
+            "dvc_projects",
+            config,
+            "rocm-libraries config must have dvc_projects for hipdnn golden data",
+        )
+
+        # Verify it contains external-rocm-libraries
+        self.assertEqual(
+            config["dvc_projects"],
+            ["external-rocm-libraries"],
+            "dvc_projects should contain external-rocm-libraries path",
         )
 
 
@@ -142,8 +151,8 @@ class TestFetchSourcesArgsGeneration(unittest.TestCase):
         self.assertIn("--skip-submodules rocm-systems", config_json_line)
         self.assertIn("--dvc-projects external-rocm-systems", config_json_line)
 
-    def test_rocm_libraries_no_dvc_args(self):
-        """Test that rocm-libraries doesn't generate --dvc-projects (not needed)."""
+    def test_rocm_libraries_generates_dvc_args(self):
+        """Test that rocm-libraries generates --dvc-projects in fetch_sources_args."""
         rc = detect_external_repo_config_main(
             [
                 "--repository",
@@ -156,12 +165,12 @@ class TestFetchSourcesArgsGeneration(unittest.TestCase):
         with open(self.temp_file, "r") as f:
             output = f.read()
 
-        # rocm-libraries should only have skip-submodules
+        # rocm-libraries should have both skip-submodules and dvc-projects
         self.assertIn("--skip-submodules rocm-libraries", output)
-        self.assertNotIn(
-            "--dvc-projects",
+        self.assertIn(
+            "--dvc-projects external-rocm-libraries",
             output,
-            "rocm-libraries shouldn't generate dvc-projects args",
+            "Should include --dvc-projects external-rocm-libraries",
         )
 
 


### PR DESCRIPTION
## Summary

Fixes #8131. `REPO_CONFIGS["rocm-libraries"]` in `detect_external_repo_config.py` was missing a `dvc_projects` entry (unlike `rocm-systems`), so CI never generated `--dvc-projects` for the `external-rocm-libraries` checkout and `fetch_dvc_artifacts.pull()` was never invoked for it. This left DVC-tracked golden `.bin` blobs under `dnn-providers/integration-tests/integration-test-bundles/` unmaterialized, failing hipdnn integration tests in [ROCm/rocm-libraries#11692](https://github.com/ROCm/rocm-libraries/pull/11692) (run [34392986403](https://github.com/ROCm/rocm-libraries/actions/runs/34392986403)) with `Bundle not available (DVC not pulled?)`.

## Risk Assessment

Low risk. Single-key config addition, isolated to the `rocm-libraries` external-repo path; unit-tested and mirrors the existing `rocm-systems` entry exactly. The change affects every rocm-libraries external-repo CI checkout going forward (adds a DVC pull step), but the behavior is well-understood and identical to the already-shipped `rocm-systems` case.

## ASIC Coverage

None required. This is CI/build-tooling config (which artifacts get DVC-pulled during checkout) — it does not touch kernel selection, op support surface, or default runtime behavior, and is not arch-scoped. Standard PR CI is sufficient.

## Testing Summary

- Unit tests covering `REPO_CONFIGS`, `fetch_sources_args` generation, and DVC-args formatting for both `rocm-libraries` and `rocm-systems`.
- Manual CLI verification that `detect_external_repo_config.py --repository rocm-libraries` now emits `--dvc-projects external-rocm-libraries`.
- Traced the full call chain (`detect_external_repo_config.py` -> `fetch_sources.py` `pull_large_files` -> `fetch_dvc_artifacts.pull`) against the failing CI logs to confirm root cause and fix.

## Testing Checklist

- [x] Config/detection unit tests - `python -m unittest build_tools/github_actions/tests/detect_external_repo_config_test.py build_tools/github_actions/tests/dvc_external_repo_test.py` - Status: Passed
- [x] fetch_sources DVC unit tests - `python -m unittest build_tools/tests/fetch_sources_dvc_test.py` - Status: Passed
- [ ] PR CI - GitHub PR checks - Status: Pending
- [ ] Downstream validation - rerun of ROCm/rocm-libraries Multi-Arch CI once this ref is picked up - Status: Pending (requires a separate ref bump in rocm-libraries' `therock-multi-arch-ci.yml`)

## Technical Changes

- Add `"dvc_projects": ["external-rocm-libraries"]` to the `rocm-libraries` entry in `REPO_CONFIGS` (`build_tools/github_actions/detect_external_repo_config.py`), so `--dvc-projects external-rocm-libraries` is generated for that checkout, mirroring `rocm-systems`.
- Update `dvc_external_repo_test.py`: two tests (`test_rocm_libraries_no_dvc_projects`, `test_rocm_libraries_no_dvc_args`) previously asserted the absence of `dvc_projects`/`--dvc-projects` for rocm-libraries, encoding the bug as intended behavior; rewritten to assert the corrected behavior, mirroring the existing rocm-systems test cases.