### PR TITLE
fix(ci): skip the libraries baseline gate instead of failing it

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux.yml
+++ b/.github/workflows/multi_arch_build_portable_linux.yml
@@ -427,7 +427,10 @@ jobs:
   # ==========================================================================
   libraries_baseline_ready:
     name: "Libraries Baseline Ready"
-    if: always()
+    # No `if:` on purpose: GitHub skips a job whose `needs:` did not all
+    # succeed, and bump_automation.py rejects any conclusion but "success", so
+    # skipping rejects the baseline without failing the calling job and the
+    # test matrix behind it.
     needs:
       [
         runtime-tests,
@@ -442,12 +445,8 @@ jobs:
       ]
     runs-on: ubuntu-24.04
     steps:
-      - name: Require reused stages to have succeeded
-        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
-        run: |
-          echo "One or more stages rocm-libraries reuses via baseline_run_id did not succeed:"
-          echo '${{ toJSON(needs) }}'
-          exit 1
+      - name: Report reused stage results
+        run: echo '${{ toJSON(needs) }}'
 
   notify_quartz_completed:
     if: ${{ always() && vars.NOTIFY_QUARTZ_ENABLED == 'true' }}

--- a/.github/workflows/multi_arch_build_windows.yml
+++ b/.github/workflows/multi_arch_build_windows.yml
@@ -242,16 +242,12 @@ jobs:
   # ==========================================================================
   libraries_baseline_ready:
     name: "Libraries Baseline Ready"
-    if: always()
+    # Skipped rather than failed; see the Linux copy for why.
     needs: [runtime-tests, debug-tools, media-libs]
     runs-on: ubuntu-24.04
     steps:
-      - name: Require reused stages to have succeeded
-        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
-        run: |
-          echo "One or more stages rocm-libraries reuses via baseline_run_id did not succeed:"
-          echo '${{ toJSON(needs) }}'
-          exit 1
+      - name: Report reused stage results
+        run: echo '${{ toJSON(needs) }}'
 
   notify_quartz_completed:
     if: ${{ always() && vars.NOTIFY_QUARTZ_ENABLED == 'true' }}

--- a/build_tools/github_actions/tests/bump_automation_test.py
+++ b/build_tools/github_actions/tests/bump_automation_test.py
@@ -165,6 +165,16 @@ class BaselineGateJobsSucceededTest(unittest.TestCase):
                 _baseline_gate_jobs_succeeded("ROCm/TheRock", "token", 111)
             )
 
+    def test_false_when_the_gate_job_was_skipped(self):
+        # Skipping is how the gate reports a reused stage that did not succeed,
+        # so this is the primary rejection path rather than an edge case.
+        with patch(
+            "bump_automation.gh_api", return_value=_jobs_page([_gate_job("skipped")])
+        ):
+            self.assertFalse(
+                _baseline_gate_jobs_succeeded("ROCm/TheRock", "token", 111)
+            )
+
 
 class GetBaselineRunIdFromMergedPrTest(unittest.TestCase):
     MERGE_SHA = "df3d451a3c054e14705ddf94e58498e1208df8d5"


### PR DESCRIPTION
## Motivation

GitHub issue: https://github.com/ROCm/TheRock/issues/7202

The `libraries_baseline_ready` job added in #8069 exists for one purpose: to let `bump_automation.py` decide whether a completed run's reused stages are good enough to hand out as a `baseline_run_id`. #8069 assessed it as inert:

> The new `libraries_baseline_ready` job is additive: nothing else in Multi-Arch CI depends on it, so a bug in it can make its own status wrong but cannot block or skip any other job in the run.

That does not hold in practice. The job lives inside the reusable workflows `multi_arch_build_portable_linux.yml` / `multi_arch_build_windows.yml`, so when it fails, the **calling** `build_multi_arch_stages` job is marked failed. `test_artifacts_per_family` is guarded by `if: ${{ !failure() && !cancelled() }}` and therefore never starts — the test matrix does not even expand.

