### PR TITLE
feat(ci): allow excluding a source repo's component tests from the multi-arch test matrix

### DIFF
--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -40,6 +40,14 @@ on:
         description: 'Comma-separated list of projects to test (e.g., "rocblas,hipblas" or "projects/rocblas"). Empty = run all tests.'
         type: string
         default: ""
+      exclude_test_owners:
+        description: "Comma-separated source repos whose component tests to drop (forwarded to test_artifacts.yml)."
+        type: string
+        default: ""
+      exclude_projects_to_test:
+        description: "Comma-separated component keys to drop directly (forwarded to test_artifacts.yml)."
+        type: string
+        default: ""
       repository:
         description: "Repository to checkout. Defaults to github.repository."
         type: string
@@ -150,6 +158,8 @@ jobs:
       test_labels: ${{ matrix.family_info.test_labels_for_family && toJSON(matrix.family_info.test_labels_for_family) || inputs.test_labels }}
       sanity_check_only_for_family: ${{ matrix.family_info.sanity_check_only_for_family }}
       changed_projects: ${{ inputs.changed_projects }}
+      exclude_test_owners: ${{ inputs.exclude_test_owners }}
+      exclude_projects_to_test: ${{ inputs.exclude_projects_to_test }}
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/multi_arch_ci_windows.yml
+++ b/.github/workflows/multi_arch_ci_windows.yml
@@ -34,6 +34,14 @@ on:
         description: 'Comma-separated list of projects to test (e.g., "rocblas,hipblas" or "projects/rocblas"). Empty = run all tests.'
         type: string
         default: ""
+      exclude_test_owners:
+        description: "Comma-separated source repos whose component tests to drop (forwarded to test_artifacts.yml)."
+        type: string
+        default: ""
+      exclude_projects_to_test:
+        description: "Comma-separated component keys to drop directly (forwarded to test_artifacts.yml)."
+        type: string
+        default: ""
       repository:
         description: "Repository to checkout. Defaults to github.repository."
         type: string
@@ -151,6 +159,8 @@ jobs:
       test_labels: ${{ inputs.test_labels }}
       sanity_check_only_for_family: ${{ matrix.family_info.sanity_check_only_for_family }}
       changed_projects: ${{ inputs.changed_projects }}
+      exclude_test_owners: ${{ inputs.exclude_test_owners }}
+      exclude_projects_to_test: ${{ inputs.exclude_projects_to_test }}
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -35,6 +35,14 @@ on:
         description: 'Comma-separated list of projects to test (e.g., "rocblas,hipblas" or "projects/rocblas"). Empty = run all tests.'
         type: string
         default: ""
+      exclude_test_owners:
+        description: 'Comma-separated source repos whose component tests to drop from the selected matrix, expanded via TEST_COMPONENTS_BY_OWNER in fetch_test_configurations.py (e.g. "rocm-systems"). Used by cross-repo consumers whose CI should not re-run another repo''s tests. Empty = exclude nothing.'
+        type: string
+        default: ""
+      exclude_projects_to_test:
+        description: "Comma-separated component keys to drop from the selected matrix directly (unioned with exclude_test_owners). Empty = exclude nothing."
+        type: string
+        default: ""
       release_type:
         description: 'Release type for the artifacts being tested.'
         type: choice
@@ -94,6 +102,14 @@ on:
         default: 'false'
       changed_projects:
         description: 'Comma-separated list of projects to test (e.g., "rocblas,hipblas" or "projects/rocblas"). Empty = run all tests.'
+        type: string
+        default: ""
+      exclude_test_owners:
+        description: 'Comma-separated source repos whose component tests to drop from the selected matrix, expanded via TEST_COMPONENTS_BY_OWNER in fetch_test_configurations.py (e.g. "rocm-systems"). Used by cross-repo consumers whose CI should not re-run another repo''s tests. Empty = exclude nothing.'
+        type: string
+        default: ""
+      exclude_projects_to_test:
+        description: "Comma-separated component keys to drop from the selected matrix directly (unioned with exclude_test_owners). Empty = exclude nothing."
         type: string
         default: ""
       release_type:
@@ -183,6 +199,8 @@ jobs:
           TEST_TYPE: ${{ inputs.test_type }}
           TEST_LABELS: ${{ inputs.test_labels }}
           RUN_EXTENDED_TESTS: ${{ inputs.run_extended_tests }}
