### PR TITLE
docs(skills): ground rocm-pr-quality testing guidance in TESTING.md + risk dimensions

### DIFF
--- a/skills/rocm-pr-quality/SKILL.md
+++ b/skills/rocm-pr-quality/SKILL.md
@@ -47,7 +47,15 @@ ______________________________________________________________________
 1. **Follow the repo's own standards.** When a component repo ships its own
    testing/contributing/standards docs (e.g. `CONTRIBUTING.md`, a `docs/testing*.md`, a per-repo
    best-practices file), read and apply them rather than inventing guidance. The skill checks that
-   repo standards are followed; it does not replace them.
+   repo standards are followed; it does not replace them. In particular, ROCm components are
+   rolling out a standard **`TESTING.md`** — a per-component testing-strategy doc (piloted by
+   hipBLASLt: `projects/hipblaslt/TESTING.md` and `projects/hipblaslt/tensilelite/TESTING.md` in
+   `rocm-libraries`) naming what actually gates a merge versus what is informational, its test
+   tiers, and its known gaps. Where one exists — check the repo root, then walk up from each
+   changed path to the nearest component-level copy — it is the canonical source for testing
+   questions on that component; see "Discover the component's `TESTING.md` first" in
+   `reference.md`. Its absence is not a blocker (rollout in progress); fall back to CI-config
+   discovery and this skill's generic guidance instead.
 1. **Discover, do not hardcode.** Supported architectures, CI labels, test lanes, and
    tracker prefixes drift. Discover them from the repo and CI config at run time.
 1. **Evidence over assertion.** Ground every finding in a `file:line`, a CI link, a diff
@@ -136,6 +144,13 @@ public API, perf-critical path, incomplete coverage; 5 = cross-project/architect
 behavior change in a critical path, ABI break, large unproven refactor, known unresolved
 failures. Residual coverage gaps (a required sweep that has not passed) raise the level.
 
+Pick the level through the seven-factor risk-dimension lens in `reference.md` (component
+criticality, historical regression risk, blast radius, sensitive-path exposure, code churn,
+test-coverage delta, release-phase timing). The **required validation floor** for that level
+should come from the component's discovered `TESTING.md` first — its own documented tiers and
+what actually gates — falling back to the generic floor table in `reference.md` only when no
+`TESTING.md` covers the touched component.
+
 ### Interlinking — every PR is an entry point
 
 A PR should never be a dead end. From any artifact a reader should follow links outward to the
@@ -165,6 +180,13 @@ not render empty `N/A` fields in the body.
    not found in the contributing guide so the author knows where it came from.
 1. Inspect the diff: `gh pr view`, `gh pr diff`, `git diff --stat`, targeted file reads.
 1. Classify the change (one or more classes; stricter when unsure).
