### PR TITLE
fix(packaging): Duplicate libamd_comgr.so.3 rocm-sdk-core and rocm-sdk-devel

### DIFF
--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -421,6 +421,10 @@ def _run_kpack_split(
     # mode the generic test binaries are host-only and can't run without device
     # code. Tests will be reintroduced via a dedicated package later.
     devel = PopulatedDistPackage(params, logical_name="devel", target_family=None)
+
+    devel.rpath_dep(core, "lib")
+    devel.rpath_dep(core, "lib/llvm/lib")
+
     devel.populate_devel_files(
         addl_artifact_names=[
             # Header-only libraries not included in runtime packages.
@@ -522,6 +526,10 @@ def _run_legacy(
         devel = PopulatedDistPackage(
             params, logical_name="devel", target_family=target_family
         )
+
+        devel.rpath_dep(core, "lib")
+        devel.rpath_dep(core, "lib/llvm/lib")
+
         devel.populate_devel_files(
             addl_artifact_names=[
                 # Since prim and rocwmma are header only libraries, they are not


### PR DESCRIPTION
## Motivation

rocm-sdk-devel has a hard link to libamd_comgr.so.3
Changed so that rocm-sdk-core owns the real library, while rocm-sdk-devel now contains a symlink to the core copy instead of a hard link.

https://amd-hub.atlassian.net/browse/ROCM-30167

## Technical Details

Add devel.rpath_dep

## Test Plan

Compare libamd_comgr.so in core and devel of wheel build and my change 

## Test Result

Comparison of libamd_comgr.so.3

Before the change — installed from the wheel:

Core package:
-rwxr-xr-x 2 root root 14M
_rocm_sdk_core/lib/libamd_comgr.so.3

Devel package:
lrwxrwxrwx 1 root root 17
_rocm_sdk_devel/lib/libamd_comgr.so.3.5.0 -> libamd_comgr.so.3

-rwxr-xr-x 2 root root 14M
_rocm_sdk_devel/lib/libamd_comgr.so.3

libamd_comgr.so.3 is a hardlink in devel

After the change:

Core package:
-rwxr-xr-x 1 root root 14M
_rocm_sdk_core/lib/libamd_comgr.so.3

Devel package:
lrwxrwxrwx 1 root root 17
_rocm_sdk_devel/lib/libamd_comgr.so.3.5.0 -> libamd_comgr.so.3

lrwxrwxrwx 1 root root 42
_rocm_sdk_devel/lib/libamd_comgr.so.3 -> ../../_rocm_sdk_core/lib/libamd_comgr.so.3

Result:

devel libamd_comgr.so.3 entry now points to the core-owned library. now replaced by a symlink, removing the duplicate hardlink


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
