### PR TITLE
fix(ci): set LD_LIBRARY_PATH for the driver / GPU sanity check step

### DIFF
--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -162,8 +162,6 @@ jobs:
         if: ${{ !fromJSON(inputs.component).linux_cpu_runner }}
         timeout-minutes: 3
         env:
-          # Must append to (not replace) the existing value - python needs its
-          # own entry here (e.g. libpython3.12.so.1.0) or it won't start.
           LD_LIBRARY_PATH: >-
             ${{ env.THEROCK_BIN_DIR }}/../lib:${{ env.THEROCK_BIN_DIR }}/../lib/rocm_sysdeps/lib:${{ env.LD_LIBRARY_PATH }}
         run: |

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -158,12 +158,20 @@ jobs:
         run: |
           python ./build_tools/health_status.py
 
-      - name: Driver / GPU sanity check
-        if: ${{ !fromJSON(inputs.component).linux_cpu_runner }}
-        timeout-minutes: 3
+        # TODO(#3755): Clean this up after final sanitizer environment variable flags are determined
+      - name: Enable sanitizer-specific test flags
+        if: ${{ contains(inputs.artifact_group, 'asan') }}
         env:
           LD_LIBRARY_PATH: >-
             ${{ env.THEROCK_BIN_DIR }}/../lib:${{ env.THEROCK_BIN_DIR }}/../lib/rocm_sysdeps/lib:${{ env.LD_LIBRARY_PATH }}
+        run: |
+          echo "ASAN_OPTIONS=detect_odr_violation=0:quarantine_size_mb=600" >> $GITHUB_ENV
+          echo "HSA_XNACK=1" >> $GITHUB_ENV
+          echo "ASAN_SYMBOLIZER_PATH=${{ env.OUTPUT_ARTIFACTS_DIR }}/llvm/bin/llvm-symbolizer" >> $GITHUB_ENV
+
+      - name: Driver / GPU sanity check
+        if: ${{ !fromJSON(inputs.component).linux_cpu_runner }}
+        timeout-minutes: 3
         run: |
           python ./build_tools/print_driver_gpu_info.py
 
@@ -172,14 +180,6 @@ jobs:
         run: |
           python ./build_tools/install_additional_requirements.py \
             --requirements-files ${{ join(fromJSON(inputs.component).additional_requirements_files, ',') }}
-
-        # TODO(#3755): Clean this up after final sanitizer environment variable flags are determined
-      - name: Enable sanitizer-specific test flags
-        if: ${{ contains(inputs.artifact_group, 'asan') }}
-        run: |
-          echo "ASAN_OPTIONS=detect_odr_violation=0:quarantine_size_mb=600" >> $GITHUB_ENV
-          echo "HSA_XNACK=1" >> $GITHUB_ENV
-          echo "ASAN_SYMBOLIZER_PATH=${{ env.OUTPUT_ARTIFACTS_DIR }}/llvm/bin/llvm-symbolizer" >> $GITHUB_ENV
 
       # Set thread limits from KUBE_CPU_REQUEST (Kubernetes-injected) to avoid oversubscription.
       # Must be done at runtime since container env vars aren't in GitHub's env context.

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -162,15 +162,8 @@ jobs:
         if: ${{ !fromJSON(inputs.component).linux_cpu_runner }}
         timeout-minutes: 3
         env:
-          # install_rocm_from_artifacts.py only extracts artifacts, it never
-          # sets LD_LIBRARY_PATH. amd-smi's drm_amdgpu backend needs
-          # librocm_sysdeps_drm_amdgpu.so.1 (part of the sysdeps_lib artifact,
-          # included in the sanity check's --base-only fetch, present on disk)
-          # but the sanity check bypasses the test harness's own
-          # LD_LIBRARY_PATH setup (test_hiptests.py::setup_env()), so the
-          # linker can't find it and amd-smi/rocminfo report incomplete data.
-          # Append to (not replace) the existing value - python itself needs
-          # its own entry here (e.g. libpython3.12.so.1.0) or it won't start.
+          # Must append to (not replace) the existing value - python needs its
+          # own entry here (e.g. libpython3.12.so.1.0) or it won't start.
           LD_LIBRARY_PATH: >-
             ${{ env.THEROCK_BIN_DIR }}/../lib:${{ env.THEROCK_BIN_DIR }}/../lib/rocm_sysdeps/lib:${{ env.LD_LIBRARY_PATH }}
         run: |

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -162,10 +162,12 @@ jobs:
         # Must run before sanity check so ASAN_RUNTIME_PATH is available for LD_PRELOAD
       - name: Enable sanitizer-specific test flags
         if: ${{ contains(inputs.artifact_group, 'asan') }}
