### PR TITLE
fix(ci): surface external-repo shared/* and emulation/* paths for selection

### DIFF
--- a/build_tools/github_actions/configure_external_repo_ci.py
+++ b/build_tools/github_actions/configure_external_repo_ci.py
@@ -73,7 +73,28 @@ FULL_TEST_TRIGGER_PATTERNS = [
     ".github/scripts/repo_config_model.py",
     ".github/scripts/pr_detect_changed_subtrees.py",
     ".github/repos-config.json",
+    # shared/ctest holds the CTest categorization logic consumed by every
+    # project's tests; a change there can alter selection everywhere, so treat
+    # it as a full-test trigger rather than a single surfaced component.
+    "shared/ctest/*",
 ]
+
+# CI-relevant monorepo directories that are NOT subtree-synced repos and so are
+# absent from an external repo's repos-config.json. Without these, a PR confined
+# to shared/* or emulation/* yields no matched subtree -> empty changed_projects
+# -> TheRock falls back to building and testing everything. Each entry MUST have
+# a corresponding mapping in TheRock (build-topology alias + the test selector's
+# _EXTERNAL_SUBTREE_ALIASES); the test selector hard-fails on an unmapped
+# shared/* or emulation/* path, so keep this list in lock-step with TheRock when
+# adding directories. (Currently enumerates rocm-systems' non-subtree dirs;
+# rocm-libraries paths already resolve as repos-config subtrees.)
+CI_RELEVANT_NON_SUBTREE_PREFIXES = {
+    "shared/amdgpu-windows-interop",
+    "shared/kpack",
+    "shared/machine-readable-isa",
+    "emulation/mirage",
+    "emulation/rocjitsu",
+}
 
 
 @dataclass
@@ -244,6 +265,28 @@ def set_github_output(outputs: Mapping[str, str]) -> None:
             f.write(f"{k}={v}\n")
 
 
+def _subtree_prefix(path: str) -> str:
+    """First two path components, matching find_matched_subtrees()."""
+    return "/".join(path.split("/", 2)[:2])
+
+
+def get_unclassified_paths(paths: Iterable[str], valid_prefixes: Set[str]) -> List[str]:
+    """Non-skippable changed paths that map to no known subtree.
+
+    A PR can mix a recognized path (e.g. ``projects/rdc/...``) with a path we
+    cannot classify (a top-level file, or a directory absent from both
+    repos-config.json and CI_RELEVANT_NON_SUBTREE_PREFIXES). find_matched_subtrees
+    silently drops the unclassified path, which would let CI narrow the build to
+    the recognized subset and miss the impact of the unclassified change. Callers
+    should treat any such path conservatively (run the full suite).
+    """
+    return [
+        p
+        for p in paths
+        if not is_skippable(p) and _subtree_prefix(p) not in valid_prefixes
+    ]
+
+
 def configure(
     event_name: str,
     github_repo: str,
@@ -312,7 +355,22 @@ def configure(
             changed_projects="", run_all_tests=True, skip_tests=False
         )
 
-    valid_prefixes = get_valid_prefixes(config)
+    valid_prefixes = get_valid_prefixes(config) | CI_RELEVANT_NON_SUBTREE_PREFIXES
+
+    # Conservative guard: if any non-skippable change cannot be classified to a
+    # known subtree, we cannot reason about its build/test impact. Narrowing on
+    # just the recognized subset would silently drop the unclassified change, so
+    # fall back to a full run instead.
+    unclassified = get_unclassified_paths(modified_paths, valid_prefixes)
+    if unclassified:
+        logger.info(
+            f"Unclassified non-skippable change(s) {sorted(unclassified)[:5]}"
+            " - running all tests"
+        )
+        return ConfigureResult(
+            changed_projects="", run_all_tests=True, skip_tests=False
+        )
+
     matched = find_matched_subtrees(modified_paths, valid_prefixes)
     logger.info(f"Matched projects: {matched}")
 

--- a/build_tools/tests/configure_external_repo_ci_test.py
+++ b/build_tools/tests/configure_external_repo_ci_test.py
@@ -13,10 +13,12 @@ from unittest.mock import patch
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent / "github_actions"))
 
 from configure_external_repo_ci import (
+    CI_RELEVANT_NON_SUBTREE_PREFIXES,
     ConfigureResult,
     RepoEntry,
     configure,
     find_matched_subtrees,
+    get_unclassified_paths,
     get_valid_prefixes,
     has_non_skippable,
     is_skippable,
@@ -280,6 +282,80 @@ class ConfigureTest(unittest.TestCase):
             config_path="",
         )
         self.assertEqual(result.run_all_tests, True)
+
+
+class GetUnclassifiedPathsTest(unittest.TestCase):
+    """Tests for get_unclassified_paths()."""
+
+    def test_unmapped_nonskippable_is_unclassified(self):
+        valid = {"projects/rocblas"}
+        self.assertEqual(
+            get_unclassified_paths(["tools/build/x.py"], valid),
+            ["tools/build/x.py"],
+        )
+
+    def test_recognized_and_skippable_are_not_unclassified(self):
+        valid = {"projects/rocblas"}
+        self.assertEqual(
+            get_unclassified_paths(["projects/rocblas/src/a.cpp", "README.md"], valid),
+            [],
+        )
+
+
+class ConfigureNonSubtreeTest(unittest.TestCase):
+    """Surfacing of non-subtree shared/* + emulation/* paths and the
+    unclassified-change fallback (rocm-systems multi-arch gap)."""
+
+    def _configure(self, paths, config=None):
+        with patch(
+            "configure_external_repo_ci.get_modified_paths_api",
+            return_value=set(paths),
+        ), patch(
+            "configure_external_repo_ci.load_repo_config",
+            return_value=config
+            or [RepoEntry(name="rocm-core", url="", branch="", category="projects")],
+        ):
+            return configure(
+                event_name="pull_request",
+                github_repo="ROCm/rocm-systems",
+                base_sha="abc123",
+                head_sha="def456",
+                config_path=".github/repos-config.json",
+            )
+
+    def test_shared_component_is_surfaced(self):
+        r = self._configure(["shared/amdgpu-windows-interop/pal/x.cpp"])
+        self.assertEqual(r.changed_projects, "shared/amdgpu-windows-interop")
+        self.assertFalse(r.run_all_tests)
+        self.assertFalse(r.skip_tests)
+
+    def test_emulation_components_are_surfaced(self):
+        r = self._configure(["emulation/mirage/a.cpp", "emulation/rocjitsu/b.cpp"])
+        self.assertEqual(
+            sorted(r.changed_projects.split(",")),
+            ["emulation/mirage", "emulation/rocjitsu"],
+        )
+
+    def test_ctest_harness_triggers_full_run(self):
+        r = self._configure(["shared/ctest/TestCategories.cmake"])
+        self.assertTrue(r.run_all_tests)
+        self.assertEqual(r.changed_projects, "")
+
+    def test_mixed_recognized_and_unclassified_runs_all(self):
+        r = self._configure(
+            ["projects/rocm-core/src/x.cpp", "tools/rocm-build/helper.py"]
+        )
+        self.assertTrue(r.run_all_tests)
+        self.assertEqual(r.changed_projects, "")
+
+    def test_recognized_plus_skippable_still_narrows(self):
+        r = self._configure(["projects/rocm-core/src/x.cpp", "README.md"])
+        self.assertFalse(r.run_all_tests)
+        self.assertEqual(r.changed_projects, "projects/rocm-core")
+
+    def test_declared_prefixes_are_wellformed(self):
+        for prefix in CI_RELEVANT_NON_SUBTREE_PREFIXES:
+            self.assertEqual(len(prefix.split("/")), 2, prefix)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

External repos compute multi-arch CI selection via
`configure_external_repo_ci.py`, whose valid changed-subtree prefixes come from
the caller's `repos-config.json` — which lists only subtree-synced `projects/*`
repos. rocm-systems' in-monorepo `shared/*` (amdgpu-windows-interop, kpack,
machine-readable-isa) and `emulation/*` (mirage, rocjitsu) are not subtree
repos, so a PR confined to them matches no subtree, `changed_projects` is empty,
and CI builds/tests everything.

ISSUE ID : https://github.com/ROCm/rocm-systems/issues/11198

## Technical Details

- `CI_RELEVANT_NON_SUBTREE_PREFIXES` (rocm-systems shared/* + emulation/* dirs)
  unioned into the valid prefixes so those paths surface as `changed_projects`.
  Explicit by design: the test selector (`determine_rocm_test_dependencies.py`)
  hard-fails on an unmapped `shared/*`/`emulation/*` path (#7921), so this list
  stays in lock-step with the alias map. Build-topology already resolves these
  dirs via `source_paths`; the test-selector aliases landed in #8075.
- `shared/ctest/*` added to `FULL_TEST_TRIGGER_PATTERNS` (shared CTest
  categorization affects every project's tests).
- `get_unclassified_paths()` guard: a mixed PR (recognized path + an unmapped
  non-skippable path) now runs the full suite rather than narrowing and
  dropping the unclassified change.

Only rocm-systems paths are enumerated; rocm-libraries paths already resolve as
repos-config subtrees, so its behavior is unchanged.

## Test Plan

- `python -m pytest build_tools/tests/configure_external_repo_ci_test.py`

## Test Result

- 35 passed.
- Verified: shared/* + emulation/* dirs surface; shared/ctest -> run-all;
  recognized+unclassified and top-level files -> run-all; recognized+docs still
  narrows; projects/* unchanged.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.