### PR TITLE
feat(ci): extend setup environment timeout to 60m for ASAN builds

### DIFF
--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -133,10 +133,10 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: Run setup test environment workflow
-        timeout-minutes: 15
+        timeout-minutes: ${{ inputs.build_variant == 'asan' && 60 || 15 }}
         env:
           RETRY_THIS_STEP: "true"
-          STEP_TIMEOUT_MINUTES: "15" # should match timeout-minutes specified above at this step
+          STEP_TIMEOUT_MINUTES: ${{ inputs.build_variant == 'asan' && '60' || '15' }}
         uses: './.github/actions/setup_test_environment'
         with:
           ARTIFACT_RUN_ID: ${{ env.ARTIFACT_RUN_ID }}


### PR DESCRIPTION
Due to larger ASAN build sizes, (36GB from last calculation), we are extending the timeout to a larger range (in case of network issues)

test complete so adding ci:skip https://github.com/ROCm/TheRock/actions/runs/34536577977/job/103069678719