### PR TITLE
ci(bump-automation): add manual pin-only replay dispatch for rocm-libraries/systems

### DIFF
--- a/.github/workflows/bump_submodules.yml
+++ b/.github/workflows/bump_submodules.yml
@@ -17,6 +17,21 @@ on:
           - rocm-libraries
           - rocgdb
           - mesa-fork
+      pin_before:
+        description: >-
+          Manual pin-bump replay only (leave empty otherwise): a TheRock SHA
+          where `submodule`'s pinned commit differs from pin_after. Required
+          together with pin_after to replay the push-event ref/pin update for
+          `submodule` (e.g. rocm-libraries) without opening a new "Bump
+          <submodule>" submodule PR.
+        required: false
+        default: ''
+      pin_after:
+        description: >-
+          Manual pin-bump replay only (leave empty otherwise): the TheRock
+          SHA to pin `submodule`'s CI to. Required together with pin_before.
+        required: false
+        default: ''
   schedule:
     - cron: "0 */12 * * *" # Runs every 12 hrs at 12AM and 12PM
   push:
@@ -73,11 +88,37 @@ jobs:
           pip install requests
 
       - name: Run scheduled bump automation
-        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        if: >-
+          github.event_name == 'schedule' ||
+          (github.event_name == 'workflow_dispatch' &&
+           github.event.inputs.pin_before == '' &&
+           github.event.inputs.pin_after == '')
         run: |
           python3 build_tools/github_actions/bump_automation.py \
             --event_type "schedule" \
             --submodule "${{ github.event.inputs.submodule || 'all' }}" \
+            --systems_token "${{ steps.systems-token.outputs.token }}" \
+            --libraries_token "${{ steps.librarian-token.outputs.token }}" \
+            --rocgdb_token "${{ steps.systems-token.outputs.token }}" \
+            --mesa_token "${{ steps.systems-token.outputs.token }}"
+
+      # Manually replays the push-event ref/pin update for one submodule
+      # (operator-supplied pin_before/pin_after) without opening a new "Bump
+      # <submodule>" PR in TheRock. Useful for re-running a bump_automation.py
+      # fix against an already-landed submodule bump instead of waiting for
+      # the next real one.
+      - name: Run manual pin-only bump automation
+        if: >-
+          github.event_name == 'workflow_dispatch' &&
+          github.event.inputs.pin_before != '' &&
+          github.event.inputs.pin_after != ''
+        run: |
+          python3 build_tools/github_actions/bump_automation.py \
+            --event_type "push" \
+            --before "${{ github.event.inputs.pin_before }}" \
+            --after "${{ github.event.inputs.pin_after }}" \
+            --only_submodule "${{ github.event.inputs.submodule }}" \
+            --skip_next_bump \
             --systems_token "${{ steps.systems-token.outputs.token }}" \
             --libraries_token "${{ steps.librarian-token.outputs.token }}" \
             --rocgdb_token "${{ steps.systems-token.outputs.token }}" \

--- a/build_tools/github_actions/bump_automation.py
+++ b/build_tools/github_actions/bump_automation.py
@@ -714,13 +714,27 @@ def handle_schedule(tokens: dict[str, str], submodule: str = "all") -> None:
         create_therock_bump("third-party/sysdeps/common/mesa-fork", tokens["mesa-fork"])
 
 
-def handle_push(before: str, after: str, tokens: dict[str, str]) -> None:
-    """Push event: update TheRock refs, close stale PRs, create next bump PR."""
-    changed = None
-    for path in SUBMODULE_CONFIG:
-        if submodule_changed(before, after, path):
-            changed = path
-            break
+def handle_push(
+    before: str,
+    after: str,
+    tokens: dict[str, str],
+    only_submodule: str | None = None,
+    skip_next_bump: bool = False,
+) -> None:
+    """Push event: update TheRock refs, close stale PRs, create next bump PR.
+
+    `only_submodule` and `skip_next_bump` exist for the manual
+    `workflow_dispatch` replay path in bump_submodules.yml (operator-supplied
+    `pin_before`/`pin_after`), which re-runs the ref/pin-update half of this
+    function for one specific submodule without also queuing a new "Bump
+    <submodule>" PR in TheRock. Real push events never set either.
+    """
+    changed = only_submodule
+    if changed is None:
+        for path in SUBMODULE_CONFIG:
+            if submodule_changed(before, after, path):
+                changed = path
+                break
     if not changed:
         print("[INFO] No monitored submodule changed")
         return
