### PR TITLE
packaging: default MSI install root to ProgramFiles64Folder

### DIFF
--- a/build_tools/packaging/windows/generate_msi_wxs.py
+++ b/build_tools/packaging/windows/generate_msi_wxs.py
@@ -553,12 +553,14 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--install-root",
-        default="ProgramFilesFolder",
+        default="ProgramFiles64Folder",
         metavar="ROOT",
         help=(
             "Where to root the install tree. Accepts a Windows Installer "
-            "standard-directory token (e.g. ProgramFilesFolder) or an "
-            "absolute path (e.g. C:\\AMD). Default: ProgramFilesFolder"
+            "standard-directory token (e.g. ProgramFiles64Folder) or an "
+            "absolute path (e.g. C:\\AMD). Default: ProgramFiles64Folder "
+            "(64-bit C:\\Program Files; ProgramFilesFolder is the 32-bit "
+            "C:\\Program Files (x86) and is wrong for x64 ROCm)."
         ),
     )
     parser.add_argument(

--- a/build_tools/packaging/windows/msi-generator-usage.md
+++ b/build_tools/packaging/windows/msi-generator-usage.md
@@ -87,19 +87,19 @@ The default install path is assembled as:
 
 For example: `C:\Program Files\AMD\ROCm\core-7.15\`
 
-| Flag                      | Default              | Description                                                                                                         |
-| ------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `--install-root ROOT`     | `ProgramFilesFolder` | Root of the install tree. Accepts a Windows Installer standard-directory token or an absolute path (e.g. `C:\AMD`). |
-| `--product-dir NAME`      | `AMD`                | First subdirectory under `--install-root`.                                                                          |
-| `--version-dir NAME`      | `ROCm`               | Second subdirectory under `--product-dir`.                                                                          |
-| `--package-version X.Y.Z` | From `version.json`  | MSI version string. Auto-detected from the repo's `version.json`.                                                   |
+| Flag                      | Default                | Description                                                                                                         |
+| ------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `--install-root ROOT`     | `ProgramFiles64Folder` | Root of the install tree. Accepts a Windows Installer standard-directory token or an absolute path (e.g. `C:\AMD`). |
+| `--product-dir NAME`      | `AMD`                  | First subdirectory under `--install-root`.                                                                          |
+| `--version-dir NAME`      | `ROCm`                 | Second subdirectory under `--product-dir`.                                                                          |
+| `--package-version X.Y.Z` | From `version.json`    | MSI version string. Auto-detected from the repo's `version.json`.                                                   |
 
 **Standard-directory tokens** resolve at install time on the target machine:
 
-| Token                            | Resolves to                              |
-| -------------------------------- | ---------------------------------------- |
-| `ProgramFilesFolder` *(default)* | `C:\Program Files\`                      |
-| `ProgramFiles64Folder`           | `C:\Program Files\` (always 64-bit view) |
+| Token                              | Resolves to                                          |
+| ---------------------------------- | ---------------------------------------------------- |
+| `ProgramFiles64Folder` *(default)* | `C:\Program Files\` (64-bit; correct for x64 ROCm)   |
+| `ProgramFilesFolder`               | `C:\Program Files (x86)\` (32-bit; not for x64 ROCm) |
 
 **Absolute paths** (e.g. `C:\AMD`) bake a fixed default into the MSI.
 

--- a/build_tools/packaging/windows/tests/generate_msi_wxs_test.py
+++ b/build_tools/packaging/windows/tests/generate_msi_wxs_test.py
@@ -8,6 +8,7 @@ import argparse
 import sys
 import tempfile
 import unittest
+import unittest.mock
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
@@ -21,6 +22,7 @@ from generate_msi_wxs import (
     collect_files_from_catalog,
     make_id,
     build_wxs,
+    parse_args,
     create_wix_document,
     resolve_install_layout,
     add_install_directory_tree,
@@ -318,7 +320,7 @@ class TestBuildWxs(unittest.TestCase):
             package=package,
             build_root=build,
             output=out,
-            install_root="ProgramFilesFolder",
+            install_root="ProgramFiles64Folder",
             product_dir="AMD",
             version_dir="ROCm",
             package_version="1.2.3",
@@ -410,7 +412,7 @@ class TestBuildWxs(unittest.TestCase):
                 package="runtime",
                 build_root=empty_build,
                 output=out,
-                install_root="ProgramFilesFolder",
+                install_root="ProgramFiles64Folder",
                 product_dir="AMD",
                 version_dir="ROCm",
                 package_version="1.2.3",
@@ -572,7 +574,7 @@ class TestBuildWxsHelpers(unittest.TestCase):
     def _args(self, **overrides):
         defaults = dict(
             package="runtime",
-            install_root="ProgramFilesFolder",
+            install_root="ProgramFiles64Folder",
             product_dir="AMD",
             version_dir="ROCm",
         )
@@ -594,11 +596,20 @@ class TestBuildWxsHelpers(unittest.TestCase):
 
     def test_install_layout_uses_standard_dir(self):
         std = resolve_install_layout(
-            self._args(install_root="ProgramFilesFolder"), "1.2.3"
+            self._args(install_root="ProgramFiles64Folder"), "1.2.3"
         )
         self.assertTrue(std.uses_standard_dir)
         custom = resolve_install_layout(self._args(install_root="C:\\AMD"), "1.2.3")
         self.assertFalse(custom.uses_standard_dir)
+
+    def test_default_install_root_is_64bit_program_files(self):
+        # ProgramFilesFolder resolves to C:\Program Files (x86) even in an x64
+        # package; ROCm is 64-bit, so the default must be ProgramFiles64Folder
+        # (C:\Program Files). Guards against regressing to the 32-bit token.
+        argv = ["generate_msi_wxs.py", "--package", "runtime"]
+        with unittest.mock.patch.object(sys, "argv", argv):
+            args = parse_args()
+        self.assertEqual(args.install_root, "ProgramFiles64Folder")
 
     def test_stable_guid_is_deterministic_and_upper(self):
         a = _stable_guid("System32", "amdhip64_7.dll")


### PR DESCRIPTION
## Summary

Fixes the default Windows MSI install root. `generate_msi_wxs.py` defaulted
`--install-root` to `ProgramFilesFolder`, which Windows Installer resolves to
`C:\Program Files (x86)` **even in an x64 package** — so 64-bit ROCm installed
under the 32-bit Program Files tree. Default to `ProgramFiles64Folder`
(`C:\Program Files`), which is correct for the x64 MSI.

## Changes

- `generate_msi_wxs.py`: default `--install-root` → `ProgramFiles64Folder`;
  clarified the help text (why the x86 token is wrong for x64 ROCm).
- `msi-generator-usage.md`: fixed the standard-directory token table, which
  incorrectly claimed `ProgramFilesFolder` resolves to `C:\Program Files\`.
- Added `test_default_install_root_is_64bit_program_files` (parses args and
  asserts the default is the 64-bit token); updated existing tests to use the
  corrected token.

## Testing

- All 53 generator unit tests pass; `pre-commit` (black + mdformat) clean.
- Built a `runtime` MSI with WiX 4.0.6 and **installed it** — files land in
  `C:\Program Files\AMD\ROCm\...` (previously `C:\Program Files (x86)\...`).
- Verified the compiled MSI embeds `ProgramFiles64Folder` and zero references to
  the x86 `ProgramFilesFolder`.

Part of the Windows installer effort (#1987).
