### PR TITLE
chore(compiler): remove THEROCK_ENABLE_HOTSWAP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,6 @@ option(THEROCK_COMPOSABLE_KERNEL_FOR_MIOPEN_ONLY
 
 option(THEROCK_BUILD_LLVM_TOOLS "Enables building all LLVM tools (not just minimum required)" OFF)
 option(THEROCK_BUILD_LLVM_TESTS "Enables building LLVM LIT tests" OFF)
-option(THEROCK_ENABLE_HOTSWAP "Enables the comgr hotswap transpiler/tool and loads it in the runtime via HSA_TOOLS_LIB" ON)
 option(THEROCK_USE_NEW_HOSTCALL_IMPL "Use the new phase/occupancy-based hostcall implementation in device-libs and clr" OFF)
 set(THEROCK_COMGR_DLL_NAME "" CACHE STRING "Override the Comgr DLL name for the comgr build and CLR load (e.g. amd_comgr_opencl.dll); empty = component default")
 

--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -208,16 +208,6 @@ if(THEROCK_ENABLE_COMPILER)
   # version script, avoiding symbol interposition issues.
   ##############################################################################
 
-  set(_comgr_hotswap_cmake_args)
-  if(THEROCK_ENABLE_HOTSWAP)
-    list(APPEND _comgr_hotswap_cmake_args -DCOMGR_ENABLE_HOTSWAP_TRANSPILE=ON)
-    if(NOT WIN32)
-      list(APPEND _comgr_hotswap_cmake_args
-        -DHOTSWAP_BUILD_TOOL=ON
-        "-DHOTSWAP_TOOL_HSA_INCLUDE_ROOT=${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rocr-runtime/runtime/hsa-runtime")
-    endif()
-  endif()
-
   # Optionally override the comgr DLL/shared-library output name (Windows). Kept
   # in sync with the CLR load side via the same THEROCK_COMGR_DLL_NAME option.
   set(_comgr_dll_name_cmake_args)
@@ -240,7 +230,6 @@ if(THEROCK_ENABLE_COMPILER)
       -DTHEROCK_BUILD_COMGR_TESTS=${THEROCK_BUILD_COMGR_TESTS}
       "-DLLVM_VERSION_SUFFIX=-rocm${ROCM_MAJOR_VERSION}"
       -DLLVM_ENABLE_SYMBOL_VERSIONING=ON
-      ${_comgr_hotswap_cmake_args}
       ${_comgr_dll_name_cmake_args}
     BUILD_DEPS
       rocm-cmake


### PR DESCRIPTION
JIRA ID: LCOMPILER-2780

Removes `THEROCK_ENABLE_HOTSWAP` and the comgr cmake args it gated.

## Why

The option gated three things:

- `-DCOMGR_ENABLE_HOTSWAP_TRANSPILE=ON` — builds comgr's **cross-generation IR transpiler**, which is still in development and has no public C entry point.
- `-DHOTSWAP_BUILD_TOOL=ON` and `-DHOTSWAP_TOOL_HSA_INCLUDE_ROOT=...` — **dead since ROCm/llvm-project#3007** removed `HOTSWAP_BUILD_TOOL` from comgr. TheRock has been passing cmake args that comgr silently ignores.

Comgr's own `COMGR_ENABLE_HOTSWAP_TRANSPILE` defaults OFF, so dropping the option simply restores that default rather than changing behaviour in any other direction.

Note the byte-level HotSwap **rewriter** was never gated by this option — it is built unconditionally inside comgr. It is being removed separately in ROCm/llvm-project#4406.

## Follow-on

This also unblocks ROCm/llvm-project#4407, which renames comgr's `COMGR_ENABLE_HOTSWAP_TRANSPILE` to `COMGR_ENABLE_TRANSPILER`. TheRock is the only external consumer of that name, so landing this first avoids needing a deprecated-alias shim on the comgr side.

## Scope

Two files, 12 deletions. The unrelated **rocjitsu-hotswap** feature (`THEROCK_ENABLE_ROCJITSU_HOTSWAP`, `emulation/`, `comm-libs/`, `BUILD_TOPOLOGY.toml`, `test_tools/therock_consumer_graph.json`) is deliberately untouched — it shares the name but nothing else.

`THEROCK_ROCM_SYSTEMS_SOURCE_DIR`, referenced by the removed `HOTSWAP_TOOL_HSA_INCLUDE_ROOT` line, is still used by six other subprojects and stays.