+          EXCLUDE_TEST_OWNERS: ${{ inputs.exclude_test_owners }}
+          EXCLUDE_PROJECTS_TO_TEST: ${{ inputs.exclude_projects_to_test }}
           PROJECTS_TO_TEST: ${{ steps.test_deps.outputs.projects_to_test }}
           CI_CONFIG_PATH: ci-config
           BUILD_VARIANT: ${{ inputs.build_variant }}

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -195,6 +195,46 @@ _rocgdb_common = {
 #   "exclude_family": {"linux": ["gfx1030"]}                # skip a single target
 #   "include_family": {"linux": ["gfx908", "gfx90a", "gfx942"]}  # opt in to a set
 
+# Ownership of test-matrix components by the source repo that hosts them, so a
+# downstream consumer can drop another repo's component tests from its run.
+# ROCm/rocm-libraries' multi-arch CI excludes owner "rocm-systems" so its full
+# ("*") test set does not re-run rocm-systems component tests (already covered by
+# rocm-systems' own CI). Selected via the EXCLUDE_TEST_OWNERS env (see run()).
+# Only the repos that need excluding are listed; add an owner (e.g.
+# "rocm-libraries") when a consumer needs to skip it. Values are test_matrix keys.
+TEST_COMPONENTS_BY_OWNER: dict[str, frozenset] = {
+    "rocm-systems": frozenset(
+        {
+            # base / runtime (ROCR-Runtime, amdsmi, hipFile)
+            "amdsmi",
+            "hipfile",
+            "rocrtst",
+            # clr / hip runtime
+            "hip-tests",
+            # comm-libs
+            "rccl",
+            "rocshmem",
+            # media-libs
+            "rocdecode",
+            "rocjpeg",
+            # profiler-apps
+            "aqlprofile",
+            "rocprofiler-sdk",
+            "rocprofiler-compute",
+            "rocprofiler-systems",
+            # debug-tools. rocgdb (ROCm/ROCgdb) and libhipcxx (ROCm/libhipcxx)
+            # are standalone repos, grouped here as systems/runtime tooling; move
+            # them to their own owner if they ever need separate exclusion.
+            "rocr-debug-agent",
+            "rocgdb-cpu",
+            "rocgdb-gpu",
+            "rocgdb-corefile",
+            "libhipcxx_amdclang",
+            "libhipcxx_hiprtc",
+        }
+    ),
+}
+
 test_matrix = {
     # Sanity tests - always run first as a prerequisite for other component tests
     "sanity": {
@@ -946,6 +986,44 @@ def run():
     run_extended_tests = str2bool(os.getenv("RUN_EXTENDED_TESTS", "false"))
     build_variant = os.getenv("BUILD_VARIANT", "release")
 
+    # Opt-in test exclusion (default: none, so TheRock's own CI and every other
+    # consumer are unaffected):
+    #   EXCLUDE_TEST_OWNERS       comma-separated source repos whose component
+    #                             tests to drop, expanded via
+    #                             TEST_COMPONENTS_BY_OWNER (e.g. "rocm-systems").
+    #   EXCLUDE_PROJECTS_TO_TEST  comma-separated component keys to drop directly
+    #                             (path-/change-specific policies compute this).
+    # The two are unioned; "sanity" is never excluded.
+    exclude_projects_to_test: set = {
+        p.strip()
+        for p in os.getenv("EXCLUDE_PROJECTS_TO_TEST", "").split(",")
+        if p.strip()
+    }
+    exclude_test_owners = [
+        o.strip() for o in os.getenv("EXCLUDE_TEST_OWNERS", "").split(",") if o.strip()
+    ]
+    _unknown_owners = [
+        o for o in exclude_test_owners if o not in TEST_COMPONENTS_BY_OWNER
+    ]
+    if _unknown_owners:
+        logging.warning(
+            f"EXCLUDE_TEST_OWNERS has unknown owner(s) {_unknown_owners}; "
+            f"known owners: {sorted(TEST_COMPONENTS_BY_OWNER)}"
+        )
+    for _owner in exclude_test_owners:
+        exclude_projects_to_test |= set(TEST_COMPONENTS_BY_OWNER.get(_owner, ()))
+    if exclude_projects_to_test:
+        _unknown = sorted(exclude_projects_to_test - set(test_matrix))
+        if _unknown:
+            logging.warning(
+                "Excluded name(s) not in test_matrix (stale after a rename/"
+                f"removal?): {_unknown}"
+            )
+        logging.info(
+            f"Excluding {len(exclude_projects_to_test)} component(s) from test "
+            f"selection: {sorted(exclude_projects_to_test)}"
+        )
+
     # Get runner config for per-component runner selection
     # This enables better load distribution across runner pools
     test_runs_on_labels = None
@@ -1047,6 +1125,13 @@ def run():
         ]
         if key != "sanity" and expanded_test_labels and key not in expanded_test_labels:
             logging.info(f"Excluding job {job_name} since it's not in the test labels")
+            continue
+
+        # Skip components the caller excluded (EXCLUDE_TEST_OWNERS /
+        # EXCLUDE_PROJECTS_TO_TEST). Independent of project selection so it also
+        # trims the full "*" set. "sanity" is always kept as a prerequisite.
+        if key != "sanity" and key in exclude_projects_to_test:
+            logging.info(f"Excluding job {job_name}: excluded by caller")
             continue
 
         # If the test is enabled for a particular platform and a particular (or all) projects are selected.

--- a/build_tools/github_actions/tests/fetch_test_configurations_test.py
+++ b/build_tools/github_actions/tests/fetch_test_configurations_test.py
@@ -787,6 +787,77 @@ class FetchTestConfigurationsTest(unittest.TestCase):
         self.assertIn("rocdecode", names)
         self.assertIn("rocjpeg", names)
 
+    # -----------------------------------
+    # Test exclusion (EXCLUDE_TEST_OWNERS / EXCLUDE_PROJECTS_TO_TEST)
+    # -----------------------------------
+
+    def test_owner_map_values_are_matrix_keys(self):
+        """Every owned component must be a real test_matrix key."""
+        owned = set().union(
+            *fetch_test_configurations.TEST_COMPONENTS_BY_OWNER.values()
+        )
+        missing = owned - set(fetch_test_configurations.test_matrix)
+        self.assertEqual(missing, set(), f"stale owned names: {sorted(missing)}")
+
+    def test_rocm_systems_included_by_default_under_star(self):
+        """Without any exclusion, the full ('*') set still includes rocm-systems."""
+        os.environ["PROJECTS_TO_TEST"] = "*"
+        os.environ.pop("EXCLUDE_TEST_OWNERS", None)
+        os.environ.pop("EXCLUDE_PROJECTS_TO_TEST", None)
+        fetch_test_configurations.run()
+        names = {job["job_name"] for job in self._get_components()}
+        self.assertIn("rccl", names)
+        self.assertIn("amdsmi", names)
+
+    def test_exclude_owner_drops_rocm_systems_tests(self):
+        """EXCLUDE_TEST_OWNERS=rocm-systems removes every rocm-systems component
+        from the '*' set while keeping library jobs (e.g. rocblas)."""
+        os.environ["PROJECTS_TO_TEST"] = "*"
+        os.environ["EXCLUDE_TEST_OWNERS"] = "rocm-systems"
+        fetch_test_configurations.run()
+        names = {job["job_name"] for job in self._get_components()}
+        systems = fetch_test_configurations.TEST_COMPONENTS_BY_OWNER["rocm-systems"]
+        self.assertEqual(names & systems, set(), f"leaked: {sorted(names & systems)}")
+        self.assertIn("rocblas", names)
+
+    def test_exclude_explicit_projects_list(self):
+        """EXCLUDE_PROJECTS_TO_TEST drops the named components directly."""
+        os.environ["PROJECTS_TO_TEST"] = "*"
+        os.environ["EXCLUDE_PROJECTS_TO_TEST"] = "rccl, amdsmi"
+        fetch_test_configurations.run()
+        names = {job["job_name"] for job in self._get_components()}
+        self.assertNotIn("rccl", names)
+        self.assertNotIn("amdsmi", names)
+        self.assertIn("rocshmem", names)
+
+    def test_exclude_owner_and_explicit_are_unioned(self):
+        os.environ["PROJECTS_TO_TEST"] = "*"
+        os.environ["EXCLUDE_TEST_OWNERS"] = "rocm-systems"
+        os.environ["EXCLUDE_PROJECTS_TO_TEST"] = "rocblas"
+        fetch_test_configurations.run()
+        names = {job["job_name"] for job in self._get_components()}
+        systems = fetch_test_configurations.TEST_COMPONENTS_BY_OWNER["rocm-systems"]
+        self.assertEqual(names & systems, set())
+        self.assertNotIn("rocblas", names)
+        self.assertIn("hipblas", names)
+
+    def test_exclude_owner_is_noop_for_library_target(self):
+        """A targeted library run never selects rocm-systems, so the exclusion is
+        a no-op there."""
+        os.environ["PROJECTS_TO_TEST"] = "rocblas"
+        os.environ["EXCLUDE_TEST_OWNERS"] = "rocm-systems"
+        fetch_test_configurations.run()
+        names = {job["job_name"] for job in self._get_components()}
+        self.assertEqual(names, {"rocblas"})
+
+    def test_unknown_owner_is_ignored_with_warning(self):
+        os.environ["PROJECTS_TO_TEST"] = "*"
+        os.environ["EXCLUDE_TEST_OWNERS"] = "does-not-exist"
+        fetch_test_configurations.run()
+        names = {job["job_name"] for job in self._get_components()}
+        self.assertIn("rccl", names)
+        self.assertIn("rocblas", names)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

TheRock's multi-arch pipeline runs a single shared test matrix. When a
downstream consumer builds the full ROCm stack and requests the complete
test set, every component's tests are scheduled regardless of which repository
owns the component.
The immediate driver is ROCm/rocm-libraries: on a pull request its Multi-Arch CI
runs the full test set, which includes rocm-systems component tests (rccl,
amdsmi, hip-tests, rocprofiler-*, rocdecode/rocjpeg, rocshmem, debug tooling).
Those are already covered by rocm-systems' own CI, so re-running them on
rocm-libraries PRs ties up the scarce shared gfx94x/gfx950 test runners for no
added signal. This PR adds the mechanism; rocm-libraries opts in via a follow-up.

GitHub issue: https://github.com/ROCm/TheRock/issues/<NNNN>

## Technical Details

Adds two opt-in, default-off knobs to test selection. Because only
`fetch_test_configurations.py` knows the full test matrix, the exclusion lives
there and is threaded through the reusable workflows:

- `build_tools/github_actions/fetch_test_configurations.py`
  - `TEST_COMPONENTS_BY_OWNER`: a map of source repo → owned test-matrix
    components. Only repos that need excluding are listed (currently
    `rocm-systems`, 18 components across the base/runtime, clr/hip, comm-libs,
    media-libs, profiler-apps, and debug-tools stages).
  - `EXCLUDE_TEST_OWNERS` (comma-separated repos, resolved via the map) and
    `EXCLUDE_PROJECTS_TO_TEST` (comma-separated component keys, for future
    path-/change-specific policies). The two are unioned; matching components are
    skipped in the selection loop before the `*`/project gate, so the exclusion
    also trims the full set. `sanity` is never excluded. Unknown owners and stale
    component names log a warning and are otherwise ignored.
- `.github/workflows/test_artifacts.yml`,
  `.github/workflows/multi_arch_ci_linux.yml`,
  `.github/workflows/multi_arch_ci_windows.yml`
  - New `exclude_test_owners` and `exclude_projects_to_test` string inputs, both
    defaulting to `""`, forwarded down to the `fetch_test_configurations.py`
    environment.

Both inputs default to empty, so TheRock's own CI, the ASAN/nightly workflows,
and every other reusable-workflow caller behave identically — only a caller that
explicitly sets an input sees a difference. The change affects only the test
matrix (which pytest jobs are scheduled), not the build graph, so artifacts and
artifact-structure validation are unaffected. `rocgdb` (ROCm/ROCgdb) and
`libhipcxx` (ROCm/libhipcxx) are standalone repos grouped under `rocm-systems` as
systems-adjacent tooling; they can be split into their own owner later if needed.

## Test Plan

- Unit tests in `build_tools/github_actions/tests/fetch_test_configurations_test.py`
  (7 new): owner-map values are valid matrix keys; components included by default
  under `*`; `EXCLUDE_TEST_OWNERS=rocm-systems` drops exactly the owned set while
  keeping library jobs; explicit `EXCLUDE_PROJECTS_TO_TEST` list; owner + explicit
  list are unioned; no-op on a targeted library run; unknown owner ignored.
- End-to-end CLI simulation of the `test_artifacts.yml` chain
  (`determine_rocm_test_dependencies.py` → `fetch_test_configurations.py`) for
  linux/windows and presubmit/full scenarios.

## Test Result

- `pytest fetch_test_configurations_test.py` → 58 passed (51 pre-existing
  unchanged + 7 new).
- CLI, linux gfx94X with `PROJECTS_TO_TEST=*`: 50 components with no exclusion →
  32 with `EXCLUDE_TEST_OWNERS=rocm-systems` (exactly the 18 rocm-systems
  components removed, all library jobs retained, `sanity` kept). Windows gfx110X
  → 27. Targeted `rocblas,hipblas` with the flag set → `{rocblas, hipblas}`
  (no-op, as expected). Unknown owner → full set, with a warning.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.