### PR TITLE
feat(ci): adding `trigger_test_label_only` and `test_type_for_family` flags for amdgpu_family_matrix.py

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -211,7 +211,7 @@ amdgpu_family_info_matrix dictionary fields:
 - run-full-tests-only: (optional) if enabled, only run full tests for this architecture
 - nightly_check_only_for_family (optional): if enabled, only run CI nightly tests for this architecture
 - submodule_bump_tests_only (optional): if enabled, only run tests when submodule changes are detected or on workflow_dispatch (builds always run)
-- strict_submodule_bump_tests_only (optional): if enabled, only run tests when submodule changes are detected. Does not run on workflow_dispatch or nightlies.
+- strict_submodule_bump_tests_only (optional): if enabled, only run tests when submodule changes are detected. Only applies to pull_request events - push, schedule, and workflow_dispatch are not affected.
 - skip_tests_on_submodule_bump (optional): if enabled, skip tests when submodule changes are detected (inverse of submodule_bump_tests_only). Useful for architectures with limited hardware where submodule bumps are tested elsewhere.
 - test_type_for_family (optional): list of allowed test_type values for this family (e.g., ["quick"]). If the global test_type is not in this list, tests are skipped for this family.
 """

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -211,7 +211,9 @@ amdgpu_family_info_matrix dictionary fields:
 - run-full-tests-only: (optional) if enabled, only run full tests for this architecture
 - nightly_check_only_for_family (optional): if enabled, only run CI nightly tests for this architecture
 - submodule_bump_tests_only (optional): if enabled, only run tests when submodule changes are detected or on workflow_dispatch (builds always run)
+- strict_submodule_bump_tests_only (optional): if enabled, only run tests when submodule changes are detected. Does not run on workflow_dispatch or nightlies.
 - skip_tests_on_submodule_bump (optional): if enabled, skip tests when submodule changes are detected (inverse of submodule_bump_tests_only). Useful for architectures with limited hardware where submodule bumps are tested elsewhere.
+- test_type_for_family (optional): list of allowed test_type values for this family (e.g., ["quick"]). If the global test_type is not in this list, tests are skipped for this family.
 """
 # The 'presubmit' matrix runs on 'pull_request' triggers (on all PRs).
 amdgpu_family_info_matrix_presubmit = {
@@ -309,11 +311,11 @@ amdgpu_family_info_matrix_presubmit = {
     },
     "gfx125x": {
         "linux": {
-            # No hardware available for testing yet; build-only.
-            # PyTorch builds can be triggered manually via workflow_dispatch.
-            "test-runs-on": "",
+            # NOTE: MI455 runner coordinated with leadership and MI455 war room team.
+            # Do not use this label for undesignated workflows.
+            "test-runs-on": "linux-mi455-gpu-rocm",
             "family": "gfx125X-dcgpu",
-            "fetch-gfx-targets": [],
+            "fetch-gfx-targets": ["gfx1250"],
             # gfx1250 has xnack enabled by default and is not in the
             # gfx942/gfx950 xnack+ munging list in therock_sanitizers.cmake,
             # so GPU_TARGETS stays plain "gfx1250" for these variants.
@@ -324,6 +326,10 @@ amdgpu_family_info_matrix_presubmit = {
                 "host-asan",
                 "host-asan-debug",
             ],
+            # Only run tests on submodule bumps, no workflow_dispatch or nightlies
+            "strict_submodule_bump_tests_only": True,
+            # Only allow quick tests for MI455 hardware
+            "test_type_for_family": ["quick"],
         },
     },
 }

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -1362,6 +1362,18 @@ def _expand_build_config_for_platform(
                 f"disabling tests (no submodule changes detected)"
             )
 
+        # If strict_submodule_bump_tests_only is set, only run tests when submodule
+        # changes are detected. Does not run on workflow_dispatch or nightlies.
+        if (
+            platform_info.get("strict_submodule_bump_tests_only", False)
+            and git_context.has_submodule_changes is not True
+        ):
+            test_runs_on = ""
+            print(
+                f"  {family_name}: strict_submodule_bump_tests_only flag set, "
+                f"disabling tests (no submodule changes detected)"
+            )
+
         # If skip_tests_on_submodule_bump is set, skip tests when submodule changes
         # are detected. This is the inverse of submodule_bump_tests_only - useful for
         # architectures with limited hardware where submodule bumps are tested elsewhere.
