### PR TITLE
feat(ci) add missing binaries to the update alternatives

### DIFF
--- a/build_tools/packaging/linux/template/scripts/amdrocm-developer-tools-postinst.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-developer-tools-postinst.j2
@@ -44,7 +44,24 @@ do_update_alternatives(){
     # previous patch level is small.
     altscore=$((altscore*1000000+(now-1600000000)/60))
 
-    binaries=( rocgdb rocprofv3 rocprofv3-avail rocpd rocminfo amd-smi rocm_agent_enumerator )
+    binaries=(
+        rocgdb
+        rocprofv3
+        rocprofv3-avail
+        rocprof-attach
+        rocprof-compute
+        rocprof-sys-attach
+        rocprof-sys-avail
+        rocprof-sys-causal
+        rocprof-sys-instrument
+        rocprof-sys-python
+        rocprof-sys-run
+        rocprof-sys-sample
+        rocpd
+        rocminfo
+        amd-smi
+        rocm_agent_enumerator
+    )
 
     {% if target == "deb" %}
        PKG_INSTALL_PREFIX={{ install_prefix }}

--- a/build_tools/packaging/linux/template/scripts/amdrocm-developer-tools-prerm.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-developer-tools-prerm.j2
@@ -1,6 +1,23 @@
 #!/bin/bash
 
-binaries=( rocgdb rocprofv3 rocprofv3-avail rocpd rocminfo amd-smi rocm_agent_enumerator )
+binaries=(
+    rocgdb
+    rocprofv3
+    rocprofv3-avail
+    rocprof-attach
+    rocprof-compute
+    rocprof-sys-attach
+    rocprof-sys-avail
+    rocprof-sys-causal
+    rocprof-sys-instrument
+    rocprof-sys-python
+    rocprof-sys-run
+    rocprof-sys-sample
+    rocpd
+    rocminfo
+    amd-smi
+    rocm_agent_enumerator
+)
 
 is_debian_like() {
     local id_like="$1"


### PR DESCRIPTION
## Motivation

Rocm Compute and systems profiler is not in the default path add missing binaries to the update alternatives. Binaries are available in /opt/rocm/bin folder. But, /opt/rocm/bin is not in default path

JIRA ID : ROCM-30680
https://amd-hub.atlassian.net/browse/ROCM-30680

## Technical Details

add missing binaries to the update alternatives

## Test Plan

Verify that path is available with correct symlinks 

## Test Result
Symlinks are present after change

(.venv) root@CTR-SVDT-L004:/dockerx/2026_9_11_rocm_path/TheRock/output/packages# ls -al /opt/rocm/core/bin | grep rocprof
-rwxr-xr-x  1 root root      8406 Sep  7 11:46 rocprof-attach
-rwxr-xr-x  1 root root       423 Sep  7 11:48 rocprof-compute
-rwxr-xr-x  1 root root    629840 Sep 11 17:38 rocprof-sys-attach
-rwxr-xr-x  1 root root  20586776 Sep 11 17:38 rocprof-sys-avail
-rwxr-xr-x  1 root root   6712112 Sep 11 17:38 rocprof-sys-causal
-rwxr-xr-x  1 root root   5563656 Sep 11 17:38 rocprof-sys-instrument
-rwxr-xr-x  1 root root      1120 Sep  7 11:51 rocprof-sys-python
-rwxr-xr-x  1 root root   7068616 Sep 11 17:38 rocprof-sys-run
-rwxr-xr-x  1 root root   7068616 Sep 11 17:38 rocprof-sys-sample
-rwxr-xr-x  1 root root    104408 Sep  7 11:46 rocprofv3
-rwxr-xr-x  1 root root     20207 Sep  7 11:46 rocprofv3-avail

(.venv) root@CTR-SVDT-L004:/dockerx/2026_9_11_rocm_path/TheRock/output/packages# ls -al /usr/bin | grep rocprof
lrwxrwxrwx 1 root root         32 Sep  7 11:46 rocprof-attach -> /etc/alternatives/rocprof-attach
lrwxrwxrwx 1 root root         33 Sep  7 11:48 rocprof-compute -> /etc/alternatives/rocprof-compute
lrwxrwxrwx 1 root root         36 Sep 11 17:38 rocprof-sys-attach -> /etc/alternatives/rocprof-sys-attach
lrwxrwxrwx 1 root root         35 Sep 11 17:38 rocprof-sys-avail -> /etc/alternatives/rocprof-sys-avail
lrwxrwxrwx 1 root root         36 Sep 11 17:38 rocprof-sys-causal -> /etc/alternatives/rocprof-sys-causal
lrwxrwxrwx 1 root root         40 Sep 11 17:38 rocprof-sys-instrument -> /etc/alternatives/rocprof-sys-instrument
lrwxrwxrwx 1 root root         36 Sep  7 11:51 rocprof-sys-python -> /etc/alternatives/rocprof-sys-python
lrwxrwxrwx 1 root root         33 Sep 11 17:38 rocprof-sys-run -> /etc/alternatives/rocprof-sys-run
lrwxrwxrwx 1 root root         36 Sep 11 17:38 rocprof-sys-sample -> /etc/alternatives/rocprof-sys-sample
lrwxrwxrwx 1 root root         27 Sep  7 11:46 rocprofv3 -> /etc/alternatives/rocprofv3
lrwxrwxrwx 1 root root         33 Sep  7 11:46 rocprofv3-avail -> /etc/alternatives/rocprofv3-avail

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