+1. Discover the nearest `TESTING.md`(s) for the changed paths (repo root, then walk up from each
+   changed file's directory) — see "Discover the component's `TESTING.md` first" in
+   `reference.md`. Use its documented tiers and its real-gate-vs-informational distinction to
+   describe testing accurately in the Testing Summary/Checklist and Device/Architecture Coverage,
+   and explicitly flag in the PR body if the change touches a documented Known Risk/Gap. If none
+   exists for the touched component yet, fall back to the risk-dimension lens and CI-config
+   discovery, and note the gap as a `SUGGESTION`.
 1. Scan branch name, commit messages, and diff for tracker keys, issue numbers, and referenced
    PRs; pre-fill the Related section; prompt for anything obviously missing (e.g. "this fixes a
    defect — link the defect ticket").
@@ -205,6 +227,12 @@ web diff alone has lower confidence). Do not modify files during review.
 1. Testing review is required every time, even when no test files changed. Do not equate "tests
    added" with "behavior covered" — read assertions, run the mutation question, run the smell
    scan, and check the test "why" for non-obvious choices.
+1. Discover the nearest `TESTING.md`(s) for the changed paths and reconcile the PR's testing
+   claims against them (see "Discover the component's `TESTING.md` first" in `reference.md`). A
+   claim that a lane "passed"/"gates" the change when the doc marks that lane informational-only
+   or a documented known gap is a finding (`BLOCKING`, per the finding-tiers table). If the PR
+   touches an area a Known Risks/Gaps row already names, check whether that row should be
+   updated (closed, tightened, or left with a note) alongside the code change.
 1. Assess blast radius and device/arch coverage; reconcile what the content warrants against what
    the PR actually tested/claimed. Flag gaps; do not over-escalate.
 1. Answer the four review questions explicitly: (1) what new/changed functionality lands,
@@ -273,6 +301,10 @@ merge queue, and it does not force a CI rerun by default.
 - **Impacted open PRs (advisory).** Optionally identify other open PRs that touch the same
   high-coupling files and would be affected by this merge. You may *draft* a courtesy
   "consider rebasing" comment for those PRs — but never post it without explicit human approval.
+- **Validation floor met.** For a Level 4–5 PR (or one whose discovered `TESTING.md` names an
+  equivalent gate), confirm the sign-off it requires — named SME approval, or SME **and**
+  QA/release sign-off — actually happened, not just that CI is green. See "Required validation
+  floor by risk level" in `reference.md`.
 
 **Output:** a go / caution / hold summary with the specific reason and the recommended action
 (e.g. "overlap on a high-coupling file — rebase + re-run before merge"). The decision stays with

--- a/skills/rocm-pr-quality/reference.md
+++ b/skills/rocm-pr-quality/reference.md
@@ -160,12 +160,12 @@ ______________________________________________________________________
 
 ## Finding tiers (individual findings)
 
-| Tier            | Meaning                                                                                                                                                                                                                                                                                                                                                        |
-| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **BLOCKING**    | Must fix before merge: correctness/logic error, security issue, leak/crash in normal use, ABI/API break, breaking change without a migration path, missing required tests for new functionality, an untested broad-blast-radius change to a default/shipping path, or incomplete cleanup of code this PR modifies (dead params/constants/helpers left behind). |
-| **IMPORTANT**   | Should fix: real behavioral risk, missing validation for a likely edge case, meaningful test gap, missing required device/arch coverage, or a maintainability issue likely to cause defects soon.                                                                                                                                                              |
-| **SUGGESTION**  | Nice to have on code already being touched: clarity, naming, a small refactor, an extra test case.                                                                                                                                                                                                                                                             |
-| **FUTURE WORK** | Out of scope for this PR: improvements to code not being modified, larger refactors, follow-up features. Track separately; do not block this PR.                                                                                                                                                                                                               |
+| Tier            | Meaning                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **BLOCKING**    | Must fix before merge: correctness/logic error, security issue, leak/crash in normal use, ABI/API break, breaking change without a migration path, missing required tests for new functionality, an untested broad-blast-radius change to a default/shipping path, incomplete cleanup of code this PR modifies (dead params/constants/helpers left behind), or asserting a lane as validation coverage for the change when the component's `TESTING.md` documents that lane as non-gating/informational or a known gap. |
+| **IMPORTANT**   | Should fix: real behavioral risk, missing validation for a likely edge case, meaningful test gap, missing required device/arch coverage, or a maintainability issue likely to cause defects soon.                                                                                                                                                                                                                                                                                                                       |
+| **SUGGESTION**  | Nice to have on code already being touched: clarity, naming, a small refactor, an extra test case, or resolving/worsening a documented Known Risk/Gap in `TESTING.md` without updating that entry.                                                                                                                                                                                                                                                                                                                      |
+| **FUTURE WORK** | Out of scope for this PR: improvements to code not being modified, larger refactors, follow-up features. Track separately; do not block this PR.                                                                                                                                                                                                                                                                                                                                                                        |
 
 Decision framework: correctness/security issue, or incomplete cleanup of code being modified → **BLOCKING**; will cause problems for users/developers soon → **IMPORTANT**; an improvement to code being modified → **SUGGESTION**; otherwise → **FUTURE WORK**. Do not mark unrelated improvements BLOCKING, and do not soften incomplete cleanup to SUGGESTION/FUTURE WORK.
 
@@ -179,6 +179,65 @@ Decision framework: correctness/security issue, or incomplete cleanup of code be
 
 ______________________________________________________________________
 
+## Discover the component's `TESTING.md` first
+
+ROCm components are rolling out a standard `TESTING.md` — a per-component testing-strategy
+document (piloted by hipBLASLt: `projects/hipblaslt/TESTING.md` and
+`projects/hipblaslt/tensilelite/TESTING.md` in `rocm-libraries`). Where one exists, it is the
+canonical source of truth for testing questions on that component — treat it the same way as
+`CONTRIBUTING.md`: read and apply it rather than inventing guidance.
+
+**Discovery rule:** check the repo root for a `TESTING.md` (many repos, including this one, have
+one covering repo/build-level testing), then walk up from each changed file's directory to the
+nearest component-level `TESTING.md`. A PR spanning multiple components may need to consult more
+than one.
+
+**What to extract from it:**
+
+- Which lanes actually **gate** a merge versus which are **informational** (green-but-not-required,
+  or documented as silently skipped in some environment). This distinction is the whole point of
+  the document — "is CI covering that?" should be a lookup, not a guess.
+- The component's own test tiers/suites and what each is for, so the Testing Summary/Checklist
+  can name the right one instead of a generic label.
+- The **Known Risks and Gaps** table (or equivalent). If the PR touches an area a gap row already
+  names, say so explicitly rather than silently rediscovering it — and check whether the PR should
+  update that row (close it, tighten it, or leave it, with a note either way).
+- Owners / review cadence, if the change needs a named domain reviewer beyond standard CODEOWNERS.
+
+**No `TESTING.md` for this component yet?** The rollout is in progress — absence is not a
+blocker. Fall back to CI-config discovery and the risk-dimension lens below, and add a
+`SUGGESTION`/`FUTURE WORK` note that the component would benefit from one, pointing at the
+hipBLASLt pilot as a reference example.
+
+______________________________________________________________________
+
+## Risk dimensions (the lens for picking a level)
+
+Use these seven factors to judge a risk level (1–5, below) and to sanity-check a `TESTING.md`'s
+documented validation against the change actually in front of you. This is a weighting *lens*,
+not a literal point formula — do not invent a numeric score or bake in dated defect-rate
+statistics; regression history in particular should come from *this* repo's own defect/revert
+history (Jira, `git revert` patterns, CI flake logs), discovered at run time, never a fixed
+percentage table.
+
+- **Primary (weigh heaviest):**
+  - *Component criticality* — how central the touched component is to the product (e.g. runtime/
+    driver/kernel-adjacent code outweighs a peripheral tool).
+  - *Historical regression risk* — this component's/path's own track record of regressions or
+    reverts, not an assumed rate.
+  - *Blast radius / dependency impact* — how many components, consumers, or downstream frameworks
+    (e.g. PyTorch/JAX) could be affected; an API/ABI change has a wider radius than an internal
+    helper.
+- **Secondary:**
+  - *Sensitive-path exposure* — whether the diff touches paths the repo itself treats as
+    sensitive (discover these from CODEOWNERS, a documented sensitive-paths list, or directory
+    naming convention such as `memory/`, `scheduler/`, `driver/` — do not hardcode a fixed list).
+- **Modifiers (raise or lower the primary/secondary read, rather than standing alone):**
+  - *Code churn* — lines/files changed and whether it reads as a large refactor.
+  - *Test-coverage delta* — did the PR add coverage, hold it steady, or reduce it.
+  - *Release-phase timing* — the same change carries more risk closer to a code freeze or release
+    candidate; tighten scrutiny accordingly.
+
 ## Risk levels (1–5)
 
 | Level | Meaning                                                                                                                                    |
@@ -190,6 +249,30 @@ ______________________________________________________________________
 | 5     | Cross-project/architectural, default behavior change in a critical path, ABI break, large unproven refactor, or known unresolved failures. |
 
 A required-but-not-yet-passed device/arch run raises the residual risk.
+
+## Required validation floor by risk level (fallback)
+
+**Use the discovered `TESTING.md`'s own tiers/gates first.** This table is the fallback lens —
+apply it only when no `TESTING.md` covers the touched component, or to sanity-check that a
+documented tier is not obviously mismatched to the assessed level (e.g. a change touching a
+named sensitive path landing in a component whose `TESTING.md` marks the relevant lane
+informational-only). It generalizes a proposed ROCm-wide CI-enforcement ladder onto the existing
+1–5 scale; the concrete lane names are illustrative, not prescriptive — map them onto whatever
+this repo actually runs.
+
+| Level | Cumulative validation floor                                                                    | Review gate                                            |
+| ----- | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| 1     | Build + lint + unit tests.                                                                     | Ready for review immediately after CI passes.          |
+| 2     | + component tests, sanitizer smoke.                                                            | Ready after those tests pass.                          |
+| 3     | + integration tests, API/ABI compatibility check, multi-arch smoke, feature-flag verification. | Ready after enhanced validation passes.                |
+| 4     | + full component regression, cross-stack (framework) smoke, stress/perf smoke.                 | Named SME approval required before merge.              |
+| 5     | + full-stack regression, system validation, perf qualification, canary/soak.                   | SME **and** QA/release sign-off required before merge. |
+
+**Review eligibility should track real validation, not just approval or a green rollup.** Do not
+treat a Level 4–5 PR (or one whose `TESTING.md` gates say the equivalent) as ready for full review
+until the validation its floor requires has actually run — a valid-looking green summary can hide
+a skipped lane, a lane marked informational, or a documented known gap in exactly the area the PR
+touches.
 
 ______________________________________________________________________
 


### PR DESCRIPTION
## Motivation

ISSUE ID : #8135

The `rocm-pr-quality` skill's testing guidance was generic — it told authors/reviewers to test appropriately but gave no concrete way to discover what "appropriate" means for a given component, or to distinguish a real CI gate from an informational check.

Two inputs ground this:

1. ROCm components are rolling out a standard `TESTING.md` testing-strategy template, piloted by hipBLASLt ([rocm-libraries#10266](https://github.com/ROCm/rocm-libraries/pull/10266)). It's designed so "is CI covering that?" is a lookup, not a conversation, and so a reviewer can tell a real gate from an informational check. This should be the skill's primary source of truth wherever it exists.
2. A proposed ROCm-wide risk-based CI validation framework scores PR risk across seven weighted dimensions (component criticality, historical regression rate, blast radius, sensitive-path exposure, code churn, test-coverage delta, release-phase timing) mapped to escalating required validation. This becomes the skill's general risk lens and a fallback validation floor for components without a `TESTING.md` yet.

## Technical Details

- `skills/rocm-pr-quality/SKILL.md`:
  - Name `TESTING.md` explicitly in the "follow the repo's own standards" operating principle, with the discovery rule (repo root, then nearest per changed path).
  - Extend the Risk level section to point at the new risk-dimension lens and validation-floor guidance in `reference.md`.
  - Action 1 (author assist): discover the nearest `TESTING.md`(s) and use them to fill in testing/coverage sections accurately; flag known gaps the change touches.
  - Action 2 (review assist): reconcile testing claims against the discovered `TESTING.md`; a claim that an informational lane "gates" the change is a finding.
  - Action 3 (pre-merge gate): confirm the sign-off a Level 4-5 change requires actually happened.
- `skills/rocm-pr-quality/reference.md`:
  - New "Discover the component's `TESTING.md` first" section.
  - New "Risk dimensions" section (the seven-factor lens, no numeric formula or dated stats).
  - New fallback "Required validation floor by risk level" table.
  - Finding-tiers additions for misrepresenting an informational lane as a gate, and for leaving a `TESTING.md` Known Risks/Gaps entry stale.

Docs-only change to the advisory skill; no product code, no CI config.

## Test Plan

`pre-commit run --files skills/rocm-pr-quality/SKILL.md skills/rocm-pr-quality/reference.md` (mdformat, trailing-whitespace, no-tabs, etc.) — all hooks pass.

## Test Result

All applicable pre-commit hooks passed; no other files touched.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.

## Risk level

None. Documentation-only change to an advisory skill (no product code, no test code, no CI configuration). Worst case is the guidance is imprecise, which is correctable in a follow-up.