@@ -816,6 +830,10 @@ def handle_push(before: str, after: str, tokens: dict[str, str]) -> None:
 
     os.chdir(original_cwd)
 
+    if skip_next_bump:
+        print(f"[INFO] skip_next_bump set, not queuing a new Bump {changed} PR")
+        return
+
     # Immediately queue the next bump PR so the cycle continues without
     # waiting for the next scheduled run.
     print(f"[INFO] Creating next bump PR for {changed} after merge")
@@ -835,6 +853,27 @@ def main() -> None:
     )
     parser.add_argument("--before")
     parser.add_argument("--after")
+    parser.add_argument(
+        "--only_submodule",
+        default=None,
+        choices=["rocm-systems", "rocm-libraries", "rocgdb", "mesa-fork"],
+        help=(
+            "Manual workflow_dispatch replay only: treat this submodule as "
+            "the one that changed between --before/--after, instead of "
+            "auto-detecting it. Lets an operator re-run the ref/pin-update "
+            "half of a push event (e.g. to pick up a bump_automation.py fix) "
+            "without a real submodule-bump commit landing on main."
+        ),
+    )
+    parser.add_argument(
+        "--skip_next_bump",
+        action="store_true",
+        help=(
+            "Manual workflow_dispatch replay only: skip queuing a new "
+            "Bump <submodule> PR in TheRock after updating the downstream "
+            "ref/pins. Real push events always queue the next bump."
+        ),
+    )
     parser.add_argument("--systems_token", required=True)
     parser.add_argument("--libraries_token", required=True)
     parser.add_argument("--rocgdb_token", required=True)
@@ -854,7 +893,13 @@ def main() -> None:
     if args.event_type == "schedule":
         handle_schedule(tokens, args.submodule)
     elif args.event_type == "push":
-        handle_push(args.before, args.after, tokens)
+        handle_push(
+            args.before,
+            args.after,
+            tokens,
+            only_submodule=args.only_submodule,
+            skip_next_bump=args.skip_next_bump,
+        )
 
 
 if __name__ == "__main__":

--- a/build_tools/github_actions/tests/bump_automation_test.py
+++ b/build_tools/github_actions/tests/bump_automation_test.py
@@ -964,6 +964,97 @@ class HandlePushTest(unittest.TestCase):
         self.assertEqual(mock_close_ref.call_args.args[0], "ROCm/rocm-libraries")
         self.assertEqual(mock_close_ref.call_args.args[3], "assistant-librarian[bot]")
 
+    def test_only_submodule_bypasses_auto_detection(self):
+        """The manual workflow_dispatch replay path (bump_submodules.yml's
+        pin_before/pin_after inputs) passes only_submodule to target one
+        submodule directly; submodule_changed must never be consulted."""
+        with patch("bump_automation.submodule_changed") as mock_changed:
+            with patch(
+                "bump_automation.get_submodule_sha", return_value="oldsha1234567"
+            ):
+                with patch("bump_automation.close_stale_prs"):
+                    with patch(
+                        "bump_automation.get_baseline_run_id_from_merged_pr",
+                        return_value=None,
+                    ):
+                        with patch("bump_automation.run"):
+                            with patch("bump_automation.os.chdir"):
+                                with patch(
+                                    "bump_automation.os.path.exists",
+                                    return_value=True,
+                                ):
+                                    with patch("bump_automation.update_ci_env_file"):
+                                        with patch(
+                                            "bump_automation.find_therock_workflow_files",
+                                            return_value=[],
+                                        ):
+                                            with patch(
+                                                "bump_automation.gh_api",
+                                                return_value={"number": 1},
+                                            ):
+                                                with patch(
+                                                    "bump_automation.close_stale_therock_ref_prs"
+                                                ):
+                                                    with patch(
+                                                        "bump_automation.create_therock_bump"
+                                                    ) as mock_bump:
+                                                        handle_push(
+                                                            "before",
+                                                            "after",
+                                                            {
+                                                                "systems": "systems-token",
+                                                                "libraries": "libraries-token",
+                                                            },
+                                                            only_submodule="rocm-libraries",
+                                                        )
+
+        mock_changed.assert_not_called()
+        mock_bump.assert_called_once_with("rocm-libraries", "libraries-token")
+
+    def test_skip_next_bump_does_not_queue_next_bump(self):
+        """The manual replay path sets skip_next_bump so it never opens a new
+        Bump <submodule> PR in TheRock after updating the downstream pin,
+        unlike a real push event which always queues the next bump."""
+        with patch("bump_automation.get_submodule_sha", return_value="oldsha1234567"):
+            with patch("bump_automation.close_stale_prs"):
+                with patch(
+                    "bump_automation.get_baseline_run_id_from_merged_pr",
+                    return_value=None,
+                ):
+                    with patch("bump_automation.run"):
+                        with patch("bump_automation.os.chdir"):
+                            with patch(
+                                "bump_automation.os.path.exists",
+                                return_value=True,
+                            ):
+                                with patch("bump_automation.update_ci_env_file"):
+                                    with patch(
+                                        "bump_automation.find_therock_workflow_files",
+                                        return_value=[],
+                                    ):
+                                        with patch(
+                                            "bump_automation.gh_api",
+                                            return_value={"number": 1},
+                                        ):
+                                            with patch(
+                                                "bump_automation.close_stale_therock_ref_prs"
+                                            ):
+                                                with patch(
+                                                    "bump_automation.create_therock_bump"
+                                                ) as mock_bump:
+                                                    handle_push(
+                                                        "before",
+                                                        "after",
+                                                        {
+                                                            "systems": "systems-token",
+                                                            "libraries": "libraries-token",
+                                                        },
+                                                        only_submodule="rocm-libraries",
+                                                        skip_next_bump=True,
+                                                    )
+
+        mock_bump.assert_not_called()
+
 
 class CreateTheRockBumpTest(unittest.TestCase):
     def test_skips_when_pr_already_open(self):


