### PR TITLE
feat(ci): add hipdnn-cudnn-samples component test job

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -676,6 +676,26 @@ test_matrix = {
             "windows": 1,
         },
     },
+    # NVIDIA cuDNN sample corpus built against hipDNN's cuDNN compatibility
+    # shim. Distinct from "hipdnn-samples" above, which is hipDNN's own sample
+    # suite; these two are easy to confuse and test entirely different things.
+    "hipdnn-cudnn-samples": {
+        "job_name": "hipdnn-cudnn-samples",
+        # No "fetch_artifact_args" on purpose: this job calls
+        # find_package(hipdnn_frontend), whose config file and headers live in
+        # the "dev" component, and install_rocm_from_artifacts.py expands each
+        # selected artifact to <name>_lib plus <name>_test only -- never
+        # <name>_dev. Omitting the key takes the fetch-everything branch, which
+        # is why "hipdnn_install" omits it too. Do not "fix" this by adding the
+        # enumerated artifact flags back; find_package would fail.
+        "timeout_minutes": 60,
+        "test_script": f"python {_get_script_path('test_hipdnn_cudnn_samples.py')}",
+        "platform": ["linux", "windows"],
+        "total_shards_dict": {
+            "linux": 1,
+            "windows": 1,
+        },
+    },
     # MIOpen provider tests
     "miopenprovider": {
         "job_name": "miopenprovider",

--- a/build_tools/github_actions/test_executable_scripts/test_hipdnn_cudnn_samples.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipdnn_cudnn_samples.py
@@ -1,0 +1,485 @@
+#!/usr/bin/env python3
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+NVIDIA cudnn-frontend sample corpus compatibility test.
+
+Drives the standalone CMake harness shipped inside the hipDNN artifact at
+share/hipdnn/cudnn_samples. That harness acquires NVIDIA's unmodified
+cudnn-frontend sample corpus and compiles it against hipDNN's cuDNN
+compatibility shim.
+
+This is not hipDNN's own sample suite; that one is test_hipdnn_samples.py.
+
+The harness owns every policy decision: whether the shim is present at all,
+which translation units are expected to compile, and which are expected to
+fail. This driver only configures, builds, tests, and reports.
+"""
+
+import argparse
+import json
+import logging
+import os
+import platform
+import shlex
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+OUTPUT_ARTIFACTS_DIR = os.getenv("OUTPUT_ARTIFACTS_DIR")
+SCRIPT_DIR = Path(__file__).resolve().parent
+THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
+
+SHARD_INDEX = os.getenv("SHARD_INDEX", "1")
+TOTAL_SHARDS = os.getenv("TOTAL_SHARDS", "1")
+
+# Location of the harness project inside the installed artifact tree.
+PAYLOAD_RELPATH = Path("share") / "hipdnn" / "cudnn_samples"
+
+# These two are coupled and must stay together. The keep-going flag is Ninja's,
+# not cmake's, so it travels after "--" and is only valid while the generator
+# below is Ninja. Adding another generator means changing both: get it wrong and
+# the build silently produces nothing while every sample reports as a compile
+# failure.
+CMAKE_GENERATOR = "Ninja"
+BUILD_KEEP_GOING_ARGS = ["-k", "0"]
+
+# The single test the harness registers when the compatibility shim is absent.
+SKIP_TEST_NAME = "cudnn_samples_skipped"
+
+# Per-translation-unit JSON sidecars, written by the harness.
+REPORT_DIR_NAME = "cudnn_samples_report"
+
+# The payload is installed unconditionally, so a missing directory means the
+# artifact did not ship it -- a wiring bug, distinct from the shim being off.
+EXIT_PAYLOAD_MISSING = 11
+EXIT_FLAG_REQUIRED_BUT_OFF = 10
+
+# Outcome tokens the harness writes into the sidecars. Any other value is
+# surfaced as an anomaly instead of being folded into a count.
+OUTCOME_COMPILED = "compiled"
+OUTCOME_COMPILE_FAILED = "compile-failed"
+OUTCOME_XFAIL_STILL_FAILING = "xfail-still-failing"
+OUTCOME_XFAIL_NOW_COMPILES = "xfail-now-compiles"
+OUTCOME_RAN_CLEAN = "ran-clean"
+OUTCOME_RAN_NO_ASSERTIONS = "ran-no-assertions"
+OUTCOME_RAN_WITH_ASSERTION_FAILURES = "ran-with-assertion-failures"
+OUTCOME_CRASHED = "crashed"
+OUTCOME_EXCLUDED = "excluded"
+
+KNOWN_OUTCOMES = {
+    OUTCOME_COMPILED,
+    OUTCOME_COMPILE_FAILED,
+    OUTCOME_XFAIL_STILL_FAILING,
+    OUTCOME_XFAIL_NOW_COMPILES,
+    OUTCOME_RAN_CLEAN,
+    OUTCOME_RAN_NO_ASSERTIONS,
+    OUTCOME_RAN_WITH_ASSERTION_FAILURES,
+    OUTCOME_CRASHED,
+    OUTCOME_EXCLUDED,
+}
+
+# A translation unit that ran necessarily compiled first. "compiled" is both an
+# intermediate and a terminal token: the compile probe writes it, and a RUN-tier
+# run probe then rewrites the sidecar to one of the "ran-*" values. An entry
+# left at "compiled" simply never reached its run probe.
+RAN_OUTCOMES = {
+    OUTCOME_RAN_CLEAN,
+    OUTCOME_RAN_NO_ASSERTIONS,
+    OUTCOME_RAN_WITH_ASSERTION_FAILURES,
+    OUTCOME_CRASHED,
+}
+COMPILED_OUTCOMES = RAN_OUTCOMES | {OUTCOME_COMPILED, OUTCOME_XFAIL_NOW_COMPILES}
+
+logging.basicConfig(level=logging.INFO)
+
+
+def get_parallelism() -> int:
+    """CPU budget for both the build and the test run.
+
+    KUBE_CPU_REQUEST is Kubernetes-injected and may be fractional ("8.0"), so
+    truncate at the dot the way the workflow's ${KUBE_CPU_REQUEST%.*} does.
+    """
+    kube_cpu_request = os.getenv("KUBE_CPU_REQUEST")
+    if kube_cpu_request:
+        try:
+            return max(1, int(kube_cpu_request.split(".")[0]))
+        except ValueError:
+            logging.warning(f"Ignoring unparsable KUBE_CPU_REQUEST={kube_cpu_request!r}")
+    return max(1, os.cpu_count() or 1)
+
+
+def get_default_build_dir() -> Path:
+    """A deliberately short build root.
+
+    The harness registers dozens of targets whose object and link paths nest
+    deeply; rooting the build inside the workspace overruns Windows MAX_PATH.
+    """
+    temp_root = os.getenv("RUNNER_TEMP") or tempfile.gettempdir()
+    return Path(temp_root) / "cdnns"
+
+
+def build_environment(artifacts_path: Path) -> dict:
+    """Environment for CMake, the compiler, and the sample executables."""
+    environ_vars = os.environ.copy()
+    environ_vars["HIP_PLATFORM"] = "amd"
+
+    if platform.system() == "Windows":
+        # Both bin and lib, not just the prefix root: hipdnn_backend.dll and the ROCm
+        # runtime DLLs live in those subdirectories, and Windows resolves imports off
+        # PATH. Missing them surfaces as exit 0xC0000135 (STATUS_DLL_NOT_FOUND) from
+        # every sample, which the launcher correctly-but-unhelpfully reports as a crash.
+        prefixes = [str(artifacts_path / "bin"), str(artifacts_path / "lib"),
+                    str(artifacts_path)]
+        existing = environ_vars.get("PATH", "")
+        environ_vars["PATH"] = ";".join(prefixes + ([existing] if existing else []))
+    else:
+        existing = environ_vars.get("LD_LIBRARY_PATH", "")
+        rocm_lib = str(artifacts_path / "lib")
+        environ_vars["LD_LIBRARY_PATH"] = ":".join(
+            [rocm_lib] + ([existing] if existing else [])
+        )
+
+    return environ_vars
+
+
+def configure(
+    source_dir: Path, build_dir: Path, artifacts_path: Path, environ_vars: dict
+):
+    """Configure the harness as an external consumer of the installed hipDNN.
+
+    The harness decides skip-vs-run here, from its find_package query for the
+    cudnn_compatibility component, and acquires the sample corpus itself.
+    Neither is this driver's business.
+    """
+    is_windows = platform.system() == "Windows"
+    compiler_ext = ".exe" if is_windows else ""
+
+    configure_cmd = [
+        "cmake",
+        "-B",
+        str(build_dir),
+        "-S",
+        str(source_dir),
+        f"-G{CMAKE_GENERATOR}",
+        f"-DCMAKE_PREFIX_PATH={artifacts_path}",
+        f"-DCMAKE_CXX_COMPILER={artifacts_path}/lib/llvm/bin/clang++{compiler_ext}",
+        f"-DCMAKE_C_COMPILER={artifacts_path}/lib/llvm/bin/clang{compiler_ext}",
+    ]
+
+    # Windows needs a resource compiler specified
+    if is_windows:
+        configure_cmd.append("-DCMAKE_RC_COMPILER=rc.exe")
+
+    logging.info(f"++ Configure: {shlex.join(configure_cmd)}")
+    subprocess.run(configure_cmd, check=True, cwd=THEROCK_DIR, env=environ_vars)
+
+
+def build(build_dir: Path, jobs: int, environ_vars: dict):
+    """Build every sample target, keeping going past failures.
+
+    The build exit status is ignored on purpose: each translation unit's
+    compilation is itself a ctest case, so a compile failure must be reported
+    per-sample rather than aborting the driver. Keeping going past the first
+    error is what stops one broken sample from hiding every other result.
+    """
+    # "-j" is a cmake option and must precede "--"; everything after it goes to
+    # the generator's native tool. See BUILD_KEEP_GOING_ARGS.
+    build_cmd = [
+        "cmake",
+        "--build",
+        str(build_dir),
+        "-j",
+        str(jobs),
+        "--",
+        *BUILD_KEEP_GOING_ARGS,
+    ]
+    logging.info(f"++ Build: {shlex.join(build_cmd)}")
+    result = subprocess.run(build_cmd, check=False, cwd=THEROCK_DIR, env=environ_vars)
+    logging.info(
+        f"++ Build exited with {result.returncode}; status ignored on purpose "
+        "(compilation is reported as a ctest case, not as a driver failure)"
+    )
+
+
+def run_ctest(build_dir: Path, jobs: int, environ_vars: dict) -> int:
+    """Run the harness test suite. Failures are reported, never raised."""
+    test_cmd = [
+        "ctest",
+        "--test-dir",
+        str(build_dir),
+        "--output-on-failure",
+        "--parallel",
+        str(jobs),
+    ]
+    logging.info(f"++ Test: {shlex.join(test_cmd)}")
+    result = subprocess.run(test_cmd, check=False, cwd=THEROCK_DIR, env=environ_vars)
+    logging.info(f"++ Test exited with {result.returncode}")
+    return result.returncode
+
+
+def list_registered_tests(build_dir: Path, environ_vars: dict) -> list:
+    """Names of the tests the harness registered, or [] if unavailable."""
+    list_cmd = ["ctest", "--test-dir", str(build_dir), "--show-only=json-v1"]
+    result = subprocess.run(
+        list_cmd,
+        check=False,
+        cwd=THEROCK_DIR,
+        env=environ_vars,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        logging.warning(f"Could not enumerate ctest tests: {result.stderr.strip()}")
+        return []
+    try:
+        listing = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        logging.warning(f"Could not parse the ctest test listing: {exc}")
+        return []
+    return [test.get("name", "") for test in listing.get("tests", [])]
+
+
+def is_skip_run(test_names: list) -> bool:
+    """True when the harness registered only its shim-absent placeholder."""
+    return test_names == [SKIP_TEST_NAME]
+
+
+def report_skip() -> int:
+    """Announce that nothing was tested, and decide whether that is fatal."""
+    print(
+        "::notice title=cuDNN samples skipped::"
+        "hipDNN was built with HIPDNN_ENABLE_CUDNN_COMPATIBILITY off, so the "
+        "cuDNN compatibility shim is not installed. No sample was compiled or "
+        "run: this job tested the wiring and nothing else."
+    )
+    if os.getenv("HIPDNN_CUDNN_SAMPLES_REQUIRE_FLAG") == "1":
+        print(
+            "::error title=cuDNN samples required but skipped::"
+            "HIPDNN_CUDNN_SAMPLES_REQUIRE_FLAG=1 demands a real run, but "
+            "HIPDNN_ENABLE_CUDNN_COMPATIBILITY is off in this build."
+        )
+        return EXIT_FLAG_REQUIRED_BUT_OFF
+    return 0
+
+
+def normalize_outcome(outcome) -> str:
+    """Fold sidecar outcome spellings onto the canonical hyphenated token."""
+    return str(outcome).strip().lower().replace("_", "-").replace(" ", "-")
+
+
+def load_sidecars(report_dir: Path):
+    """Read the per-translation-unit sidecars.
+
+    Returns (entries, anomalies). A missing or malformed sidecar is recorded as
+    an anomaly; it never aborts the run, because the report is the one thing
+    this driver must always produce.
+
+    EXCLUDED entries are written at configure time and have no ctest case at
+    all, so sidecars and tests do not correspond one-to-one.
+    """
+    entries = []
+    anomalies = []
+
+    if not report_dir.is_dir():
+        anomalies.append(f"No sidecar directory at {report_dir}")
+        return entries, anomalies
+
+    sidecars = sorted(report_dir.glob("*.json"))
+    if not sidecars:
+        anomalies.append(f"No sidecars found in {report_dir}")
+
+    for sidecar in sidecars:
+        try:
+            entry = json.loads(sidecar.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            anomalies.append(f"{sidecar.name}: unreadable ({exc})")
+            continue
+        if not isinstance(entry, dict):
+            anomalies.append(f"{sidecar.name}: expected a JSON object")
+            continue
+        if not entry.get("tu"):
+            anomalies.append(f"{sidecar.name}: missing 'tu'")
+            entry["tu"] = sidecar.stem
+        if normalize_outcome(entry.get("outcome", "")) not in KNOWN_OUTCOMES:
+            anomalies.append(
+                f"{entry['tu']}: unrecognized outcome {entry.get('outcome')!r}"
+            )
+        entries.append(entry)
+
+    entries.sort(key=lambda entry: str(entry["tu"]))
+    return entries, anomalies
+
+
+def summarize(entries: list) -> dict:
+    """The headline counts."""
+    counts = {
+        "compiled": 0,
+        "ran": 0,
+        "ran-clean": 0,
+        "ran-no-assertions": 0,
+        "ran-with-assertion-failures": 0,
+        "xfail-still-failing": 0,
+    }
+    for entry in entries:
+        outcome = normalize_outcome(entry.get("outcome", ""))
+        if outcome in COMPILED_OUTCOMES:
+            counts["compiled"] += 1
+        if outcome in RAN_OUTCOMES:
+            counts["ran"] += 1
+        if outcome == OUTCOME_RAN_CLEAN:
+            counts["ran-clean"] += 1
+        if outcome == OUTCOME_RAN_NO_ASSERTIONS:
+            counts["ran-no-assertions"] += 1
+        if outcome == OUTCOME_RAN_WITH_ASSERTION_FAILURES:
+            counts["ran-with-assertion-failures"] += 1
+        if outcome == OUTCOME_XFAIL_STILL_FAILING:
+            counts["xfail-still-failing"] += 1
+    return counts
+
+
+def _cell(value) -> str:
+    """Render one markdown table cell, keeping the row's pipes intact."""
+    return str(value).replace("|", "\\|")
+
+
+def _detail(entry: dict) -> str:
+    parts = []
+    assertion_failures = entry.get("assertion_failures")
+    if isinstance(assertion_failures, int):
+        parts.append(str(assertion_failures))
+    reason = entry.get("reason")
+    if reason:
+        parts.append(str(reason))
+    return " / ".join(parts) if parts else "-"
+
+
+def format_report(entries: list, anomalies: list, counts: dict) -> str:
+    lines = ["## hipDNN cuDNN sample corpus", ""]
+    lines.append(
+        "Counts: " + ", ".join(f"{name} {value}" for name, value in counts.items())
+    )
+    lines.append("")
+
+    # An XFAIL entry that started compiling means the manifest has rotted. It is
+    # the report's most consequential row, so call it out above the table.
+    rotted = [
+        entry
+        for entry in entries
+        if normalize_outcome(entry.get("outcome", "")) == OUTCOME_XFAIL_NOW_COMPILES
+    ]
+    if rotted:
+        lines.append(
+            f"**Manifest rot: {len(rotted)} translation unit(s) marked "
+            "XFAIL_COMPILE now compile. Retier them.**"
+        )
+        lines.append("")
+        for entry in rotted:
+            lines.append(f"- `{entry.get('tu', '?')}`")
+        lines.append("")
+
+    lines.append("| TU | Tier | Outcome | Assertion failures / reason |")
+    lines.append("| --- | --- | --- | --- |")
+    for entry in entries:
+        outcome = entry.get("outcome", "?")
+        if normalize_outcome(outcome) == OUTCOME_XFAIL_NOW_COMPILES:
+            outcome = f"**{outcome}**"
+        lines.append(
+            f"| {_cell(entry.get('tu', '?'))} "
+            f"| {_cell(entry.get('tier', '?'))} "
+            f"| {_cell(outcome)} "
+            f"| {_cell(_detail(entry))} |"
+        )
+    if not entries:
+        lines.append("| _(no sidecars)_ | - | - | - |")
+
+    if anomalies:
+        lines.append("")
+        lines.append("### Report anomalies")
+        lines.append("")
+        for anomaly in anomalies:
+            lines.append(f"- {anomaly}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def emit_report(build_dir: Path):
+    """Aggregate the sidecars into the job summary and onto stdout."""
+    entries, anomalies = load_sidecars(build_dir / REPORT_DIR_NAME)
+    counts = summarize(entries)
+    report = format_report(entries, anomalies, counts)
+
+    # Always print: the step summary only exists under GitHub Actions, and a
+    # local run needs to be readable too.
+    print(report)
+
+    step_summary = os.getenv("GITHUB_STEP_SUMMARY")
+    if step_summary:
+        with open(step_summary, "a", encoding="utf-8") as summary_file:
+            summary_file.write(report)
+            summary_file.write("\n")
+
+    for anomaly in anomalies:
+        logging.warning(f"Report anomaly: {anomaly}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Build and run NVIDIA's cudnn-frontend samples against "
+        "hipDNN's cuDNN compatibility shim"
+    )
+    parser.add_argument(
+        "--build-dir",
+        type=Path,
+        help="Build directory path (will be created if doesn't exist). "
+        "If not specified, uses a short directory under the runner temp dir. "
+        "Keep any override short: deep paths overrun MAX_PATH on Windows.",
+    )
+    args = parser.parse_args()
+
+    if not OUTPUT_ARTIFACTS_DIR:
+        raise RuntimeError("OUTPUT_ARTIFACTS_DIR environment variable not set")
+
+    logging.info(f"Using OUTPUT_ARTIFACTS_DIR: {OUTPUT_ARTIFACTS_DIR}")
+    logging.info(f"Shard {SHARD_INDEX} of {TOTAL_SHARDS}")
+
+    artifacts_path = Path(OUTPUT_ARTIFACTS_DIR).resolve()
+    source_dir = artifacts_path / PAYLOAD_RELPATH
+    if not source_dir.is_dir():
+        logging.error(
+            f"cuDNN sample harness not found at {source_dir}. The payload is "
+            "installed unconditionally, so this means the hipDNN artifact did "
+            "not ship it, not that the compatibility shim is disabled."
+        )
+        return EXIT_PAYLOAD_MISSING
+
+    build_dir = (args.build_dir or get_default_build_dir()).resolve()
+    build_dir.mkdir(parents=True, exist_ok=True)
+    logging.info(f"Using build directory: {build_dir}")
+
+    jobs = get_parallelism()
+    logging.info(f"Using {jobs} parallel jobs")
+
+    environ_vars = build_environment(artifacts_path)
+
+    configure(source_dir, build_dir, artifacts_path, environ_vars)
+    build(build_dir, jobs, environ_vars)
+    ctest_returncode = run_ctest(build_dir, jobs, environ_vars)
+
+    if is_skip_run(list_registered_tests(build_dir, environ_vars)):
+        if ctest_returncode == 0:
+            return report_skip()
+        logging.error(
+            f"The harness registered only {SKIP_TEST_NAME}, but ctest exited "
+            f"with {ctest_returncode} instead of reporting it as skipped."
+        )
+        return ctest_returncode
+
+    emit_report(build_dir)
+    return ctest_returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ml-libs/artifact-hipdnn.toml
+++ b/ml-libs/artifact-hipdnn.toml
@@ -16,4 +16,5 @@ include = [
   "bin/*hipdnn_*_test*",
   "bin/hipdnn/CTestTestfile.cmake",
   "lib/test_plugins/**",
+  "share/hipdnn/cudnn_samples/**",
 ]


### PR DESCRIPTION
## Motivation

JIRA ID : ALMIOPEN-2043

Adds the TheRock-side wiring for a new component test job, `hipdnn-cudnn-samples`, which
compiles NVIDIA's unmodified `cudnn-frontend` `samples/cpp` corpus (pinned to `v1.24.0`)
against the *installed* hipDNN cuDNN-compatibility shim and runs what compiles. Today the
only thing measuring shim parity is hand-written hipDNN tests, which can only assert the
surface we already thought to implement; the upstream corpus is the external, adversarial
definition of "does a real cuDNN program build against this."

All of the harness itself — the CMake project, the manifest, the overlay headers, the
per-TU probe — lives in rocm-libraries (ROCm/rocm-libraries#12124). This PR contributes
only the three things that must live in TheRock: the test-matrix row, the driver script the
component-test workflow invokes, and the artifact glob that ships the harness payload.

The job lands **dark**: `HIPDNN_ENABLE_CUDNN_COMPATIBILITY` defaults `OFF`
(`FLAGS.cmake:103-111`), so the steady state is one ctest case reporting `Skipped`
(`SKIP_RETURN_CODE 77`) plus a GitHub `::notice` — never a silent pass. Turning the flag on
is a separate PR; the flag-on behaviour is evidenced below.

## Technical Details

- **`build_tools/github_actions/fetch_test_configurations.py`** — new `hipdnn-cudnn-samples`
  entry in `test_matrix`: Linux + Windows, 1 shard each, 60-minute timeout. Deliberately
  carries **no** `fetch_artifact_args`: the job calls `find_package(hipdnn_frontend)`, whose
  config file and headers live in the `dev` component, and `install_rocm_from_artifacts.py`
  expands each enumerated artifact to `<name>_lib` plus `<name>_test` only — never
  `<name>_dev`. Omitting the key takes the fetch-everything branch, which is why the adjacent
  `hipdnn_install` entry omits it too. The key is deliberately distinct from the existing
  `hipdnn-samples` (hipDNN's *own* samples, untouched) so the two never blur.
- **`build_tools/github_actions/test_executable_scripts/test_hipdnn_cudnn_samples.py`** — the
  driver: configure the harness out of the installed artifact tree, build with `-- -k 0`
  (keep-going; `-k` is Ninja's flag and must follow `--`), ignore the build status because
  each TU's compilation is its own ctest case, run `ctest`, then aggregate the per-TU JSON
  sidecars into `$GITHUB_STEP_SUMMARY`. Every policy decision — skip-vs-run, tiers, corpus
  acquisition — lives in the harness in rocm-libraries, not here. Two distinct non-zero exits
  keep failure modes apart: `11` = payload missing from the artifact (a wiring bug), `10` =
  `HIPDNN_CUDNN_SAMPLES_REQUIRE_FLAG=1` set on a build where the shim is off.
- **`ml-libs/artifact-hipdnn.toml`** — adds `share/hipdnn/cudnn_samples/**` to the `test`
  component include list so the harness payload travels with the hipDNN test artifact. No
  `COMPONENT` selection is involved: the descriptor globs the staged tree, matching how
  hipDNN's own test binaries are already picked up.

## Merge order (read before merging)

Job selection is `key in project_array or "*" in project_array`
(`fetch_test_configurations.py:1065-1067`), and `PROJECTS_TO_TEST` defaults to `"*"`
(line 952). So unlike the companion PR's matrix rows — which are inert until TheRock knows
the key — **this** row goes live the moment it merges. If it merges before the payload exists
in the hipDNN artifact, the driver hits `EXIT_PAYLOAD_MISSING` (exit 11) and reds the job.

Required order:

1. ROCm/rocm-libraries#12124 merges to `develop` (installs the payload).
2. TheRock's `rocm-libraries` submodule pin advances past it.
3. This PR merges.

Taken in that order every step is green; taken in reverse, step 3 fails loudly rather than
silently, which is the intended failure mode but still a broken `main`.

## Test Plan

- **Flag-on preview, real CI, two platforms** — a throwaway TheRock branch applying only
  `-DTHEROCK_FLAG_HIPDNN_ENABLE_CUDNN_COMPATIBILITY=ON` on top of this work, to exercise the
  compile and run tiers, the artifact round trip, Windows, and the corpus `git clone` from the
  component-test runner before the flag-flip PR lands. This is the only way to test the driver
  against a non-trivial workload while the flag is off everywhere.
- **Steady-state (flag-off) path** — the one thing this PR actually turns on in TheRock CI:
  the job selects, fetches, configures, registers one skipped test, and exits 0 with a
  `::notice`. Pending, because it needs the merge-order prerequisite above.
- **PR CI** — the three touched files are Python/TOML; `pre-commit` and the policy bot are the
  relevant gates.

### Testing Checklist

- [x] Flag-on preview, Linux gfx94X-dcgpu (gfx942) — TheRock Multi-Arch CI run
  [34875069528](https://github.com/ROCm/TheRock/actions/runs/34875069528), job
  `Test hipdnn-cudnn-samples (shard 1/1) (gfx94X-dcgpu)`
  ([log](https://github.com/ROCm/TheRock/actions/runs/34875069528/job/104117892615)) —
  Status: Passed
- [x] Flag-on preview, Windows gfx110X-all (gfx1100/1101/1102/1103) — same run, job
  `Test hipdnn-cudnn-samples (shard 1/1) (gfx110X-all)`
  ([log](https://github.com/ROCm/TheRock/actions/runs/34875069528/job/104145075731)) —
  Status: Passed
- [ ] Steady-state flag-off run: `hipdnn-cudnn-samples` visible by name reporting `Skipped` —
  blocked on the merge order above — Status: Pending
- [ ] `pre-commit` — `pre-commit run --all-files` — Status: **Failed** (Black reformats two
  hunks in `test_hipdnn_cudnn_samples.py`; fix pending)
- [ ] PR CI - GitHub PR checks - Status: Pending

## Test Result

Both preview jobs: **79/79 ctest cases passed, 0 failed**. Corpus cloned at `v1.24.0`;
`64 staged, 64 manifest entries`; counts identical on both platforms —
`compiled 34, ran 34, ran-clean 3, ran-no-assertions 16, ran-with-assertion-failures 15,
xfail-still-failing 11`; **0 crashes**; per-TU table emitted to the job step summary.

Scoping the evidence honestly: run 34875069528 concluded `failure` **overall** — unrelated
lanes in that multi-arch run failed. The two `hipdnn-cudnn-samples` jobs linked above each
concluded `success`; that is the claim being made, not that the whole run was green.

Why the run tier is a no-crash bar rather than an exit-status bar: a sample whose `REQUIRE`
fails at `graph->build(handle, {HeurMode_t::A})` is a provider capability gap on that GPU, not
a shim defect, and must not red the job. The report separates ran-clean / ran-no-assertions /
ran-with-assertion-failures on purpose — collapsing them would report 18 clean where the true
figure is 3.

The preview lane builds with `HIPDNN_ENABLE_SDPA=OFF`, so 11 `requires_sdpa` manifest entries
re-tier to `EXCLUDED` at configure time: 44 RUN − 10 = 34 compiled, 12 `XFAIL_COMPILE` − 1 =
11, and 34 + 34 + 11 = the 79 registered ctest cases.

## Risk Assessment

**3.** Test/CI infrastructure plus one artifact-descriptor glob; no library code, no build
flags flipped, no behaviour change to any existing job. Two things keep it off 2: (1) the new
matrix row is live-on-merge (see *Merge order*), so landing it out of sequence reds CI for
every family; and (2) the driver runs on both Linux and Windows component-test runners and
clones from `github.com` at test time, which adds a network dependency to a lane that
previously had none — a `cudnn-frontend` outage or tag removal would fail the job. Both are
bounded: with the compat flag off the driver never reaches the clone.

## ASIC Coverage

In the state this PR lands in, the blast radius is **architecture-independent**: with the
compat flag off, the job configures, registers one skipped test, and stops — no clone, no
staging, no compile, no GPU work. **Passing PR CI is sufficient for this PR.**

For completeness, the flag-on path was exercised on **gfx942** (Linux) and
**gfx1100/1101/1102/1103** (Windows) in the preview run. Not covered: **gfx950**, **gfx1151**,
**gfx125X**. Those belong to the flag-flip PR, where the run tier actually executes on the GPU
and the SDPA engine exists — that PR should carry a full multi-arch sweep. Demanding one here,
against a job that does nothing, would be escalation.

## Related

- Companion (required, merges first): ROCm/rocm-libraries#12124 — the harness itself
  (CMake project, `manifest.json`, overlay headers, `sample_probe.py`), plus the
  `projects_to_test` rows in `.github/scripts/therock_matrix.py`.
- Predecessor (merged): #7465 — adds the `HIPDNN_ENABLE_CUDNN_COMPATIBILITY` flag.
- Follow-up: the flag-flip PR (`-DTHEROCK_FLAG_HIPDNN_ENABLE_CUDNN_COMPATIBILITY=ON`,
  optionally `HIPDNN_CUDNN_SAMPLES_REQUIRE_FLAG=1`). Nothing in this PR turns a flag on.

## Flags / Guardrails

| State | Behaviour |
| --- | --- |
| compat OFF (the default, and every CI run of this PR) | one ctest case, `Skipped` via `SKIP_RETURN_CODE 77`, plus an `::notice`. No clone, no staging, no build. |
| compat ON / SDPA OFF | full run, tier 34 of 56. **Evidenced by run 34875069528.** |
| compat ON / SDPA ON | full run, whole manifest, tier 44 of 56. Evidenced locally in the companion PR. |

`HIPDNN_CUDNN_SAMPLES_REQUIRE_FLAG=1` is the opt-in guard that turns "skipped" into a hard
failure; it is **not** set anywhere in this PR.

## Adjacent Tests Considered

- `hipdnn-samples` — a different job, hipDNN's own sample suite. Untouched; the new key is
  deliberately `hipdnn-cudnn-samples` so the two are never confused.
- `hipdnn_install` — already consumes the `cudnn_compatibility` `find_package` component this
  harness gates on, so the component export stays covered independently of this job. It is
  also the precedent for omitting `fetch_artifact_args`.
- `artifact-hipdnn.toml` `test` component — widening the glob changes what every hipDNN test
  artifact carries. The added subtree is install-only data (~1.3k lines of CMake/JSON/Python/
  headers) under a new `share/hipdnn/cudnn_samples/` path; it cannot collide with the existing
  `bin/` and `lib/` patterns.
- `test/therock/test_hipdnn_cudnn_samples.py` in the companion PR is a **mirror** kept only by
  repo convention. The live driver is the one added here: `.github/workflows/test_component.yml`
  checks out this repo (`sparse-checkout: build_tools`, L110-116) and runs
  `component.test_script` (L219-220), so the rocm-libraries copy is never executed by the
  component-test path.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