+        env:
+          LD_LIBRARY_PATH: >-
+            ${{ env.THEROCK_BIN_DIR }}/../lib:${{ env.THEROCK_BIN_DIR }}/../lib/rocm_sysdeps/lib:${{ env.LD_LIBRARY_PATH }}
         run: |
           python ./build_tools/github_actions/configure_asan_env.py \
             --artifacts-dir "${{ env.OUTPUT_ARTIFACTS_DIR }}"
-          echo "LD_LIBRARY_PATH=${{ env.THEROCK_BIN_DIR }}/../lib:${{ env.THEROCK_BIN_DIR }}/../lib/rocm_sysdeps/lib:${{ env.LD_LIBRARY_PATH }}" >> $GITHUB_ENV
 
       - name: Driver / GPU sanity check
         if: ${{ !fromJSON(inputs.component).linux_cpu_runner }}

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -161,13 +161,11 @@ jobs:
         # TODO(#3755): Clean this up after final sanitizer environment variable flags are determined
       - name: Enable sanitizer-specific test flags
         if: ${{ contains(inputs.artifact_group, 'asan') }}
-        env:
-          LD_LIBRARY_PATH: >-
-            ${{ env.THEROCK_BIN_DIR }}/../lib:${{ env.THEROCK_BIN_DIR }}/../lib/rocm_sysdeps/lib:${{ env.LD_LIBRARY_PATH }}
         run: |
           echo "ASAN_OPTIONS=detect_odr_violation=0:quarantine_size_mb=600" >> $GITHUB_ENV
           echo "HSA_XNACK=1" >> $GITHUB_ENV
           echo "ASAN_SYMBOLIZER_PATH=${{ env.OUTPUT_ARTIFACTS_DIR }}/llvm/bin/llvm-symbolizer" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=${{ env.THEROCK_BIN_DIR }}/../lib:${{ env.THEROCK_BIN_DIR }}/../lib/rocm_sysdeps/lib:${{ env.LD_LIBRARY_PATH }}" >> $GITHUB_ENV
 
       - name: Driver / GPU sanity check
         if: ${{ !fromJSON(inputs.component).linux_cpu_runner }}

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -162,9 +162,6 @@ jobs:
         # Must run before sanity check so ASAN_RUNTIME_PATH is available for LD_PRELOAD
       - name: Enable sanitizer-specific test flags
         if: ${{ contains(inputs.artifact_group, 'asan') }}
-        env:
-          LD_LIBRARY_PATH: >-
-            ${{ env.THEROCK_BIN_DIR }}/../lib:${{ env.THEROCK_BIN_DIR }}/../lib/rocm_sysdeps/lib:${{ env.LD_LIBRARY_PATH }}
         run: |
           python ./build_tools/github_actions/configure_asan_env.py \
             --artifacts-dir "${{ env.OUTPUT_ARTIFACTS_DIR }}"

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -161,6 +161,18 @@ jobs:
       - name: Driver / GPU sanity check
         if: ${{ !fromJSON(inputs.component).linux_cpu_runner }}
         timeout-minutes: 3
+        env:
+          # install_rocm_from_artifacts.py only extracts artifacts, it never
+          # sets LD_LIBRARY_PATH. amd-smi's drm_amdgpu backend needs
+          # librocm_sysdeps_drm_amdgpu.so.1 (part of the sysdeps_lib artifact,
+          # included in the sanity check's --base-only fetch, present on disk)
+          # but the sanity check bypasses the test harness's own
+          # LD_LIBRARY_PATH setup (test_hiptests.py::setup_env()), so the
+          # linker can't find it and amd-smi/rocminfo report incomplete data.
+          # Append to (not replace) the existing value - python itself needs
+          # its own entry here (e.g. libpython3.12.so.1.0) or it won't start.
+          LD_LIBRARY_PATH: >-
+            ${{ env.THEROCK_BIN_DIR }}/../lib:${{ env.THEROCK_BIN_DIR }}/../lib/rocm_sysdeps/lib:${{ env.LD_LIBRARY_PATH }}
         run: |
           python ./build_tools/print_driver_gpu_info.py
 