This bites any caller that narrows the build graph with `build_stages`. The stages it deliberately excluded report `skipped`, the gate treats `skipped` as not-success and fails, and the run goes red having run no tests. Observed on the rocm-systems host-asan presubmit in https://github.com/ROCm/rocm-systems/actions/runs/34608811109, where both requested stages built cleanly:

| Job | Result |
| --- | --- |
| `compiler-runtime / Stage - Compiler Runtime` | success |
| `runtime-tests / Stage - Runtime Tests` | success |
| the other 8 library stages | skipped (excluded via `build_stages`) |
| `Libraries Baseline Ready` | **failure** |
| `Test ${{ matrix.family_info.amdgpu_family }}` | skipped — matrix never expanded |

Worth noting the gate fired in a context nothing will ever read: `get_baseline_run_id_from_merged_pr()` only scans TheRock's own `Multi-Arch CI` runs after a merge, never an external repo's run.

## Technical Details

Dropped `if: always()` and the conditional failing step. GitHub's default `needs:` semantics already express exactly the intent — a job whose `needs:` did not all succeed is skipped — so the gate now runs only when every reused stage succeeded, and is skipped otherwise.

The rejection signal is unchanged from the bump automation's point of view. `_baseline_gate_jobs_succeeded()` keys on `conclusion == "success"`, and skipped jobs are still returned by the Actions jobs API with `conclusion: "skipped"`, so a skipped gate rejects the baseline exactly as a failed one did. All three cases still land correctly:

- every reused stage green → gate succeeds → baseline usable
- any reused stage failed, cancelled or skipped → gate skipped → baseline rejected
- run no longer goes red, so downstream tests are unaffected

The remaining step now just echoes `toJSON(needs)` for diagnosis when the gate does run.

## Test Plan

- `python -m pytest build_tools/github_actions/tests/bump_automation_test.py -q`
- `pre-commit run --files .github/workflows/multi_arch_build_portable_linux.yml .github/workflows/multi_arch_build_windows.yml build_tools/github_actions/tests/bump_automation_test.py`

## Test Result

63 passed. Targeted pre-commit passed, including `actionlint` on both workflow files.

## Risk Assessment

Risk 2. CI wiring on the libraries/systems bump path. The change strictly reduces what the gate can break: it can no longer fail, so it can no longer propagate failure to a calling job. The baseline-rejection behavior the gate was added for is preserved, and is now covered by a test asserting a `skipped` gate job is rejected.

## Related

- Introduced the gate: #8069 (work tracking #8068)
- Unblocks: #7202 host-asan presubmit, which relies on `build_stages` narrowing

## Device / Architecture Coverage

No device code. CI workflow and unit-test change only.

## Testing Summary

Added `test_false_when_the_gate_job_was_skipped`, covering the path that is now the primary rejection route: a gate job skipped because a reused stage did not succeed must not be handed out as a baseline. Existing coverage for succeeded / failed / missing / multi-platform gate jobs is unchanged and still passes.

## Testing Checklist

- [x] Bump automation unit tests - `python -m pytest build_tools/github_actions/tests/bump_automation_test.py -q` - Status: Passed (63)
- [x] Targeted pre-commit incl. actionlint - Status: Passed
- [ ] PR CI - GitHub PR checks - Status: Pending

## Flags / Guardrails

None.

## Adjacent Tests Considered

`GetBaselineRunIdFromMergedPrTest` exercises the lookup end to end against mocked job lists and needed no change, since it already drives `_baseline_gate_jobs_succeeded` through non-success conclusions.

## Risk Acceptance / Waivers

None.

## Technical Changes

- Remove `if: always()` and the conditional `exit 1` step from `libraries_baseline_ready` in both the Linux and Windows multi-arch build workflows, so the job is skipped rather than failed when a reused stage did not succeed.
- Add a unit test asserting a skipped gate job is rejected as a baseline.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