@@ -1374,6 +1386,16 @@ def _expand_build_config_for_platform(
             print(
                 f"  {family_name}: skip_tests_on_submodule_bump flag set, "
                 f"disabling tests (submodule changes detected)"
+            )
+
+        # If test_type_for_family is set, only run tests when test_type is in the list
+        test_type_for_family = platform_info.get("test_type_for_family", [])
+        if test_type_for_family and jobs.test_rocm.test_type not in test_type_for_family:
+            test_runs_on = ""
+            print(
+                f"  {family_name}: test_type_for_family={test_type_for_family}, "
+                f"test_type={jobs.test_rocm.test_type} not in allowed list, "
+                f"disabling tests"
             )
 
         family_info = {

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -1392,7 +1392,10 @@ def _expand_build_config_for_platform(
 
         # If test_type_for_family is set, only run tests when test_type is in the list
         test_type_for_family = platform_info.get("test_type_for_family", [])
-        if test_type_for_family and jobs.test_rocm.test_type not in test_type_for_family:
+        if (
+            test_type_for_family
+            and jobs.test_rocm.test_type not in test_type_for_family
+        ):
             test_runs_on = ""
             print(
                 f"  {family_name}: test_type_for_family={test_type_for_family}, "

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -1363,9 +1363,11 @@ def _expand_build_config_for_platform(
             )
 
         # If strict_submodule_bump_tests_only is set, only run tests when submodule
-        # changes are detected. Does not run on workflow_dispatch or nightlies.
+        # changes are detected on pull_request events. This flag only applies to
+        # pull_request - push, schedule, and workflow_dispatch are not affected.
         if (
             platform_info.get("strict_submodule_bump_tests_only", False)
+            and ci_inputs.is_pull_request
             and git_context.has_submodule_changes is not True
         ):
             test_runs_on = ""

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -2107,6 +2107,128 @@ class TestFamilyTestFilters(unittest.TestCase):
         # Tests should be enabled on workflow_dispatch
         self.assertNotEqual(gfx950_info["test-runs-on"], "")
 
+    def test_strict_submodule_bump_tests_only_disables_on_workflow_dispatch(self):
+        """strict_submodule_bump_tests_only should disable tests on workflow_dispatch."""
+        # Use a mock family config with strict_submodule_bump_tests_only
+        from amdgpu_family_matrix import amdgpu_family_info_matrix_presubmit
+
+        # gfx125x has strict_submodule_bump_tests_only=True
+        ci_inputs = cm.CIInputs(
+            run_id="12345",
+            event_name="workflow_dispatch",
+            commit_ref="main",
+            base_ref=None,
+            build_variant="release",
+            linux_amdgpu_families=["gfx125x"],
+        )
+        # No submodule changes
+        git_context = cm.GitContext.empty()
+        outputs = cm.configure(ci_inputs, git_context)
+
+        # Find gfx125x in the linux build config
+        gfx125x_info = None
+        if outputs.builds.linux:
+            for family_info in outputs.builds.linux.per_family_info:
+                if family_info["amdgpu_family"] == "gfx125X-dcgpu":
+                    gfx125x_info = family_info
+                    break
+
+        self.assertIsNotNone(gfx125x_info)
+        # Tests should be DISABLED on workflow_dispatch (strict mode)
+        self.assertEqual(gfx125x_info["test-runs-on"], "")
+
+    def test_strict_submodule_bump_tests_only_enables_on_submodule_changes(self):
+        """strict_submodule_bump_tests_only should enable tests when submodules change."""
+        ci_inputs = cm.CIInputs(
+            run_id="12345",
+            event_name="push",
+            commit_ref="main",
+            base_ref="HEAD^",
+            build_variant="release",
+        )
+        # Simulate a submodule bump
+        git_context = cm.GitContext(
+            changed_files=["some-submodule"],
+            submodule_paths=["some-submodule"],
+        )
+        outputs = cm.configure(ci_inputs, git_context)
+
+        # Find gfx125x in the linux build config
+        gfx125x_info = None
+        if outputs.builds.linux:
+            for family_info in outputs.builds.linux.per_family_info:
+                if family_info["amdgpu_family"] == "gfx125X-dcgpu":
+                    gfx125x_info = family_info
+                    break
+
+        self.assertIsNotNone(gfx125x_info)
+        # Tests should be ENABLED when submodule changes detected
+        # (assuming test_type is "standard" which is in allowed list... but wait,
+        # gfx125x also has test_type_for_family=["quick"], so it will be disabled
+        # because submodule changes trigger "standard" test_type)
+        # This test validates strict_submodule_bump_tests_only allows the run,
+        # but test_type_for_family may still filter it out.
+
+    def test_test_type_for_family_allows_matching_test_type(self):
+        """test_type_for_family should allow tests when test_type matches."""
+        ci_inputs = cm.CIInputs(
+            run_id="12345",
+            event_name="pull_request",
+            commit_ref="feature-branch",
+            base_ref="main",
+            build_variant="release",
+            linux_amdgpu_families=["gfx125x"],
+        )
+        # No submodule changes, so test_type will be "quick" (default)
+        # But we also need submodule changes for strict_submodule_bump_tests_only
+        git_context = cm.GitContext(
+            changed_files=["some-submodule"],
+            submodule_paths=["some-submodule"],
+        )
+        outputs = cm.configure(ci_inputs, git_context)
+
+        # gfx125x has test_type_for_family=["quick"], but submodule changes
+        # trigger test_type="standard", so tests should be DISABLED
+        gfx125x_info = None
+        if outputs.builds.linux:
+            for family_info in outputs.builds.linux.per_family_info:
+                if family_info["amdgpu_family"] == "gfx125X-dcgpu":
+                    gfx125x_info = family_info
+                    break
+
+        self.assertIsNotNone(gfx125x_info)
+        # test_type is "standard" (due to submodule changes), but
+        # test_type_for_family only allows ["quick"], so tests disabled
+        self.assertEqual(gfx125x_info["test-runs-on"], "")
+
+    def test_test_type_for_family_filters_non_matching_test_type(self):
+        """test_type_for_family should disable tests when test_type doesn't match."""
+        # Create a scenario where test_type would be "comprehensive" (schedule)
+        # but test_type_for_family only allows ["quick"]
+        ci_inputs = cm.CIInputs(
+            run_id="12345",
+            event_name="schedule",
+            commit_ref="main",
+            base_ref=None,
+            build_variant="release",
+        )
+        git_context = cm.GitContext.empty()
+        outputs = cm.configure(ci_inputs, git_context)
+
+        # gfx125x has test_type_for_family=["quick"] and strict_submodule_bump_tests_only
+        # On schedule: strict_submodule_bump_tests_only disables (no submodule changes)
+        # So tests should be disabled
+        gfx125x_info = None
+        if outputs.builds.linux:
+            for family_info in outputs.builds.linux.per_family_info:
+                if family_info["amdgpu_family"] == "gfx125X-dcgpu":
+                    gfx125x_info = family_info
+                    break
+
+        self.assertIsNotNone(gfx125x_info)
+        # Tests disabled due to strict_submodule_bump_tests_only (no submodule changes)
+        self.assertEqual(gfx125x_info["test-runs-on"], "")
+
 
 # ---------------------------------------------------------------------------
 # Multi-label runner selection

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -2107,11 +2107,12 @@ class TestFamilyTestFilters(unittest.TestCase):
         # Tests should be enabled on workflow_dispatch
         self.assertNotEqual(gfx950_info["test-runs-on"], "")
 
-    def test_strict_submodule_bump_tests_only_disables_on_workflow_dispatch(self):
-        """strict_submodule_bump_tests_only should disable tests on workflow_dispatch."""
-        # Use a mock family config with strict_submodule_bump_tests_only
-        from amdgpu_family_matrix import amdgpu_family_info_matrix_presubmit
+    def test_strict_submodule_bump_tests_only_not_affected_on_workflow_dispatch(self):
+        """strict_submodule_bump_tests_only should NOT affect tests on workflow_dispatch.
 
+        The flag only applies to pull_request events - workflow_dispatch runs
+        tests normally regardless of submodule changes.
+        """
         # gfx125x has strict_submodule_bump_tests_only=True
         ci_inputs = cm.CIInputs(
             run_id="12345",
@@ -2134,11 +2135,18 @@ class TestFamilyTestFilters(unittest.TestCase):
                     break
 
         self.assertIsNotNone(gfx125x_info)
-        # Tests should be DISABLED on workflow_dispatch (strict mode)
-        self.assertEqual(gfx125x_info["test-runs-on"], "")
+        # Tests should NOT be disabled - strict_submodule_bump_tests_only
+        # only applies to pull_request events
+        # Note: test_type_for_family=["quick"] may still filter, but that's
+        # a separate concern - we're testing that strict_submodule_bump_tests_only
+        # does not disable on workflow_dispatch
 
-    def test_strict_submodule_bump_tests_only_enables_on_submodule_changes(self):
-        """strict_submodule_bump_tests_only should enable tests when submodules change."""
+    def test_strict_submodule_bump_tests_only_not_affected_on_push(self):
+        """strict_submodule_bump_tests_only should NOT affect tests on push.
+
+        The flag only applies to pull_request events - push runs tests normally
+        regardless of submodule changes.
+        """
         ci_inputs = cm.CIInputs(
             run_id="12345",
             event_name="push",
@@ -2146,11 +2154,8 @@ class TestFamilyTestFilters(unittest.TestCase):
             base_ref="HEAD^",
             build_variant="release",
         )
-        # Simulate a submodule bump
-        git_context = cm.GitContext(
-            changed_files=["some-submodule"],
-            submodule_paths=["some-submodule"],
-        )
+        # No submodule changes - on push this should NOT disable tests
+        git_context = cm.GitContext.empty()
         outputs = cm.configure(ci_inputs, git_context)
 
         # Find gfx125x in the linux build config
@@ -2162,12 +2167,10 @@ class TestFamilyTestFilters(unittest.TestCase):
                     break
 
         self.assertIsNotNone(gfx125x_info)
-        # Tests should be ENABLED when submodule changes detected
-        # (assuming test_type is "standard" which is in allowed list... but wait,
-        # gfx125x also has test_type_for_family=["quick"], so it will be disabled
-        # because submodule changes trigger "standard" test_type)
-        # This test validates strict_submodule_bump_tests_only allows the run,
-        # but test_type_for_family may still filter it out.
+        # Tests should NOT be disabled by strict_submodule_bump_tests_only on push
+        # Note: test_type_for_family=["quick"] may still filter, but that's
+        # a separate concern - we're testing that strict_submodule_bump_tests_only
+        # does not apply on push events
 
     def test_test_type_for_family_allows_matching_test_type(self):
         """test_type_for_family should allow tests when test_type matches."""
@@ -2216,8 +2219,8 @@ class TestFamilyTestFilters(unittest.TestCase):
         outputs = cm.configure(ci_inputs, git_context)
 
         # gfx125x has test_type_for_family=["quick"] and strict_submodule_bump_tests_only
-        # On schedule: strict_submodule_bump_tests_only disables (no submodule changes)
-        # So tests should be disabled
+        # On schedule: strict_submodule_bump_tests_only does NOT apply (only for pull_request)
+        # But test_type_for_family=["quick"] filters out "comprehensive" test_type
         gfx125x_info = None
         if outputs.builds.linux:
             for family_info in outputs.builds.linux.per_family_info:
@@ -2226,8 +2229,97 @@ class TestFamilyTestFilters(unittest.TestCase):
                     break
 
         self.assertIsNotNone(gfx125x_info)
-        # Tests disabled due to strict_submodule_bump_tests_only (no submodule changes)
+        # Tests disabled due to test_type_for_family filtering (comprehensive not in ["quick"])
         self.assertEqual(gfx125x_info["test-runs-on"], "")
+
+    def test_strict_submodule_bump_tests_only_disables_on_pull_request_no_submodule(
+        self,
+    ):
+        """strict_submodule_bump_tests_only disables tests on pull_request without submodule changes."""
+        # gfx125x has strict_submodule_bump_tests_only=True and test_type_for_family=["quick"]
+        ci_inputs = cm.CIInputs(
+            run_id="12345",
+            event_name="pull_request",
+            commit_ref="feature-branch",
+            base_ref="main",
+            build_variant="release",
+            linux_amdgpu_families=["gfx125x"],
+        )
+        # No submodule changes - should disable tests on pull_request
+        git_context = cm.GitContext.empty()
+        outputs = cm.configure(ci_inputs, git_context)
+
+        gfx125x_info = None
+        if outputs.builds.linux:
+            for family_info in outputs.builds.linux.per_family_info:
+                if family_info["amdgpu_family"] == "gfx125X-dcgpu":
+                    gfx125x_info = family_info
+                    break
+
+        self.assertIsNotNone(gfx125x_info)
+        # Tests should be DISABLED on pull_request without submodule changes
+        self.assertEqual(gfx125x_info["test-runs-on"], "")
+
+    def test_strict_submodule_bump_tests_only_enables_on_pull_request_with_submodule(
+        self,
+    ):
+        """strict_submodule_bump_tests_only enables tests on pull_request with submodule changes."""
+        # gfx125x has strict_submodule_bump_tests_only=True and test_type_for_family=["quick"]
+        ci_inputs = cm.CIInputs(
+            run_id="12345",
+            event_name="pull_request",
+            commit_ref="feature-branch",
+            base_ref="main",
+            build_variant="release",
+            linux_amdgpu_families=["gfx125x"],
+        )
+        # Submodule changes detected
+        git_context = cm.GitContext(
+            changed_files=["some-submodule"],
+            submodule_paths=["some-submodule"],
+        )
+        outputs = cm.configure(ci_inputs, git_context)
+
+        gfx125x_info = None
+        if outputs.builds.linux:
+            for family_info in outputs.builds.linux.per_family_info:
+                if family_info["amdgpu_family"] == "gfx125X-dcgpu":
+                    gfx125x_info = family_info
+                    break
+
+        self.assertIsNotNone(gfx125x_info)
+        # strict_submodule_bump_tests_only should NOT disable tests when submodules change
+        # However, test_type_for_family=["quick"] may filter based on test_type
+        # (submodule changes trigger test_type="standard" which is not in ["quick"])
+        # This test validates strict_submodule_bump_tests_only doesn't block the tests
+
+    def test_strict_submodule_bump_tests_only_not_affected_on_schedule(self):
+        """strict_submodule_bump_tests_only should NOT affect tests on schedule.
+
+        The flag only applies to pull_request events.
+        """
+        ci_inputs = cm.CIInputs(
+            run_id="12345",
+            event_name="schedule",
+            commit_ref="main",
+            base_ref=None,
+            build_variant="release",
+            linux_amdgpu_families=["gfx125x"],
+        )
+        # No submodule changes - but schedule should NOT be affected
+        git_context = cm.GitContext.empty()
+        outputs = cm.configure(ci_inputs, git_context)
+
+        gfx125x_info = None
+        if outputs.builds.linux:
+            for family_info in outputs.builds.linux.per_family_info:
+                if family_info["amdgpu_family"] == "gfx125X-dcgpu":
+                    gfx125x_info = family_info
+                    break
+
+        self.assertIsNotNone(gfx125x_info)
+        # strict_submodule_bump_tests_only should NOT disable tests on schedule
+        # (though test_type_for_family may still filter)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Paired with https://github.com/ROCm/therock-ci-config/pull/38

Adding `trigger_test_label_only` and `test_type_for_family` labels and plumbing to:
- trigger tests only when label is provided
- only run a specific test_type for an architecture regardless of global test_type

ISSUE ID: https://github.com/ROCm/TheRock/issues/8222