### PR TITLE
Raise version to 10.2.0

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "rocm-version": "10.1.0",
+  "rocm-version": "10.2.0",
   "release-metadata": {
     "base-date": ""
   }


### PR DESCRIPTION
## Motivation

We have cut the `release/therock-10.1` release branch, therefore the version on `main` is bumped to `10.2.0`.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.