### PR DESCRIPTION
## Summary

Adds a manual `workflow_dispatch` path to `bump_submodules.yml` that replays the push-event ref/pin-update logic for one submodule (e.g. `rocm-libraries`) without opening a new "Bump `<submodule>`" PR in TheRock. This is the capability I used by hand (via a scratch branch) to get #8069's fix applied against the already-landed rocm-libraries bump instead of waiting for the next real one — landing it properly so it doesn't need to be reinvented next time.

## Risk Assessment

Risk 2. Purely additive: the two new `workflow_dispatch` inputs (`pin_before`, `pin_after`) default to `''`, and the new step only runs when both are non-empty. Real `schedule` and `push` events never set them, so their code paths are byte-for-byte unchanged. Already validated live (see Testing Summary).

## Related

- Related PRs: #8069 (the fix this replay path was built to apply without waiting for a new bump), #8068 (original bug report)
- Related: ROCm/rocm-libraries#11952 (the PR this workflow path produced during validation)

## Device / Architecture Coverage

No device code. CI-only change; passing PR CI is sufficient.

## Testing Summary

- Unit tests cover `only_submodule` bypassing the auto-detection loop and `skip_next_bump` suppressing the next-bump queue.
- Live validation: dispatched this exact workflow (from this branch, before this PR existed) with `submodule=rocm-libraries`, `pin_before=<TheRock commit before the last rocm-libraries bump>`, `pin_after=<current main tip>`. It opened ROCm/rocm-libraries#11952 with the correct 7-file pin rewrite and baseline run ID, closed 19 stale bot PRs, and did not open a new submodule-bump PR in TheRock.

## Testing Checklist

- [x] Bump automation unit tests - `python -m pytest build_tools/github_actions/tests/bump_automation_test.py -q` - Status: Passed (64 passed)
- [x] Targeted pre-commit (black, actionlint) - `pre-commit run --files build_tools/github_actions/bump_automation.py build_tools/github_actions/tests/bump_automation_test.py .github/workflows/bump_submodules.yml` - Status: Passed
- [x] Live workflow_dispatch run on this branch - Status: Passed - Link: https://github.com/ROCm/TheRock/actions/runs/34532206232
- [ ] PR CI - GitHub PR checks - Status: Pending

## Flags / Guardrails

None needed: the new step is gated on the two new inputs being explicitly set, which real schedule/push events never do.

## Adjacent Tests Considered

Existing `HandlePushTest` cases (submodule-only bailout, ci-env vs ref bot-author routing) are unchanged and still pass, confirming the new parameters don't disturb auto-detection when unset.

## Technical Changes

- `bump_submodules.yml`: add `pin_before`/`pin_after` `workflow_dispatch` inputs and a new "Run manual pin-only bump automation" step; guard the existing scheduled-bump step to skip when they're set.
- `bump_automation.py`: `handle_push()` gains `only_submodule` (bypass auto-detection) and `skip_next_bump` (skip queuing the next submodule-bump PR) parameters, wired to new `--only_submodule`/`--skip_next_bump` CLI flags.
- Add unit tests for both new parameters.