--- a/build_tools/github_actions/configure_asan_env.py
+++ b/build_tools/github_actions/configure_asan_env.py
@@ -103,6 +103,15 @@ def _resolve_symbolizer(artifacts_dir: Path) -> tuple[Optional[Path], Optional[s
     return symbolizer.resolve(), None
 
 
+def _resolve_library_path(artifacts_dir: Path) -> str:
+    lib_dir = (artifacts_dir / "lib").resolve()
+    parts = [str(lib_dir), str(lib_dir / "rocm_sysdeps" / "lib")]
+    existing = os.environ.get("LD_LIBRARY_PATH")
+    if existing:
+        parts.append(existing)
+    return ":".join(parts)
+
+
 def resolve_asan_env(artifacts_dir: Path) -> tuple[dict[str, str], list[str]]:
     """Returns (environment variables to export, warnings to surface)."""
     env = dict(STATIC_ASAN_ENV)
@@ -119,6 +128,8 @@ def resolve_asan_env(artifacts_dir: Path) -> tuple[dict[str, str], list[str]]:
         env["ASAN_SYMBOLIZER_PATH"] = str(symbolizer)
     if warning:
         warnings.append(warning)
+
+    env["LD_LIBRARY_PATH"] = _resolve_library_path(artifacts_dir)
 
     return env, warnings
 
@@ -141,6 +152,7 @@ def main(argv=None) -> int:
         print(f"Resolved ASAN runtime: {env['ASAN_RUNTIME_PATH']}")
     if "ASAN_SYMBOLIZER_PATH" in env:
         print(f"Resolved ASAN symbolizer: {env['ASAN_SYMBOLIZER_PATH']}")
+    print(f"Resolved LD_LIBRARY_PATH: {env['LD_LIBRARY_PATH']}")
 
     gha_set_env(env)
     return 0


### PR DESCRIPTION
ISSUE ID: [6626](https://github.com/ROCm/TheRock/issues/6626)

## Summary

`amd-smi static` in the "Driver / GPU sanity check" step reports `N/A` for ASIC identity because it cannot load `librocm_sysdeps_drm_amdgpu.so.1`.

The library is present on disk - it ships in the `sysdeps_lib` artifact, which this job's `--base-only` fetch already pulls - but nothing puts it on the loader path. `install_rocm_from_artifacts.py` only extracts the archives, and `configure_asan_env.py` exports the ASAN runtime and symbolizer but not `LD_LIBRARY_PATH`. `amd-smi` degrades gracefully rather than failing, so the step passes while silently losing the fields that library resolves.

A step-scoped `env:` on "Enable sanitizer-specific test flags" was tried first, but that only applies to the step it's attached to - it never reaches "Driver / GPU sanity check". Resolving and exporting `LD_LIBRARY_PATH` from `configure_asan_env.py` via `GITHUB_ENV`, alongside the runtime and symbolizer paths it already exports, makes it visible to every later step in the job.

## Change

`build_tools/github_actions/configure_asan_env.py`:

```python
def _resolve_library_path(artifacts_dir: Path) -> str:
    lib_dir = (artifacts_dir / "lib").resolve()
    parts = [str(lib_dir), str(lib_dir / "rocm_sysdeps" / "lib")]
    existing = os.environ.get("LD_LIBRARY_PATH")
    if existing:
        parts.append(existing)
    return ":".join(parts)
```

Called from `resolve_asan_env()`, so the result is exported the same way as `ASAN_RUNTIME_PATH` and `ASAN_SYMBOLIZER_PATH`. No workflow YAML changes - the step already calls this script.

## Scope

The step is gated on `contains(inputs.artifact_group, 'asan')`, so this covers ASAN jobs only. `test_hiptests.py::setup_env()` adds `build/lib` but not `build/lib/rocm_sysdeps/lib` on either the ASAN or non-ASAN path, so non-ASAN Linux GPU jobs are likely affected too. Left for a follow-up rather than widened speculatively.

## Test plan

- [x] Manually dispatched `test_artifacts.yml` against real nightly ASAN build artifacts, confirmed `amd-smi` reports full ASIC identity instead of `N/A` (evidence captured on an earlier revision of this PR, before the fix moved into `configure_asan_env.py`; behavior is equivalent)
- [ ] CI on this PR
