### PR TITLE
feat(build): emit Comgr PDB for Windows driver builds

### DIFF
--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -89,12 +89,19 @@ endif()
 
 # Options added to every subproject when THEROCK_FLAG_WINDOWS_DRIVER_BUILD is set.
 # The compile flag is spelled per compiler; the link flag goes through CMake's
-# LINKER: prefix, which handles the driver difference.
+# LINKER: prefix, which handles the driver difference. Multiple link flags are
+# comma separated, per the LINKER: syntax.
 # /machine and /DYNAMICBASE are omitted: CMake emits the former and the linker
 # defaults to the latter.
-set(THEROCK_WINDOWS_DRIVER_BUILD_MSVC_COMPILE_FLAGS "/guard:cf")
-set(THEROCK_WINDOWS_DRIVER_BUILD_CLANG_COMPILE_FLAGS "-mguard=cf")
-set(THEROCK_WINDOWS_DRIVER_BUILD_LINK_FLAGS "/guard:cf")
+# /Zi (-gcodeview) plus /DEBUG make the linker emit a separate .pdb beside each
+# DLL. The driver package does not ship the PDB: it is submitted to the MSFT
+# Hardware Dev Center so WHQL crash telemetry resolves to function names rather
+# than a single amd_comgr_3.dll!Unknown bucket. Neither flag disables
+# optimization, and the shipped DLL is unchanged apart from the debug directory
+# entry pointing at the PDB.
+set(THEROCK_WINDOWS_DRIVER_BUILD_MSVC_COMPILE_FLAGS "/guard:cf /Zi")
+set(THEROCK_WINDOWS_DRIVER_BUILD_CLANG_COMPILE_FLAGS "-mguard=cf -gcodeview -g")
+set(THEROCK_WINDOWS_DRIVER_BUILD_LINK_FLAGS "/guard:cf,/DEBUG")
 
 # Generates a command prefix that can be prepended to any custom command line
 # to perform log/console redirection and pretty printing.

--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -93,13 +93,18 @@ endif()
 # comma separated, per the LINKER: syntax.
 # /machine and /DYNAMICBASE are omitted: CMake emits the former and the linker
 # defaults to the latter.
-# /Zi (-gcodeview) plus /DEBUG make the linker emit a separate .pdb beside each
+# /Z7 (-gcodeview) plus /DEBUG make the linker emit a separate .pdb beside each
 # DLL. The driver package does not ship the PDB: it is submitted to the MSFT
 # Hardware Dev Center so WHQL crash telemetry resolves to function names rather
 # than a single amd_comgr_3.dll!Unknown bucket. Neither flag disables
 # optimization, and the shipped DLL is unchanged apart from the debug directory
 # entry pointing at the PDB.
-set(THEROCK_WINDOWS_DRIVER_BUILD_MSVC_COMPILE_FLAGS "/guard:cf /Zi")
+# /Z7 rather than /Zi: /Zi routes debug info through a per-target compiler PDB
+# named by /Fd, which collides with LLVM's shared precompiled header (error
+# C2859, "is not the pdb file that was used when this precompiled header was
+# created"). /Z7 keeps the debug info in the object files, so there is no shared
+# PDB to conflict over, and the linker still emits a single .pdb per binary.
+set(THEROCK_WINDOWS_DRIVER_BUILD_MSVC_COMPILE_FLAGS "/guard:cf /Z7")
 set(THEROCK_WINDOWS_DRIVER_BUILD_CLANG_COMPILE_FLAGS "-mguard=cf -gcodeview -g")
 set(THEROCK_WINDOWS_DRIVER_BUILD_LINK_FLAGS "/guard:cf,/DEBUG")
 

--- a/compiler/artifact-amd-llvm.toml
+++ b/compiler/artifact-amd-llvm.toml
@@ -47,8 +47,17 @@ exclude = [
 # in the build tree because they need to be built separately in order to
 # install to different prefixes).
 [components.lib."compiler/amd-comgr/stage"]
+# 'run' is a catch-all for this stage dir, so the Windows driver build's PDB has
+# to be handed off explicitly to 'dbg' below; otherwise it lands in the shipped
+# runtime component.
 [components.run."compiler/amd-comgr/stage"]
+exclude = [
+  "**/*.pdb",
+]
 [components.dbg."compiler/amd-comgr/stage"]
+include = [
+  "**/*.pdb",
+]
 [components.dev."compiler/amd-comgr/stage"]
 [components.doc."compiler/amd-comgr/stage"]
 

--- a/compiler/post_hook_amd-comgr.cmake
+++ b/compiler/post_hook_amd-comgr.cmake
@@ -1,0 +1,22 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# Install the linker generated PDB beside the comgr DLL.
+#
+# install(TARGETS) does not install PDB files, so without this the PDB is
+# produced in the build tree and then discarded at stage time. Scoped to the
+# Windows driver build: that is the configuration whose DLL is submitted to the
+# MSFT Hardware Dev Center for WHQL signing, where the symbols are stripped and
+# indexed for crash telemetry. The PDB is not shipped to end users; it is routed
+# into the dbg artifact component (see artifact-amd-llvm.toml).
+if(MSVC AND THEROCK_FLAG_WINDOWS_DRIVER_BUILD AND TARGET amd_comgr)
+  get_target_property(_comgr_target_type amd_comgr TYPE)
+  if(_comgr_target_type STREQUAL "SHARED_LIBRARY")
+    install(
+      FILES "$<TARGET_PDB_FILE:amd_comgr>"
+      DESTINATION "${CMAKE_INSTALL_BINDIR}"
+      COMPONENT amd-comgr
+      OPTIONAL
+    )
+  endif()
+endif()


### PR DESCRIPTION
## Motivation

Windows driver packages ship Comgr without symbols, so Microsoft's WHQL crash telemetry cannot attribute failures to a function — every crash collapses into a single `amd_comgr_3.dll!Unknown` bucket. With symbols indexed at Microsoft, those
become per-function buckets that can be triaged as individual bugs.

The PDB is not shipped to end users. It goes only into the WHQL signing package submitted to the Microsoft Hardware Dev Center.

Related: #6034

## Technical Details

Scoped entirely to `THEROCK_FLAG_WINDOWS_DRIVER_BUILD`; no effect on any other configuration.

- `cmake/therock_subproject.cmake` — add `/Z7` and `/DEBUG` to the driver-build flag set, next to the existing `/guard:cf`.
- `compiler/post_hook_amd-comgr.cmake` (new) — install the linker-generated PDB. `install(TARGETS)` does not install PDBs, so otherwise it is produced in the build tree and discarded at stage time.
- `compiler/artifact-amd-llvm.toml` — route the PDB to the `dbg` component. The `exclude` on `run` is required, since a bare `[components.run."<stage>"]` entry is a catch-all and would otherwise ship the PDB in the runtime artifact.


## Test Plan

Built on Windows (MSVC 19.51 / VS 18):

cmake -B build --preset windows-release -DTHEROCK_AMDGPU_FAMILIES=gfx110X-dgpu
  -DTHEROCK_ENABLE_ALL=OFF -DTHEROCK_ENABLE_COMPILER=ON
  -DTHEROCK_FLAG_WINDOWS_DRIVER_BUILD=ON
cmake --build build --target artifact-group-compiler

## Test Result

Build succeeded. The PDB is the only `.pdb` under `build/artifacts`, and lands in `dbg` rather than `run`:

amd-llvm_lib_generic/compiler/amd-comgr/stage/bin/amd_comgr_drivers.dll
amd-llvm_dbg_generic/compiler/amd-comgr/stage/bin/amd_comgr_drivers.pdb

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.